### PR TITLE
fix(cli): support Bedrock in ai_summary template prompt

### DIFF
--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -352,18 +352,25 @@ class TemplateEngine:
 
 # Global template engine instance (lazily initialized)
 _engine: TemplateEngine | None = None
-_engine_signature: tuple[str | None, str | None, str | None, str | None, str | None] | None = None
+_engine_signature: tuple[str | None, ...] | None = None
 
 
-def _llm_signature(llm_config: LLMConfig | None) -> tuple[str | None, str | None, str | None, str | None]:
+def _llm_signature(llm_config: LLMConfig | None) -> tuple[str | None, ...]:
     """Return a tuple of LLM config values used as a cache key for the template engine."""
     if not llm_config:
-        return (None, None, None, None)
+        return (None,) * 11
     return (
         llm_config.provider.value,
         llm_config.annotation_model,
         llm_config.base_url,
         llm_config.api_key,
+        llm_config.access_key,
+        llm_config.secret_key,
+        llm_config.aws_region,
+        llm_config.gcp_project,
+        llm_config.gcp_location,
+        llm_config.service_account_json,
+        llm_config.key_file,
     )
 
 

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -434,6 +434,33 @@ class TestGetTemplateEngine:
 
         assert engine1 is engine2
 
+    def test_creates_new_engine_when_bedrock_region_changes(self):
+        """get_template_engine should invalidate cache when bedrock region changes."""
+        import nao_core.templates.engine as engine_module
+
+        engine_module._engine = None
+        engine_module._engine_signature = None
+
+        llm1 = LLMConfig(
+            provider=LLMProvider.BEDROCK,
+            annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            access_key="AKIA_TEST",
+            secret_key="SECRET_TEST",
+            aws_region="us-east-1",
+        )
+        llm2 = LLMConfig(
+            provider=LLMProvider.BEDROCK,
+            annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            access_key="AKIA_TEST",
+            secret_key="SECRET_TEST",
+            aws_region="eu-west-1",
+        )
+
+        engine1 = get_template_engine(llm_config=llm1)
+        engine2 = get_template_engine(llm_config=llm2)
+
+        assert engine1 is not engine2
+
 
 class TestDefaultTemplatesDir:
     """Tests for the DEFAULT_TEMPLATES_DIR constant."""


### PR DESCRIPTION
Closes #514

## What changed
- Updated TemplateEngine._prompt(...) to use LLMConfig.requires_api_key instead of a hardcoded provider check.
- Added Bedrock provider dispatch in ai_summary prompt helper.
- Added _generate_bedrock(...) using Bedrock Runtime converse API.
- Bedrock runtime now uses:
  - llm.aws_region (fallback: AWS_REGION, then us-east-1)
  - optional static creds from llm.access_key + llm.secret_key
  - clear error if only one of static creds is set.

## Why
i_summary currently fails for llm.provider: bedrock with:
1. API key required error (incorrect for bedrock)
2. unsupported provider error

This PR fixes both paths so Bedrock works in ai_summary templates the same way it is expected to work in the rest of the CLI.

## Tests
- python -m ruff check
- python -m ruff check --select I .
- python -m pytest tests/nao_core/templates/test_engine.py -q
- python -m pytest tests/nao_core/config tests/nao_core/templates/test_engine.py -q

Added tests:
- prompt helper supports Bedrock without API key
- Bedrock generator uses configured AWS creds/region
- Bedrock generator rejects partial static credentials
