### PR TITLE
CLI fix : Ollama config

### DIFF
--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -11,7 +11,7 @@ from cyclopts import Parameter
 from rich.console import Console
 
 from nao_core import __version__
-from nao_core.config import LLMProvider, NaoConfig
+from nao_core.config import NaoConfig
 from nao_core.mode import MODE
 from nao_core.tracking import track_command
 
@@ -178,9 +178,11 @@ def chat(port: Annotated[Optional[int], Parameter(name=["-p", "--port"])] = None
         # Set LLM API key from config if available
         if config and config.llm:
             env_var_name = f"{config.llm.provider.upper()}_API_KEY"
-            if config.llm.api_key is not None and config.llm.provider != LLMProvider.OLLAMA:
-                env[env_var_name] = config.llm.api_key
+            if config.llm.api_key is not None:
                 console.print(f"[bold green]✓[/bold green] Set {env_var_name} from config")
+            api_key_value = config.llm.get_effective_api_key_for_env()
+            if api_key_value is not None:
+                env[env_var_name] = api_key_value
             if config.llm.base_url:
                 base_url_var = f"{config.llm.provider.upper()}_BASE_URL"
                 env[base_url_var] = config.llm.base_url

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -24,9 +24,21 @@ class LLMConfig(BaseModel):
     api_key: str | None = Field(default=None, description="The API key to use")
     base_url: str | None = Field(default=None, description="Optional custom base URL for the provider API")
 
+    @property
+    def requires_api_key(self) -> bool:
+        return self.provider != LLMProvider.OLLAMA
+
+    def get_effective_api_key_for_env(self) -> str | None:
+        """Return the API key value to export via environment variables."""
+        if self.api_key:
+            return self.api_key
+        if self.requires_api_key:
+            return None
+        return f"{self.provider.value}_api_key"
+
     @model_validator(mode="after")
     def validate_api_key(self) -> "LLMConfig":
-        if self.provider != LLMProvider.OLLAMA and not self.api_key:
+        if self.requires_api_key and not self.api_key:
             raise ValueError(f"api_key is required for provider {self.provider.value}")
         return self
 


### PR DESCRIPTION
## Summary

- Improve LLM provider config handling so providers that need an API key stay strict, while Ollama works without requiring one.
- Ensure the chat command exports the right LLM environment variables from `nao_config.yaml` (with a safe fallback for Ollama).