### PR TITLE
feat(cli): add nao upgrade command to check and install latest version from PyPI

### DIFF
--- a/cli/nao_core/commands/__init__.py
+++ b/cli/nao_core/commands/__init__.py
@@ -3,5 +3,6 @@ from nao_core.commands.debug import debug
 from nao_core.commands.init import init
 from nao_core.commands.sync import sync
 from nao_core.commands.test import test
+from nao_core.commands.upgrade import upgrade
 
-__all__ = ["chat", "debug", "init", "sync", "test"]
+__all__ = ["chat", "debug", "init", "sync", "test", "upgrade"]

--- a/cli/nao_core/commands/upgrade.py
+++ b/cli/nao_core/commands/upgrade.py
@@ -1,0 +1,64 @@
+import shutil
+import subprocess
+import sys
+
+from nao_core import __version__
+from nao_core.ui import UI, ask_confirm
+from nao_core.version import clear_version_cache, get_latest_version, parse_version
+
+
+def upgrade() -> None:
+    """Upgrade nao-core to the latest version."""
+
+    # Clear cache to ensure we get fresh version info from PyPI
+    clear_version_cache()
+
+    UI.info("\n⬆️  Checking for updates...\n")
+
+    # Get current version
+    current_version = __version__
+    UI.print(f"Current version: {current_version}")
+
+    # Check latest version
+    latest_version = get_latest_version()
+
+    if latest_version is None:
+        UI.error("Failed to check for updates. Please try again later.")
+        return
+
+    UI.print(f"Latest version: {latest_version}")
+
+    # Check if already up to date
+    if parse_version(current_version) >= parse_version(latest_version):
+        UI.success("\n✓ You are already on the latest version!")
+        return
+
+    if not ask_confirm(f"\nUpgrade from {current_version} to {latest_version}?", default=True):
+        UI.print("Upgrade cancelled.")
+        return
+
+    # Perform upgrade
+    UI.print(f"\n🔄 Upgrading nao-core {current_version} → {latest_version}...\n")
+
+    # Use uv if available, otherwise fallback to pip
+    if shutil.which("uv"):
+        cmd = ["uv", "pip", "install", "--upgrade", "nao-core"]
+    else:
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "nao-core"]
+
+    try:
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        UI.success(f"Upgrade complete! Now on version {latest_version}")
+        UI.print("\nPlease restart your terminal or run 'source ~/.zshrc' to use the new version.")
+
+    except subprocess.CalledProcessError as e:
+        UI.error(f"Upgrade failed: {e}")
+        UI.print(f"Error output: {e.stderr}")
+        UI.print("\nYou can manually upgrade by running:")
+        UI.print("  pip install --upgrade nao-core")

--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -2,7 +2,7 @@ from cyclopts import App
 from dotenv import load_dotenv
 
 from nao_core import __version__
-from nao_core.commands import chat, debug, init, sync, test
+from nao_core.commands import chat, debug, init, sync, test, upgrade
 from nao_core.version import check_for_updates
 
 load_dotenv()
@@ -14,6 +14,7 @@ app.command(debug)
 app.command(init)
 app.command(sync)
 app.command(test)
+app.command(upgrade)
 
 
 def main():

--- a/cli/nao_core/version.py
+++ b/cli/nao_core/version.py
@@ -13,24 +13,36 @@ PYPI_URL = "https://pypi.org/pypi/nao-core/json"
 CHECK_INTERVAL = 24 * 60 * 60
 
 
-def _parse_version(v: str) -> tuple[int, ...]:
+def parse_version(v: str) -> tuple[int, ...]:
     """Parse a version string like '0.0.37' into a comparable tuple."""
     return tuple(int(x) for x in v.split("."))
+
+
+def get_latest_version() -> str | None:
+    """Get latest version from PyPI."""
+    latest = _read_cache()
+    if latest is None:
+        latest = _fetch_and_cache()
+    return latest
 
 
 def check_for_updates() -> None:
     """Check PyPI for a newer version of nao-core, using a 24h local cache."""
     try:
-        latest = _read_cache()
-        if latest is None:
-            latest = _fetch_and_cache()
+        latest = get_latest_version()
         if latest is None:
             return
 
-        if _parse_version(latest) > _parse_version(__version__):
-            UI.warn(f"Update available: {__version__} → {latest}. Run: pip install -U nao-core")
+        if parse_version(latest) > parse_version(__version__):
+            UI.warn(f"Update available: {__version__} → {latest}. Run: nao upgrade")
     except Exception:
         pass  # do nothing
+
+
+def clear_version_cache() -> None:
+    """Clear the version check cache file."""
+    if CACHE_FILE.exists():
+        CACHE_FILE.unlink()
 
 
 def _read_cache() -> str | None:


### PR DESCRIPTION
**Summary**
Added a new `nao upgrade` command that allows users to self-update the CLI to the latest version from PyPI without manually running pip commands.

**Changes**
- **New file**: `cli/nao_core/commands/upgrade.py` - Implements the upgrade command
  - Checks current installed version vs latest on PyPI
  - Clears version cache to ensure fresh version check
  - Interactive confirmation before upgrading
  - Performs upgrade using pip
  - Clear error messages if upgrade fails
  
- **Modified**: `cli/nao_core/commands/__init__.py` - Export upgrade command
- **Modified**: `cli/nao_core/main.py` - Register upgrade command in CLI
- **Modified**: `cli/nao_core/version.py` - Update update message to suggest `nao upgrade`

**Usage**
nao upgrade

**Example output**
Checking for updates...
Current version: 0.0.37
Latest version: 0.0.44
Upgrade from 0.0.37 to 0.0.44? Yes
Upgrading nao-core 0.0.37 → 0.0.44...
✓ Upgrade complete!
Please restart your terminal or run 'source ~/.zshrc' to use the new version.

<img width="928" height="445" alt="Screenshot 2026-02-11 at 15 04 19" src="https://github.com/user-attachments/assets/0c67ed3d-dcb9-4fac-aa3b-3b9a28e743a8" />