### PR TITLE
implemented new charts

### DIFF
--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -9,8 +9,8 @@ export default tool<displayChart.Input, displayChart.Output>({
 	outputSchema: displayChart.OutputSchema,
 
 	execute: async ({ chart_type: chartType, x_axis_key: xAxisKey, series }) => {
-		// Validate xAxisKey is provided for bar/area charts
-		if ((chartType === 'bar' || chartType === 'line') && !xAxisKey) {
+		// Validate xAxisKey is provided for cartesian and polar charts
+		if (['bar', 'line', 'area', 'stacked_area', 'scatter', 'radar'].includes(chartType) && !xAxisKey) {
 			return { _version: '1', success: false, error: `xAxisKey is required for ${chartType} charts.` };
 		}
 
@@ -24,12 +24,12 @@ export default tool<displayChart.Input, displayChart.Output>({
 			return { _version: '1', success: false, error: 'At least one series is required.' };
 		}
 
-		// Stacked bar requires at least two series
-		if (chartType === 'stacked_bar' && series.length < 2) {
+		// Stacked charts require at least two series
+		if ((chartType === 'stacked_bar' || chartType === 'stacked_area') && series.length < 2) {
 			return {
 				_version: '1',
 				success: false,
-				error: 'Stacked bar chart requires at least two series. You may need to pivot the data to create a series for each stack.',
+				error: `Stacked ${chartType === 'stacked_bar' ? 'bar' : 'area'} chart requires at least two series. You may need to pivot the data to create a series for each stack.`,
 			};
 		}
 

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -91,6 +91,13 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or
 					any non-ISO-date strings.
 				</ListItem>
+				<ListItem>
+					For display_chart chart_type: use "scatter" for correlations between two numeric variables (set
+					x_axis_type to "number"). Use "radar" for comparing multiple metrics across a fixed set of
+					categories on a spider/web chart. Use "area" for time-series trends where filled area emphasis is
+					desired (similar to "line"). Use "stacked_area" to show how multiple series compose a total over
+					time (e.g. revenue by payment method, users by plan) — requires 2+ series and pivoted data.
+				</ListItem>
 				{hasClickHouse && (
 					<ListItem>
 						When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -1,5 +1,23 @@
 import React from 'react';
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, Customized, Pie, PieChart, XAxis, YAxis } from 'recharts';
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Customized,
+	Pie,
+	PieChart,
+	PolarAngleAxis,
+	PolarGrid,
+	PolarRadiusAxis,
+	Radar,
+	RadarChart,
+	Scatter,
+	ScatterChart,
+	XAxis,
+	YAxis,
+} from 'recharts';
 
 import * as displayChart from './tools/display-chart';
 
@@ -49,8 +67,14 @@ export function buildChart(props: BuildChartProps) {
 	if (resolved.chartType === 'pie') {
 		return buildPieChart(resolved);
 	}
-	if (resolved.chartType === 'line') {
+	if (resolved.chartType === 'line' || resolved.chartType === 'area' || resolved.chartType === 'stacked_area') {
 		return buildAreaChart(resolved);
+	}
+	if (resolved.chartType === 'scatter') {
+		return buildScatterChart(resolved);
+	}
+	if (resolved.chartType === 'radar') {
+		return buildRadarChart(resolved);
 	}
 	return buildBarChart(resolved);
 }
@@ -169,7 +193,10 @@ function buildBarChart(props: ResolvedProps) {
 }
 
 function buildAreaChart(props: ResolvedProps) {
-	const { data, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } = props;
+	const { data, chartType, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } =
+		props;
+	const isStacked = chartType === 'stacked_area';
+
 	return (
 		<AreaChart data={data} accessibilityLayer margin={margin}>
 			<defs>
@@ -204,10 +231,55 @@ function buildAreaChart(props: ResolvedProps) {
 					type='monotone'
 					stroke={colorFor(s.data_key, i)}
 					fill={`url(#grad-${i})`}
+					stackId={isStacked ? 'stack' : undefined}
 					isAnimationActive={false}
 				/>
 			))}
 		</AreaChart>
+	);
+}
+
+function buildScatterChart(props: ResolvedProps) {
+	const { data, xAxisKey, xAxisType, series, colorFor, showGrid, children, margin } = props;
+
+	return (
+		<ScatterChart data={data} accessibilityLayer margin={margin}>
+			{showGrid && <CartesianGrid strokeDasharray='3 3' />}
+			<XAxis dataKey={xAxisKey} type={xAxisType ?? 'number'} tickLine={false} axisLine={false} minTickGap={12} />
+			<YAxis tickLine={false} axisLine={false} minTickGap={12} />
+			{children}
+			{series.map((s, i) => (
+				<Scatter
+					key={s.data_key}
+					dataKey={s.data_key}
+					fill={colorFor(s.data_key, i)}
+					isAnimationActive={false}
+				/>
+			))}
+		</ScatterChart>
+	);
+}
+
+function buildRadarChart(props: ResolvedProps) {
+	const { data, xAxisKey, series, colorFor, children, margin } = props;
+
+	return (
+		<RadarChart data={data} accessibilityLayer margin={margin}>
+			<PolarGrid />
+			<PolarAngleAxis dataKey={xAxisKey} />
+			<PolarRadiusAxis />
+			{children}
+			{series.map((s, i) => (
+				<Radar
+					key={s.data_key}
+					dataKey={s.data_key}
+					stroke={colorFor(s.data_key, i)}
+					fill={colorFor(s.data_key, i)}
+					fillOpacity={0.3}
+					isAnimationActive={false}
+				/>
+			))}
+		</RadarChart>
 	);
 }
 

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -1,6 +1,16 @@
 import z from 'zod/v3';
 
-export const ChartTypeEnum = z.enum(['bar', 'stacked_bar', 'line', 'pie', 'kpi_card']);
+export const ChartTypeEnum = z.enum([
+	'bar',
+	'stacked_bar',
+	'line',
+	'area',
+	'stacked_area',
+	'pie',
+	'kpi_card',
+	'scatter',
+	'radar',
+]);
 
 export const XAxisTypeEnum = z.enum(['date', 'number', 'category']);
 


### PR DESCRIPTION
fix #327 

New charts supported : 

- simple area chart
- stacked area chart
- scatter chart
- radar chart

<img width="847" height="505" alt="Capture d’écran 2026-03-24 à 11 48 38" src="https://github.com/user-attachments/assets/15177f5f-7858-444d-8dfa-7665b39efb3b" />
<img width="844" height="472" alt="Capture d’écran 2026-03-24 à 11 45 53" src="https://github.com/user-attachments/assets/7dc6f8ea-8f40-4135-b2d1-8110d4219f36" />
<img width="861" height="496" alt="Capture d’écran 2026-03-24 à 11 45 43" src="https://github.com/user-attachments/assets/26051be4-38fe-4816-a2fc-6418bf32069b" />
