### PR TITLE
fix: show 'Just now' instead of '0s' for recent timestamps

### DIFF
--- a/apps/frontend/src/lib/time-ago.ts
+++ b/apps/frontend/src/lib/time-ago.ts
@@ -34,5 +34,5 @@ export function getTimeAgo(timestamp: number): TimeAgo {
 	if (minutes > 0) {
 		return { value: minutes, unit: 'minute', humanReadable: `${minutes}m ago` };
 	}
-	return { value: seconds, unit: 'second', humanReadable: `${seconds}s ago` };
+	return { value: seconds, unit: 'second', humanReadable: 'Just now' };
 }


### PR DESCRIPTION
Changes the `humanReadable` value for seconds in `getTimeAgo()` from `${seconds}s ago` to `'Just now'`, so new chats display 'Just now' instead of '0s'.

Closes #300

Generated with [Claude Code](https://claude.ai/code)