### PR TITLE
Fix cubic review comments on PR #526

### DIFF
--- a/apps/backend/migrations-postgres/0031_live_stories.sql
+++ b/apps/backend/migrations-postgres/0031_live_stories.sql
@@ -27,6 +27,24 @@ ALTER TABLE "story_version" DROP CONSTRAINT "story_version_chat_id_chat_id_fk";
 --> statement-breakpoint
 DROP INDEX "shared_story_chat_story_idx";--> statement-breakpoint
 DROP INDEX "story_version_chat_story_idx";--> statement-breakpoint
+INSERT INTO "story" ("id", "chat_id", "slug", "title", "archived_at", "created_at", "updated_at")
+SELECT
+	gen_random_uuid()::text,
+	sv."chat_id",
+	sv."story_id",
+	(array_agg(sv."title" ORDER BY sv."version" DESC))[1],
+	(array_agg(sv."archived_at" ORDER BY sv."version" DESC))[1],
+	min(sv."created_at"),
+	max(sv."created_at")
+FROM "story_version" sv
+GROUP BY sv."chat_id", sv."story_id"
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+UPDATE "story_version" SET "story_id" = st."id"
+FROM "story" st
+WHERE "story_version"."chat_id" = st."chat_id" AND "story_version"."story_id" = st."slug";--> statement-breakpoint
+UPDATE "shared_story" SET "story_id" = st."id"
+FROM "story" st
+WHERE "shared_story"."chat_id" = st."chat_id" AND "shared_story"."story_id" = st."slug";--> statement-breakpoint
 ALTER TABLE "story" ADD CONSTRAINT "story_chat_id_chat_id_fk" FOREIGN KEY ("chat_id") REFERENCES "public"."chat"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "story_data_cache" ADD CONSTRAINT "story_data_cache_story_id_story_id_fk" FOREIGN KEY ("story_id") REFERENCES "public"."story"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "story_chatId_idx" ON "story" USING btree ("chat_id");--> statement-breakpoint

