### PR TITLE
fix : profiling even on complex types from tables (array, json, etc)

### DIFF
--- a/cli/nao_core/config/databases/athena.py
+++ b/cli/nao_core/config/databases/athena.py
@@ -14,6 +14,12 @@ from .context import DatabaseContext
 
 
 class AthenaDatabaseContext(DatabaseContext):
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
+        return f"{table_sql} CROSS JOIN UNNEST({col_sql}) AS t({alias})"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"CAST({col_sql} AS VARCHAR)"
+
     def _quote(self, name: str) -> str:
         return f'"{name}"'
 

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -130,7 +130,7 @@ class DatabaseConfig(BaseModel, ABC):
 
             if hasattr(cursor, "description") and cursor.description is not None and hasattr(cursor, "fetchall"):
                 columns = [desc[0] for desc in cursor.description]
-                return pd.DataFrame(cursor.fetchall(), columns=columns)  # type: ignore[arg-type]
+                return pd.DataFrame([tuple(row) for row in cursor.fetchall()], columns=columns)  # type: ignore[arg-type]
 
             raise TypeError(
                 f"Unsupported raw_sql result type: {type(cursor).__name__}. "

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -278,6 +278,12 @@ class BigQueryDatabaseContext(DatabaseContext):
             return f"`{cols[0]}` >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
         return ""
 
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
+        return f"{table_sql}, UNNEST({col_sql}) AS {alias}"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"TO_JSON_STRING({col_sql})"
+
 
 def _time_based_partition_filter(col: str, col_type: str, partition_id: str) -> str:
     """Build a partition filter for time-based columns, handling all BigQuery granularities."""

--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -564,6 +564,12 @@ class ClickHouseDatabaseContext(DatabaseContext):
             )
             return []
 
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
+        return f"{table_sql} ARRAY JOIN {col_sql} AS {alias}"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"toString({col_sql})"
+
 
 class ClickHouseConfig(DatabaseConfig):
     """ClickHouse-specific configuration."""

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -99,37 +99,141 @@ class DatabaseContext:
             cols = self.columns()
             if not cols:
                 return None
-
             total_count = self.row_count()
-            profiles = []
-
-            for col in cols:
-                col_type = self._normalize_type(col["type"])
-                is_numeric = self._is_numeric_stats_column(col)
-                is_date = any(t in col_type.lower() for t in ("date", "timestamp", "time"))
-
-                query = self._build_profiling_query(col)
-                row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
-                if not row:
-                    continue
-
-                profile = self._parse_profiling_row(row, col, total_count)
-
-                distinct_count = profile["distinct_count"]
-                if distinct_count and distinct_count <= 50 and not is_numeric and not is_date:
-                    top_vals = self._fetch_top_values(col)
-                    if top_vals:
-                        profile["top_values"] = top_vals
-
-                profiles.append(profile)
-
-            return {
-                "computed_at": datetime.now(timezone.utc).isoformat(),
-                "columns": profiles,
-            }
-
         except Exception:
             return None
