### PR TITLE
fix: preserve non-ASCII characters in to_json Jinja filter

### DIFF
--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -63,7 +63,7 @@ class TemplateEngine:
 
         def to_json(value: Any, indent: int | None = None) -> str:
             """Convert value to JSON string."""
-            return json.dumps(value, indent=indent, default=str)
+            return json.dumps(value, indent=indent, default=str, ensure_ascii=False)
 
         def truncate_middle(text: str, max_length: int = 50) -> str:
             """Truncate text in the middle if it exceeds max_length."""

--- a/cli/nao_core/templates/render.py
+++ b/cli/nao_core/templates/render.py
@@ -112,7 +112,7 @@ def render_template(
     # Register custom filters
     import json
 
-    env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str)
+    env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str, ensure_ascii=False)
 
     # Create the nao context
     nao = create_nao_context(config)

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -207,6 +207,34 @@ class TestTemplateFilters:
         parsed = json.loads(result)
         assert parsed == {"key": "value", "num": 42}
 
+    def test_to_json_filter_preserves_non_ascii(self, tmp_path: Path):
+        """to_json filter preserves non-ASCII characters (e.g. Japanese, emoji)."""
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "test.j2").write_text("{{ data | to_json }}")
+
+        engine = TemplateEngine(project_path=tmp_path)
+        result = engine.render("test.j2", data={"name": "テスト", "emoji": "🎉"})
+
+        assert "テスト" in result
+        assert "🎉" in result
+        assert "\\u" not in result
+        parsed = json.loads(result)
+        assert parsed == {"name": "テスト", "emoji": "🎉"}
+
+    def test_to_json_filter_non_ascii_with_indent(self, tmp_path: Path):
+        """to_json filter preserves non-ASCII characters even with indentation."""
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "test.j2").write_text("{{ data | to_json(indent=2) }}")
+
+        engine = TemplateEngine(project_path=tmp_path)
+        result = engine.render("test.j2", data={"city": "東京", "country": "日本"})
+
+        assert "東京" in result
+        assert "日本" in result
+        assert "\\u" not in result
+
     def test_to_json_filter_with_indent(self, tmp_path: Path):
         """to_json filter supports indent parameter."""
         templates_dir = tmp_path / "templates"

--- a/cli/tests/nao_core/templates/test_render.py
+++ b/cli/tests/nao_core/templates/test_render.py
@@ -1,0 +1,65 @@
+"""Unit tests for the user template renderer (render.py)."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from nao_core.templates.render import render_template
+
+
+class TestRenderTemplateToJsonFilter:
+    """Tests for the to_json filter inside render_template."""
+
+    def test_to_json_preserves_non_ascii(self, tmp_path: Path):
+        """to_json filter in render_template preserves non-ASCII characters."""
+        template = tmp_path / "test.md.j2"
+        template.write_text("{{ nao.data | to_json }}")
+
+        mock_context = {"data": {"name": "テスト", "emoji": "🎉"}}
+
+        with patch("nao_core.templates.render.create_nao_context") as mock_create:
+            mock_nao = type("Nao", (), mock_context)()
+            mock_create.return_value = mock_nao
+
+            output_path = render_template(
+                template_path=Path("test.md.j2"),
+                project_path=tmp_path,
+                config=None,  # type: ignore[arg-type]
+            )
+
+        rendered = output_path.read_text()
+        assert "テスト" in rendered
+        assert "🎉" in rendered
+        assert "\\u" not in rendered
+        parsed = json.loads(rendered)
+        assert parsed == {"name": "テスト", "emoji": "🎉"}
+
+    def test_to_json_non_ascii_roundtrips(self, tmp_path: Path):
+        """Non-ASCII data round-trips through to_json correctly."""
+        template = tmp_path / "test.md.j2"
+        template.write_text("{{ nao.rows | to_json(indent=2) }}")
+
+        rows = [
+            {"id": 1, "city": "東京"},
+            {"id": 2, "city": "서울"},
+            {"id": 3, "city": "القاهرة"},
+        ]
+        mock_context = {"rows": rows}
+
+        with patch("nao_core.templates.render.create_nao_context") as mock_create:
+            mock_nao = type("Nao", (), mock_context)()
+            mock_create.return_value = mock_nao
+
+            output_path = render_template(
+                template_path=Path("test.md.j2"),
+                project_path=tmp_path,
+                config=None,  # type: ignore[arg-type]
+            )
+
+        rendered = output_path.read_text()
+        assert "東京" in rendered
+        assert "서울" in rendered
+        assert "القاهرة" in rendered
+        assert "\\u" not in rendered
+        parsed = json.loads(rendered)
+        assert parsed == rows


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `ensure_ascii=False` to the `json.dumps` calls in `engine.py` and `render.py` so non-ASCII characters render as UTF-8 instead of `\uXXXX` escapes.

Closes #535
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4369027e-efbc-4862-acfa-a6cacf6a914e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4369027e-efbc-4862-acfa-a6cacf6a914e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

