### PR TITLE
Allow overriding BETTER_AUTH_URL and FASTAPI_URL via env vars

### DIFF
--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -158,8 +158,8 @@ def chat():
             console.print("[bold green]✓[/bold green] Set Slack environment variables from config")
 
         env["NAO_DEFAULT_PROJECT_PATH"] = str(Path.cwd())
-        env["BETTER_AUTH_URL"] = f"http://localhost:{SERVER_PORT}"
-        env["FASTAPI_URL"] = f"http://localhost:{FASTAPI_PORT}"
+        env.setdefault("BETTER_AUTH_URL", f"http://localhost:{SERVER_PORT}")
+        env.setdefault("FASTAPI_URL", f"http://localhost:{FASTAPI_PORT}")
         env["MODE"] = MODE
 
         # Start the FastAPI server first


### PR DESCRIPTION
## Summary
- Use `env.setdefault()` instead of hard-coded assignment for `BETTER_AUTH_URL` and `FASTAPI_URL` in `nao chat`
- This allows users to override these URLs via their local environment (e.g. for remote or custom deployments) while keeping the default localhost behavior

## Test plan
- [ ] Run `nao chat` without setting env vars — should default to `localhost` as before
- [ ] Set `BETTER_AUTH_URL` / `FASTAPI_URL` in the environment before running `nao chat` — should use the custom values