### PR TITLE
remove 'alternateAction' for both login and signup

### DIFF
--- a/apps/frontend/src/components/auth-form.tsx
+++ b/apps/frontend/src/components/auth-form.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
 import { trpc } from '../main';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,14 +12,9 @@ interface AuthFormProps {
 	submitText: string;
 	children: React.ReactNode;
 	serverError?: string;
-	alternateAction?: {
-		text: string;
-		linkText: string;
-		href: string;
-	};
 }
 
-export function AuthForm({ form, title, submitText, children, serverError, alternateAction }: AuthFormProps) {
+export function AuthForm({ form, title, submitText, children, serverError }: AuthFormProps) {
 	const isGoogleSetup = useQuery(trpc.google.isSetup.queryOptions());
 
 	return (
@@ -66,15 +60,6 @@ export function AuthForm({ form, title, submitText, children, serverError, alter
 						Continue with Google
 					</Button>
 				</div>
-			)}
-
-			{alternateAction && (
-				<p className='text-center text-sm text-muted-foreground mt-6'>
-					{alternateAction.text}{' '}
-					<Link to={alternateAction.href} className='text-primary hover:underline font-medium'>
-						{alternateAction.linkText}
-					</Link>
-				</p>
 			)}
 		</div>
 	);

--- a/apps/frontend/src/routes/login.tsx
+++ b/apps/frontend/src/routes/login.tsx
@@ -24,13 +24,7 @@ function Login() {
 	});
 
 	return (
-		<AuthForm
-			form={form}
-			title='Log In'
-			submitText='Log In'
-			serverError={serverError}
-			alternateAction={{ text: "Don't have an account?", linkText: 'Sign up', href: '/signup' }}
-		>
+		<AuthForm form={form} title='Log In' submitText='Log In' serverError={serverError}>
 			<FormTextField form={form} name='email' type='email' placeholder='Email' />
 			<FormTextField form={form} name='password' type='password' placeholder='Password' />
 		</AuthForm>

--- a/apps/frontend/src/routes/signup.tsx
+++ b/apps/frontend/src/routes/signup.tsx
@@ -24,13 +24,7 @@ function SignUp() {
 	});
 
 	return (
-		<AuthForm
-			form={form}
-			title='Sign Up'
-			submitText='Sign Up'
-			serverError={serverError}
-			alternateAction={{ text: 'Already have an account?', linkText: 'Log in', href: '/login' }}
-		>
+		<AuthForm form={form} title='Sign Up' submitText='Sign Up' serverError={serverError}>
 			<FormTextField form={form} name='name' placeholder='Name' />
 			<FormTextField form={form} name='email' type='email' placeholder='Email' />
 			<FormTextField form={form} name='password' type='password' placeholder='Password' />


### PR DESCRIPTION
Fix #143 

⚠️ Careful, the possibility to switch between login and signup has been added back in PR #121 

<img width="552" height="442" alt="Capture d’écran 2026-02-09 à 10 29 55" src="https://github.com/user-attachments/assets/b0a680ab-ce00-4a36-ac0f-a39685d8f8bc" />
<img width="563" height="413" alt="Capture d’écran 2026-02-09 à 10 46 14" src="https://github.com/user-attachments/assets/e68e01ba-08fe-465d-a838-e273157d2bb3" />