+
+        profiles = []
+        for col in cols:
+            try:
+                if self._is_complex_type_column(col):
+                    profile = self._profile_complex_type_column(col, total_count)
+                else:
+                    profile = self._profile_standard_column(col, total_count)
+                if profile:
+                    profiles.append(profile)
+            except Exception:
+                continue
+
+        return {
+            "computed_at": datetime.now(timezone.utc).isoformat(),
+            "columns": profiles,
+        }
+
+    def _profile_standard_column(self, col: dict, total_count: int) -> dict[str, Any] | None:
+        col_type = self._normalize_type(col["type"])
+        is_numeric = self._is_numeric_stats_column(col)
+        is_date = any(t in col_type.lower() for t in ("date", "timestamp", "time"))
+
+        query = self._build_profiling_query(col)
+        row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
+        if not row:
+            return None
+
+        profile = self._parse_profiling_row(row, col, total_count)
+
+        distinct_count = profile["distinct_count"]
+        if distinct_count and distinct_count <= 50 and not is_numeric and not is_date:
+            top_vals = self._fetch_top_values(col)
+            if top_vals:
+                profile["top_values"] = top_vals
+
+        return profile
+
+    def _profile_complex_type_column(self, col: dict, total_count: int) -> dict[str, Any] | None:
+        """Profile a complex type column (array, struct, map, json, tuple, variant, …).
+
+        Always computes null_count. Then enriches with distinct_count and top_values
+        following this priority:
+          1. array type  + _array_unnest_join → element-level distinct count + top values via UNNEST
+          2. any complex + _cast_complex_to_string → distinct count + top values via string cast
+          3. otherwise   → null_count only
+        """
+        col_sql = self._quote(col["name"])
+        col_type = col["type"].lower()
+        table_sql = f"{self._quote(self._schema)}.{self._quote(self._table_name)}"
+        partition_filter = self._partition_filter()
+        where_clause = f"WHERE {partition_filter}" if partition_filter else ""
+
+        query = f"SELECT {self._null_count_sql(col_sql)} AS null_count FROM {table_sql} {where_clause}".strip()
+        row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
+        if not row:
+            return None
+
+        null_count = int(row[0] or 0)
+        profile: dict[str, Any] = {
+            "column": col["name"],
+            "type": self._normalize_type(col["type"]),
+            "total_count": total_count,
+            "null_count": null_count,
+            "null_percentage": round(null_count / total_count * 100, 2) if total_count else None,
+            "distinct_count": None,
+        }
+
+        unnest_from = self._array_unnest_join(table_sql, col_sql, "val") if self._is_array_type(col_type) else None
+
+        if unnest_from:
+            base_conditions = [partition_filter] if partition_filter else []
+            base_where = f"WHERE {' AND '.join(base_conditions)}" if base_conditions else ""
+            val_where = "WHERE " + " AND ".join(base_conditions + ["val IS NOT NULL"])
+            try:
+                row = self._fetchone(
+                    self._conn.raw_sql(  # type: ignore[union-attr]
+                        f"SELECT COUNT(DISTINCT val) FROM {unnest_from} {base_where}".strip()
+                    )
+                )
+                if row and row[0] is not None:
+                    profile["distinct_count"] = int(row[0])
+            except Exception:
+                pass
+            if profile["distinct_count"] and profile["distinct_count"] <= 50:
+                try:
+                    rows = self._fetchall(
+                        self._conn.raw_sql(  # type: ignore[union-attr]
+                            f"SELECT val, COUNT(*) AS cnt FROM {unnest_from} {val_where} "
+                            f"GROUP BY val ORDER BY cnt DESC, val ASC LIMIT 10".strip()
+                        )
+                    )
+                    top_vals = [
+                        {"value": self._json_safe_value(r[0]), "count": int(r[1])} for r in rows if r[0] is not None
+                    ]
+                    if top_vals:
+                        profile["top_values"] = top_vals
+                except Exception:
+                    pass
+        else:
+            string_expr = self._cast_complex_to_string(col_sql)
+            if string_expr:
+                try:
+                    row = self._fetchone(
+                        self._conn.raw_sql(  # type: ignore[union-attr]
+                            f"SELECT COUNT(DISTINCT {string_expr}) FROM {table_sql} {where_clause}".strip()
+                        )
+                    )
+                    if row and row[0] is not None:
+                        profile["distinct_count"] = int(row[0])
+                except Exception:
+                    pass
+                if profile["distinct_count"] and profile["distinct_count"] <= 50:
+                    try:
+                        conditions = [partition_filter] if partition_filter else []
+                        conditions.append(f"{string_expr} IS NOT NULL")
+                        top_where = "WHERE " + " AND ".join(conditions)
+                        rows = self._fetchall(
+                            self._conn.raw_sql(  # type: ignore[union-attr]
+                                f"SELECT {string_expr} AS val, COUNT(*) AS cnt FROM {table_sql} {top_where} "
+                                f"GROUP BY {string_expr} ORDER BY COUNT(*) DESC, {string_expr} ASC LIMIT 10".strip()
+                            )
+                        )
+                        top_vals = [
+                            {"value": self._json_safe_value(r[0]), "count": int(r[1])} for r in rows if r[0] is not None
+                        ]
+                        if top_vals:
+                            profile["top_values"] = top_vals
+                    except Exception:
+                        pass
+
+        return profile
 
     # ─── SQL primitives ───────────────────────────────────────────────────────
 
@@ -148,6 +252,14 @@ class DatabaseContext:
     def _distinct_count_sql(self, col_sql: str) -> str:
         """How to express COUNT(DISTINCT col) — overridable for MSSQL."""
         return f"COUNT(DISTINCT {col_sql})"
+
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str | None:
+        """Return the FROM clause for unnesting an array column, or None if unsupported."""
+        return None
+
+    def _cast_complex_to_string(self, col_sql: str) -> str | None:
+        """Return an expression casting a complex type to string for distinct count, or None if unsupported."""
+        return None
 
     def _null_count_sql(self, col_sql: str) -> str:
         return f"COUNT(*) - COUNT({col_sql})"
@@ -292,6 +404,17 @@ class DatabaseContext:
         if normalized == "int64":
             return "int32"
         return normalized
+
+    @staticmethod
+    def _is_complex_type_column(col: dict) -> bool:
+        """Return True for column types that require specialised profiling."""
+        col_type = col["type"].lower()
+        return col_type.startswith(("array", "struct", "map", "json", "row", "tuple", "variant", "object", "super"))
+
+    @staticmethod
+    def _is_array_type(col_type: str) -> bool:
+        """Return True only for array types — the only ones where element-level unnesting applies."""
+        return col_type.startswith("array")
 
     @staticmethod
     def _is_numeric_stats_column(col: dict) -> bool:

