### PR TITLE
Add app version metadata to Project settings (fixes #167)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ ANTHROPIC_API_KEY=sk-123456789
 SLACK_BOT_TOKEN=
 SLACK_SIGNING_SECRET=
 
+# App metadata (optional)
+APP_VERSION=dev
+APP_COMMIT=unknown
+APP_BUILD_DATE=
+
 # Context folder (to change for your setup)
 NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,10 @@ jobs:
               id: sha
               run: echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
+            - name: Get build date
+              id: build_date
+              run: echo "value=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
 
@@ -59,6 +63,9 @@ jobs:
                   cache-to: type=gha,mode=max
                   build-args: |
                       GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+                      APP_VERSION=${{ github.ref_name }}
+                      APP_COMMIT=${{ steps.sha.outputs.short_sha }}
+                      APP_BUILD_DATE=${{ steps.build_date.outputs.value }}
 
             - name: Update Docker Hub description
               if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,10 @@ RUN uv pip install --system .
 # =============================================================================
 FROM python:3.12-slim AS runtime
 
+ARG APP_VERSION=dev
+ARG APP_COMMIT=unknown
+ARG APP_BUILD_DATE=
+
 # Install Node.js, Bun, git, and supervisor
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -128,6 +132,9 @@ ENV MODE=prod
 ENV NODE_ENV=production
 ENV BETTER_AUTH_URL=http://localhost:5005
 ENV FASTAPI_PORT=8005
+ENV APP_VERSION=$APP_VERSION
+ENV APP_COMMIT=$APP_COMMIT
+ENV APP_BUILD_DATE=$APP_BUILD_DATE
 ENV NAO_DEFAULT_PROJECT_PATH=/app/example
 ENV NAO_CONTEXT_SOURCE=local
 

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -33,6 +33,9 @@ const envSchema = z.object({
 	SLACK_SIGNING_SECRET: z.string().optional(),
 
 	FASTAPI_PORT: z.coerce.number().default(8005),
+	APP_VERSION: z.string().default('dev'),
+	APP_COMMIT: z.string().default('unknown'),
+	APP_BUILD_DATE: z.string().default(''),
 
 	NAO_DEFAULT_PROJECT_PATH: z.string().optional(),
 

--- a/apps/backend/src/trpc/router.ts
+++ b/apps/backend/src/trpc/router.ts
@@ -5,6 +5,7 @@ import { googleRoutes } from './google.routes';
 import { mcpRoutes } from './mcp.routes';
 import { posthogRoutes } from './posthog.routes';
 import { projectRoutes } from './project.routes';
+import { systemRoutes } from './system.routes';
 import { router } from './trpc';
 import { usageRoutes } from './usage.routes';
 import { userRoutes } from './user.routes';
@@ -19,6 +20,7 @@ export const trpcRouter = router({
 	google: googleRoutes,
 	account: accountRoutes,
 	mcp: mcpRoutes,
+	system: systemRoutes,
 });
 
 export type TrpcRouter = typeof trpcRouter;

--- a/apps/backend/src/trpc/system.routes.ts
+++ b/apps/backend/src/trpc/system.routes.ts
@@ -1,0 +1,10 @@
+import { env } from '../env';
+import { adminProtectedProcedure } from './trpc';
+
+export const systemRoutes = {
+	version: adminProtectedProcedure.query(() => ({
+		version: env.APP_VERSION,
+		commit: env.APP_COMMIT,
+		buildDate: env.APP_BUILD_DATE,
+	})),
+};

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
@@ -42,6 +42,10 @@ function ProjectPage() {
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
 
 	const isAdmin = project.data?.userRole === 'admin';
+	const appVersion = useQuery({
+		...trpc.system.version.queryOptions(),
+		enabled: isAdmin,
+	});
 
 	return (
 		<div className='flex flex-row gap-6'>
@@ -90,6 +94,31 @@ function ProjectPage() {
 								<SettingsCard title='Google Credentials'>
 									<GoogleConfigSection isAdmin={isAdmin} />
 								</SettingsCard>
+
+								{isAdmin && (
+									<SettingsCard title='Application'>
+										<div className='space-y-3 text-sm'>
+											<div className='flex items-center justify-between gap-4 border-b border-border/60 pb-2'>
+												<span className='text-muted-foreground'>Version</span>
+												<span className='font-mono text-foreground'>
+													{appVersion.data?.version ?? 'unknown'}
+												</span>
+											</div>
+											<div className='flex items-center justify-between gap-4 border-b border-border/60 pb-2'>
+												<span className='text-muted-foreground'>Commit</span>
+												<span className='font-mono text-foreground'>
+													{appVersion.data?.commit ?? 'unknown'}
+												</span>
+											</div>
+											<div className='flex items-center justify-between gap-4'>
+												<span className='text-muted-foreground'>Build date</span>
+												<span className='font-mono text-foreground'>
+													{appVersion.data?.buildDate || 'unknown'}
+												</span>
+											</div>
+										</div>
+									</SettingsCard>
+								)}
 							</div>
 						)}
 


### PR DESCRIPTION
Closes #167

## Summary
- Add a new admin-protected backend route `system.version` exposing:
  - `version`
  - `commit`
  - `buildDate`
- Display this metadata in **Settings > Project** under a new **Application** card (admin only).
- Wire Docker/build metadata into runtime env:
  - `APP_VERSION`
  - `APP_COMMIT`
  - `APP_BUILD_DATE`
- Align FastAPI env usage to `FASTAPI_PORT` across backend/CLI/docs/compose/workflow.

## Why
As requested in #167, admins need to identify exactly which app build is running, including commit SHA in Docker deployments.

## Testing
- Live smoke test passed:
  1. Started backend with:
     - `APP_VERSION=1.2.3`
     - `APP_COMMIT=abc1234`
     - `APP_BUILD_DATE=2026-02-11T00:00:00Z`
  2. Signed up an admin user via `/api/auth/sign-up/email`
  3. Confirmed project/admin context via `/api/trpc/project.getCurrent`
  4. Queried `/api/trpc/system.version` with auth cookie and got:
     ```json
     {"version":"1.2.3","commit":"abc1234","buildDate":"2026-02-11T00:00:00Z"}
     ```

## Notes
- Full repo lint/typecheck has existing unrelated failures; this change was validated with runtime smoke testing on the affected path.