--- a/apps/backend/migrations-sqlite/0031_live_stories.sql
+++ b/apps/backend/migrations-sqlite/0031_live_stories.sql
@@ -1,3 +1,4 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE `story` (
 	`id` text PRIMARY KEY NOT NULL,
 	`chat_id` text NOT NULL,
@@ -23,7 +24,25 @@ CREATE TABLE `story_data_cache` (
 	FOREIGN KEY (`story_id`) REFERENCES `story`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
+INSERT INTO `story` (`id`, `chat_id`, `slug`, `title`, `archived_at`, `created_at`, `updated_at`)
+SELECT
+	lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+	sv.`chat_id`,
+	sv.`story_id`,
+	sv.`title`,
+	sv.`archived_at`,
+	min(sv.`created_at`),
+	max(sv.`created_at`)
+FROM `story_version` sv
+GROUP BY sv.`chat_id`, sv.`story_id`;--> statement-breakpoint
+UPDATE `story_version` SET `story_id` = (
+	SELECT st.`id` FROM `story` st
+	WHERE st.`chat_id` = `story_version`.`chat_id` AND st.`slug` = `story_version`.`story_id`
+);--> statement-breakpoint
+UPDATE `shared_story` SET `story_id` = (
+	SELECT st.`id` FROM `story` st
+	WHERE st.`chat_id` = `shared_story`.`chat_id` AND st.`slug` = `shared_story`.`story_id`
+);--> statement-breakpoint
 CREATE TABLE `__new_shared_story` (
 	`id` text PRIMARY KEY NOT NULL,
 	`story_id` text NOT NULL,
@@ -39,7 +58,6 @@ CREATE TABLE `__new_shared_story` (
 INSERT INTO `__new_shared_story`("id", "story_id", "project_id", "user_id", "visibility", "created_at") SELECT "id", "story_id", "project_id", "user_id", "visibility", "created_at" FROM `shared_story`;--> statement-breakpoint
 DROP TABLE `shared_story`;--> statement-breakpoint
 ALTER TABLE `__new_shared_story` RENAME TO `shared_story`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE INDEX `shared_story_projectId_idx` ON `shared_story` (`project_id`);--> statement-breakpoint
 CREATE INDEX `shared_story_storyId_idx` ON `shared_story` (`story_id`);--> statement-breakpoint
 CREATE TABLE `__new_story_version` (
@@ -56,5 +74,6 @@ CREATE TABLE `__new_story_version` (
 INSERT INTO `__new_story_version`("id", "story_id", "version", "code", "action", "source", "created_at") SELECT "id", "story_id", "version", "code", "action", "source", "created_at" FROM `story_version`;--> statement-breakpoint
 DROP TABLE `story_version`;--> statement-breakpoint
 ALTER TABLE `__new_story_version` RENAME TO `story_version`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE INDEX `story_version_storyId_idx` ON `story_version` (`story_id`);--> statement-breakpoint
 CREATE UNIQUE INDEX `story_version_story_version_unique` ON `story_version` (`story_id`,`version`);

--- a/apps/backend/src/queries/story.queries.ts
+++ b/apps/backend/src/queries/story.queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, isNull, max, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, max, or, sql } from 'drizzle-orm';
 
 import s, { type DBStory, type DBStoryDataCache, type DBStoryVersion } from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -20,13 +20,17 @@ export async function getOrCreateStory(data: { chatId: string; slug: string; tit
 		return existing;
 	}
 
-	const [created] = await db
+	await db
 		.insert(s.story)
 		.values({ chatId: data.chatId, slug: data.slug, title: data.title })
-		.returning()
+		.onConflictDoNothing({ target: [s.story.chatId, s.story.slug] })
 		.execute();
 
-	return created;
+	const row = await getStoryByChatAndSlug(data.chatId, data.slug);
+	if (!row) {
+		throw new Error(`Failed to create or retrieve story: ${data.chatId}/${data.slug}`);
+	}
+	return row;
 }
 
 export async function createVersion(data: {
@@ -188,15 +192,17 @@ export async function archiveStory(chatId: string, slug: string): Promise<void> 
 }
 
 export async function archiveMany(stories: { chatId: string; slug: string }[]): Promise<void> {
-	await Promise.all(
-		stories.map(({ chatId, slug }) =>
-			db
-				.update(s.story)
-				.set({ archivedAt: new Date() })
-				.where(and(eq(s.story.chatId, chatId), eq(s.story.slug, slug)))
-				.execute(),
-		),
-	);
+	if (stories.length === 0) {
+		return;
+	}
+
+	const conditions = stories.map(({ chatId, slug }) => and(eq(s.story.chatId, chatId), eq(s.story.slug, slug)));
+
+	await db
+		.update(s.story)
+		.set({ archivedAt: new Date() })
+		.where(or(...conditions))
+		.execute();
 }
 
 export async function unarchiveStory(chatId: string, slug: string): Promise<void> {

--- a/apps/backend/src/services/live-story.ts
+++ b/apps/backend/src/services/live-story.ts
@@ -230,10 +230,21 @@ function buildNumericSummaries(rows: Record<string, unknown>[], columns: string[
 			continue;
 		}
 
-		const sum = values.reduce((total, value) => total + value, 0);
+		let min = Infinity;
+		let max = -Infinity;
+		let sum = 0;
+		for (const v of values) {
+			if (v < min) {
+				min = v;
+			}
+			if (v > max) {
+				max = v;
+			}
+			sum += v;
+		}
 		summaries[column] = {
-			min: Math.min(...values),
-			max: Math.max(...values),
+			min,
+			max,
 			avg: sum / values.length,
 			sum,
 			count: values.length,

--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
+import * as chatQueries from '../queries/chat.queries';
 import * as projectQueries from '../queries/project.queries';
 import * as sharedStoryQueries from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
@@ -104,7 +105,17 @@ export const sharedStoryRoutes = {
 
 	getLiveQueryData: protectedProcedure
 		.input(z.object({ chatId: z.string(), queryId: z.string() }))
-		.query(async ({ input }) => {
+		.query(async ({ input, ctx }) => {
+			const projectId = await chatQueries.getChatProjectId(input.chatId);
+			if (!projectId) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
+			}
+
+			const member = await projectQueries.getProjectMember(projectId, ctx.user.id);
+			if (!member) {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this chat.' });
+			}
+
 			return executeLiveQuery(input.chatId, input.queryId);
 		}),
 
@@ -117,6 +128,13 @@ export const sharedStoryRoutes = {
 		const member = await projectQueries.getProjectMember(shared.projectId, ctx.user.id);
 		if (!member) {
 			throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
+		}
+
+		if (shared.visibility === 'specific' && shared.userId !== ctx.user.id) {
+			const hasAccess = await sharedStoryQueries.canUserAccessSharedStory(shared.id, ctx.user.id);
+			if (!hasAccess) {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
+			}
 		}
 
 		const { queryData } = await refreshStoryData(shared.chatId, shared.slug);

--- a/apps/frontend/src/hooks/use-time-ago.ts
+++ b/apps/frontend/src/hooks/use-time-ago.ts
@@ -5,8 +5,6 @@ import { getTimeAgo } from '@/lib/time-ago';
 /** Calculate how long ago a timestamp is and update it with a dynamic interval */
 export const useTimeAgo = (timestamp: number): TimeAgo => {
 	const [timeAgo, setTimeAgo] = useState(getTimeAgo(timestamp));
-	console.log('timeAgo', timeAgo);
-	console.log('timestamp', timestamp);
 
 	useEffect(() => {
 		let intervalTime = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes all 8 issues raised by cubic-dev-ai in PR #526 (Add live stories).

## Changes

### P0: Postgres migration data migration (0031_live_stories.sql)
- Added `INSERT INTO story ... SELECT FROM story_version GROUP BY chat_id, story_id` to populate the new `story` table from existing data before FK constraints are added
- Added `UPDATE story_version/shared_story SET story_id = ...` to rewrite slug-based references to the new `story.id` UUIDs

### P1: SQLite migration foreign key handling (0031_live_stories.sql)
- Wrapped the entire migration in `PRAGMA foreign_keys=OFF/ON` so both the `shared_story` and `story_version` table recreations happen without FK enforcement
- Added equivalent data migration steps (UUID generation via `randomblob`, UPDATE to rewrite `story_id` columns)

### P1: Race condition in `getOrCreateStory` (story.queries.ts)
- Changed from INSERT-then-return to `INSERT ... ON CONFLICT DO NOTHING` followed by a re-SELECT, preventing unique constraint violations when two concurrent calls race on the same `(chatId, slug)`

### P1: `Math.min`/`Math.max` stack overflow (live-story.ts)
- Replaced `Math.min(...values)` / `Math.max(...values)` spread with a simple loop to avoid `RangeError` on large datasets (>65k rows)

### P1: Missing access check on `getLiveQueryData` (shared-story.routes.ts)
- Added project membership verification before executing live queries, preventing any authenticated user from running SQL for arbitrary chats

### P2: Missing visibility check on `refreshData` (shared-story.routes.ts)
- Added `shared.visibility === 'specific'` access check (matching the pattern in the `get` route) so restricted shared stories can't be refreshed by unauthorized project members

### P2: Console logging in `useTimeAgo` (use-time-ago.ts)
- Removed debug `console.log` calls that would fire on every render

### P2: `archiveMany` performance (story.queries.ts)
- Replaced N individual UPDATE queries with a single batched UPDATE using `or(...)` filter

## Verification
- `npm run lint` passes with zero errors and zero warnings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94ebf46f-4201-4452-acf4-750dd967462a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94ebf46f-4201-4452-acf4-750dd967462a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

