### PR TITLE
interval for bigger charts

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -101,7 +101,11 @@ export const DisplayChartToolCall = ({
 		return filterByDateRange(sourceData.data, config.x_axis_key, dataRange);
 	}, [sourceData?.data, config, dataRange]);
 
+	const isPaginable = config?.chart_type !== 'pie' && config?.chart_type !== 'kpi_card';
 	const intervals = useMemo(() => {
+		if (!isPaginable) {
+			return null;
+		}
 		const total = filteredData.length;
 		if (total <= INTERVAL_PAGE_SIZE) {
 			return null;
@@ -115,7 +119,7 @@ export const DisplayChartToolCall = ({
 			pages.push({ value: String(i), label: `${i + 1} – ${end}`, end });
 		}
 		return pages;
-	}, [filteredData.length]);
+	}, [filteredData.length, isPaginable]);
 
 	useEffect(() => {
 		setSelectedInterval('0');

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -84,7 +84,11 @@ function buildResolved(props: BuildChartProps) {
 	if (props.title) {
 		margin = { ...margin, top: (margin?.top ?? 0) + 30 };
 	}
-	if (shouldRotateLabels(props.data, props.xAxisType)) {
+	if (
+		props.chartType !== 'pie' &&
+		props.chartType !== 'kpi_card' &&
+		shouldRotateLabels(props.data, props.xAxisType)
+	) {
 		margin = { ...margin, bottom: (margin?.bottom ?? 0) + 50 };
 	}
 


### PR DESCRIPTION
## Summary
- Add interval pagination for charts with >20 data points, splitting into evenly-sized pages with a dropdown selector (e.g. "1–16", "17–32")
- Rotate X axis labels at -45° and truncate to 10 chars when there are >8 category values
- Add bottom margin when labels are rotated to prevent clipping
- Fix chart title invisible in dark mode (`fill='currentColor'` instead of hardcoded color)


## Visuals
<img width="987" height="443" alt="Screenshot 2026-03-18 at 2 59 31 PM" src="https://github.com/user-attachments/assets/37f8c804-54e1-4b56-8f92-335356a32b69" />


## Test plan
- [ ] Create a bar/line chart with >20 data points — interval dropdown should appear
- [ ] Verify page divisions are even (no tiny last page like "61–62")
- [ ] Switching intervals re-renders the chart with the correct slice of data
- [ ] Charts with ≤20 data points show no dropdown
- [ ] Pie and KPI card charts don't show the interval dropdown
- [ ] Chart title is visible in both light and dark mode
- [ ] Date range selector still works alongside interval pagination

Fixes #467
