### PR TITLE
Fix : resolve chats replay error tool navigation

### DIFF
--- a/apps/frontend/src/components/chat-messages/assistant-message.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-message.tsx
@@ -35,7 +35,7 @@ export const AssistantMessage = memo(
 		}
 
 		return (
-			<AssistantMessageProvider isSettled={isSettled} isReplay={false}>
+			<AssistantMessageProvider isSettled={isSettled}>
 				<div className={cn('group px-3 flex flex-col gap-2 bg-transparent')}>
 					<MessageParts parts={messageParts} />
 

--- a/apps/frontend/src/components/chat-messages/chat-messages-readonly.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-messages-readonly.tsx
@@ -82,7 +82,7 @@ const AssistantMessageReadonly = memo(({ message }: { message: UIMessage }) => {
 	}
 
 	return (
-		<AssistantMessageProvider isSettled={true} isReplay={true}>
+		<AssistantMessageProvider isSettled={true}>
 			<div className={cn('group px-3 flex flex-col gap-2 bg-transparent')}>
 				<MessageParts parts={messageParts} />
 

--- a/apps/frontend/src/components/settings/chats-replay-panel.tsx
+++ b/apps/frontend/src/components/settings/chats-replay-panel.tsx
@@ -8,6 +8,7 @@ import { ChatMessagesReadonly } from '@/components/chat-messages/chat-messages-r
 import { Button } from '@/components/ui/button';
 import { InlineStatusBar } from '@/components/settings/chats-replay-inline-status-bar';
 import { ReadonlyAgentMessagesProvider } from '@/contexts/agent.provider';
+import { ChatViewProvider } from '@/contexts/chat-view';
 import { useReplayNav } from '@/hooks/use-replay-nav';
 import { trpc } from '@/main';
 
@@ -85,9 +86,11 @@ export function ChatsReplayPanel({ chatInfo, onClose }: ChatsReplayPanelProps) {
 					) : chatReplayQuery.isError ? (
 						<div className='text-sm text-destructive'>Failed to load chat.</div>
 					) : chatReplayQuery.data ? (
-						<ReadonlyAgentMessagesProvider messages={chatReplayQuery.data.messages}>
-							<ChatMessagesReadonly messages={chatReplayQuery.data.messages} />
-						</ReadonlyAgentMessagesProvider>
+						<ChatViewProvider expandOnError={true}>
+							<ReadonlyAgentMessagesProvider messages={chatReplayQuery.data.messages}>
+								<ChatMessagesReadonly messages={chatReplayQuery.data.messages} />
+							</ReadonlyAgentMessagesProvider>
+						</ChatViewProvider>
 					) : (
 						<div className='text-sm text-muted-foreground'>Select a chat to preview.</div>
 					)}

--- a/apps/frontend/src/components/tool-calls/tool-calls-group.tsx
+++ b/apps/frontend/src/components/tool-calls/tool-calls-group.tsx
@@ -3,9 +3,9 @@ import { ToolCall } from './index';
 import type { GroupablePart } from '@/types/ai';
 import { Expandable } from '@/components/ui/expandable';
 import { AssistantReasoning } from '@/components/chat-messages/assistant-reasoning';
+import { useChatView } from '@/contexts/chat-view';
 import { isReasoningPart } from '@/lib/ai';
 import { useToolGroupSummaryTitle } from '@/hooks/use-tool-group-summary-title';
-import { useAssistantMessage } from '@/contexts/assistant-message';
 
 interface Props {
 	parts: GroupablePart[];
@@ -13,16 +13,16 @@ interface Props {
 }
 
 export const ToolCallsGroup = memo(({ parts, isSettled }: Props) => {
-	const { isReplay } = useAssistantMessage();
 	const isLoading = !isSettled;
-	const hasError = isReplay && parts.some((p) => !isReasoningPart(p) && p.state === 'output-error');
-	const [isExpanded, setIsExpanded] = useState(isLoading || hasError);
+	const hasError = parts.some((p) => !isReasoningPart(p) && p.state === 'output-error');
+	const { expandOnError } = useChatView();
+	const [isExpanded, setIsExpanded] = useState(isLoading || (expandOnError && hasError));
 
 	useEffect(() => {
-		if (isLoading || hasError) {
+		if (isLoading || (expandOnError && hasError)) {
 			setIsExpanded(true);
 		}
-	}, [isLoading, hasError]);
+	}, [isLoading, expandOnError, hasError]);
 
 	const title = useToolGroupSummaryTitle({ parts, isLoading });
 	return (

--- a/apps/frontend/src/contexts/assistant-message.tsx
+++ b/apps/frontend/src/contexts/assistant-message.tsx
@@ -3,7 +3,6 @@ import { useMemoObject } from '@/hooks/useMemoObject';
 
 interface AssistantMessageContextValue {
 	isSettled: boolean;
-	isReplay: boolean;
 }
 
 const AssistantMessageContext = createContext<AssistantMessageContextValue | null>(null);
@@ -19,14 +18,12 @@ export const useAssistantMessage = () => {
 export const AssistantMessageProvider = ({
 	children,
 	isSettled,
-	isReplay = false,
 }: {
 	children: React.ReactNode;
 	isSettled: boolean;
-	isReplay?: boolean;
 }) => {
 	return (
-		<AssistantMessageContext.Provider value={useMemoObject({ isSettled, isReplay })}>
+		<AssistantMessageContext.Provider value={useMemoObject({ isSettled })}>
 			{children}
 		</AssistantMessageContext.Provider>
 	);

--- a/apps/frontend/src/contexts/chat-view.tsx
+++ b/apps/frontend/src/contexts/chat-view.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+import { useMemoObject } from '@/hooks/useMemoObject';
+
+interface ChatViewContextValue {
+	expandOnError: boolean;
+}
+
+const ChatViewContext = createContext<ChatViewContextValue>({
+	expandOnError: false,
+});
+
+export const useChatView = () => useContext(ChatViewContext);
+
+export const ChatViewProvider = ({ expandOnError, children }: { expandOnError: boolean; children: ReactNode }) => {
+	const value = useMemoObject({ expandOnError });
+	return <ChatViewContext.Provider value={value}>{children}</ChatViewContext.Provider>;
+};


### PR DESCRIPTION
## Summary

- Set the tool group to expand when the chat is replayed and got error.
- So that the previous/next tool error scrolling doesn't skip over tool errors in the explore tool group.

## Linked issue

#459 