### PR TITLE
Fix project not found when NAO_DEFAULT_PROJECT_PATH changes

### DIFF
--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -228,14 +228,14 @@ export const ensureOrganizationSetup = async (): Promise<void> => {
 	await db.update(s.project).set({ orgId: org.id }).where(isNull(s.project.orgId)).execute();
 
 	// Ensure a project exists for the current NAO_DEFAULT_PROJECT_PATH
-	await ensureDefaultProject(org, firstUser.id);
+	await ensureDefaultProject(org);
 };
 
 /**
  * Ensures a project exists for the current NAO_DEFAULT_PROJECT_PATH.
  * When users change the project path and restart, the DB may not have a record for the new path.
  */
-const ensureDefaultProject = async (org: DBOrganization, firstUserId: string): Promise<void> => {
+const ensureDefaultProject = async (org: DBOrganization): Promise<void> => {
 	const projectPath = env.NAO_DEFAULT_PROJECT_PATH;
 	if (!projectPath) {
 		return;


### PR DESCRIPTION
## Summary
- When users run `nao chat` from a new directory, the DB had no project record for the new `NAO_DEFAULT_PROJECT_PATH`, causing all requests to fail with "No project configured"
- Added `ensureDefaultProject` to server startup (`ensureOrganizationSetup`) that automatically creates a project for the current path and adds all org members to it

Closes #517

## Test plan
- [ ] Run `nao chat` from directory A, verify it works
- [ ] Stop the server, run `nao chat` from directory B, verify the new project is created and accessible
- [ ] Verify existing projects are not affected when restarting with the same path

🤖 Generated with [Claude Code](https://claude.com/claude-code)