### PR TITLE
fix: add authorization check in password change mutation

### DIFF
--- a/apps/backend/src/trpc/account.routes.ts
+++ b/apps/backend/src/trpc/account.routes.ts
@@ -55,20 +55,12 @@ export const accountRoutes = {
 	modifyPassword: projectProtectedProcedure
 		.input(
 			z.object({
-				userId: z.string(),
 				newPassword: z.string(),
 				confirmPassword: z.string(),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
-			if (input.userId !== ctx.user.id) {
-				throw new TRPCError({
-					code: 'FORBIDDEN',
-					message: 'You are not authorized to modify this password.',
-				});
-			}
-
-			const account = await accountQueries.getAccountById(input.userId);
+			const account = await accountQueries.getAccountById(ctx.user.id);
 			if (!account || !account.password) {
 				throw new TRPCError({
 					code: 'NOT_FOUND',
@@ -93,6 +85,6 @@ export const accountRoutes = {
 
 			const hashedPassword = await hashPassword(input.newPassword);
 
-			await accountQueries.updateAccountPassword(account.id, hashedPassword, input.userId, false);
+			await accountQueries.updateAccountPassword(account.id, hashedPassword, ctx.user.id, false);
 		}),
 };

--- a/apps/frontend/src/components/modify-password.tsx
+++ b/apps/frontend/src/components/modify-password.tsx
@@ -7,7 +7,6 @@ import { Input } from '@/components/ui/input';
 
 export function ModifyPassword() {
 	const { refetch } = useSession();
-	const { data: sessionData } = useSession();
 	const [newPassword, setNewPassword] = useState('');
 	const [confirmPassword, setConfirmPassword] = useState('');
 	const [error, setError] = useState('');
@@ -27,18 +26,12 @@ export function ModifyPassword() {
 		e.preventDefault();
 		setError('');
 
-		if (!sessionData?.user?.id) {
-			setError('User not found');
-			return;
-		}
-
 		if (newPassword !== confirmPassword) {
 			setError('Passwords do not match');
 			return;
 		}
 
 		await modifyUserPassword.mutateAsync({
-			userId: sessionData.user.id,
 			newPassword: newPassword,
 			confirmPassword: confirmPassword,
 		});


### PR DESCRIPTION
Found that the modifyPassword endpoint only checks if you're logged in, not if the  password you're changing is actually yours. Any authenticated user could change another user's password by passing their userId. Added a check to make sure input.userId matches the logged-in user before allowing the
   password change.