### PR TITLE
Breakdown key added to series config schema to allow for multi series charts

### DIFF
--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -24,13 +24,23 @@ export default tool<displayChart.Input, displayChart.Output>({
 			return { _version: '1', success: false, error: 'At least one series is required.' };
 		}
 
-		// Stacked bar requires at least two series
-		if (chartType === 'stacked_bar' && series.length < 2) {
+		if (series.some((s) => s.breakdown_key) && series.some((s) => s.breakdown_key === undefined)) {
 			return {
 				_version: '1',
 				success: false,
-				error: 'Stacked bar chart requires at least two series. You may need to pivot the data to create a series for each stack.',
+				error: 'Cannot combine breakdown series and none breakdown series',
 			};
+		}
+
+		// Stacked bar requires at least two series or a breakdown
+		if (chartType === 'stacked_bar' && series.length < 2) {
+			if (!series[0]?.breakdown_key) {
+				return {
+					_version: '1',
+					success: false,
+					error: 'Stacked bar chart requires at least two series or a breakdown key. Pivot the data to create a series for each stack or provide a breakdown key.',
+				};
+			}
 		}
 
 		// TODO: check that the chart is displayable and that the data is valid

--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -19,16 +19,31 @@ export default tool<displayChart.Input, displayChart.Output>({
 			return { _version: '1', success: false, error: 'Pie charts require exactly one series.' };
 		}
 
+		// Validate breakdown key not set when for pie charts
+		if (chartType === 'pie' && series[0].breakdown_key) {
+			return { _version: '1', success: false, error: 'Pie charts do not accept a breakdown key.' };
+		}
+
 		// Validate series is not empty
 		if (series.length === 0) {
 			return { _version: '1', success: false, error: 'At least one series is required.' };
 		}
 
+		// Validates that breakdown series are not combined with non-breakdown series
 		if (series.some((s) => s.breakdown_key) && series.some((s) => s.breakdown_key === undefined)) {
 			return {
 				_version: '1',
 				success: false,
-				error: 'Cannot combine breakdown series and none breakdown series',
+				error: 'Cannot combine breakdown and non-breakdown series.',
+			};
+		}
+
+		// Validates that only one breakdown series is passed
+		if (series.filter((s) => s.breakdown_key).length > 1) {
+			return {
+				_version: '1',
+				success: false,
+				error: 'Multiple breakdown series are not supported. Use a single series with a breakdown key.',
 			};
 		}
 

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -91,6 +91,10 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or
 					any non-ISO-date strings.
 				</ListItem>
+				<ListItem>
+					For multi-series charts where data has a categorical column (e.g. payment_method, region), use
+					breakdown_key on the series instead of pivoting in SQL.
+				</ListItem>
 				{hasClickHouse && (
 					<ListItem>
 						When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -246,11 +246,26 @@ export const ChartDisplay = memo(function ChartDisplay({
 	title,
 	showGrid = true,
 }: ChartDisplayProps) {
-	const { visibleSeries, hiddenSeriesKeys, handleToggleSeriesVisibility } = useSeriesVisibility(series);
+	const { finalSeries, finalData } = useMemo(() => {
+		if (!series.some((s) => s.breakdown_key)) {
+			return {
+				finalSeries: series,
+				finalData: data,
+			};
+		}
+		const { pivotedData, expandedSeries } = handleBreakdownKeys(series, xAxisKey, data);
+
+		return {
+			finalSeries: expandedSeries,
+			finalData: pivotedData,
+		};
+	}, [data, series, xAxisKey]);
+
+	const { visibleSeries, hiddenSeriesKeys, handleToggleSeriesVisibility } = useSeriesVisibility(finalSeries);
 
 	const chartConfig = useMemo((): ChartConfig => {
 		if (chartType === 'pie') {
-			const values = new Set(data.map((item) => String(item[xAxisKey])));
+			const values = new Set(finalData.map((item) => String(item[xAxisKey])));
 			return [...values].reduce(
 				(acc, v, index) => {
 					acc[toKey(v)] = {
@@ -267,14 +282,14 @@ export const ChartDisplay = memo(function ChartDisplay({
 			);
 		}
 
-		return series.reduce((acc, s, idx) => {
+		return finalSeries.reduce((acc, s, idx) => {
 			acc[s.data_key] = {
 				label: s.label || labelize(s.data_key),
 				color: s.color || Colors[idx % Colors.length],
 			};
 			return acc;
 		}, {} as ChartConfig);
-	}, [series, xAxisKey, data, chartType]);
+	}, [finalSeries, xAxisKey, finalData, chartType]);
 
 	const colorFor = useMemo(
 		() =>
@@ -286,19 +301,19 @@ export const ChartDisplay = memo(function ChartDisplay({
 
 	const legendPayload = useMemo(
 		() =>
-			series.map((s, idx) => ({
+			finalSeries.map((s, idx) => ({
 				value: s.label || labelize(s.data_key),
 				dataKey: s.data_key,
 				color: s.color || Colors[idx % Colors.length],
 				isHidden: hiddenSeriesKeys.has(s.data_key),
 			})),
-		[series, hiddenSeriesKeys],
+		[finalSeries, hiddenSeriesKeys],
 	);
 
 	const chartElement = useMemo(
 		() =>
 			buildChart({
-				data,
+				data: finalData,
 				chartType,
 				xAxisKey,
 				xAxisType,
@@ -326,7 +341,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 				title,
 			}),
 		[
-			data,
+			finalData,
 			chartType,
 			xAxisKey,
 			xAxisType,
@@ -352,6 +367,59 @@ export const ChartDisplay = memo(function ChartDisplay({
 		</div>
 	);
 });
+
+/** Handles breakdown keys in series config - expands the series and pivots the data  */
+const handleBreakdownKeys = (
+	series: displayChart.SeriesConfig[],
+	xAxisKey: string,
+	data: Record<string, unknown>[],
+): {
+	pivotedData: Record<string, unknown>[];
+	expandedSeries: displayChart.SeriesConfig[];
+} => {
+	const grouped = new Map<string, Record<string, unknown>>();
+	const expandedSeries: displayChart.SeriesConfig[] = [];
+
+	for (const row of data) {
+		const x = row[xAxisKey] as string;
+		if (x == null) {
+			continue;
+		}
+
+		if (!grouped.has(x)) {
+			grouped.set(x, { [xAxisKey]: x });
+		}
+
+		const target = grouped.get(x)!;
+
+		for (const s of series) {
+			if (!s.breakdown_key) {
+				continue;
+			}
+
+			const breakdown = row[s.breakdown_key] as string;
+			const value = row[s.data_key];
+
+			if (breakdown == null) {
+				continue;
+			}
+
+			target[breakdown] = value;
+
+			if (!expandedSeries.some((es) => es.data_key === breakdown)) {
+				expandedSeries.push({
+					data_key: breakdown,
+					label: labelize(breakdown),
+				});
+			}
+		}
+	}
+
+	return {
+		pivotedData: Array.from(grouped.values()),
+		expandedSeries,
+	};
+};
 
 /** Manages which series are visible and hidden */
 const useSeriesVisibility = (series: displayChart.SeriesConfig[]) => {

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -397,12 +397,8 @@ const handleBreakdownKeys = (
 				continue;
 			}
 
-			const breakdown = row[s.breakdown_key] as string;
+			const breakdown = (row[s.breakdown_key] ?? 'Null') as string;
 			const value = row[s.data_key];
-
-			if (breakdown == null) {
-				continue;
-			}
 
 			target[breakdown] = value;
 
@@ -417,7 +413,7 @@ const handleBreakdownKeys = (
 
 	return {
 		pivotedData: Array.from(grouped.values()),
-		expandedSeries,
+		expandedSeries: expandedSeries.sort((a, b) => a.data_key.localeCompare(b.data_key)),
 	};
 };
 

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -6,6 +6,12 @@ export const XAxisTypeEnum = z.enum(['date', 'number', 'category']);
 
 export const SeriesConfigSchema = z.object({
 	data_key: z.string().describe('Column name from SQL result to plot.'),
+	breakdown_key: z
+		.string()
+		.describe(
+			'Column name from SQL. Creates a series for each value in the column. Useful for generating multiseries charts without pivoting',
+		)
+		.optional(),
 	color: z.string().describe('CSS color (defaults to theme colors).').optional(),
 	label: z.string().describe('Label to display in the legend.').optional(),
 });


### PR DESCRIPTION
## Summary
Implements idea from #414 
* Added optional breakdown key to series config schema 
* Updated validation in backend
* Added pivot logic and series expansion to the display chart component

## Examples
### The Query
<img width="1144" height="553" alt="image" src="https://github.com/user-attachments/assets/b07c1e1f-9398-4820-ba2d-99c49a26a3e6" />

### Stacked Bar
<img width="1028" height="642" alt="image" src="https://github.com/user-attachments/assets/132b292b-3ae2-476b-b43e-56828c8d2460" />

### Line
<img width="867" height="636" alt="image" src="https://github.com/user-attachments/assets/35cdbebc-e27e-4bb0-86cc-fed5d39b379f" />

### Bar
<img width="972" height="638" alt="image" src="https://github.com/user-attachments/assets/8fa476c8-5e2b-49d6-9cfb-696dd330577a" />

### Tool Call Examples 
```json
"{""title"": ""Sales by month by payment method"", ""series"": [{""color"": """", ""label"": ""Sales"", ""data_key"": ""sales_amount"", ""breakdown_key"": ""payment_method""}], ""query_id"": ""query_91cdb958"", ""chart_type"": ""stacked_bar"", ""x_axis_key"": ""order_month"", ""x_axis_type"": ""date""}"
```
```json
"{""title"": ""Sales by month by payment method"", ""series"": [{""color"": """", ""label"": ""Sales"", ""data_key"": ""sales_amount"", ""breakdown_key"": ""payment_method""}], ""query_id"": ""query_91cdb958"", ""chart_type"": ""bar"", ""x_axis_key"": ""order_month"", ""x_axis_type"": ""date""}"
```

```json
"{""title"": ""Sales by month by payment method"", ""series"": [{""color"": """", ""label"": ""Sales"", ""data_key"": ""sales_amount"", ""breakdown_key"": ""payment_method""}], ""query_id"": ""query_91cdb958"", ""chart_type"": ""line"", ""x_axis_key"": ""order_month"", ""x_axis_type"": ""date""}"
```


