### PR TITLE
added button to download charts as png

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -27,11 +27,15 @@ export const DisplayChartToolCall = ({
 
 	const showRangeSelector = config?.chart_type !== 'pie' && config?.x_axis_type === 'date';
 
-	const handleDownload = () => {
+	const handleDownload = async () => {
 		if (!chartRef.current) {
 			return;
 		}
-		downloadChartAsPng(chartRef.current, config?.title || 'chart');
+		try {
+			await downloadChartAsPng(chartRef.current, config?.title || 'chart');
+		} catch (error) {
+			console.error('Failed to download chart:', error);
+		}
 	};
 
 	const sourceData = useMemo(() => {

--- a/apps/frontend/src/lib/charts.utils.ts
+++ b/apps/frontend/src/lib/charts.utils.ts
@@ -131,7 +131,11 @@ function svgToPngDownload(svgUrl: string, width: number, height: number, filenam
 			canvas.width = width * scale;
 			canvas.height = height * scale;
 
-			const ctx = canvas.getContext('2d')!;
+			const ctx = canvas.getContext('2d');
+			if (!ctx) {
+				reject(new Error('Failed to create canvas context'));
+				return;
+			}
 			ctx.scale(scale, scale);
 			ctx.fillStyle = '#ffffff';
 			ctx.fillRect(0, 0, width, height);


### PR DESCRIPTION
feat: add chart download button (PNG export)

Closes #356

## Summary

Adds a download button to export charts as PNG files.

- Uses native SVG serialization + Canvas API (no new dependencies)
- Download button appears on all chart types:
  - Bar
  - Line
  - Pie
  - Stacked bar
- For timeline charts, the download button is positioned to the left of the range selector

## Approach

Recharts renders charts as SVG. The export pipeline works as follows:

1. Clone the SVG from the `[data-chart]` container
2. Resolve CSS variable references (`var(--color-xxx)`) using `getComputedStyle`
3. Serialize the resolved SVG into a Blob
4. Render the SVG onto a 2x canvas (retina-quality) with a white background
5. Trigger a PNG download using the chart title as the filename

This ensures accurate color rendering (including theme variables) and high-resolution output without introducing additional libraries.

## Files Changed

- `apps/frontend/src/components/tool-calls/display-chart.tsx`  
  - Added download button  
  - Restructured toolbar layout

- `apps/frontend/src/lib/charts.utils.ts`  
  - Added `downloadChartAsPng` utility  
  - Added `resolveCssVariables` helper  
  - Added `svgToPngDownload` helper  

## Test Plan

- [x] Verify download button appears on bar, line, stacked bar, and pie charts
- [x] Click download and confirm a PNG file is saved with correct colors
- [x] Verify button placement:
  - Left of range selector on timeline charts
  - Right-aligned on non-timeline charts
- [x] Test in both light and dark mode
- [x] Confirm no regressions in existing chart rendering or range selector behavior