### PR TITLE
fix: error message was displayed for each message groups

### DIFF
--- a/apps/frontend/src/components/chat-error.tsx
+++ b/apps/frontend/src/components/chat-error.tsx
@@ -35,11 +35,11 @@ export function ChatError({ className }: Props) {
 
 	return (
 		<div className={cn('flex items-start gap-2.5 px-4 py-3 text-red-500', className)}>
-			<AlertCircleIcon className='size-4 shrink-0 mt-0.5' />
+			<AlertCircleIcon className='size-4 shrink-0 mt-1' />
 
 			<div className='flex-1 min-w-0 text-sm break-words'>
 				{parsed.error && <span className='font-medium'>{parsed.error}</span>}
-				{parsed.message && <p className='text-red-400 mt-0.5 leading-relaxed'>{parsed.message}</p>}
+				{parsed.message && <p className='text-red-400 mt leading-relaxed'>{parsed.message}</p>}
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/components/chat-messages.tsx
+++ b/apps/frontend/src/components/chat-messages.tsx
@@ -93,6 +93,7 @@ const ChatMessagesContent = ({ isAgentGenerating }: { isAgentGenerating: boolean
 					/>
 				))
 			)}
+			<ChatError className='mt-4' />
 		</>
 	);
 };
@@ -107,10 +108,7 @@ function MessageGroup({ group, showResponseLoader }: { group: MessageGroup; show
 					showResponseLoader={showResponseLoader && isLast(message, group.responses)}
 				/>
 			))}
-
 			{showResponseLoader && !group.responses.length && <AgentMessageLoader />}
-
-			<ChatError />
 		</div>
 	);
 }


### PR DESCRIPTION
before we displayed error message for each groups:

<img width="900" height="730" alt="Screenshot from 2026-01-28 00-03-09" src="https://github.com/user-attachments/assets/ac1ca2a2-78d5-4c7b-9b6a-e836ac9e6211" />

now:

<img width="900" height="730" alt="Screenshot from 2026-01-28 00-17-20" src="https://github.com/user-attachments/assets/8a1fc85e-e414-401f-a7b9-259bea525593" />

also do we want to attach the eventual "error answer" to the message group to display each of them linked to the user input? we might have different errors in same conversation?