### PR TITLE
fix : sending feedback to right id message

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -235,6 +235,8 @@ class AgentManager {
 		return createUIMessageStream<UIMessage>({
 			generateId: () => crypto.randomUUID(),
 			execute: async ({ writer }) => {
+				writer.write({ type: 'start' });
+
 				if (opts.events?.newChat) {
 					writer.write({
 						type: 'data-newChat',


### PR DESCRIPTION
## Summary

- Emit the start event before other stream parts so the frontend uses the server-generated message ID instead of generating a nanoid, ensuring feedback targets the correct message.

## Related issue

#429 