### PR TITLE
Fix incorrect cli_path resolution in FastAPI server

### DIFF
--- a/apps/backend/fastapi/main.py
+++ b/apps/backend/fastapi/main.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 
 load_dotenv()
 
-cli_path = Path(__file__).parent.parent.parent / "cli"
+cli_path = Path(__file__).resolve().parent.parent.parent.parent / "cli"
 sys.path.insert(0, str(cli_path))
 
 from nao_core.config import NaoConfig, NaoConfigError


### PR DESCRIPTION
## Summary
- Fixes #330 — `cli_path` in `apps/backend/fastapi/main.py` was resolving to `apps/cli` (doesn't exist) instead of the project root's `cli/` directory
- The path traversal was missing one `.parent` level: `apps/backend/fastapi → apps/backend → apps → (project root)`
- Added `.resolve()` for robustness with symlinks

## Test plan
- [ ] Run `npm run dev` and verify the FastAPI server starts without `NaoConfigError` import failures
- [ ] Verify `/health` endpoint returns successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)