--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -76,6 +76,12 @@ class DatabricksDatabaseContext(DatabaseContext):
             return f"`{cols[0]}` >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
         return ""
 
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
+        return f"{table_sql} LATERAL VIEW EXPLODE({col_sql}) _tmp AS {alias}"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"CAST({col_sql} AS STRING)"
+
 
 def _get_databricks_partition_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
     query = f"""

--- a/cli/nao_core/config/databases/duckdb.py
+++ b/cli/nao_core/config/databases/duckdb.py
@@ -11,6 +11,12 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
+from .context import DatabaseContext
+
+
+class DuckDBDatabaseContext(DatabaseContext):
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"CAST({col_sql} AS VARCHAR)"
 
 
 class DuckDBConfig(DatabaseConfig):
@@ -57,3 +63,6 @@ class DuckDBConfig(DatabaseConfig):
         finally:
             if conn is not None:
                 conn.disconnect()
+
+    def create_context(self, conn: BaseBackend, schema: str, table_name: str) -> DuckDBDatabaseContext:
+        return DuckDBDatabaseContext(conn, schema, table_name)

--- a/cli/nao_core/config/databases/postgres.py
+++ b/cli/nao_core/config/databases/postgres.py
@@ -59,6 +59,9 @@ class PostgresDatabaseContext(DatabaseContext):
     def _cast_float(self, expr: str) -> str:
         return f"CAST({expr} AS DOUBLE PRECISION)"
 
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"{col_sql}::TEXT"
+
 
 class PostgresConfig(DatabaseConfig):
     """PostgreSQL-specific configuration."""

--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -73,6 +73,7 @@ class RedshiftDatabaseContext(DatabaseContext):
             "date": "date",
             "timestamp without time zone": "timestamp",
             "timestamp with time zone": "timestamp",
+            "super": "super",
         }
 
         ibis_type = type_map.get(data_type, "string")
@@ -141,6 +142,9 @@ class RedshiftDatabaseContext(DatabaseContext):
 
     def _cast_float(self, expr: str) -> str:
         return f"{expr}::float"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"JSON_SERIALIZE({col_sql})"
 
 
 class RedshiftSSHTunnelConfig(BaseModel):

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -65,6 +65,9 @@ class SnowflakeDatabaseContext(DatabaseContext):
     def _cast_float(self, expr: str) -> str:
         return f"{expr}::FLOAT"
 
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"TO_JSON({col_sql})::VARCHAR"
+
     def _partition_filter(self) -> str:
         cols = self.partition_columns()
         if cols:

--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -29,6 +29,12 @@ def _is_excluded_schema(value: object) -> bool:
 
 
 class TrinoDatabaseContext(DatabaseContext):
+    def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
+        return f"{table_sql} CROSS JOIN UNNEST({col_sql}) AS t({alias})"
+
+    def _cast_complex_to_string(self, col_sql: str) -> str:
+        return f"CAST({col_sql} AS VARCHAR)"
+
     def _stddev(self, expr: str) -> str:
         return f"STDDEV_POP({expr})"
 

--- a/cli/tests/nao_core/commands/sync/test_context_profiling_query.py
+++ b/cli/tests/nao_core/commands/sync/test_context_profiling_query.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from nao_core.config.databases.athena import AthenaDatabaseContext
 from nao_core.config.databases.bigquery import BigQueryDatabaseContext
 from nao_core.config.databases.context import DatabaseContext
@@ -9,6 +11,7 @@ from nao_core.config.databases.databricks import DatabricksDatabaseContext
 from nao_core.config.databases.mssql import MssqlDatabaseContext
 from nao_core.config.databases.redshift import RedshiftDatabaseContext
 from nao_core.config.databases.snowflake import SnowflakeDatabaseContext
+from nao_core.config.databases.trino import TrinoDatabaseContext
 
 
 def make_context(cls, schema="my_schema", table="my_table", partition_cols=None):
@@ -30,6 +33,9 @@ INT_COL = {"name": "id", "type": "int32"}
 STR_COL = {"name": "status", "type": "string"}
 FLOAT_COL = {"name": "amount", "type": "float64"}
 DATE_COL = {"name": "created_at", "type": "date"}
+ARRAY_COL = {"name": "tags", "type": "array<string>"}
+STRUCT_COL = {"name": "meta", "type": "struct<x: int>"}
+JSON_COL = {"name": "props", "type": "json"}
 
 
 class TestBaseProfilingQuery:
@@ -86,6 +92,101 @@ class TestBaseProfilingQuery:
             FROM "my_schema"."my_table"
         """)
         assert normalize(sql) == expected
