### PR TITLE
remove the cache on logout which fix the chat initialization on login

### DIFF
--- a/apps/frontend/src/components/header.tsx
+++ b/apps/frontend/src/components/header.tsx
@@ -1,4 +1,5 @@
 import { useNavigate, Link } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
 import { ButtonConnection } from './ui/button';
 import { useSession, signOut } from '@/lib/auth-client';
@@ -6,9 +7,11 @@ import { useSession, signOut } from '@/lib/auth-client';
 export const Header = () => {
 	const { data: session } = useSession();
 	const navigate = useNavigate();
+	const queryClient = useQueryClient();
 
 	const handleSignOut = async (e: React.FormEvent) => {
 		e.preventDefault();
+		queryClient.clear();
 		await signOut();
 		navigate({ to: '/login' });
 	};

--- a/apps/frontend/src/routes/user.tsx
+++ b/apps/frontend/src/routes/user.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { Folder, Key, LogOut, Pen } from 'lucide-react';
 import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -18,8 +19,10 @@ function UserPage() {
 	const { data: session } = useSession();
 	const user = session?.user;
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+	const queryClient = useQueryClient();
 
 	const handleSignOut = async () => {
+		queryClient.clear();
 		await signOut({
 			fetchOptions: {
 				onSuccess: () => {


### PR DESCRIPTION
Fixes #44 

- Clear cache on logout
- Chats in the sidebar are initialized correctly when on another user connection