### PR TITLE
ci: clean up stale PR previews in nightly workflow + manual dispatch

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -4,6 +4,7 @@ on:
     schedule:
         # Every day at 1am
         - cron: '0 1 * * *'
+    workflow_dispatch:
 
 jobs:
     remove-old-artifacts:
@@ -18,6 +19,69 @@ jobs:
               uses: c-hive/gha-remove-artifacts@v1
               with:
                   age: '5 days'
+
+    cleanup-pr-previews:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        permissions:
+            pull-requests: read
+
+        steps:
+            - name: Get open PR numbers
+              id: open-prs
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prs = await github.paginate(github.rest.pulls.list, {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          state: 'open',
+                      });
+                      const numbers = prs.map(pr => pr.number);
+                      core.setOutput('numbers', numbers.join(','));
+                      console.log(`Open PRs: ${numbers.join(', ') || 'none'}`);
+
+            - name: Cleanup stale preview deployments
+              uses: appleboy/ssh-action@master
+              with:
+                  host: ${{ secrets.VM_HOST }}
+                  username: github-actions-demo
+                  key: ${{ secrets.PRIVATE_KEY }}
+                  script: |
+                      OPEN_PRS="${{ steps.open-prs.outputs.numbers }}"
+
+                      CONTAINERS=$(docker ps -a --filter "name=nao-preview-" --format "{{.Names}}" 2>/dev/null || true)
+
+                      if [ -z "$CONTAINERS" ]; then
+                          echo "No preview containers found"
+                          exit 0
+                      fi
+
+                      CLEANED=0
+                      for CONTAINER in $CONTAINERS; do
+                          PR_NUMBER=$(echo "$CONTAINER" | sed 's/nao-preview-//')
+
+                          if echo ",$OPEN_PRS," | grep -q ",$PR_NUMBER,"; then
+                              echo "PR #${PR_NUMBER} is still open — keeping preview"
+                              continue
+                          fi
+
+                          echo "PR #${PR_NUMBER} is merged or closed — cleaning up..."
+
+                          docker rm -f "nao-preview-${PR_NUMBER}" 2>/dev/null || true
+                          rm -f /home/github-actions-demo/nginx/preview.d/pr-${PR_NUMBER}-*.conf
+                          docker images --format "{{.Repository}}:{{.Tag}}" | grep "preview:pr-${PR_NUMBER}" | xargs -r docker rmi 2>/dev/null || true
+
+                          CLEANED=$((CLEANED + 1))
+                      done
+
+                      if [ "$CLEANED" -gt 0 ]; then
+                          docker exec nginx nginx -s reload 2>/dev/null || true
+                          echo "Cleaned up $CLEANED stale preview(s)"
+                      else
+                          echo "No stale previews to clean up"
+                      fi
 
     cleanup-docker-images:
         runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Adds two improvements to the **Nightly cleanup** workflow (`.github/workflows/remove-old-artifacts.yml`):

### 1. Manual dispatch trigger (`workflow_dispatch`)

The workflow can now be triggered manually from the Actions tab, useful for on-demand cleanup without waiting for the nightly schedule.

### 2. New `cleanup-pr-previews` job

Removes PR preview deployments that are still running on the VM but whose PRs have been merged or closed. This catches previews that weren't cleaned up by the `pr-preview.yml` close event (e.g. due to transient failures).

**How it works:**
1. Fetches all currently open PR numbers via the GitHub API (`actions/github-script`)
2. SSHs into the preview VM and lists all `nao-preview-*` containers
3. For each container, extracts the PR number — if the PR is no longer open, it:
   - Removes the Docker container
   - Deletes the nginx config for that preview
   - Removes associated Docker images
4. Reloads nginx only if something was actually cleaned up
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-536bc7eb-d5c0-412d-9c6d-a1c39c40d07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-536bc7eb-d5c0-412d-9c6d-a1c39c40d07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

