### PR TITLE
CLI inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ WORKDIR /app
 
 # Copy all artifacts with --chown to avoid expensive recursive `chown -R`
 COPY --from=python-builder --chown=nao:nao /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=python-builder --chown=nao:nao /usr/local/bin/nao /usr/local/bin/nao
 COPY --from=deps --chown=nao:nao /app/package.json ./
 COPY --from=deps --chown=nao:nao /app/node_modules ./node_modules
 


### PR DESCRIPTION
## Summary

- Fix `nao` CLI not being available inside the Docker container (closes #448)
- The Python `site-packages` were already copied to the runtime image, but the CLI entry point script at `/usr/local/bin/nao` was not — added a single `COPY` line to include it


## Test plan

- [x] `docker compose up -d --build`
- [x] `docker exec -it nao-nao-1 bash`
- [x] `which nao` → `/usr/local/bin/nao`
- [x] Clone a real git repo inside the container to test full sync:
  ```bash
  cd /app/example/repos && rm -rf dbt && git clone https://github.com/dbt-labs/jaffle_shop_duckdb.git dbt
  ```
- [x] `cd /app/example && nao sync` → repos sync with `✓ dbt`, databases sync, no errors


