### PR TITLE
Add env support in `nao_config.yaml` file

### DIFF
--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -49,7 +49,6 @@ class NaoConfig(BaseModel):
         """Load the configuration from a YAML file."""
         config_file = path / "nao_config.yaml"
         content = config_file.read_text()
-
         content = cls._process_env_vars(content)
         data = yaml.safe_load(content)
         return cls.model_validate(data)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "uvicorn>=0.40.0",
     "cryptography>=46.0.3",
     "dotenv>=0.9.9",
+    "pytest>=9.0.2",
 ]
 
 [project.scripts]
@@ -64,3 +65,9 @@ exclude = ["**/example/**"]
 
 [tool.ruff]
 line-length = 120
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -1,0 +1,36 @@
+import os
+from unittest.mock import patch
+
+from nao_core.config.base import NaoConfig
+
+
+def test_env_var_replacement():
+    """Test replacement of a environment variable."""
+    with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
+        content = "database: ${{ env('TEST_VAR') }}"
+        result = NaoConfig._process_env_vars(content)
+        assert result == "database: test_value"
+
+
+def test_multiple_env_vars_replacement():
+    """Test replacement of multiple environment variables."""
+    with patch.dict(os.environ, {"VAR1": "value1", "VAR2": "value2"}):
+        content = "host: ${{ env('VAR1') }}, port: ${{ env('VAR2') }}"
+        result = NaoConfig._process_env_vars(content)
+        assert result == "host: value1, port: value2"
+
+
+def test_missing_env_var_returns_empty_string():
+    """Test that missing environment variable is replaced with empty string."""
+    with patch.dict(os.environ, {}):
+        content = "value: ${{ env('NONEXISTENT_VAR') }}"
+        result = NaoConfig._process_env_vars(content)
+        assert result == "value: "
+
+
+def test_same_env_var_multiple_times():
+    """Test the same environment variable used multiple times."""
+    with patch.dict(os.environ, {"REPEATED": "repeated_value"}):
+        content = "${{ env('REPEATED') }} and ${{ env('REPEATED') }} again"
+        result = NaoConfig._process_env_vars(content)
+        assert result == "repeated_value and repeated_value again"

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -949,6 +949,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1240,6 +1249,7 @@ dependencies = [
     { name = "ibis-framework", extra = ["bigquery", "databricks", "duckdb", "postgres", "snowflake"] },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pytest" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "uvicorn" },
@@ -1260,6 +1270,7 @@ requires-dist = [
     { name = "ibis-framework", extras = ["bigquery", "duckdb", "databricks", "snowflake", "postgres"], specifier = ">=9.0.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
@@ -1469,6 +1480,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1811,6 +1831,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #34

Now `nao_config.yaml` can read env variables.

Demo: https://paulsojan.neetorecord.com/watch/487a05fb213ccf5c4c21

I have kept the syntax like this:

```yaml
llm:
    provider: openai
    api_key: ${{ env('OPENAI_API_KEY') }}
```
I used the GitHub workflow syntax style to access the environment from a YAML file.
Ref: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#using-contexts-to-access-variable-values
