### PR TITLE
refactor parser_database_config

### DIFF
--- a/cli/nao_core/config/databases/__init__.py
+++ b/cli/nao_core/config/databases/__init__.py
@@ -53,8 +53,9 @@ def parse_database_config(data: dict) -> DatabaseConfig:
     config_class = DATABASE_CONFIG_CLASSES.get(db_type)
     if not config_class:
         raise ValueError(f"Unknown database type: {db_type}")
-    return config_class.model_validate(data)        
-       
+    return config_class.model_validate(data)
+
+
 __all__ = [
     "AnyDatabaseConfig",
     "AthenaConfig",


### PR DESCRIPTION
Remove the `if else` statement for parser_database_config

It is not necessary to modify this def when adding new backend types.

Now you need only to add a new type at DATABASE_CONFIG_CLASSES dict.

```

# Mapping of database type to config class
DATABASE_CONFIG_CLASSES: dict[DatabaseType, type[DatabaseConfig]] = {
    DatabaseType.ATHENA: AthenaConfig,
    DatabaseType.BIGQUERY: BigQueryConfig,
    DatabaseType.DUCKDB: DuckDBConfig,
    DatabaseType.DATABRICKS: DatabricksConfig,
    DatabaseType.MSSQL: MssqlConfig,
    DatabaseType.SNOWFLAKE: SnowflakeConfig,
    DatabaseType.POSTGRES: PostgresConfig,
    DatabaseType.REDSHIFT: RedshiftConfig,
    DatabaseType.TRINO: TrinoConfig,
}

```

```
def parse_database_config(data: dict) -> DatabaseConfig:
    """Parse a database config dict into the appropriate type."""
    db_type = data.get("type")
    config_class = DATABASE_CONFIG_CLASSES.get(db_type)
    if not config_class:
        raise ValueError(f"Unknown database type: {db_type}")
    return config_class.model_validate(data)   
```