### PR TITLE
[BQ] Annotate queries with metadata and enforce cost limit

### DIFF
--- a/apps/backend/fastapi/test_main.py
+++ b/apps/backend/fastapi/test_main.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import yaml
 from fastapi.testclient import TestClient
-
 from main import app
 
 

--- a/apps/backend/src/agents/tools/execute-sql.ts
+++ b/apps/backend/src/agents/tools/execute-sql.ts
@@ -3,10 +3,12 @@ import { executeSql as schemas } from '@nao/shared/tools';
 import { tool } from 'ai';
 
 import { env } from '../../env';
+import { getRequestContext } from '../../utils/request-context';
 import { getProjectFolder } from '../../utils/tools';
 
 export async function executeQuery({ sql_query, database_id }: executeSql.Input): Promise<executeSql.Output> {
 	const naoProjectFolder = getProjectFolder();
+	const { userEmail } = getRequestContext();
 
 	const response = await fetch(`${env.FASTAPI_URL}/execute_sql`, {
 		method: 'POST',
@@ -17,6 +19,7 @@ export async function executeQuery({ sql_query, database_id }: executeSql.Input)
 			sql: sql_query,
 			nao_project_folder: naoProjectFolder,
 			...(database_id && { database_id }),
+			...(userEmail && { user_email: userEmail }),
 		}),
 	});
 

--- a/apps/backend/src/utils/request-context.ts
+++ b/apps/backend/src/utils/request-context.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestContext {
+	userEmail?: string;
+}
+
+const store = new AsyncLocalStorage<RequestContext>();
+
+export function runWithRequestContext<T>(context: RequestContext, fn: () => T): T {
+	return store.run(context, fn);
+}
+
+export function getRequestContext(): RequestContext {
+	return store.getStore() ?? {};
+}

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -90,6 +90,13 @@ class DatabaseConfig(BaseModel, ABC):
 
         return True
 
+    def annotate_query(self, sql: str, *, project_name: str, user_email: str | None = None) -> str:
+        """Prepend metadata annotations to a query. No-op by default."""
+        return sql
+
+    def validate_query_cost(self, connection: BaseBackend, sql: str) -> None:
+        """Validate that a query won't exceed cost limits. No-op by default."""
+
     @abstractmethod
     def get_database_name(self) -> str:
         """Get the database name for this database type."""


### PR DESCRIPTION
## Summary
- **Query annotation**: Prepend SQL comments with project name and user email for BigQuery audit logs
- **Cost guard**: Dry-run queries before execution and reject any that would scan more than a configurable cost limit (default $1)
- **Request context**: Use `AsyncLocalStorage` to propagate the user email from the chat route down to the SQL execution tool without threading it through every function

## Changes
- `cli/`: Add `annotate_query()` and `validate_query_cost()` hooks to `DatabaseConfig` (no-op by default), with BigQuery implementations
- `apps/backend/`: Add `request-context.ts` using `AsyncLocalStorage`, wrap the chat route handler, and pass `user_email` to the FastAPI execute endpoint
- `apps/backend/fastapi/`: Call annotation and cost validation before executing queries

## Test plan
- [ ] Run a cheap BQ query — should execute normally with metadata comments prepended
- [ ] Run an expensive BQ query (>$1 estimated) — should be rejected with a clear error message
- [ ] Verify non-BQ databases are unaffected (base class methods are no-ops)