### PR TITLE
fix(slack): convert markdown headings and clean up orphaned bold markers

### DIFF
--- a/apps/backend/src/utils/slack.ts
+++ b/apps/backend/src/utils/slack.ts
@@ -67,8 +67,24 @@ export const createCompletionCard = (chatUrl: string, vote?: 'up' | 'down'): Car
 	});
 
 export const createTextBlock = (text: string): CardChild => {
-	return CardText(text);
+	return CardText(mdToMrkdwn(text));
 };
+
+function mdToMrkdwn(text: string): string {
+	// Split on fenced and inline code spans so we never mutate literal content
+	const parts = text.split(/(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)/);
+	return parts
+		.map((part, i) => {
+			if (i % 2 === 1) return part;
+			return part
+				.replace(/^#{1,6}\s+(.+)$/gm, '*$1*')
+				.replace(/\*\*(.+?)\*\*/g, '*$1*')
+				.replace(/\*\*\s*\*\*/g, '')
+				.replace(/^\*\*$/gm, '')
+				.replace(/\*\*(?!\S)/g, '');
+		})
+		.join('');
+}
 
 export const createImageBlock = (url: string): CardChild => {
 	return Image({ url, alt: 'image' });


### PR DESCRIPTION
## Problem

Slack messages from nao render raw Markdown syntax instead of formatting it properly:
- `### Requête SQL` shows as literal `### Requête SQL` (Slack doesn't support `#` headings)
- Standalone `**` appears as literal `**` when the AI generates orphaned bold markers

## Root cause

The `@chat-adapter/slack` library's `markdownToMrkdwn` only handles `**bold**` → `*bold*`. It doesn't convert headings or strip orphaned markers.

## Fix

Add a `mdToMrkdwn` pre-processing step in `createTextBlock` that:
- Converts `# H1` through `###### H6` headings to Slack bold (`*text*`)
- Removes empty/orphaned `**` markers (e.g. trailing `**` with no content between them)

## Before / After

| Input | Before | After |
|---|---|---|
| `### Requête SQL` | `### Requête SQL` | `*Requête SQL*` (bold) |
| `**` (orphaned) | `**` | _(removed)_ |