### PR TITLE
Fix project init and first user

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,10 +1,15 @@
 import app from './app';
+import { assignAdminToOrphanedProject } from './queries/project.queries';
 
-app.listen({ host: '0.0.0.0', port: 5005 })
+assignAdminToOrphanedProject()
+	.then(() => {
+		return app.listen({ host: '0.0.0.0', port: 5005 });
+	})
 	.then((address) => {
 		console.log(`Server is running on ${address}`);
 	})
 	.catch((err) => {
-		app.log.error(err);
+		console.error('\n❌ Server failed to start:\n');
+		console.error(`   ${err.message}\n`);
 		process.exit(1);
 	});

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -100,3 +100,21 @@ export const initializeDefaultProjectForFirstUser = async (userId: string): Prom
 		role: 'admin',
 	});
 };
+
+/**
+ * Startup check: If NAO_DEFAULT_PROJECT_PATH is defined, there's a project with that path
+ * but no admin, auto-assign that the first user as admin.
+ */
+export const assignAdminToOrphanedProject = async (): Promise<void> => {
+	const projectPath = process.env.NAO_DEFAULT_PROJECT_PATH;
+	if (!projectPath) {
+		throw new Error('[Startup] NAO_DEFAULT_PROJECT_PATH environment variable is not defined.');
+	}
+
+	const firstUser = await userQueries.getFirstUser();
+	if (!firstUser) {
+		return;
+	}
+
+	await initializeDefaultProjectForFirstUser(firstUser.id);
+};

--- a/apps/backend/src/queries/user.queries.ts
+++ b/apps/backend/src/queries/user.queries.ts
@@ -19,3 +19,8 @@ export const countUsers = async (): Promise<number> => {
 	const [result] = await db.select({ count: count() }).from(s.user).execute();
 	return result?.count ?? 0;
 };
+
+export const getFirstUser = async (): Promise<User | null> => {
+	const [user] = await db.select().from(s.user).limit(1).execute();
+	return user ?? null;
+};


### PR DESCRIPTION
When init without the NAO_DEFAULT_PROJECT_FOLDER fails, then attribute the project to the first user.
