### PR TITLE
feat(chart): add data labels support for charts

### DIFF
--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -10,6 +10,7 @@ interface ChartBlock {
 	xAxisType: string | null;
 	series: Array<{ data_key: string; color: string; label?: string }>;
 	title: string;
+	showDataLabels?: boolean;
 }
 
 export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart: ChartBlock }) {
@@ -53,6 +54,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart:
 				xAxisType={xAxisType}
 				series={chart.series}
 				title={chart.title}
+				showDataLabels={chart.showDataLabels}
 			/>
 		</div>
 	);

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -153,7 +153,9 @@ export const DisplayChartToolCall = ({
 		}
 
 		const seriesJson = JSON.stringify(config.series);
-		const chartBlock = `<chart query_id="${escapeDoubleQuotedAttr(config.query_id)}" chart_type="${escapeDoubleQuotedAttr(config.chart_type)}" x_axis_key="${escapeDoubleQuotedAttr(config.x_axis_key)}" x_axis_type="${escapeDoubleQuotedAttr(config.x_axis_type ?? '')}" series='${escapeSingleQuotedAttr(seriesJson)}' title="${escapeDoubleQuotedAttr(config.title ?? '')}" />`;
+		const showDataLabelsAttr =
+			config.show_data_labels !== undefined ? ` show_data_labels="${String(config.show_data_labels)}"` : '';
+		const chartBlock = `<chart query_id="${escapeDoubleQuotedAttr(config.query_id)}" chart_type="${escapeDoubleQuotedAttr(config.chart_type)}" x_axis_key="${escapeDoubleQuotedAttr(config.x_axis_key)}" x_axis_type="${escapeDoubleQuotedAttr(config.x_axis_type ?? '')}" series='${escapeSingleQuotedAttr(seriesJson)}' title="${escapeDoubleQuotedAttr(config.title ?? '')}" ${showDataLabelsAttr} />`;
 		const newCode = latest.code.trimEnd() + '\n\n' + chartBlock;
 
 		addToStoryMutation.mutate({
@@ -216,6 +218,7 @@ export const DisplayChartToolCall = ({
 				series={config.series}
 				xAxisType={config.x_axis_type === 'number' ? 'number' : 'category'}
 				title={config.title}
+				showDataLabels={config.show_data_labels}
 			/>
 		</div>
 	);
@@ -230,6 +233,7 @@ export interface ChartDisplayProps {
 	series: displayChart.SeriesConfig[];
 	title?: string;
 	showGrid?: boolean;
+	showDataLabels?: boolean;
 }
 
 export const ChartDisplay = memo(function ChartDisplay({
@@ -241,6 +245,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 	series,
 	title,
 	showGrid = true,
+	showDataLabels,
 }: ChartDisplayProps) {
 	const { visibleSeries, hiddenSeriesKeys, handleToggleSeriesVisibility } = useSeriesVisibility(series);
 
@@ -302,6 +307,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 				colorFor,
 				labelFormatter: xAxisLabelFormatter,
 				showGrid,
+				showDataLabels,
 				margin: { top: 0, right: 0, bottom: 0, left: -18 },
 				children: [
 					<ChartTooltip
@@ -330,6 +336,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 			colorFor,
 			xAxisLabelFormatter,
 			showGrid,
+			showDataLabels,
 			legendPayload,
 			handleToggleSeriesVisibility,
 			title,

--- a/apps/frontend/src/lib/story-segments.ts
+++ b/apps/frontend/src/lib/story-segments.ts
@@ -5,6 +5,7 @@ export interface ParsedChartBlock {
 	xAxisType: string | null;
 	series: Array<{ data_key: string; color: string; label?: string }>;
 	title: string;
+	showDataLabels?: boolean;
 }
 
 export interface ParsedTableBlock {
@@ -56,6 +57,8 @@ export function parseChartBlock(attrString: string): ParsedChartBlock | null {
 		});
 	}
 
+	const showDataLabels = attrs.show_data_labels === 'true';
+
 	return {
 		queryId: attrs.query_id,
 		chartType: attrs.chart_type,
@@ -63,6 +66,7 @@ export function parseChartBlock(attrString: string): ParsedChartBlock | null {
 		xAxisType: attrs.x_axis_type || null,
 		series,
 		title: attrs.title || '',
+		showDataLabels,
 	};
 }
 

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, Customized, Pie, PieChart, XAxis, YAxis } from 'recharts';
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Customized,
+	LabelList,
+	Pie,
+	PieChart,
+	XAxis,
+	YAxis,
+} from 'recharts';
 
 import * as displayChart from './tools/display-chart';
 
@@ -29,6 +41,7 @@ export interface BuildChartProps {
 	colorFor?: (key: string, index: number) => string;
 	labelFormatter?: (value: string) => string;
 	showGrid?: boolean;
+	showDataLabels?: boolean;
 	children?: React.ReactNode[];
 	margin?: { top?: number; right?: number; bottom?: number; left?: number };
 	title?: string;
@@ -129,9 +142,61 @@ function KpiCard({ value, displayName }: { value: unknown; displayName: string }
 	);
 }
 
+interface RotatedBarLabelProps {
+	x?: number | string;
+	y?: number | string;
+	width?: number | string;
+	height?: number | string;
+	value?: string | number;
+}
+
+const RotatedBarLabel = (props: RotatedBarLabelProps) => {
+	const { x, y, width, height, value } = props;
+
+	if (x === undefined || y === undefined || width === undefined || height === undefined || value === undefined) {
+		return null;
+	}
+
+	const numX = typeof x === 'string' ? parseFloat(x) : x;
+	const numY = typeof y === 'string' ? parseFloat(y) : y;
+	const numWidth = typeof width === 'string' ? parseFloat(width) : width;
+	const numHeight = typeof height === 'string' ? parseFloat(height) : height;
+
+	const formattedValue = value !== null && Number(value) !== 0 ? Number(value).toLocaleString() : '';
+
+	if (numHeight < 20 || !formattedValue) {
+		return null;
+	}
+
+	return (
+		<text
+			x={numX + numWidth / 2}
+			y={numY + numHeight / 2}
+			fill='#fff'
+			fontSize='11'
+			textAnchor='middle'
+			dominantBaseline='middle'
+			transform={`rotate(-90, ${numX + numWidth / 2}, ${numY + numHeight / 2})`}
+		>
+			{formattedValue}
+		</text>
+	);
+};
+
 function buildBarChart(props: ResolvedProps) {
-	const { data, chartType, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } =
-		props;
+	const {
+		data,
+		chartType,
+		xAxisKey,
+		xAxisType,
+		series,
+		colorFor,
+		labelFormatter,
+		showGrid,
+		children,
+		margin,
+		showDataLabels,
+	} = props;
 	const isStacked = chartType === 'stacked_bar';
 
 	return (
@@ -157,14 +222,30 @@ function buildBarChart(props: ResolvedProps) {
 					stackId={isStacked ? 'stack' : undefined}
 					radius={isStacked ? (i === series.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]) : [4, 4, 4, 4]}
 					isAnimationActive={false}
-				/>
+				>
+					{showDataLabels &&
+						(isStacked ? (
+							<LabelList
+								dataKey={s.data_key}
+								position='center'
+								fontSize='11'
+								fill='#fff'
+								formatter={(value: number) =>
+									value !== null && Number(value) !== 0 ? Number(value).toLocaleString() : ''
+								}
+							/>
+						) : (
+							<LabelList dataKey={s.data_key} content={RotatedBarLabel} />
+						))}
+				</Bar>
 			))}
 		</BarChart>
 	);
 }
 
 function buildAreaChart(props: ResolvedProps) {
-	const { data, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } = props;
+	const { data, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, showDataLabels, children, margin } =
+		props;
 	return (
 		<AreaChart data={data} accessibilityLayer margin={margin}>
 			<defs>
@@ -200,7 +281,18 @@ function buildAreaChart(props: ResolvedProps) {
 					stroke={colorFor(s.data_key, i)}
 					fill={`url(#grad-${i})`}
 					isAnimationActive={false}
-				/>
+				>
+					{showDataLabels && (
+						<LabelList
+							dataKey={s.data_key}
+							position='top'
+							offset={4}
+							fontSize='11'
+							fill='#374151'
+							formatter={(value: number) => (value !== null && value !== 0 ? value.toLocaleString() : '')}
+						/>
+					)}
+				</Area>
 			))}
 		</AreaChart>
 	);

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -26,6 +26,10 @@ export const InputSchema = z.object({
 		.describe(
 			'A concise and descriptive title of what the chart shows. Do not include the type of chart in the title or other chart configurations.',
 		),
+	show_data_labels: z
+		.boolean()
+		.describe('Show data labels (values) directly on chart elements (bars, points, etc.).')
+		.optional(),
 });
 
 export const OutputSchema = z.object({


### PR DESCRIPTION
# feat(charts): Add data label support

Closes: #396 

## Summary

This PR introduces the functionality to display data labels directly on chart elements (e.g., bars, line points, pie slices). This allows users to see the exact values of data points without needing to hover over them, significantly improving chart readability.

The AI agent can now be prompted to show labels (e.g., "show me sales with data labels"), and the labels will be rendered on the chart and preserved when added to stories.

## Changes
*   **Tool Schema (`display-chart.ts`)**: Added an optional `show_data_labels: boolean` field to the `display_chart` tool's input schema.
*   **Chart Builder (`chart-builder.tsx`)**:
    *   Updated the core **buildChart** logic to handle the new **showDataLabels** prop.
    *   Implemented conditional label rendering in **buildBarChart**:
        *   **Grouped Bar Charts**: Use rotated labels (-90deg) to fit within narrow bars.
        *   **Stacked Bar Charts**: Use standard, centered horizontal labels within each segment for clarity.
    *   Enabled data labels for `line/area` charts, positioned above each data point.
*   Frontend Components:
    *   Updated `display-chart.tsx` and `story-chart-embed.tsx` to pass the `showDataLabels` prop to the chart rendering logic.
    *   Modified the "Add to Story" functionality to include the `show_data_labels` attribute in the generated `<chart>` tag.
*   **Story Parsing (`story-segments.ts`)**: Updated the story parser to correctly read the show_data_labels attribute from saved stories.

### Before

Previously, charts did not display any data labels, even when requested. Values were only visible in tooltips on hover.

<img width="1600" height="1065" alt="image" src="https://github.com/user-attachments/assets/53fd78ef-1a63-4a1c-bff1-8cc19653e7ea" />

### After

Charts now clearly display data labels when the `show_data_labels` option is enabled. The label formatting is tailored to the chart type for optimal readability.

<img width="1096" height="453" alt="image" src="https://github.com/user-attachments/assets/e71da358-c222-41b6-9523-43cfe3249069" />

<img width="1094" height="464" alt="image" src="https://github.com/user-attachments/assets/afdea8a0-7075-46cb-b6b8-b6fd223861bf" />

<img width="1092" height="460" alt="image" src="https://github.com/user-attachments/assets/929fb5e7-968d-4a0a-9b0a-5425a6f090f4" />

<img width="1079" height="460" alt="image" src="https://github.com/user-attachments/assets/56b072ab-cf47-448c-a2e2-db3bc97a0d27" />

## How to test
1.  Start a new chat and ask the AI to generate a chart with data labels (e.g., "show sales by month with data labels").
2. Verify that the labels appear correctly.
3. Add the chart to a story and ensure the labels are still visible in the story view.