### PR TITLE
Fix Y-axis truncation on charts with large values

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -306,7 +306,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 				colorFor,
 				labelFormatter: xAxisLabelFormatter,
 				showGrid,
-				margin: { top: 0, right: 0, bottom: 0, left: -18 },
+				margin: { top: 0, right: 0, bottom: 0, left: 0 },
 				children: [
 					<ChartTooltip
 						key='tooltip'

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -34,6 +34,14 @@ export function labelize(key: unknown): string {
 	return str.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+export function formatYAxisTick(value: number): string {
+	const abs = Math.abs(value);
+	if (abs >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1).replace(/\.0$/, '')}B`;
+	if (abs >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+	if (abs >= 10_000) return `${(value / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
+	return String(value);
+}
+
 export function defaultColorFor(_key: string, index: number): string {
 	return DEFAULT_COLORS[index % DEFAULT_COLORS.length];
 }
@@ -161,7 +169,7 @@ function buildBarChart(props: ResolvedProps) {
 	return (
 		<BarChart data={data} accessibilityLayer margin={margin}>
 			{showGrid && <CartesianGrid horizontal vertical={false} strokeDasharray='3 3' />}
-			<YAxis tickLine={false} axisLine={false} minTickGap={12} />
+			<YAxis tickLine={false} axisLine={false} minTickGap={12} tickFormatter={formatYAxisTick} />
 			<XAxis
 				dataKey={xAxisKey}
 				type={xAxisType}
@@ -207,7 +215,7 @@ function buildAreaChart(props: ResolvedProps) {
 				})}
 			</defs>
 			{showGrid && <CartesianGrid horizontal vertical={false} strokeDasharray='3 3' />}
-			<YAxis tickLine={false} axisLine={false} minTickGap={12} />
+			<YAxis tickLine={false} axisLine={false} minTickGap={12} tickFormatter={formatYAxisTick} />
 			<XAxis
 				dataKey={xAxisKey}
 				type={xAxisType}
@@ -241,7 +249,7 @@ function buildScatterChart(props: ResolvedProps) {
 		<ScatterChart data={data} accessibilityLayer margin={margin}>
 			{showGrid && <CartesianGrid strokeDasharray='3 3' />}
 			<XAxis dataKey={xAxisKey} type={xAxisType ?? 'number'} tickLine={false} axisLine={false} minTickGap={12} />
-			<YAxis tickLine={false} axisLine={false} minTickGap={12} />
+			<YAxis tickLine={false} axisLine={false} minTickGap={12} tickFormatter={formatYAxisTick} />
 			{children}
 			{series.map((s, i) => (
 				<Scatter


### PR DESCRIPTION
## Summary
- Add `formatYAxisTick` formatter that abbreviates large Y-axis values (e.g. `100K`, `1.5M`, `2B`) for bar, area/line, and scatter charts
- Remove the negative left margin (`left: -18`) on the frontend chart container that was clipping axis labels

Closes #521

## Test plan
- [ ] Create a line chart with values > 10,000 (e.g. `execute select 1, 100000 union all 2, 400000 and draw a line chart`) — Y-axis should show `100K`, `400K` instead of truncated numbers
- [ ] Verify bar charts, area charts, and scatter charts also display abbreviated Y-axis labels
- [ ] Verify charts with small values (< 10,000) still show exact numbers
- [ ] Verify downloaded chart images also show abbreviated Y-axis labels



🤖 Generated with [Claude Code](https://claude.com/claude-code)