### PR TITLE
Merge env variables TRUSTED_ORIGINS and REDIRECT_URL into existing BETTER_AUTH_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@ POSTGRES_DB=nao
 
 # Auth
 BETTER_AUTH_SECRET= #run `openssl rand -base64 32` to generate
-# Used for signin callbacks
-BETTER_AUTH_URL= # Callback URL for signins
+# Public URL of your app (used for authentication, trusted origins, and Slack redirects)
+BETTER_AUTH_URL=http://localhost:3000
 
 # LLM providers
 OPENAI_API_KEY=sk-123456789
@@ -20,9 +20,6 @@ ANTHROPIC_API_KEY=sk-123456789
 # Slack App
 SLACK_BOT_TOKEN=
 SLACK_SIGNING_SECRET=
-
-# Frontend Url
-REDIRECT_URL='http://localhost:3000/'
 
 # Context folder (to change for your setup)
 NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,7 +86,7 @@ jobs:
                       docker pull getnao/nao:${{ needs.build-and-push.outputs.image-tag }}
                       docker rm -f nao-chat 2>/dev/null || true
                       docker run -p 5005:5005 \
-                        -e "TRUSTED_ORIGINS=https://moon.getnao.io" \
+                        -e "BETTER_AUTH_URL=https://moon.getnao.io" \
                         -e "DB_SSL=true" \
                         -e "DB_URI=postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@${{ secrets.POSTGRES_HOST }}:${{ secrets.POSTGRES_PORT }}/${{ secrets.POSTGRES_DB }}" \
                         -e "NAO_CONTEXT_SOURCE=git" \

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -12,7 +12,7 @@ export const auth = betterAuth({
 		provider: dbConfig.dialect === Dialect.Postgres ? 'pg' : 'sqlite',
 		schema: dbConfig.schema,
 	}),
-	trustedOrigins: process.env.TRUSTED_ORIGINS ? process.env.TRUSTED_ORIGINS.split(',') : undefined,
+	trustedOrigins: process.env.BETTER_AUTH_URL ? [process.env.BETTER_AUTH_URL] : undefined,
 	emailAndPassword: {
 		enabled: true,
 	},

--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -75,7 +75,7 @@ export async function getSlackConfig(): Promise<SlackConfig | null> {
 
 	const botToken = project.slackBotToken || process.env.SLACK_BOT_TOKEN;
 	const signingSecret = project.slackSigningSecret || process.env.SLACK_SIGNING_SECRET;
-	const redirectUrl = process.env.REDIRECT_URL || 'http://localhost:3000/';
+	const redirectUrl = process.env.BETTER_AUTH_URL || 'http://localhost:3000/';
 
 	if (!botToken || !signingSecret) {
 		return null;

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -136,7 +136,7 @@ export const projectRoutes = {
 				}
 			: null;
 
-		const baseUrl = process.env.REDIRECT_URL || '';
+		const baseUrl = process.env.BETTER_AUTH_URL || '';
 		return {
 			projectConfig,
 			hasEnvConfig,


### PR DESCRIPTION
Closes #96

## Summary
Consolidates `TRUSTED_ORIGINS` and `REDIRECT_URL` into the existing `BETTER_AUTH_URL` variable, so users only need to set one URL.

## Changes
- **auth.ts**: Use `BETTER_AUTH_URL` for trusted origins
- **project-slack-config.queries.ts**: Use `BETTER_AUTH_URL` for Slack redirect URL
- **project.routes.ts**: Use `BETTER_AUTH_URL` for base URL in Slack config
- **.env.example**: Removed `REDIRECT_URL`, updated comment
- **docker.yml**: Updated production deployment to use `BETTER_AUTH_URL`

## Testing
- Verified login flow works (trusted origins)
- Verified settings page loads correctly