### PR TITLE
fix: prevent email vertical truncation in sidebar user menu

### DIFF
--- a/apps/frontend/src/components/sidebar-user-menu.tsx
+++ b/apps/frontend/src/components/sidebar-user-menu.tsx
@@ -37,7 +37,7 @@ export function SidebarUserMenu({ isCollapsed }: SidebarUserMenuProps) {
 						hideIf(isCollapsed),
 					)}
 				>
-					<span className='text-sm font-medium truncate'>{username}</span>
+					<span className='text-sm leading-4 font-medium truncate'>{username}</span>
 					<span className='text-xs text-muted-foreground truncate'>{email}</span>
 				</span>
 			</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the sidebar, the user's email text was vertically truncated — descender characters like "g", "y", and "p" were visually clipped at the bottom.

## Cause

The container `<span>` wrapping the username and email had a fixed height of `h-8` (32px), but the two text lines needed ~36px total:
- `text-sm` (username): 14px font / 20px default line-height
- `text-xs` (email): 12px font / 16px default line-height

The 4px overflow caused the bottom of the email line to be cut off.

## Fix

Added `leading-4` (line-height: 16px) to the username span. This reduces its line-height from 20px to 16px, making the total content height exactly 32px and fitting within the `h-8` container without clipping.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-049ed994-d796-47b4-a433-eda9d90f6395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-049ed994-d796-47b4-a433-eda9d90f6395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

