### PR TITLE
Fix Snowflake sync

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/snowflake.py
+++ b/cli/nao_core/commands/sync/providers/databases/snowflake.py
@@ -41,7 +41,9 @@ def sync_snowflake(
         except Exception:
             # Fallback: try using raw SQL if available
             try:
-                schemas_query = f"SELECT DISTINCT SCHEMA_NAME FROM {db_name}.INFORMATION_SCHEMA.SCHEMATA ORDER BY SCHEMA_NAME"
+                schemas_query = (
+                    f"SELECT DISTINCT SCHEMA_NAME FROM {db_name}.INFORMATION_SCHEMA.SCHEMATA ORDER BY SCHEMA_NAME"
+                )
                 if hasattr(conn, "sql"):
                     schemas_result = conn.sql(schemas_query).execute()
                     schemas = [row["SCHEMA_NAME"] for row in schemas_result.to_dict("records")]


### PR DESCRIPTION
**Problem**
nao sync was not creating any .md files for Snowflake databases even when nao debug correctly detected multiple schemas (e.g. 4 schemas). 
This was because:
- Wrong API usage: The sync used conn.list_databases(), which returns databases, not schemas. For Snowflake, the connection is already scoped to a database, so we need to list schemas within that database.
- Wrong attribute: The code used db_config.schema instead of db_config.schema_name (the actual field on SnowflakeConfig).

**Solution**
- Schema discovery: When no schema is configured, we now get schemas by querying INFORMATION_SCHEMA.SCHEMATA (with fallbacks: raw SQL, then parsing from list_tables(), then list_databases()).
- Table listing: We try list_tables(database=schema) first, then fall back to listing all tables and filtering by schema, handling both schema.table and database.schema.table formats.
- Config: Use db_config.schema_name when a single schema is configured.
- 
With these changes, nao sync creates the expected markdown files (columns, preview, description) for all schemas and tables in the Snowflake database.…schema