### PR TITLE
Move linking code section to Telegram and WhatsApp pages

### DIFF
--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.index.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.index.tsx
@@ -5,7 +5,6 @@ import { SettingsCard } from '@/components/ui/settings-card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { trpc } from '@/main';
-import { LinkingCodesCard } from '@/components/settings/linking-code-section';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/')({
 	component: ProjectTabPage,
@@ -47,8 +46,6 @@ function ProjectTabPage() {
 					<GoogleConfigSection isAdmin={isAdmin} />
 				)}
 			</SettingsCard>
-
-			<LinkingCodesCard />
 		</>
 	);
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.telegram.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.telegram.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { TelegramConfigSection } from '@/components/settings/telegram-config-section';
+import { LinkingCodesCard } from '@/components/settings/linking-code-section';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/telegram')({
@@ -11,5 +12,10 @@ function ProjectTelegramTabPage() {
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const isAdmin = project.data?.userRole === 'admin';
 
-	return <TelegramConfigSection isAdmin={isAdmin} />;
+	return (
+		<>
+			<TelegramConfigSection isAdmin={isAdmin} />
+			<LinkingCodesCard />
+		</>
+	);
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.whatsapp.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.whatsapp.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { WhatsappConfigSection } from '@/components/settings/whatsapp-config-section';
+import { LinkingCodesCard } from '@/components/settings/linking-code-section';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/whatsapp')({
@@ -11,5 +12,10 @@ function ProjectWhatsappTabPage() {
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const isAdmin = project.data?.userRole === 'admin';
 
-	return <WhatsappConfigSection isAdmin={isAdmin} />;
+	return (
+		<>
+			<WhatsappConfigSection isAdmin={isAdmin} />
+			<LinkingCodesCard />
+		</>
+	);
 }


### PR DESCRIPTION
## Summary
- Removed `LinkingCodesCard` from the general project settings page
- Added it to both the Telegram and WhatsApp settings pages, where it's actually relevant

## Test plan
- [x] Verify linking code section no longer appears on the project settings page
- [x] Verify linking code section appears on the Telegram settings page
- [x] Verify linking code section appears on the WhatsApp settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)