### PR TITLE
fix: add authorization check for chat deletion

### DIFF
--- a/apps/backend/src/trpc/chat.routes.ts
+++ b/apps/backend/src/trpc/chat.routes.ts
@@ -4,7 +4,9 @@ import { z } from 'zod/v4';
 import * as chatQueries from '../queries/chat.queries';
 import { agentService } from '../services/agent.service';
 import { type ListChatResponse, type UIChat } from '../types/chat';
-import { protectedProcedure } from './trpc';
+import { ownedResourceProcedure, protectedProcedure } from './trpc';
+
+const chatOwnerProcedure = ownedResourceProcedure(chatQueries.getChatOwnerId, 'chat');
 
 export const chatRoutes = {
 	get: protectedProcedure.input(z.object({ chatId: z.string() })).query(async ({ input, ctx }): Promise<UIChat> => {
@@ -23,18 +25,9 @@ export const chatRoutes = {
 		return chatQueries.listUserChats(ctx.user.id);
 	}),
 
-	delete: protectedProcedure
-		.input(z.object({ chatId: z.string() }))
-		.mutation(async ({ input, ctx }): Promise<void> => {
-			const userId = await chatQueries.getChatOwnerId(input.chatId);
-			if (!userId) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: `Chat with id ${input.chatId} not found.` });
-			}
-			if (userId !== ctx.user.id) {
-				throw new TRPCError({ code: 'FORBIDDEN', message: `You are not authorized to delete this chat.` });
-			}
-			await chatQueries.deleteChat(input.chatId);
-		}),
+	delete: chatOwnerProcedure.input(z.object({ chatId: z.string() })).mutation(async ({ input }): Promise<void> => {
+		await chatQueries.deleteChat(input.chatId);
+	}),
 
 	stop: protectedProcedure.input(z.object({ chatId: z.string() })).mutation(async ({ input, ctx }): Promise<void> => {
 		const agent = agentService.get(input.chatId);
@@ -47,16 +40,9 @@ export const chatRoutes = {
 		agent.stop();
 	}),
 
-	rename: protectedProcedure
+	rename: chatOwnerProcedure
 		.input(z.object({ chatId: z.string(), title: z.string().min(1).max(255) }))
-		.mutation(async ({ input, ctx }): Promise<void> => {
-			const userId = await chatQueries.getChatOwnerId(input.chatId);
-			if (!userId) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: `Chat with id ${input.chatId} not found.` });
-			}
-			if (userId !== ctx.user.id) {
-				throw new TRPCError({ code: 'FORBIDDEN', message: `You are not authorized to rename this chat.` });
-			}
+		.mutation(async ({ input }): Promise<void> => {
 			await chatQueries.renameChat(input.chatId, input.title);
 		}),
 };


### PR DESCRIPTION
Found that any logged-in user can delete someone else's chat if they know the chat ID. The delete endpoint only checks if you're logged in, not if you actually own the chat. The other endpoints like rename and get already check ownership, so delete was just missed.               
Added the same ownership check pattern to delete, so it now returns a 403 if you try to delete a chat that isn't yours

 How to reproduce

  1. Sign up two users
  2. Create a chat as User A
  3. As User B, call chat.delete with User A's chat ID
  4. Before this fix, it goes through silently. After, you get a 403.

  What I changed

 Before deleting, it now looks up who owns the chat and blocks the request if it's not you. Same approach rename already uses a few lines down.