+
+
+class TestComplexTypeDetection:
+    @pytest.mark.parametrize(
+        "col_type",
+        [
+            "array<string>",
+            "struct<x: int>",
+            "map<string, int>",
+            "json",
+            "row(x int)",
+            "tuple(string, int)",
+            "variant",
+            "object",
+            "super",
+        ],
+    )
+    def test_is_complex(self, col_type):
+        assert DatabaseContext._is_complex_type_column({"type": col_type})
+
+    @pytest.mark.parametrize("col_type", ["string", "int32", "float64", "date", "timestamp"])
+    def test_is_not_complex(self, col_type):
+        assert not DatabaseContext._is_complex_type_column({"type": col_type})
+
+    @pytest.mark.parametrize("col_type", ["array<string>", "array<int>"])
+    def test_is_array(self, col_type):
+        assert DatabaseContext._is_array_type(col_type)
+
+    @pytest.mark.parametrize("col_type", ["struct<x: int>", "map<string, int>", "json", "variant"])
+    def test_is_not_array(self, col_type):
+        assert not DatabaseContext._is_array_type(col_type)
+
+
+class TestComplexTypePrimitives:
+    def test_bigquery_array_unnest(self):
+        ctx = make_context(BigQueryDatabaseContext)
+        result = ctx._array_unnest_join("`s`.`t`", "`tags`", "val")
+        assert result == "`s`.`t`, UNNEST(`tags`) AS val"
+
+    def test_bigquery_cast_to_string(self):
+        ctx = make_context(BigQueryDatabaseContext)
+        assert ctx._cast_complex_to_string("`props`") == "TO_JSON_STRING(`props`)"
+
+    def test_databricks_array_unnest(self):
+        ctx = make_context(DatabricksDatabaseContext)
+        result = ctx._array_unnest_join("`s`.`t`", "`tags`", "val")
+        assert "LATERAL VIEW EXPLODE" in result
+
+    def test_trino_array_unnest(self):
+        ctx = make_context(TrinoDatabaseContext)
+        result = ctx._array_unnest_join('"s"."t"', '"tags"', "val")
+        assert "CROSS JOIN UNNEST" in result
+
+    def test_base_returns_none(self):
+        ctx = make_context(DatabaseContext)
+        assert ctx._array_unnest_join("t", "c", "v") is None
+        assert ctx._cast_complex_to_string("c") is None
+
+
+class TestProfileComplexTypeColumn:
+    def _make_ctx_with_mock_sql(self, cls, fetchone_val, fetchall_val=None):
+        ctx = make_context(cls)
+        ctx._fetchone = MagicMock(return_value=fetchone_val)
+        ctx._fetchall = MagicMock(return_value=fetchall_val or [])
+        ctx._conn.raw_sql = MagicMock(return_value=MagicMock())
+        return ctx
+
+    def test_array_col_uses_unnest_branch(self):
+        ctx = self._make_ctx_with_mock_sql(
+            BigQueryDatabaseContext,
+            fetchone_val=(0,),  # null_count, puis distinct_count
+        )
+        ctx._fetchone.side_effect = [(0,), (42,)]  # null_count=0, distinct=42
+        profile = ctx._profile_complex_type_column(ARRAY_COL, 1000)
+        assert profile["distinct_count"] == 42
+        calls = [str(c) for c in ctx._conn.raw_sql.call_args_list]
+        assert any("UNNEST" in c for c in calls)
+
+    def test_struct_col_uses_cast_branch(self):
+        ctx = self._make_ctx_with_mock_sql(
+            BigQueryDatabaseContext,
+            fetchone_val=(0,),
+        )
+        ctx._fetchone.side_effect = [(0,), (10,)]
+        ctx._profile_complex_type_column(STRUCT_COL, 1000)
+        calls = [str(c) for c in ctx._conn.raw_sql.call_args_list]
+        assert any("TO_JSON_STRING" in c for c in calls)
+        assert any("UNNEST" not in c for c in calls)
+
+    def test_base_context_returns_null_count_only(self):
+        ctx = self._make_ctx_with_mock_sql(DatabaseContext, fetchone_val=(5,))
+        profile = ctx._profile_complex_type_column(JSON_COL, 100)
+        assert profile["null_count"] == 5
+        assert profile["distinct_count"] is None
+        assert "top_values" not in profile
 
 
 class TestMssqlProfilingQuery:


### PR DESCRIPTION
## Summary

- Add robust profiling support for complex column types (`array`, `struct`, `map`, `json`, `row`, `tuple`, `variant`, `object`, `super`) across all supported warehouses
- Basically, unpack all values from `array` types then get their distinct count and optional top values AND convert other complex types values into string one
- Add unit tests support

## Related issue

#542 