### PR TITLE
fix: handle Windows cp1252 encoding in build script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,6 +93,8 @@ jobs:
             - name: Build server and package
               working-directory: cli
               run: python build.py --force
+              env:
+                  PYTHONUTF8: '1'
 
             - name: Rename wheel with platform tag
               working-directory: cli/dist

--- a/cli/build.py
+++ b/cli/build.py
@@ -21,6 +21,12 @@ from typing import Annotated
 
 from cyclopts import App, Parameter
 
+# Windows defaults to cp1252 which cannot encode emoji used in log messages
+if sys.platform == "win32":
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+
 app = App(help="Build and package nao-core CLI.")
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #474 — the Windows CI build still fails because Python's default `cp1252` encoding on Windows cannot handle the emoji characters (📦, 🎨, ⚡, etc.) used in `build.py` print statements.

**Error from CI ([job log](https://github.com/getnao/nao/actions/runs/23289451737/job/67720999732)):**
```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f4e6' in position 0: character maps to <undefined>
```

## Fix

Two complementary approaches:

### `.github/workflows/publish.yml`
- Set `PYTHONUTF8=1` environment variable on the build step, enabling Python UTF-8 mode for the Windows runner

### `cli/build.py`
- Reconfigure `sys.stdout` and `sys.stderr` to UTF-8 when running on Windows (`sys.platform == "win32"`), so the script also works for developers building locally on Windows

## Testing

- All 39 chat command tests pass
- Lint checks pass (`ty check`, `ruff check`, `ruff format`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86d4a2e9-b9bd-469a-9e0a-599c6ef751ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86d4a2e9-b9bd-469a-9e0a-599c6ef751ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

