### PR TITLE
feat(cli): add --version flag to display package version

### DIFF
--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -1,12 +1,13 @@
 from cyclopts import App
 from dotenv import load_dotenv
 
+from nao_core import __version__
 from nao_core.commands import chat, debug, init, sync, test
 from nao_core.version import check_for_updates
 
 load_dotenv()
 
-app = App()
+app = App(version=__version__)
 
 app.command(chat)
 app.command(debug)


### PR DESCRIPTION
This is a small UX improvement to help users quickly check their installed nao-core version without checking PyPI or config files. Added `--version` flag to the CLI to display the current version of nao-core.

Changes:
- Modified `cli/nao_core/main.py` to add version support using cyclopts
- Imported `__version__` from nao_core package
- Set `version=__version__` in App initialization

Testing:
- `nao --version` displays: `nao-core version 0.0.37`
- `nao --help` shows the version flag in Options section
- Other commands still work correctly
<img width="930" height="234" alt="Screenshot 2026-02-10 at 20 19 34" src="https://github.com/user-attachments/assets/a5e0ca9f-63c8-484c-8442-697a9cf64cb5" />