### PR TITLE
Update Docker documentation README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,20 +135,35 @@ Pull the image from DockerHub:
 docker pull getnao/nao:latest
 ```
 
-Run with Docker:
+Run nao chat with Docker using the example project bundled in the image:
 
 ```bash
 docker run -d \
   --name nao \
   -p 5005:5005 \
-  -e NAO_DEFAULT_PROJECT_PATH=/app/example \
-  -e OPENAI_API_KEY=sk-... \
+  -e BETTER_AUTH_URL=http://localhost:5005 \
+  -e FASTAPI_URL=http://127.0.0.1:8005 \
+  getnao/nao:latest
+```
+
+Run nao chat with Docker using your local nao project:
+
+```bash
+docker run -d \
+  --name nao \
+  -p 5005:5005 \
+  -e BETTER_AUTH_URL=http://localhost:5005 \
+  -v /path/to/your/nao-project:/app/project \
+  -e NAO_DEFAULT_PROJECT_PATH=/app/project \
+  -e FASTAPI_URL=http://127.0.0.1:8005 \
   getnao/nao:latest
 ```
 
 Access the UI at http://localhost:5005
 
 See the [DockerHub page](https://hub.docker.com/r/getnao/nao) for more details.
+
+For end-to-end self-hosted deployment (for example on Cloud Run with PostgreSQL), see the [Deployment Guide](https://docs.getnao.io/nao-agent/self-hosting/deployment-guide).
 
 ## 👩🏻‍💻 Development
 


### PR DESCRIPTION
## Summary

This PR updates the main `README.md` to make it easier to run nao chat with Docker and to discover the recommended self‑hosted deployment flow.

## Changes

- Add a `docker run` example to launch nao chat using the example project bundled in the `getnao/nao:latest` image.
- Add a `docker run` example to launch nao chat using a local nao project mounted into the container (with a generic `/path/to/your/nao-project` path).
- Link to the self-hosted Deployment Guide for end-to-end deployment instructions (e.g. Cloud Run + PostgreSQL) at [`https://docs.getnao.io/nao-agent/self-hosting/deployment-guide`](https://docs.getnao.io/nao-agent/self-hosting/deployment-guide).
