### PR TITLE
Fix: read LLM config from nao_config.yaml as a fallback

### DIFF
--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -19,8 +19,12 @@ function readNaoConfigLlm(): NaoConfigLlm | null {
 	}
 	try {
 		const raw = readFileSync(join(projectFolder, 'nao_config.yaml'), 'utf8');
-		const config = parseYaml(raw) as { llm?: NaoConfigLlm };
-		return config?.llm ?? null;
+		const config = parseYaml(raw) as { llm?: { provider?: unknown; api_key?: unknown; base_url?: unknown } };
+		const llm = config?.llm;
+		if (!llm || typeof llm.provider !== 'string' || !(llm.provider in LLM_PROVIDERS)) {
+			return null;
+		}
+		return llm as NaoConfigLlm;
 	} catch {
 		return null;
 	}

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -1,8 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+
 import { createProviderModel, getDefaultModelId, LLM_PROVIDERS, type ProviderModelResult } from '../agents/providers';
 import * as projectLlmConfigQueries from '../queries/project-llm-config.queries';
 import { LlmProvider, ModelSelection, type ProviderSettings } from '../types/llm';
 export { getDefaultModelId };
 export type { ModelSelection };
+
+type NaoConfigLlm = { provider: LlmProvider; api_key?: string; base_url?: string };
+
+/** Read the llm section from nao_config.yaml in the project folder, if present. */
+function readNaoConfigLlm(): NaoConfigLlm | null {
+	const projectFolder = process.env.NAO_DEFAULT_PROJECT_PATH;
+	if (!projectFolder) {
+		return null;
+	}
+	try {
+		const raw = readFileSync(join(projectFolder, 'nao_config.yaml'), 'utf8');
+		const config = parseYaml(raw) as { llm?: NaoConfigLlm };
+		return config?.llm ?? null;
+	} catch {
+		return null;
+	}
+}
 
 /** Get the API key from environment for a provider */
 export function getEnvApiKey(provider: LlmProvider): string | undefined {
@@ -67,7 +89,7 @@ export function getEnvModelSelections(): ModelSelection[] {
 	}));
 }
 
-/** Resolve API key + base URL for a provider from DB config or env vars. */
+/** Resolve API key + base URL for a provider from DB config, env vars, or nao_config.yaml. */
 export async function resolveProviderSettings(
 	projectId: string,
 	provider: LlmProvider,
@@ -83,12 +105,17 @@ export async function resolveProviderSettings(
 		return { apiKey: envApiKey, ...(envBaseUrl && { baseURL: envBaseUrl }) };
 	}
 
+	const naoLlm = readNaoConfigLlm();
+	if (naoLlm?.provider === provider && naoLlm.api_key) {
+		return { apiKey: naoLlm.api_key, ...(naoLlm.base_url && { baseURL: naoLlm.base_url }) };
+	}
+
 	return null;
 }
 
 /**
- * Resolve a provider model from DB config, falling back to env vars.
- * Returns null when neither source has credentials for the provider.
+ * Resolve a provider model from DB config, env vars, or nao_config.yaml.
+ * Returns null when no source has credentials for the provider.
  */
 export async function resolveProviderModel(
 	projectId: string,
@@ -122,6 +149,15 @@ export async function resolveProviderModel(
 		return createProviderModel(provider, { apiKey: '' }, modelId);
 	}
 
+	const naoLlm = readNaoConfigLlm();
+	if (naoLlm?.provider === provider && naoLlm.api_key) {
+		return createProviderModel(
+			provider,
+			{ apiKey: naoLlm.api_key, ...(naoLlm.base_url && { baseURL: naoLlm.base_url }) },
+			modelId,
+		);
+	}
+
 	return null;
 }
 
@@ -151,6 +187,18 @@ export const getProjectAvailableModels = async (
 		.filter((s) => !configs.some((c) => c.provider === s.provider))
 		.map((s) => ({ ...s, name: getModelName(s.provider, s.modelId) }));
 	models.push(...envSelections);
+
+	// Also add the nao_config.yaml provider if not already covered by DB or env
+	const naoLlm = readNaoConfigLlm();
+	if (naoLlm?.api_key) {
+		const alreadyCovered =
+			configs.some((c) => c.provider === naoLlm.provider) ||
+			envSelections.some((s) => s.provider === naoLlm.provider);
+		if (!alreadyCovered) {
+			const modelId = getDefaultModelId(naoLlm.provider);
+			models.push({ provider: naoLlm.provider, modelId, name: getModelName(naoLlm.provider, modelId) });
+		}
+	}
 
 	return models;
 };

