### PR TITLE
Remove notion config from example nao_config.yaml

### DIFF
--- a/example/nao_config.yaml
+++ b/example/nao_config.yaml
@@ -15,9 +15,6 @@ repos:
 - name: dbt
   url: https://github.com/dbt-labs/jaffle_shop_duckdb.git
   branch: null
-notion:
-  api_key: {{ env('NOTION_API_KEY') }}
-  pages:
-  - https://naolabs.notion.site/Jaffle-shop-information-2f8c7a70bc0680a4b7d0caf99f055360
+notion: null
 llm: null
 slack: null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The example `nao_config.yaml` included a Notion integration block with an `api_key` template (`{{ env('NOTION_API_KEY') }}`). When users set up the example project without a `NOTION_API_KEY` environment variable configured, this caused setup crashes.

## Solution

Replace the full Notion configuration block with `notion: null`, matching the pattern already used by `llm` and `slack` in the same file. Users who want Notion integration can still configure it — this just removes it from the default example so new users aren't blocked by a missing API key.

## Changes

- `example/nao_config.yaml`: Replaced the `notion` block (api_key + pages) with `notion: null`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e425034-cca9-4c4e-bebd-ff2ea415508a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e425034-cca9-4c4e-bebd-ff2ea415508a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

