### PR TITLE
fix: truncate long email/username in sidebar user menu

### DIFF
--- a/apps/frontend/src/components/sidebar-user-menu.tsx
+++ b/apps/frontend/src/components/sidebar-user-menu.tsx
@@ -28,17 +28,17 @@ export function SidebarUserMenu({ isCollapsed }: SidebarUserMenuProps) {
 				isCollapsed ? 'p-1.5' : 'p-3 py-2',
 			)}
 		>
-			<div className='flex items-center gap-2'>
+			<div className='flex items-center gap-2 min-w-0'>
 				{username && <Avatar username={username} className='shrink-0' />}
 
 				<span
 					className={cn(
-						'flex flex-col justify-center text-left transition-[opacity,visibility] h-8 duration-300',
+						'flex flex-col justify-center text-left transition-[opacity,visibility] h-8 duration-300 min-w-0',
 						hideIf(isCollapsed),
 					)}
 				>
-					<span className='text-sm font-medium'>{username}</span>
-					<span className='text-xs text-muted-foreground'>{email}</span>
+					<span className='text-sm font-medium truncate'>{username}</span>
+					<span className='text-xs text-muted-foreground truncate'>{email}</span>
 				</span>
 			</div>
 		</Link>


### PR DESCRIPTION
## Summary
- Fixes #452 — long emails overflow the sidebar user menu
- Added `truncate` class to both the username and email `<span>` elements
- Added `min-w-0` to the flex containers so truncation can take effect inside a flex layout

## Test plan
- [ ] Log in with a very long email address and verify it shows with ellipsis in the sidebar
- [ ] Verify the username also truncates correctly when long

🤖 Generated with [Claude Code](https://claude.com/claude-code)