--- a/apps/backend/tests/llm.test.ts
+++ b/apps/backend/tests/llm.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+	readFileSync: vi.fn<() => string>(),
+	getProjectLlmConfigByProvider: vi.fn(),
+	getProjectLlmConfigs: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({ readFileSync: mocks.readFileSync }));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigByProvider: mocks.getProjectLlmConfigByProvider,
+	getProjectLlmConfigs: mocks.getProjectLlmConfigs,
+}));
+
+const { resolveProviderSettings, resolveProviderModel, getProjectAvailableModels } = await import('../src/utils/llm');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setNaoConfig(llm: { provider: string; api_key: string } | null) {
+	if (llm === null) {
+		mocks.readFileSync.mockImplementation(() => {
+			throw new Error('file not found');
+		});
+	} else {
+		mocks.readFileSync.mockReturnValue(`llm:\n  provider: ${llm.provider}\n  api_key: ${llm.api_key}`);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env.NAO_DEFAULT_PROJECT_PATH = '/fake/project';
+	mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+	mocks.getProjectLlmConfigs.mockResolvedValue([]);
+	delete process.env.ANTHROPIC_API_KEY;
+	delete process.env.OPENAI_API_KEY;
+});
+
+afterEach(() => {
+	delete process.env.NAO_DEFAULT_PROJECT_PATH;
+});
+
+// ---------------------------------------------------------------------------
+// resolveProviderSettings
+// ---------------------------------------------------------------------------
+
+describe('resolveProviderSettings', () => {
+	it('returns null when no source has credentials', async () => {
+		setNaoConfig(null);
+		expect(await resolveProviderSettings('proj', 'anthropic')).toBeNull();
+	});
+
+	it('returns settings from nao_config.yaml when DB and env are empty', async () => {
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		expect(await resolveProviderSettings('proj', 'anthropic')).toEqual({ apiKey: 'sk-nao' });
+	});
+
+	it('ignores nao_config.yaml when provider does not match', async () => {
+		setNaoConfig({ provider: 'openai', api_key: 'sk-openai' });
+		expect(await resolveProviderSettings('proj', 'anthropic')).toBeNull();
+	});
+
+	it('prefers env vars over nao_config.yaml', async () => {
+		process.env.ANTHROPIC_API_KEY = 'sk-env';
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		expect((await resolveProviderSettings('proj', 'anthropic'))?.apiKey).toBe('sk-env');
+	});
+
+	it('prefers DB config over nao_config.yaml', async () => {
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue({ apiKey: 'sk-db', baseUrl: null });
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		expect((await resolveProviderSettings('proj', 'anthropic'))?.apiKey).toBe('sk-db');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveProviderModel
+// ---------------------------------------------------------------------------
+
+describe('resolveProviderModel', () => {
+	it('returns null when no source has credentials', async () => {
+		setNaoConfig(null);
+		expect(await resolveProviderModel('proj', 'anthropic', 'claude-sonnet-4-5')).toBeNull();
+	});
+
+	it('returns a model from nao_config.yaml when DB and env are empty', async () => {
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		expect(await resolveProviderModel('proj', 'anthropic', 'claude-sonnet-4-5')).not.toBeNull();
+	});
+
+	it('ignores nao_config.yaml when provider does not match', async () => {
+		setNaoConfig({ provider: 'openai', api_key: 'sk-openai' });
+		expect(await resolveProviderModel('proj', 'anthropic', 'claude-sonnet-4-5')).toBeNull();
+	});
+
+	it('prefers env vars over nao_config.yaml and does not read the file', async () => {
+		process.env.ANTHROPIC_API_KEY = 'sk-env';
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		expect(await resolveProviderModel('proj', 'anthropic', 'claude-sonnet-4-5')).not.toBeNull();
+		expect(mocks.readFileSync).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getProjectAvailableModels
+// ---------------------------------------------------------------------------
+
+describe('getProjectAvailableModels', () => {
+	it('returns empty list when no source is configured', async () => {
+		setNaoConfig(null);
+		expect(await getProjectAvailableModels('proj')).toHaveLength(0);
+	});
+
+	it('includes the nao_config.yaml provider when not covered by DB or env', async () => {
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		const models = await getProjectAvailableModels('proj');
+		expect(models.some((m) => m.provider === 'anthropic')).toBe(true);
+	});
+
+	it('does not duplicate the provider when already in env', async () => {
+		process.env.ANTHROPIC_API_KEY = 'sk-env';
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		const models = await getProjectAvailableModels('proj');
+		expect(models.filter((m) => m.provider === 'anthropic')).toHaveLength(1);
+	});
+
+	it('does not duplicate the provider when already in DB', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([{ provider: 'anthropic', apiKey: 'sk-db', enabledModels: [] }]);
+		setNaoConfig({ provider: 'anthropic', api_key: 'sk-nao' });
+		const models = await getProjectAvailableModels('proj');
+		expect(models.filter((m) => m.provider === 'anthropic')).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

- The UI backend was silently ignoring the `llm` section in
  `nao_config.yaml`, causing "The selected model could not be resolved"
  errors whenever the internal SQLite DB was reset (e.g. after rebasing
  from upstream)
- Users were forced to re-enter their API key through the UI settings
  even though it was already declared in `nao_config.yaml`

## What changed

`apps/backend/src/utils/llm.ts` — added `nao_config.yaml` as a third
fallback in the credential resolution chain:

**Priority: DB config → env vars → `nao_config.yaml`**

The three affected functions are:
- `resolveProviderSettings` — used by web search tools
- `resolveProviderModel` — used by the agent on every chat message
- `getProjectAvailableModels` — used to populate the model selector in the UI

`apps/backend/tests/llm.test.ts` — 13 unit tests covering:
- Returns null when no source is configured
- Picks up credentials from `nao_config.yaml`
- Ignores `nao_config.yaml` when provider doesn't match
- Respects priority: DB > env > yaml
- No duplication in `getProjectAvailableModels` when provider is already covered

## Test plan

- [x] `npx vitest run tests/llm.test.ts` — 13 tests pass
- [x] `npm run lint` — no errors
- [x] Start the app without DB or env keys, with only `llm` in
  `nao_config.yaml` — model resolves correctly and chat works