### PR TITLE
feat(ui): add settings dropdown to sidebar profile

### DIFF
--- a/apps/frontend/src/components/sidebar-user-menu.tsx
+++ b/apps/frontend/src/components/sidebar-user-menu.tsx
@@ -8,8 +8,8 @@ import {
 	DropdownMenuTrigger,
 } from './ui/dropdown-menu';
 
-import { cn } from '@/lib/utils';
 import { useSession } from '@/lib/auth-client';
+import { cn, hideIf } from '@/lib/utils';
 
 interface SidebarUserMenuProps {
 	isCollapsed: boolean;
@@ -31,19 +31,19 @@ export function SidebarUserMenu({ isCollapsed }: SidebarUserMenuProps) {
 						'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
 						'data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground',
 						'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-						'transition-colors duration-200',
-						isCollapsed ? 'p-1.5 justify-center' : 'px-3 py-2',
+						'transition-[background-color,padding] duration-300',
+						isCollapsed ? 'p-1.5' : 'px-3 py-2',
 					)}
 				>
 					{username && <Avatar username={username} className='shrink-0 size-8' />}
 
 					<span
 						className={cn(
-							'grid flex-1 text-left text-sm leading-tight transition-[width,opacity] duration-200 overflow-hidden',
-							isCollapsed ? 'w-0 opacity-0' : 'w-auto opacity-100',
+							'flex flex-col justify-center text-left h-8 transition-[opacity,visibility] duration-300 overflow-hidden',
+							hideIf(isCollapsed),
 						)}
 					>
-						<span className='truncate font-semibold'>{username}</span>
+						<span className='truncate text-sm font-semibold'>{username}</span>
 						<span className='truncate text-xs text-muted-foreground'>{email}</span>
 					</span>
 				</button>

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -1,6 +1,6 @@
-import { ArrowLeftFromLine, ArrowRightToLine, PlusIcon, ArrowLeft, ChevronRight, SearchIcon } from 'lucide-react';
-import { useEffect, useCallback, useState } from 'react';
-import { Link, useNavigate, useMatchRoute } from '@tanstack/react-router';
+import { ArrowLeft, ArrowLeftFromLine, ArrowRightToLine, ChevronRight, PlusIcon, SearchIcon } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router';
 import { ChatList } from './sidebar-chat-list';
 import { SidebarUserMenu } from './sidebar-user-menu';
 import { SidebarSettingsNav } from './sidebar-settings-nav';
@@ -123,7 +123,7 @@ export function Sidebar() {
 				<SidebarNav chats={chats.data?.chats || []} isCollapsed={effectiveIsCollapsed} />
 			)}
 
-			<div className='mt-auto p-2'>
+			<div className={cn('mt-auto transition-[padding] duration-300', effectiveIsCollapsed ? 'p-1' : 'p-2')}>
 				<div className='my-2 border-t border-sidebar-border' />
 				<SidebarUserMenu isCollapsed={effectiveIsCollapsed} />
 			</div>


### PR DESCRIPTION
## Why

Previously, clicking the profile area navigated directly to  
`/settings/general`.

Users had no way to jump to Memory, Project, or Usage & Cost without landing on General first and then navigating.

| Light Mode | Dark Mode |
|------------|-----------|
| ![Before](https://github.com/user-attachments/assets/2fc58d9e-9cf7-4604-99d7-622efba53851) | ![After](https://github.com/user-attachments/assets/b21c9da3-04dc-422c-a4f0-465d186cc5bd) |

---

## Testing

- [x] Click profile → dropdown opens above button  
- [x] Click General / Memory / Project / Usage & Cost → navigates correctly  
- [x] Click Log Out → session cleared, redirected to login  
- [x] Hover Log Out → turns red  
- [x] Press Escape → dropdown closes  
- [x] Click outside → dropdown closes  
- [x] Collapse sidebar → arrow hidden, dropdown still works  
- [x] `npm run lint` passes  

<img width="1253" height="185" alt="image" src="https://github.com/user-attachments/assets/387b2cd7-8697-4ba1-97f1-d8a481dfe048" />

---

## Next

To make more polished needs additional code changes.  
I’ll address this in a **separate PR**.

@Bl3f 
Please review this and add comments where needed to guide me in the right direction.
(https://www.figma.com/design/4Q0ljxsbfAtc3PUw1H3lmI/Nao-Labs?node-id=64-872&t=q3Q76kUoFRTUGUBd-1)

---

## UI Change In Figma File (Experiments)
| Light Mode | Dark Mode |
|------------|------------|
| <img src="https://github.com/user-attachments/assets/98136110-220a-49bb-abf8-12e89e6d9741" width="500" /> | <img src="https://github.com/user-attachments/assets/6ca7a4c3-b9c5-49df-80ae-1662eb9f3c08" width="500" /> |

