### PR TITLE
fix: make display_chart series color optional to prevent chart loading failure

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -266,7 +266,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 		return series.reduce((acc, s, idx) => {
 			acc[s.data_key] = {
 				label: s.label || labelize(s.data_key),
-				color: s.color || Colors[idx % Colors.length],
+				color: (s.color && s.color !== 'auto') ? s.color : Colors[idx % Colors.length],
 			};
 			return acc;
 		}, {} as ChartConfig);
@@ -285,7 +285,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 			series.map((s, idx) => ({
 				value: s.label || labelize(s.data_key),
 				dataKey: s.data_key,
-				color: s.color || Colors[idx % Colors.length],
+				color: (s.color && s.color !== 'auto') ? s.color : Colors[idx % Colors.length],
 				isHidden: hiddenSeriesKeys.has(s.data_key),
 			})),
 		[series, hiddenSeriesKeys],

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -6,7 +6,7 @@ export const XAxisTypeEnum = z.enum(['date', 'number', 'category']);
 
 export const SeriesConfigSchema = z.object({
 	data_key: z.string().describe('Column name from SQL result to plot.'),
-	color: z.string().describe('CSS color (defaults to theme colors).'),
+	color: z.string().describe('CSS color (defaults to theme colors).').optional().default('auto'),
 	label: z.string().describe('Label to display in the legend.').optional(),
 });
 


### PR DESCRIPTION
## Problem

  LLMs frequently omit the `color` field when calling the `display_chart` tool — the `series` array is
  generated as `[{"data_key": "...", "label": "..."}]` without a `color` property.

  Since `SeriesConfigSchema.color` is currently **required**, Zod validation rejects the input with:

  Invalid input for tool display_chart: Type validation failed
  "series", 0, "color" — "expected": "string", "received": "undefined"

  The chart component gets stuck in "Loading chart" state permanently because the tool state never
  transitions from `input-streaming` to `result`.

  ## Root Cause

  The `color` field description says "defaults to theme colors" but the schema doesn't actually provide
   a default — it's a required string. The frontend already has fallback logic (`s.color || Colors[idx
  % Colors.length]`) but it's never reached because validation fails first.

  ## Fix

  - **`apps/shared/src/tools/display-chart.ts`**: Make `color` optional with
  `.optional().default('auto')`
  - **`apps/frontend/src/components/tool-calls/display-chart.tsx`**: Handle `'auto'` sentinel value,
  falling back to theme colors (2 locations: chart config + legend payload)

Author: Leon <leoncuhk@gmail.com>