### PR TITLE
fix(slack): correct redirect URL for chat links

### DIFF
--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -82,13 +82,11 @@ export async function getSlackConfig(): Promise<SlackConfig | null> {
 		return null;
 	}
 
-	const baseUrl = redirectUrl.endsWith('/') ? redirectUrl.slice(0, -1) : redirectUrl;
-
 	return {
 		projectId: project.id,
 		botToken,
 		signingSecret,
-		redirectUrl: `${baseUrl}/p/${project.id}/`,
+		redirectUrl,
 	};
 }
 

--- a/apps/backend/src/services/slack.service.ts
+++ b/apps/backend/src/services/slack.service.ts
@@ -164,7 +164,7 @@ export class SlackService {
 	}
 
 	private async _replaceStopButtonWithLink(chatId: string): Promise<void> {
-		const chatUrl = `${this._redirectUrl}${chatId}`;
+		const chatUrl = new URL(`${chatId}`, `${this._redirectUrl}`).toString();
 		await this._slackClient.chat.update({
 			channel: this._channel,
 			text: `<${chatUrl}|View full conversation>`,


### PR DESCRIPTION
Fixes #127 

Remove the /p/{projectId}/ prefix from the redirectUrl that was preventing the 'View full conversation' link from working in Slack threads.

The frontend route is /{chatId}, not /p/{projectId}/{chatId}, so the redirectUrl should just be the base URL.