### PR TITLE
Feat/search in chats

### DIFF
--- a/apps/frontend/src/components/command-menu.tsx
+++ b/apps/frontend/src/components/command-menu.tsx
@@ -27,6 +27,7 @@ import { useRegisterCommandMenuCallback } from '@/contexts/command-menu-callback
 import { trpc } from '@/main';
 import { useSearchChatsQuery } from '@/queries/use-search-chats-query';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
+import { TextShimmer } from '@/components/ui/text-shimmer';
 
 type CommandConfig = {
 	id: string;
@@ -54,7 +55,7 @@ export function CommandMenu() {
 	});
 
 	const isSearchMode = searchValue.length >= 2;
-	const hasConversationResults = isSearchMode && searchResults && searchResults.length > 0;
+	const hasSearchResults = isSearchMode && searchResults && searchResults.length > 0;
 	const isPendingSearch = isSearchMode && (searchValue !== debouncedSearch || isSearching);
 
 	const commands: CommandConfig[] = useMemo(
@@ -72,14 +73,14 @@ export function CommandMenu() {
 				label: 'Open General Settings',
 				icon: UserIcon,
 				action: () => navigate({ to: '/settings/general' }),
-				group: 'Jump to',
+				group: 'Actions',
 			},
 			{
 				id: 'open-project-settings',
 				label: 'Open Project Settings',
 				icon: SettingsIcon,
 				action: () => navigate({ to: '/settings/project' }),
-				group: 'Jump to',
+				group: 'Actions',
 			},
 			{
 				id: 'open-llm-provider-settings',
@@ -94,7 +95,7 @@ export function CommandMenu() {
 				label: 'Usage & Costs',
 				icon: CreditCardIcon,
 				action: () => navigate({ to: '/settings/usage' }),
-				group: 'Jump to',
+				group: 'Actions',
 				visible: project.data?.userRole === 'admin',
 			},
 			{
@@ -110,23 +111,8 @@ export function CommandMenu() {
 		[navigate, theme, setTheme, project.data?.userRole],
 	);
 
-	const filteredCommands = useMemo(() => {
-		if (!searchValue) {
-			return commands;
-		}
-		const lowerSearch = searchValue.toLowerCase();
-		return commands.filter((cmd) => cmd.label.toLowerCase().includes(lowerSearch));
-	}, [commands, searchValue]);
-
-	const groupedCommands = useMemo(() => {
-		const groups = new Map<string, CommandConfig[]>();
-		for (const command of filteredCommands) {
-			const group = groups.get(command.group) ?? [];
-			group.push(command);
-			groups.set(command.group, group);
-		}
-		return groups;
-	}, [filteredCommands]);
+	const jumpToCommands = useMemo(() => commands.filter((cmd) => cmd.group === 'Jump to'), [commands]);
+	const actionCommands = useMemo(() => commands.filter((cmd) => cmd.group === 'Actions'), [commands]);
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -160,6 +146,9 @@ export function CommandMenu() {
 		[navigate],
 	);
 
+	const visibleActions = actionCommands.filter((cmd) => cmd.visible ?? true);
+	const showNoResults = !hasSearchResults && !isPendingSearch && isSearchMode;
+
 	return (
 		<CommandDialog open={open} onOpenChange={handleOpenChange} shouldFilter={false} loop>
 			<CommandInput
@@ -168,52 +157,103 @@ export function CommandMenu() {
 				onValueChange={setSearchValue}
 			/>
 			<CommandList>
-				{filteredCommands.length === 0 && !hasConversationResults && !isPendingSearch && (
-					<CommandEmpty>No results found.</CommandEmpty>
-				)}
-				{isPendingSearch && !hasConversationResults && (
-					<div className='py-6 text-center text-sm text-muted-foreground'>Searching...</div>
-				)}
-				{Array.from(groupedCommands.entries()).map(([group, items]) => (
-					<CommandGroup key={group} heading={group}>
-						{items
-							.filter((command) => command.visible ?? true)
-							.map((command) => (
-								<CommandItem
-									key={command.id}
-									value={command.id}
-									onSelect={() => runCommand(command.action)}
-								>
-									<command.icon />
-									<span>{command.label}</span>
-									{command.shortcut && <CommandShortcut>{command.shortcut}</CommandShortcut>}
-								</CommandItem>
-							))}
+				{showNoResults && <CommandEmpty>No results found.</CommandEmpty>}
+
+				{jumpToCommands.length > 0 && (
+					<CommandGroup heading='Jump to'>
+						{jumpToCommands.map((command) => (
+							<CommandItem
+								key={command.id}
+								value={command.id}
+								onSelect={() => runCommand(command.action)}
+							>
+								<command.icon />
+								<span>
+									{command.label}
+									{isSearchMode && (
+										<span className='text-muted-foreground'> &ldquo;{searchValue}&rdquo;</span>
+									)}
+								</span>
+								{command.shortcut && <CommandShortcut>{command.shortcut}</CommandShortcut>}
+							</CommandItem>
+						))}
 					</CommandGroup>
-				))}
-				{hasConversationResults && (
-					<CommandGroup heading='Conversations'>
+				)}
+
+				{hasSearchResults ? (
+					<CommandGroup heading='Search results'>
 						{searchResults.map((chat) => (
 							<CommandItem
 								key={chat.id}
-								value={`conversation-${chat.id}`}
+								value={`search-${chat.id}`}
 								onSelect={() => runCommand(() => openChat(chat.id))}
 							>
 								<MessageSquareIcon />
 								<div className='flex flex-col gap-0.5 overflow-hidden'>
-									<span className='truncate'>{chat.title}</span>
+									<span className='truncate'>{highlightMatch(chat.title, debouncedSearch)}</span>
 									{chat.matchedText && (
 										<span className='text-muted-foreground truncate text-xs'>
-											...{truncateMatchedText(chat.matchedText, debouncedSearch)}...
+											...
+											{highlightMatch(
+												truncateMatchedText(chat.matchedText, debouncedSearch),
+												debouncedSearch,
+											)}
+											...
 										</span>
 									)}
 								</div>
 							</CommandItem>
 						))}
 					</CommandGroup>
+				) : isPendingSearch ? (
+					<div className='px-4 py-3'>
+						<TextShimmer text='Searching deeper...' />
+					</div>
+				) : null}
+
+				{!isSearchMode && visibleActions.length > 0 && (
+					<CommandGroup heading='Actions'>
+						{visibleActions.map((command) => (
+							<CommandItem
+								key={command.id}
+								value={command.id}
+								onSelect={() => runCommand(command.action)}
+							>
+								<command.icon />
+								<span>{command.label}</span>
+								{command.shortcut && <CommandShortcut>{command.shortcut}</CommandShortcut>}
+							</CommandItem>
+						))}
+					</CommandGroup>
 				)}
 			</CommandList>
 		</CommandDialog>
+	);
+}
+
+function highlightMatch(text: string, query: string) {
+	if (!query) {
+		return text;
+	}
+
+	const lowerText = text.toLowerCase();
+	const lowerQuery = query.toLowerCase();
+	const index = lowerText.indexOf(lowerQuery);
+
+	if (index === -1) {
+		return text;
+	}
+
+	const before = text.slice(0, index);
+	const match = text.slice(index, index + query.length);
+	const after = text.slice(index + query.length);
+
+	return (
+		<>
+			{before}
+			<span className='font-semibold text-foreground'>{match}</span>
+			{after}
+		</>
 	);
 }
 

--- a/apps/frontend/src/components/ui/command.tsx
+++ b/apps/frontend/src/components/ui/command.tsx
@@ -26,12 +26,12 @@ type CommandDialogProps = React.ComponentProps<typeof Dialog> & {
 function CommandDialog({ children, shouldFilter, loop, ...props }: CommandDialogProps) {
 	return (
 		<Dialog {...props}>
-			<DialogContent className='overflow-hidden p-0' showCloseButton={false}>
+			<DialogContent className='overflow-hidden p-0 sm:max-w-2xl' showCloseButton={false}>
 				<DialogTitle className='sr-only'>Command Menu</DialogTitle>
 				<Command
 					shouldFilter={shouldFilter}
 					loop={loop}
-					className='[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:p-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'
+					className='**:[[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 **:[[cmdk-group]]:p-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5'
 				>
 					{children}
 				</Command>
@@ -60,7 +60,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
 	return (
 		<CommandPrimitive.List
 			data-slot='command-list'
-			className={cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
+			className={cn('max-h-[500px] scroll-py-1 overflow-x-hidden overflow-y-auto', className)}
 			{...props}
 		/>
 	);
@@ -75,7 +75,7 @@ function CommandGroup({ className, ...props }: React.ComponentProps<typeof Comma
 		<CommandPrimitive.Group
 			data-slot='command-group'
 			className={cn(
-				'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+				'text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium',
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
feat(ui): restructure command palette and sidebar

## Summary

Overhauls the command palette and sidebar to be cleaner and more functional.
Closes #302 

### Command Palette
- Separated commands into "Jump to" and "Actions" groups instead of flat filtering
- Added "Recent" section showing the 3 most recent chats with relative timestamps
- Search results now highlight matched text in titles and snippets
- Replaced plain "Searching..." text with `TextShimmer` animation
- Added `openCommandMenu()` helper for triggering from the sidebar Search button
- Widened dialog (`sm:max-w-2xl`) and increased list height (`max-h-[500px]`)
- Updated `command.tsx` CSS selectors to use `**:[[attr]]` syntax

### Sidebar
- New Chat and Search use flat icon+text style instead of outlined buttons
- Keyboard shortcuts only appear on hover
- Added "Recents" label above the chat list
- User profile dropdown with settings sub-pages (General, Memory, Project, Usage & costs) and Log Out

## Visuals

https://github.com/user-attachments/assets/42381309-6d85-48dd-9bb1-89d5456b4606

## Pros
- Cleaner, more minimal sidebar with less visual clutter
- Command palette is now more useful with recent chats, search highlighting, and distinct action groups
- User dropdown provides quick access to all settings pages without navigating away
- Hover-only shortcuts reduce visual noise while remaining discoverable
- No new dependencies — uses existing components (`DropdownMenu`, `TextShimmer`, `Separator`)

## Cons
- Changes are based on current UX only.
- Command palette & sidebar layout changes may need further iteration once chat ui/ux is finalized


## Test Plan

- [x] Command palette opens with ⌘K
- [x] "Jump to" section always shows New Chat
- [x] Recent chats appear when not searching, with relative timestamps
- [x] Search highlights matched text in titles and snippets
- [x] "Actions" section shows settings/theme commands when not searching
- [x] Sidebar New Chat and Search show shortcuts only on hover
- [x] User dropdown opens with settings links and Log Out
- [x] All navigation links work correctly
- [x] Collapsed sidebar shows only icons, dropdown still works
- [x] `npm run lint` and Prettier pass
