### PR TITLE
resolve bug

### DIFF
--- a/apps/frontend/src/components/settings/chats-replay-panel.tsx
+++ b/apps/frontend/src/components/settings/chats-replay-panel.tsx
@@ -107,7 +107,10 @@ export function ChatsReplayPanel({ chatInfo, onClose }: ChatsReplayPanelProps) {
 					<div className='flex-1 overflow-auto p-4 text-sm text-destructive'>Failed to load chat.</div>
 				) : chatReplayQuery.data ? (
 					<ChatViewProvider expandOnError={true}>
-						<ReadonlyAgentMessagesProvider messages={chatReplayQuery.data.messages}>
+						<ReadonlyAgentMessagesProvider
+							messages={chatReplayQuery.data.messages}
+							chatId={chatInfo.chatId}
+						>
 							<SidePanelProvider
 								isVisible={sidePanel.isVisible}
 								currentStoryId={sidePanel.currentStoryId}


### PR DESCRIPTION
## Summary

Give read only provider chat message the chatId so the story can be load as expected.

## Related issue

#553 