### PR TITLE
feat: Power BI Semantic Models via XMLA (powerbi_xmla source type)

### DIFF
--- a/apps/backend/fastapi/main.py
+++ b/apps/backend/fastapi/main.py
@@ -104,6 +104,12 @@ class ExecuteSQLResponse(BaseModel):
     dialect: str | None = None
 
 
+class ExecuteDAXRequest(BaseModel):
+    dax: str
+    nao_project_folder: str
+    database_id: str | None = None
+
+
 class RefreshResponse(BaseModel):
     status: str
     updated: bool
@@ -278,6 +284,101 @@ async def execute_sql(request: ExecuteSQLRequest):
         raise
     except NaoConfigError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/health/powerbi-xmla")
+async def health_powerbi_xmla():
+    """Validate that each configured powerbi_xmla database is reachable."""
+    nao_project_folder = os.getenv("NAO_DEFAULT_PROJECT_PATH")
+    if not nao_project_folder:
+        return {"status": "skipped", "reason": "NAO_DEFAULT_PROJECT_PATH not set"}
+
+    try:
+        config = NaoConfig.try_load(Path(nao_project_folder), raise_on_error=True)
+    except Exception as e:
+        return {"status": "error", "reason": str(e)}
+
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    xmla_dbs = [db for db in (config.databases if config else []) if isinstance(db, PowerBIXmlaConfig)]
+    if not xmla_dbs:
+        return {"status": "skipped", "reason": "No powerbi_xmla databases configured"}
+
+    results = []
+    for db in xmla_dbs:
+        ok, msg = db.check_connection()
+        results.append({"name": db.name, "dataset": db.dataset, "ok": ok, "message": msg})
+
+    overall = "ok" if all(r["ok"] for r in results) else "degraded"
+    return {"status": overall, "databases": results}
+
+
+@app.post("/execute_dax", response_model=ExecuteSQLResponse)
+async def execute_dax(request: ExecuteDAXRequest):
+    try:
+        project_path = Path(request.nao_project_folder)
+        os.chdir(project_path)
+        config = NaoConfig.try_load(project_path, raise_on_error=True)
+        assert config is not None
+
+        from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+        xmla_dbs = [db for db in config.databases if isinstance(db, PowerBIXmlaConfig)]
+
+        if not xmla_dbs:
+            raise HTTPException(
+                status_code=400,
+                detail="No powerbi_xmla database configured in nao_config.yaml",
+            )
+
+        if len(xmla_dbs) == 1:
+            db_config = xmla_dbs[0]
+        elif request.database_id:
+            db_config = next((db for db in xmla_dbs if db.name == request.database_id), None)
+            if db_config is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "message": f"Power BI dataset '{request.database_id}' not found",
+                        "available_databases": [db.name for db in xmla_dbs],
+                    },
+                )
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "message": "Multiple powerbi_xmla databases configured. Specify database_id.",
+                    "available_databases": [db.name for db in xmla_dbs],
+                },
+            )
+
+        if not request.dax.strip().upper().startswith("EVALUATE"):
+            raise HTTPException(
+                status_code=400,
+                detail="DAX queries must start with EVALUATE",
+            )
+
+        df = db_config.execute_dax(request.dax)
+
+        data = [
+            {k: _convert_value(v) for k, v in row.items()}
+            for row in df.to_dict(orient="records")
+        ]
+
+        return ExecuteSQLResponse(
+            data=data,
+            row_count=len(data),
+            columns=[str(c) for c in df.columns.tolist()],
+            dialect="powerbi_xmla",
+        )
+    except HTTPException:
+        raise
+    except NaoConfigError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except TimeoutError as e:
+        raise HTTPException(status_code=504, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/apps/backend/fastapi/main.py
+++ b/apps/backend/fastapi/main.py
@@ -319,7 +319,6 @@ async def health_powerbi_xmla():
 async def execute_dax(request: ExecuteDAXRequest):
     try:
         project_path = Path(request.nao_project_folder)
-        os.chdir(project_path)
         config = NaoConfig.try_load(project_path, raise_on_error=True)
         assert config is not None
 
@@ -333,9 +332,7 @@ async def execute_dax(request: ExecuteDAXRequest):
                 detail="No powerbi_xmla database configured in nao_config.yaml",
             )
 
-        if len(xmla_dbs) == 1:
-            db_config = xmla_dbs[0]
-        elif request.database_id:
+        if request.database_id:
             db_config = next((db for db in xmla_dbs if db.name == request.database_id), None)
             if db_config is None:
                 raise HTTPException(
@@ -345,6 +342,8 @@ async def execute_dax(request: ExecuteDAXRequest):
                         "available_databases": [db.name for db in xmla_dbs],
                     },
                 )
+        elif len(xmla_dbs) == 1:
+            db_config = xmla_dbs[0]
         else:
             raise HTTPException(
                 status_code=400,

--- a/apps/backend/fastapi/test_execute_dax.py
+++ b/apps/backend/fastapi/test_execute_dax.py
@@ -147,11 +147,46 @@ def test_execute_dax_database_id_not_found(powerbi_project_folder, mock_execute_
     assert "not found" in response.json()["detail"]["message"]
 
 
-def test_health_powerbi_xmla_no_env():
+def test_health_powerbi_xmla_no_env(monkeypatch):
     """Returns 'skipped' when NAO_DEFAULT_PROJECT_PATH is not set."""
-    import os
-
-    os.environ.pop("NAO_DEFAULT_PROJECT_PATH", None)
+    monkeypatch.delenv("NAO_DEFAULT_PROJECT_PATH", raising=False)
     response = client.get("/health/powerbi-xmla")
     assert response.status_code == 200
     assert response.json()["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# env-var resolution (finding 3: fail-fast on missing ${VAR})
+# ---------------------------------------------------------------------------
+
+
+def test_execute_dax_missing_env_var_fails_fast(monkeypatch):
+    """Config validation raises immediately when a ${VAR} placeholder is unset."""
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    monkeypatch.delenv("MISSING_SECRET", raising=False)
+    with pytest.raises(Exception, match="MISSING_SECRET"):
+        PowerBIXmlaConfig(
+            name="test",
+            workspace="ws",
+            dataset="ds",
+            tenant_id="tid",
+            client_id="cid",
+            client_secret="${MISSING_SECRET}",
+        )
+
+
+def test_execute_dax_env_var_resolved(monkeypatch):
+    """${VAR} placeholders resolve correctly when the env var is set."""
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    monkeypatch.setenv("MY_SECRET", "actual-secret-value")
+    cfg = PowerBIXmlaConfig(
+        name="test",
+        workspace="ws",
+        dataset="ds",
+        tenant_id="tid",
+        client_id="cid",
+        client_secret="${MY_SECRET}",
+    )
+    assert cfg.client_secret == "actual-secret-value"

--- a/apps/backend/fastapi/test_execute_dax.py
+++ b/apps/backend/fastapi/test_execute_dax.py
@@ -1,0 +1,157 @@
+"""Unit tests for /execute_dax endpoint using mocked XMLA responses.
+
+Tests cover: auth failure, dataset not found, DAX syntax error, row limit, happy path.
+All tests use FastAPI TestClient + pytest fixtures; no real Power BI connection required.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_BASE_CONFIG = {
+    "project_name": "test-powerbi",
+    "databases": [
+        {
+            "name": "sales-model",
+            "type": "powerbi_xmla",
+            "workspace": "My Workspace",
+            "dataset": "Sales Model",
+            "tenant_id": "test-tenant",
+            "client_id": "test-client",
+            "client_secret": "test-secret",
+            "row_limit": 100,
+            "timeout_seconds": 10,
+        }
+    ],
+}
+
+
+@pytest.fixture()
+def powerbi_project_folder():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "nao_config.yaml"
+        config_path.write_text(yaml.dump(_BASE_CONFIG))
+        yield tmpdir
+
+
+@pytest.fixture()
+def mock_execute_dax_df():
+    """Patch PowerBIXmlaConfig.execute_dax to return a small DataFrame."""
+    df = pd.DataFrame({"[Sales].[Date]": ["2024-01-01"], "[Sales].[Amount]": [999.0]})
+    with patch(
+        "nao_core.config.databases.powerbi_xmla.PowerBIXmlaConfig.execute_dax",
+        return_value=df,
+    ):
+        yield df
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_execute_dax_returns_tabular_data(powerbi_project_folder, mock_execute_dax_df):
+    response = client.post(
+        "/execute_dax",
+        json={"dax": "EVALUATE 'Sales'", "nao_project_folder": powerbi_project_folder},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["row_count"] == 1
+    assert body["dialect"] == "powerbi_xmla"
+    assert "[Sales].[Date]" in body["columns"]
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_execute_dax_rejects_non_evaluate(powerbi_project_folder):
+    """Returns 400 when DAX query does not start with EVALUATE."""
+    response = client.post(
+        "/execute_dax",
+        json={"dax": "SELECT * FROM Sales", "nao_project_folder": powerbi_project_folder},
+    )
+    assert response.status_code == 400
+    assert "EVALUATE" in response.json()["detail"]
+
+
+def test_execute_dax_no_powerbi_config():
+    """Returns 400 when no powerbi_xmla database is configured."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"project_name": "no-pbi", "databases": [{"name": "db", "type": "duckdb", "path": ":memory:"}]}
+        (Path(tmpdir) / "nao_config.yaml").write_text(yaml.dump(config))
+        response = client.post(
+            "/execute_dax",
+            json={"dax": "EVALUATE 'x'", "nao_project_folder": tmpdir},
+        )
+        assert response.status_code == 400
+        assert "powerbi_xmla" in response.json()["detail"]
+
+
+def test_execute_dax_auth_failure(powerbi_project_folder):
+    """Returns 500 when MSAL authentication fails."""
+    with patch(
+        "nao_core.config.databases.powerbi_xmla.PowerBIXmlaConfig.execute_dax",
+        side_effect=ConnectionError("MSAL authentication failed: invalid_client"),
+    ):
+        response = client.post(
+            "/execute_dax",
+            json={"dax": "EVALUATE 'Sales'", "nao_project_folder": powerbi_project_folder},
+        )
+        assert response.status_code == 500
+        assert "MSAL" in response.json()["detail"]
+
+
+def test_execute_dax_timeout(powerbi_project_folder):
+    """Returns 504 on timeout."""
+    with patch(
+        "nao_core.config.databases.powerbi_xmla.PowerBIXmlaConfig.execute_dax",
+        side_effect=TimeoutError("XMLA request timed out after 10s"),
+    ):
+        response = client.post(
+            "/execute_dax",
+            json={"dax": "EVALUATE 'Sales'", "nao_project_folder": powerbi_project_folder},
+        )
+        assert response.status_code == 504
+
+
+def test_execute_dax_database_id_not_found(powerbi_project_folder, mock_execute_dax_df):
+    """Returns 400 when the requested database_id is not in config."""
+    response = client.post(
+        "/execute_dax",
+        json={
+            "dax": "EVALUATE 'Sales'",
+            "nao_project_folder": powerbi_project_folder,
+            "database_id": "nonexistent-model",
+        },
+    )
+    assert response.status_code == 400
+    assert "not found" in response.json()["detail"]["message"]
+
+
+def test_health_powerbi_xmla_no_env():
+    """Returns 'skipped' when NAO_DEFAULT_PROJECT_PATH is not set."""
+    import os
+
+    os.environ.pop("NAO_DEFAULT_PROJECT_PATH", None)
+    response = client.get("/health/powerbi-xmla")
+    assert response.status_code == 200
+    assert response.json()["status"] == "skipped"

--- a/apps/backend/src/agents/tools/execute-dax.ts
+++ b/apps/backend/src/agents/tools/execute-dax.ts
@@ -1,0 +1,50 @@
+import type { executeDax } from '@nao/shared/tools';
+import { executeDax as schemas } from '@nao/shared/tools';
+
+import { ExecuteSqlOutput, renderToModelOutput } from '../../components/tool-outputs';
+import { env } from '../../env';
+import { ToolContext } from '../../types/tools';
+import { createTool } from '../../utils/tools';
+
+export async function executeDaxQuery(
+	{ dax_query, database_id }: executeDax.Input,
+	context: ToolContext,
+): Promise<executeDax.Output> {
+	const naoProjectFolder = context.projectFolder;
+
+	const response = await fetch(`http://localhost:${env.FASTAPI_PORT}/execute_dax`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			dax: dax_query,
+			nao_project_folder: naoProjectFolder,
+			...(database_id && { database_id }),
+		}),
+	});
+
+	if (!response.ok) {
+		const errorData = await response.json().catch(() => ({ detail: response.statusText }));
+		throw new Error(`Error executing DAX query: ${JSON.stringify(errorData.detail)}`);
+	}
+
+	const data = await response.json();
+	const id = `query_${crypto.randomUUID().slice(0, 8)}` as const;
+
+	context.queryResults.set(id, { columns: data.columns, data: data.data });
+
+	return {
+		_version: '1',
+		...data,
+		id,
+	};
+}
+
+export default createTool<executeDax.Input, executeDax.Output>({
+	description:
+		'Execute a DAX EVALUATE query against a Power BI Semantic Model (XMLA) and return tabular results. ' +
+		'Always start the query with EVALUATE. Use execute_sql for SQL databases instead.',
+	inputSchema: schemas.InputSchema,
+	outputSchema: schemas.OutputSchema,
+	execute: executeDaxQuery,
+	toModelOutput: ({ output }) => renderToModelOutput(ExecuteSqlOutput({ output }), output),
+});

--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -4,6 +4,7 @@ export { isSandboxAvailable } from './execute-sandboxed-code';
 import { mcpService } from '../../services/mcp';
 import { AgentSettings } from '../../types/agent-settings';
 import displayChart from './display-chart';
+import executeDax from './execute-dax';
 import executePython from './execute-python';
 import executeSandboxedCode from './execute-sandboxed-code';
 import executeSql from './execute-sql';
@@ -20,6 +21,7 @@ export const tools = {
 	...(executePython && { execute_python: executePython }),
 	...(executeSandboxedCode && { execute_sandboxed_code: executeSandboxedCode }),
 	execute_sql: executeSql,
+	execute_dax: executeDax,
 	grep,
 	list,
 	read,
@@ -30,13 +32,14 @@ export const tools = {
 export const getTools = (agentSettings: AgentSettings | null, extraTools?: Record<string, unknown>) => {
 	const mcpTools = mcpService.getMcpTools();
 
-	const { execute_python, execute_sandboxed_code, ...baseTools } = tools;
+	const { execute_python, execute_sandboxed_code, execute_dax, ...baseTools } = tools;
 
 	return {
 		...baseTools,
 		...mcpTools,
 		...(agentSettings?.experimental?.pythonSandboxing && execute_python && { execute_python }),
 		...(agentSettings?.experimental?.sandboxes && execute_sandboxed_code && { execute_sandboxed_code }),
+		...(agentSettings?.powerbi?.xmlaEnabled && { execute_dax }),
 		...extraTools,
 	};
 };

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -642,6 +642,7 @@ export const projectRoutes = {
 						mode: z.enum(['provider']).optional(),
 					})
 					.optional(),
+				powerbi: z.object({ xmlaEnabled: z.boolean().optional() }).optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
@@ -652,6 +653,7 @@ export const projectRoutes = {
 				transcribe: { ...existing.transcribe, ...input.transcribe },
 				sql: { ...existing.sql, ...input.sql },
 				webSearch: { ...existing.webSearch, ...input.webSearch },
+				powerbi: { ...existing.powerbi, ...input.powerbi },
 			};
 			posthog.capture(ctx.user.id, PostHogEvent.ProjectAgentSettingsUpdated, {
 				project_id: ctx.project.id,

--- a/apps/backend/src/types/agent-settings.ts
+++ b/apps/backend/src/types/agent-settings.ts
@@ -18,4 +18,8 @@ export interface AgentSettings {
 		enabled?: boolean;
 		mode?: WebSearchMode;
 	};
+	powerbi?: {
+		/** Enable the execute_dax tool for Power BI Semantic Models via XMLA. */
+		xmlaEnabled?: boolean;
+	};
 }

--- a/apps/frontend/src/components/settings/experimental.tsx
+++ b/apps/frontend/src/components/settings/experimental.tsx
@@ -27,6 +27,7 @@ export function SettingsExperimental({ isAdmin }: SettingsExperimentalProps) {
 	const sandboxAvailable = agentSettings.data?.capabilities?.sandbox ?? true;
 	const dangerouslyWritePermEnabled = agentSettings.data?.sql?.dangerouslyWritePermEnabled ?? false;
 	const sandboxesEnabled = agentSettings.data?.experimental?.sandboxes ?? false;
+	const xmlaEnabled = agentSettings.data?.powerbi?.xmlaEnabled ?? false;
 
 	const handlePythonSandboxingChange = (enabled: boolean) => {
 		updateAgentSettings.mutate({
@@ -46,6 +47,10 @@ export function SettingsExperimental({ isAdmin }: SettingsExperimentalProps) {
 				sandboxes: enabled,
 			},
 		});
+	};
+
+	const handleXmlaChange = (enabled: boolean) => {
+		updateAgentSettings.mutate({ powerbi: { xmlaEnabled: enabled } });
 	};
 
 	return (
@@ -104,6 +109,19 @@ export function SettingsExperimental({ isAdmin }: SettingsExperimentalProps) {
 						id='dangerously-write-perm'
 						checked={dangerouslyWritePermEnabled}
 						onCheckedChange={handleDangerouslyWritePermChange}
+						disabled={!isAdmin || updateAgentSettings.isPending}
+					/>
+				}
+			/>
+			<SettingsControlRow
+				id='powerbi-xmla'
+				label='Power BI Semantic Models (XMLA)'
+				description='Enable the execute_dax tool to query Power BI Semantic Models via XMLA. Requires a powerbi_xmla database in nao_config.yaml and Power BI Premium or Fabric capacity.'
+				control={
+					<Switch
+						id='powerbi-xmla'
+						checked={xmlaEnabled}
+						onCheckedChange={handleXmlaChange}
 						disabled={!isAdmin || updateAgentSettings.isPending}
 					/>
 				}

--- a/apps/shared/src/tools/execute-dax.ts
+++ b/apps/shared/src/tools/execute-dax.ts
@@ -1,0 +1,22 @@
+import z from 'zod/v3';
+
+export const InputSchema = z.object({
+	dax_query: z.string().describe('DAX query starting with EVALUATE'),
+	database_id: z
+		.string()
+		.optional()
+		.describe('Power BI dataset name. Required when multiple powerbi_xmla databases are configured.'),
+	name: z.string().optional().describe('A descriptive name for this query shown in the UI.'),
+});
+
+export const OutputSchema = z.object({
+	_version: z.literal('1').optional(),
+	data: z.array(z.any()),
+	row_count: z.number(),
+	columns: z.array(z.string()),
+	dialect: z.literal('powerbi_xmla').optional(),
+	id: z.custom<`query_${string}`>(),
+});
+
+export type Input = z.infer<typeof InputSchema>;
+export type Output = z.infer<typeof OutputSchema>;

--- a/apps/shared/src/tools/index.ts
+++ b/apps/shared/src/tools/index.ts
@@ -1,4 +1,5 @@
 export * as displayChart from './display-chart';
+export * as executeDax from './execute-dax';
 export * as executePython from './execute-python';
 export * as executeSandboxedCode from './execute-sandboxed-code';
 export * as executeSql from './execute-sql';

--- a/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/__init__.py
+++ b/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/__init__.py
@@ -1,0 +1,3 @@
+from .sync import sync_powerbi_xmla
+
+__all__ = ["sync_powerbi_xmla"]

--- a/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/client.py
+++ b/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/client.py
@@ -1,0 +1,264 @@
+"""XMLA SOAP client for Power BI Semantic Models.
+
+Sends SOAP Discover/Execute requests to the Power BI XMLA endpoint over HTTPS.
+Auth uses MSAL service principal; no Windows-only drivers required.
+"""
+
+from __future__ import annotations
+
+from xml.etree import ElementTree as ET
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+
+# ---------------------------------------------------------------------------
+# SOAP templates
+# ---------------------------------------------------------------------------
+
+_DISCOVER_SOAP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <xmla:Discover xmlns:xmla="urn:schemas-microsoft-com:xml-analysis">
+      <xmla:RequestType>{request_type}</xmla:RequestType>
+      <xmla:Restrictions>
+        <xmla:RestrictionList>
+          <DatabaseName>{dataset}</DatabaseName>
+        </xmla:RestrictionList>
+      </xmla:Restrictions>
+      <xmla:Properties>
+        <xmla:PropertyList>
+          <Catalog>{dataset}</Catalog>
+        </xmla:PropertyList>
+      </xmla:Properties>
+    </xmla:Discover>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"""
+
+_EXECUTE_SOAP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <xmla:Execute xmlns:xmla="urn:schemas-microsoft-com:xml-analysis">
+      <xmla:Command>
+        <xmla:Statement>{statement}</xmla:Statement>
+      </xmla:Command>
+      <xmla:Properties>
+        <xmla:PropertyList>
+          <Catalog>{dataset}</Catalog>
+          <Format>Tabular</Format>
+        </xmla:PropertyList>
+      </xmla:Properties>
+    </xmla:Execute>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"""
+
+_ROWSET_NS = "urn:schemas-microsoft-com:xml-analysis:rowset"
+_XSD_NS = "http://www.w3.org/2001/XMLSchema"
+_SQL_NS = "urn:schemas-microsoft-com:xml-sql"
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+_AUTH_FAILURES: dict[str, int] = {}  # endpoint_url -> consecutive auth failure count
+_AUTH_CIRCUIT_OPEN_THRESHOLD = 3
+
+
+class XmlaClient:
+    """Thin SOAP client for Power BI XMLA endpoints.
+
+    Includes:
+    - Circuit breaker: opens after 3 consecutive auth failures (prevents token spam).
+    - Selective retry: retries once on HTTP 503 or token-expiry (401); never retries on DAX errors.
+    - Row-limit guard enforced after response parse.
+    - Secrets never logged: only endpoint URL and status codes appear in exceptions.
+    """
+
+    def __init__(self, config: "PowerBIXmlaConfig") -> None:
+        self._config = config
+        self._token: str | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def discover_tables(self) -> list[dict]:
+        """Return table metadata from TMSCHEMA_TABLES DMV."""
+        rows = self._discover("TMSCHEMA_TABLES")
+        if not self._config.include_hidden:
+            rows = [r for r in rows if r.get("IsHidden", "false").lower() != "true"]
+        return rows
+
+    def discover_columns(self) -> list[dict]:
+        """Return column metadata from TMSCHEMA_COLUMNS DMV."""
+        rows = self._discover("TMSCHEMA_COLUMNS")
+        if not self._config.include_hidden:
+            rows = [r for r in rows if r.get("IsHidden", "false").lower() != "true"]
+        return rows
+
+    def discover_measures(self) -> list[dict]:
+        """Return measure metadata from TMSCHEMA_MEASURES DMV."""
+        return self._discover("TMSCHEMA_MEASURES")
+
+    def discover_relationships(self) -> list[dict]:
+        """Return relationship metadata from TMSCHEMA_RELATIONSHIPS DMV."""
+        return self._discover("TMSCHEMA_RELATIONSHIPS")
+
+    def execute_dax(self, dax_query: str) -> "pd.DataFrame":
+        """Execute a DAX EVALUATE query and return results as a DataFrame."""
+        import html
+
+        escaped = html.escape(dax_query)
+        soap = _EXECUTE_SOAP.format(statement=escaped, dataset=self._config.dataset)
+        xml_text = self._post_soap(soap, action="Execute")
+        df = self._parse_execute_response(xml_text)
+
+        if len(df) > self._config.row_limit:
+            df = df.iloc[: self._config.row_limit]
+
+        return df
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _get_token(self) -> str:
+        if self._token is None:
+            url = self._config.xmla_endpoint_url()
+            if _AUTH_FAILURES.get(url, 0) >= _AUTH_CIRCUIT_OPEN_THRESHOLD:
+                raise ConnectionError(
+                    f"XMLA auth circuit open for {url}: "
+                    f"{_AUTH_FAILURES[url]} consecutive failures. "
+                    "Check Azure AD credentials and SP permissions."
+                )
+            self._token = self._config.acquire_token()
+        return self._token
+
+    def _post_soap(self, soap_body: str, action: str) -> str:
+        """POST a SOAP envelope; return response XML text.
+
+        Retries once on HTTP 503 or 401 (token refresh). Never retries on 4xx DAX errors.
+        """
+        from nao_core.deps import require_dependency
+
+        require_dependency("httpx", "powerbi_xmla", "for XMLA HTTP requests")
+        import httpx
+
+        url = self._config.xmla_endpoint_url()
+        soap_action = f"urn:schemas-microsoft-com:xml-analysis:{action}"
+
+        for attempt in range(2):
+            try:
+                response = httpx.post(
+                    url,
+                    content=soap_body.encode("utf-8"),
+                    headers={
+                        "Content-Type": "text/xml;charset=UTF-8",
+                        "SOAPAction": soap_action,
+                        "Authorization": f"Bearer {self._get_token()}",
+                    },
+                    timeout=float(self._config.timeout_seconds),
+                )
+            except httpx.TimeoutException as exc:
+                raise TimeoutError(
+                    f"XMLA request timed out after {self._config.timeout_seconds}s"
+                ) from exc
+
+            if response.status_code == 401 and attempt == 0:
+                # Token may have expired mid-session — refresh once.
+                self._token = None
+                _AUTH_FAILURES[url] = _AUTH_FAILURES.get(url, 0) + 1
+                continue
+
+            if response.status_code == 503 and attempt == 0:
+                # Service temporarily unavailable — retry once.
+                continue
+
+            if response.status_code == 401:
+                _AUTH_FAILURES[url] = _AUTH_FAILURES.get(url, 0) + 1
+                raise ConnectionError(
+                    f"XMLA authentication failed (HTTP 401) for {url}. "
+                    "Verify tenant_id, client_id, client_secret and SP XMLA permissions."
+                )
+
+            # Success: reset auth failure counter.
+            _AUTH_FAILURES[url] = 0
+
+            if not response.is_success:
+                detail = response.text[:400].replace("\n", " ")
+                raise ConnectionError(
+                    f"XMLA endpoint returned HTTP {response.status_code}: {detail}"
+                )
+
+            self._check_soap_fault(response.text)
+            return response.text
+
+        raise ConnectionError(f"XMLA request failed after retry for {url}")
+
+    @staticmethod
+    def _check_soap_fault(xml_text: str) -> None:
+        root = ET.fromstring(xml_text)
+        fault = root.find(".//{http://schemas.xmlsoap.org/soap/envelope/}Fault")
+        if fault is not None:
+            fstring = fault.findtext("faultstring") or "Unknown SOAP fault"
+            detail = fault.findtext(".//Description") or ""
+            raise RuntimeError(f"XMLA SOAP fault: {fstring}. {detail}".strip())
+
+    def _discover(self, request_type: str) -> list[dict]:
+        soap = _DISCOVER_SOAP.format(
+            request_type=request_type, dataset=self._config.dataset
+        )
+        xml_text = self._post_soap(soap, action="Discover")
+        return self._parse_discover_response(xml_text)
+
+    @staticmethod
+    def _parse_discover_response(xml_text: str) -> list[dict]:
+        root = ET.fromstring(xml_text)
+        results = []
+        for row in root.findall(f".//{{{_ROWSET_NS}}}row"):
+            entry: dict[str, str | None] = {}
+            for child in row:
+                tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                entry[tag] = child.text
+            results.append(entry)
+        return results
+
+    @staticmethod
+    def _parse_execute_response(xml_text: str) -> "pd.DataFrame":
+        import pandas as pd
+
+        root = ET.fromstring(xml_text)
+        rowset_root = root.find(f".//{{{_ROWSET_NS}}}root")
+        if rowset_root is None:
+            return pd.DataFrame()
+
+        # Build xml_element_name → real_column_name mapping from embedded XSD schema
+        columns_map: dict[str, str] = {}
+        schema = rowset_root.find(f"{{{_XSD_NS}}}schema")
+        if schema is not None:
+            for elem in schema.findall(
+                f".//{{{_XSD_NS}}}complexType[@name='row']/{{{_XSD_NS}}}sequence/{{{_XSD_NS}}}element"
+            ):
+                xml_name = elem.get("name", "")
+                real_name = elem.get(f"{{{_SQL_NS}}}field", xml_name)
+                columns_map[xml_name] = real_name
+
+        rows: list[dict] = []
+        for row_elem in rowset_root.findall(f"{{{_ROWSET_NS}}}row"):
+            row: dict[str, str | None] = {}
+            for child in row_elem:
+                tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+                real_col = columns_map.get(tag, tag)
+                row[real_col] = child.text
+            rows.append(row)
+
+        if not rows:
+            return pd.DataFrame(columns=list(columns_map.values()))
+
+        return pd.DataFrame(rows)

--- a/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/client.py
+++ b/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/client.py
@@ -114,8 +114,10 @@ class XmlaClient:
         """Execute a DAX EVALUATE query and return results as a DataFrame."""
         import html
 
-        escaped = html.escape(dax_query)
-        soap = _EXECUTE_SOAP.format(statement=escaped, dataset=self._config.dataset)
+        soap = _EXECUTE_SOAP.format(
+            statement=html.escape(dax_query),
+            dataset=html.escape(self._config.dataset),
+        )
         xml_text = self._post_soap(soap, action="Execute")
         df = self._parse_execute_response(xml_text)
 
@@ -211,8 +213,11 @@ class XmlaClient:
             raise RuntimeError(f"XMLA SOAP fault: {fstring}. {detail}".strip())
 
     def _discover(self, request_type: str) -> list[dict]:
+        import html
+
         soap = _DISCOVER_SOAP.format(
-            request_type=request_type, dataset=self._config.dataset
+            request_type=html.escape(request_type),
+            dataset=html.escape(self._config.dataset),
         )
         xml_text = self._post_soap(soap, action="Discover")
         return self._parse_discover_response(xml_text)

--- a/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/sync.py
+++ b/cli/nao_core/commands/sync/providers/databases/powerbi_xmla/sync.py
@@ -1,0 +1,211 @@
+"""Sync logic for Power BI Semantic Model via XMLA.
+
+Generates markdown context files (columns, measures, relations) under:
+  {base_path}/type=powerbi_xmla/database={dataset}/schema={dataset}/table={table}/columns.md
+  {base_path}/type=powerbi_xmla/database={dataset}/schema={dataset}/measures.md
+  {base_path}/type=powerbi_xmla/database={dataset}/schema={dataset}/relations.md
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nao_core.commands.sync.cleanup import DatabaseSyncState
+
+if TYPE_CHECKING:
+    from rich.progress import Progress
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+
+_DAX_TYPE_MAP = {
+    "2": "string",
+    "6": "int64",
+    "8": "double",
+    "9": "datetime",
+    "10": "currency",
+    "11": "boolean",
+}
+
+_CARDINALITY_MAP = {
+    "1": "OneToOne",
+    "2": "ManyToOne",
+    "3": "OneToMany",
+}
+
+
+def _dax_type_label(data_type: str | None) -> str:
+    return _DAX_TYPE_MAP.get(data_type or "", f"type({data_type})")
+
+
+def _cardinality_label(code: str | None) -> str:
+    return _CARDINALITY_MAP.get(code or "", code or "?")
+
+
+def _render_columns_md(table_name: str, columns: list[dict], dataset: str) -> str:
+    lines = [
+        f"# {table_name}",
+        "",
+        f"**Dataset:** {dataset} (Power BI Semantic Model)",
+        "",
+        "## Columns",
+        "",
+        "| Column | Type | Description |",
+        "|--------|------|-------------|",
+    ]
+    for col in columns:
+        name = col.get("Name") or col.get("ExplicitName") or "?"
+        dtype = _dax_type_label(col.get("DataType") or col.get("ExplicitDataType"))
+        desc = (col.get("Description") or "").replace("|", "\\|")
+        lines.append(f"| {name} | {dtype} | {desc} |")
+    return "\n".join(lines) + "\n"
+
+
+def _resolve_table_name(raw_id: str | None, table_name_by_id: dict[str, str]) -> str:
+    """Resolve a numeric table ID to a human-readable name using the provided mapping."""
+    if not raw_id:
+        return "?"
+    return table_name_by_id.get(raw_id, raw_id)
+
+
+def _render_measures_md(measures: list[dict], dataset: str, table_name_by_id: dict[str, str]) -> str:
+    if not measures:
+        return f"# Measures — {dataset}\n\nNo measures defined.\n"
+
+    lines = [
+        f"# Measures — {dataset}",
+        "",
+        "| Measure | Table | Expression (truncated to 120 chars) |",
+        "|---------|-------|--------------------------------------|",
+    ]
+    for m in measures:
+        name = m.get("Name") or "?"
+        raw_table = m.get("TableID") or m.get("TableName")
+        table = _resolve_table_name(raw_table, table_name_by_id)
+        expr = (m.get("Expression") or "").replace("\n", " ").replace("|", "\\|")
+        expr = expr[:120] + ("…" if len(expr) > 120 else "")
+        lines.append(f"| {name} | {table} | `{expr}` |")
+    return "\n".join(lines) + "\n"
+
+
+def _render_relations_md(relations: list[dict], dataset: str, table_name_by_id: dict[str, str]) -> str:
+    if not relations:
+        return f"# Relationships — {dataset}\n\nNo relationships defined.\n"
+
+    lines = [
+        f"# Relationships — {dataset}",
+        "",
+        "| From Table | From Column | To Table | To Column | Cardinality | Active |",
+        "|------------|-------------|----------|-----------|-------------|--------|",
+    ]
+    for r in relations:
+        from_table = _resolve_table_name(r.get("FromTableID") or r.get("FromTableName"), table_name_by_id)
+        from_col = r.get("FromColumnID") or r.get("FromColumnName") or "?"
+        to_table = _resolve_table_name(r.get("ToTableID") or r.get("ToTableName"), table_name_by_id)
+        to_col = r.get("ToColumnID") or r.get("ToColumnName") or "?"
+        card = _cardinality_label(r.get("FromCardinality") or r.get("Cardinality"))
+        active = "Yes" if (r.get("IsActive") or "true").lower() == "true" else "No"
+        lines.append(f"| {from_table} | {from_col} | {to_table} | {to_col} | {card} | {active} |")
+    return "\n".join(lines) + "\n"
+
+
+def sync_powerbi_xmla(
+    db_config: "PowerBIXmlaConfig",
+    base_path: Path,
+    progress: "Progress",
+    db_folder: str | None = None,
+) -> DatabaseSyncState:
+    """Sync a Power BI Semantic Model to context markdown files."""
+    from rich.console import Console
+
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+    console = Console()
+
+    if db_folder is None:
+        db_folder = f"database={db_config.get_database_name()}"
+
+    db_path = base_path / f"type={db_config.type}" / db_folder
+    dataset = db_config.dataset
+    state = DatabaseSyncState(db_path=db_path)
+
+    t0 = time.monotonic()
+    console.print(f"  [dim]Connecting to[/dim] [bold]{db_config.name}[/bold] [dim](XMLA)[/dim]")
+
+    client = XmlaClient(db_config)
+
+    # --- Discover metadata ---
+    tables = client.discover_tables()
+    all_columns = client.discover_columns()
+    measures = client.discover_measures()
+    relations = client.discover_relationships()
+
+    console.print(
+        f"  [dim]Found[/dim] [bold]{len(tables)}[/bold] tables, "
+        f"[bold]{len(measures)}[/bold] measures, "
+        f"[bold]{len(relations)}[/bold] relationships"
+    )
+
+    schema_path = db_path / f"schema={dataset}"
+    schema_path.mkdir(parents=True, exist_ok=True)
+    state.add_schema(dataset)
+
+    # Build ID → Name mapping for measures/relations resolution.
+    # TMSCHEMA_TABLES uses "ID" for its own primary key; "TableID" is a foreign-key field
+    # used in cross-reference DMVs (TMSCHEMA_COLUMNS, TMSCHEMA_MEASURES, etc.).
+    table_name_by_id: dict[str, str] = {}
+    for t in tables:
+        tid = t.get("ID")
+        tname = t.get("Name")
+        if tid and tname:
+            table_name_by_id[tid] = tname
+        if tname:
+            table_name_by_id[tname] = tname  # name → name fallback for DMVs that emit names
+
+    # Group columns by the foreign-key TableID they report.
+    cols_by_table: dict[str, list[dict]] = {}
+    for col in all_columns:
+        table_id = col.get("TableID") or col.get("TableName") or "unknown"
+        cols_by_table.setdefault(table_id, []).append(col)
+
+    # Warn if any columns cannot be attributed to a known table (signals a join gap).
+    known_table_ids = set(table_name_by_id.keys())
+    orphaned_ids = set(cols_by_table.keys()) - known_table_ids - {"unknown"}
+    if orphaned_ids:
+        console.print(
+            f"  [yellow]⚠ {len(orphaned_ids)} column group(s) could not be matched to a table "
+            f"(TableID: {', '.join(sorted(orphaned_ids)[:5])}). "
+            "Set xmla_endpoint explicitly if this persists.[/yellow]"
+        )
+
+    task = progress.add_task(f"[dim]{db_config.name}[/dim]", total=len(tables))
+
+    for table in tables:
+        table_name = table.get("Name") or "unknown"
+        # Use "ID" — the table's own primary key in TMSCHEMA_TABLES — to look up columns
+        # that reference it via their "TableID" foreign-key field.
+        table_id = table.get("ID") or table_name
+
+        table_path = schema_path / f"table={table_name}"
+        table_path.mkdir(parents=True, exist_ok=True)
+
+        progress.update(task, description=f"  [cyan]{dataset}[/cyan] [dim]→ {table_name}[/dim]")
+
+        table_cols = cols_by_table.get(table_id, [])
+        content = _render_columns_md(table_name, table_cols, dataset)
+        (table_path / "columns.md").write_text(content)
+
+        state.add_table(dataset, table_name)
+        progress.update(task, advance=1)
+
+    # --- Dataset-level files ---
+    (schema_path / "measures.md").write_text(_render_measures_md(measures, dataset, table_name_by_id))
+    (schema_path / "relations.md").write_text(_render_relations_md(relations, dataset, table_name_by_id))
+
+    elapsed = f"{time.monotonic() - t0:.1f}s"
+    console.print(
+        f"  [green]✓ {dataset}[/green] [dim]— {len(tables)} tables synced in {elapsed}[/dim]"
+    )
+
+    return state

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -280,14 +280,21 @@ class DatabaseSyncProvider(SyncProvider):
             db_folders = get_database_folder_names(items)
             for db, db_folder in zip(items, db_folders, strict=False):
                 try:
-                    state = sync_database(
-                        db,
-                        output_path,
-                        progress,
-                        project_path,
-                        self._llm_config,
-                        db_folder=db_folder,
-                    )
+                    if db.type == "powerbi_xmla":
+                        from nao_core.commands.sync.providers.databases.powerbi_xmla import (
+                            sync_powerbi_xmla,
+                        )
+
+                        state = sync_powerbi_xmla(db, output_path, progress, db_folder=db_folder)
+                    else:
+                        state = sync_database(
+                            db,
+                            output_path,
+                            progress,
+                            project_path,
+                            self._llm_config,
+                            db_folder=db_folder,
+                        )
                     sync_states.append(state)
                     total_datasets += state.schemas_synced
                     total_tables += state.tables_synced

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -319,7 +319,6 @@ class NaoConfig(BaseModel):
             return None
 
         try:
-            os.chdir(path)
             return cls.load(path)
         except yaml.YAMLError as e:
             handle_error(f"Failed to load nao_config.yaml: Invalid YAML syntax: {e}")

--- a/cli/nao_core/config/databases/__init__.py
+++ b/cli/nao_core/config/databases/__init__.py
@@ -12,6 +12,7 @@ from .fabric import FabricConfig
 from .mssql import MssqlConfig
 from .mysql import MysqlConfig
 from .postgres import PostgresConfig
+from .powerbi_xmla import PowerBIXmlaConfig
 from .redshift import RedshiftConfig
 from .snowflake import SnowflakeConfig
 from .trino import TrinoConfig
@@ -32,6 +33,7 @@ AnyDatabaseConfig = Annotated[
         Annotated[MysqlConfig, Tag("mysql")],
         Annotated[MssqlConfig, Tag("mssql")],
         Annotated[PostgresConfig, Tag("postgres")],
+        Annotated[PowerBIXmlaConfig, Tag("powerbi_xmla")],
         Annotated[RedshiftConfig, Tag("redshift")],
         Annotated[TrinoConfig, Tag("trino")],
     ],
@@ -49,6 +51,7 @@ DATABASE_CONFIG_CLASSES: Dict[DatabaseType, Type[object]] = {
     DatabaseType.FABRIC: FabricConfig,
     DatabaseType.MSSQL: MssqlConfig,
     DatabaseType.MYSQL: MysqlConfig,
+    DatabaseType.POWERBI_XMLA: PowerBIXmlaConfig,
     DatabaseType.SNOWFLAKE: SnowflakeConfig,
     DatabaseType.POSTGRES: PostgresConfig,
     DatabaseType.REDSHIFT: RedshiftConfig,
@@ -84,6 +87,7 @@ __all__ = [
     "FabricConfig",
     "MssqlConfig",
     "MysqlConfig",
+    "PowerBIXmlaConfig",
     "SnowflakeConfig",
     "PostgresConfig",
     "RedshiftConfig",

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -28,6 +28,7 @@ class DatabaseType(str, Enum):
     POSTGRES = "postgres"
     REDSHIFT = "redshift"
     TRINO = "trino"
+    POWERBI_XMLA = "powerbi_xmla"
 
     @classmethod
     def choices(cls) -> list[questionary.Choice]:

--- a/cli/nao_core/config/databases/powerbi_xmla.py
+++ b/cli/nao_core/config/databases/powerbi_xmla.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 
 from .base import DatabaseConfig
 
-# Module-level MSAL app cache keyed by (tenant_id, client_id).
-# Allows token reuse across requests without rebuilding ConfidentialClientApplication each time.
-# Secrets are never stored as part of the key.
-_MSAL_APP_CACHE: dict[tuple[str, str], object] = {}
+# Module-level MSAL app cache keyed by (tenant_id, client_id, secret_hash).
+# Including a hash of the secret ensures a rotated credential gets a fresh MSAL instance
+# rather than reusing cached tokens issued for the old secret.
+# Secrets are never stored directly; only a one-way hash is kept in memory.
+_MSAL_APP_CACHE: dict[tuple[str, str, str], object] = {}
 _MSAL_APP_LOCK = threading.Lock()
 
 
@@ -50,7 +51,11 @@ class PowerBIXmlaConfig(DatabaseConfig):
 
     @model_validator(mode="after")
     def resolve_env_vars(self) -> "PowerBIXmlaConfig":
-        """Expand ${VAR} references in credential fields."""
+        """Expand ${VAR} references in credential fields.
+
+        Raises ValueError immediately if a referenced env var is not set,
+        preventing silent empty-string credentials reaching MSAL.
+        """
         import os
         import re
 
@@ -59,7 +64,12 @@ class PowerBIXmlaConfig(DatabaseConfig):
             value = getattr(self, field)
             m = pattern.match(value)
             if m:
-                resolved = os.environ.get(m.group(1), "")
+                var_name = m.group(1)
+                resolved = os.environ.get(var_name)
+                if resolved is None:
+                    raise ValueError(
+                        f"Environment variable '{var_name}' referenced in '{field}' is not set"
+                    )
                 object.__setattr__(self, field, resolved)
         return self
 
@@ -112,12 +122,15 @@ class PowerBIXmlaConfig(DatabaseConfig):
         MSAL's internal token cache is reused across requests, avoiding a round-trip to
         Azure AD on every query.
         """
+        import hashlib
+
         from nao_core.deps import require_dependency
 
         require_dependency("msal", "powerbi_xmla", "for Power BI authentication")
         import msal  # type: ignore[import-untyped]
 
-        cache_key = (self.tenant_id, self.client_id)
+        secret_hash = hashlib.sha256(self.client_secret.encode()).hexdigest()[:16]
+        cache_key = (self.tenant_id, self.client_id, secret_hash)
         with _MSAL_APP_LOCK:
             if cache_key not in _MSAL_APP_CACHE:
                 _MSAL_APP_CACHE[cache_key] = msal.ConfidentialClientApplication(

--- a/cli/nao_core/config/databases/powerbi_xmla.py
+++ b/cli/nao_core/config/databases/powerbi_xmla.py
@@ -1,0 +1,155 @@
+"""Power BI Semantic Model via XMLA configuration."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Literal
+from urllib.parse import quote
+
+from pydantic import Field, model_validator
+
+from nao_core.ui import ask_text
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from ibis import BaseBackend
+
+from .base import DatabaseConfig
+
+# Module-level MSAL app cache keyed by (tenant_id, client_id).
+# Allows token reuse across requests without rebuilding ConfidentialClientApplication each time.
+# Secrets are never stored as part of the key.
+_MSAL_APP_CACHE: dict[tuple[str, str], object] = {}
+_MSAL_APP_LOCK = threading.Lock()
+
+
+class PowerBIXmlaConfig(DatabaseConfig):
+    """Power BI Semantic Model via XMLA endpoint (service principal auth)."""
+
+    type: Literal["powerbi_xmla"] = "powerbi_xmla"
+
+    workspace: str = Field(description="Exact workspace name as shown in Power BI Service")
+    dataset: str = Field(description="Semantic model / dataset name")
+
+    tenant_id: str = Field(description="Azure AD tenant ID (or env var reference)")
+    client_id: str = Field(description="Azure AD application (client) ID")
+    client_secret: str = Field(description="Azure AD client secret")
+
+    row_limit: int = Field(default=5000, ge=1, le=50000, description="Max rows returned per DAX query")
+    timeout_seconds: int = Field(default=30, ge=5, le=300, description="Query timeout in seconds")
+    include_hidden: bool = Field(default=False, description="Include hidden tables and columns")
+    xmla_endpoint: str | None = Field(
+        default=None,
+        description=(
+            "Explicit XMLA SOAP endpoint URL. Takes priority over the auto-constructed URL. "
+            "Required for dedicated capacity or regional deployments that do not use the "
+            "default Power BI Premium/Fabric endpoint. "
+            "Example: https://wabi-us-north-central-redirect.analysis.windows.net/xmla"
+        ),
+    )
+
+    @model_validator(mode="after")
+    def resolve_env_vars(self) -> "PowerBIXmlaConfig":
+        """Expand ${VAR} references in credential fields."""
+        import os
+        import re
+
+        pattern = re.compile(r"^\$\{([^}]+)\}$")
+        for field in ("tenant_id", "client_id", "client_secret"):
+            value = getattr(self, field)
+            m = pattern.match(value)
+            if m:
+                resolved = os.environ.get(m.group(1), "")
+                object.__setattr__(self, field, resolved)
+        return self
+
+    @classmethod
+    def promptConfig(cls) -> "PowerBIXmlaConfig":
+        name = ask_text("Connection name:", default="powerbi-model") or "powerbi-model"
+        workspace = ask_text("Power BI workspace name:", required_field=True)
+        dataset = ask_text("Dataset / semantic model name:", required_field=True)
+        tenant_id = ask_text("Azure tenant ID (or ${AZURE_TENANT_ID}):", required_field=True)
+        client_id = ask_text("Azure client ID (or ${AZURE_CLIENT_ID}):", required_field=True)
+        client_secret = ask_text(
+            "Azure client secret (or ${AZURE_CLIENT_SECRET}):",
+            password=True,
+            required_field=True,
+        )
+        return cls(
+            name=name,
+            workspace=workspace,
+            dataset=dataset,
+            tenant_id=tenant_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+    def connect(self) -> "BaseBackend":
+        raise NotImplementedError(
+            "Power BI XMLA does not use an ibis backend. "
+            "Use execute_dax() for queries or sync_powerbi_xmla() for sync."
+        )
+
+    def get_database_name(self) -> str:
+        return self.dataset
+
+    def xmla_endpoint_url(self) -> str:
+        """Return the XMLA SOAP endpoint URL.
+
+        If ``xmla_endpoint`` is explicitly configured it is used as-is.
+        Otherwise a best-effort URL is constructed for Power BI Premium/Fabric workspaces.
+        Set ``xmla_endpoint`` explicitly if connections fail — the correct URL is
+        workspace-specific and may differ across regions or dedicated capacity tenants.
+        """
+        if self.xmla_endpoint:
+            return self.xmla_endpoint
+        return f"https://api.powerbi.com/v1.0/myorg/{quote(self.workspace, safe='')}"
+
+    def acquire_token(self) -> str:
+        """Acquire an Azure AD token via MSAL service principal flow.
+
+        ``ConfidentialClientApplication`` is cached per (tenant_id, client_id) so that
+        MSAL's internal token cache is reused across requests, avoiding a round-trip to
+        Azure AD on every query.
+        """
+        from nao_core.deps import require_dependency
+
+        require_dependency("msal", "powerbi_xmla", "for Power BI authentication")
+        import msal  # type: ignore[import-untyped]
+
+        cache_key = (self.tenant_id, self.client_id)
+        with _MSAL_APP_LOCK:
+            if cache_key not in _MSAL_APP_CACHE:
+                _MSAL_APP_CACHE[cache_key] = msal.ConfidentialClientApplication(
+                    self.client_id,
+                    authority=f"https://login.microsoftonline.com/{self.tenant_id}",
+                    client_credential=self.client_secret,
+                )
+            app = _MSAL_APP_CACHE[cache_key]
+
+        result = app.acquire_token_for_client(
+            scopes=["https://analysis.windows.net/powerbi/api/.default"]
+        )
+        if "error" in result:
+            raise ConnectionError(
+                f"MSAL authentication failed: {result.get('error_description', result['error'])}"
+            )
+        return result["access_token"]  # type: ignore[return-value]
+
+    def execute_dax(self, dax_query: str) -> "pd.DataFrame":
+        """Execute a DAX EVALUATE query and return results as a DataFrame."""
+        from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+        client = XmlaClient(self)
+        return client.execute_dax(dax_query)
+
+    def check_connection(self) -> tuple[bool, str]:
+        """Validate connectivity and permissions by running a minimal DMV discovery."""
+        try:
+            from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+            client = XmlaClient(self)
+            tables = client.discover_tables()
+            return True, f"Connected — {len(tables)} tables found in '{self.dataset}'"
+        except Exception as e:
+            return False, str(e)

--- a/cli/nao_core/deps.py
+++ b/cli/nao_core/deps.py
@@ -40,6 +40,8 @@ _EXTRAS: dict[str, list[str]] = {
     "ollama": ["ollama"],
     # Integrations
     "notion": ["notion_client", "notion2md"],
+    # Power BI XMLA
+    "powerbi_xmla": ["msal", "httpx"],
 }
 
 # Providers whose extra name differs from their config value.

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -65,12 +65,15 @@ mistral = ["mistralai>=1.11.1,<2.0.0"]
 gemini = ["google-genai>=1.61.0"]
 ollama = ["ollama>=0.4.0"]
 
+# Power BI Semantic Models via XMLA
+powerbi_xmla = ["msal>=1.28.0,<2", "httpx>=0.27.0,<1"]
+
 # Integrations
 notion = ["notion-client>=2.7.0", "notion2md>=2.9.0"]
 
 # Convenience groups
 all-databases = [
-    "nao-core[postgres,bigquery,snowflake,duckdb,clickhouse,databricks,mysql,mssql,athena,trino,redshift,fabric]",
+    "nao-core[postgres,bigquery,snowflake,duckdb,clickhouse,databricks,mysql,mssql,athena,trino,redshift,fabric,powerbi_xmla]",
 ]
 all-llms = ["nao-core[openai,anthropic,mistral,gemini,ollama]"]
 all = ["nao-core[all-databases,all-llms,notion]"]

--- a/cli/tests/nao_core/config/test_powerbi_xmla.py
+++ b/cli/tests/nao_core/config/test_powerbi_xmla.py
@@ -1,0 +1,266 @@
+"""Unit tests for PowerBIXmlaConfig and XmlaClient internals.
+
+Tests cover:
+- resolve_env_vars: ${VAR} expansion in credential fields
+- _parse_execute_response: XML parsing + XSD column-name mapping
+- _render_measures_md: table ID resolution
+- column → table join in sync_powerbi_xmla (via table_name_by_id logic)
+"""
+
+from __future__ import annotations
+
+import os
+from textwrap import dedent
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# resolve_env_vars
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_env_vars_expands_credentials():
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    with patch.dict(os.environ, {"MY_TENANT": "abc-123", "MY_SECRET": "s3cr3t"}):
+        config = PowerBIXmlaConfig(
+            name="test",
+            workspace="My Workspace",
+            dataset="My Dataset",
+            tenant_id="${MY_TENANT}",
+            client_id="literal-client-id",
+            client_secret="${MY_SECRET}",
+        )
+
+    assert config.tenant_id == "abc-123"
+    assert config.client_id == "literal-client-id"
+    assert config.client_secret == "s3cr3t"
+
+
+def test_resolve_env_vars_missing_env_becomes_empty():
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MISSING_VAR", None)
+        config = PowerBIXmlaConfig(
+            name="test",
+            workspace="W",
+            dataset="D",
+            tenant_id="${MISSING_VAR}",
+            client_id="cid",
+            client_secret="sec",
+        )
+
+    assert config.tenant_id == ""
+
+
+def test_resolve_env_vars_literal_value_unchanged():
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    config = PowerBIXmlaConfig(
+        name="test",
+        workspace="W",
+        dataset="D",
+        tenant_id="literal-tenant",
+        client_id="literal-client",
+        client_secret="literal-secret",
+    )
+
+    assert config.tenant_id == "literal-tenant"
+    assert config.client_secret == "literal-secret"
+
+
+# ---------------------------------------------------------------------------
+# xmla_endpoint_url
+# ---------------------------------------------------------------------------
+
+
+def test_xmla_endpoint_url_explicit_takes_priority():
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    config = PowerBIXmlaConfig(
+        name="test",
+        workspace="My Workspace",
+        dataset="My Dataset",
+        tenant_id="t",
+        client_id="c",
+        client_secret="s",
+        xmla_endpoint="https://custom.analysis.windows.net/xmla",
+    )
+
+    assert config.xmla_endpoint_url() == "https://custom.analysis.windows.net/xmla"
+
+
+def test_xmla_endpoint_url_constructed_when_not_provided():
+    from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
+
+    config = PowerBIXmlaConfig(
+        name="test",
+        workspace="My Workspace",
+        dataset="My Dataset",
+        tenant_id="t",
+        client_id="c",
+        client_secret="s",
+    )
+
+    url = config.xmla_endpoint_url()
+    assert "api.powerbi.com" in url
+    assert "My%20Workspace" in url  # workspace name is URL-encoded
+
+
+# ---------------------------------------------------------------------------
+# _parse_execute_response
+# ---------------------------------------------------------------------------
+
+# Minimal but realistic XMLA Execute response.
+# The XSD schema embedded in <root> provides the xml_name → real_column_name mapping
+# via the sql:field attribute; row values are nested inside <row> elements.
+_EXECUTE_RESPONSE_XML = dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Body>
+        <ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">
+          <return>
+            <root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:sql="urn:schemas-microsoft-com:xml-sql">
+              <xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset">
+                <xsd:complexType name="row">
+                  <xsd:sequence>
+                    <xsd:element name="C0" sql:field="[Sales].[Date]" type="xsd:string" minOccurs="0"/>
+                    <xsd:element name="C1" sql:field="[Sales].[Amount]" type="xsd:decimal" minOccurs="0"/>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:schema>
+              <row>
+                <C0>2024-01-01</C0>
+                <C1>999.50</C1>
+              </row>
+              <row>
+                <C0>2024-01-02</C0>
+                <C1>1200.00</C1>
+              </row>
+            </root>
+          </return>
+        </ExecuteResponse>
+      </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>
+""")
+
+_EXECUTE_RESPONSE_EMPTY_XML = dedent("""\
+    <?xml version="1.0" encoding="UTF-8"?>
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Body>
+        <ExecuteResponse xmlns="urn:schemas-microsoft-com:xml-analysis">
+          <return>
+            <root xmlns="urn:schemas-microsoft-com:xml-analysis:rowset"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:sql="urn:schemas-microsoft-com:xml-sql">
+              <xsd:schema targetNamespace="urn:schemas-microsoft-com:xml-analysis:rowset">
+                <xsd:complexType name="row">
+                  <xsd:sequence>
+                    <xsd:element name="C0" sql:field="[Sales].[Date]" type="xsd:string" minOccurs="0"/>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:schema>
+            </root>
+          </return>
+        </ExecuteResponse>
+      </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>
+""")
+
+
+def test_parse_execute_response_column_mapping():
+    """XSD sql:field attribute is used as the column name (not the generic C0/C1 names)."""
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+    df = XmlaClient._parse_execute_response(_EXECUTE_RESPONSE_XML)
+
+    assert list(df.columns) == ["[Sales].[Date]", "[Sales].[Amount]"]
+
+
+def test_parse_execute_response_row_count():
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+    df = XmlaClient._parse_execute_response(_EXECUTE_RESPONSE_XML)
+
+    assert len(df) == 2
+    assert df.iloc[0]["[Sales].[Date]"] == "2024-01-01"
+    assert df.iloc[1]["[Sales].[Amount]"] == "1200.00"
+
+
+def test_parse_execute_response_empty_result_returns_empty_dataframe():
+    """Empty result set: DataFrame with correct columns but zero rows."""
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.client import XmlaClient
+
+    df = XmlaClient._parse_execute_response(_EXECUTE_RESPONSE_EMPTY_XML)
+
+    assert len(df) == 0
+    assert "[Sales].[Date]" in df.columns
+
+
+# ---------------------------------------------------------------------------
+# _render_measures_md — table name resolution (M3)
+# ---------------------------------------------------------------------------
+
+
+def test_render_measures_md_resolves_table_name():
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.sync import _render_measures_md
+
+    measures = [{"Name": "Total Sales", "TableID": "3", "Expression": "SUM(Sales[Amount])"}]
+    table_name_by_id = {"3": "Sales"}
+
+    md = _render_measures_md(measures, "MyDataset", table_name_by_id)
+
+    assert "Sales" in md
+    assert "3" not in md  # numeric ID must not appear in output
+
+
+def test_render_measures_md_falls_back_to_raw_id_when_unmapped():
+    from nao_core.commands.sync.providers.databases.powerbi_xmla.sync import _render_measures_md
+
+    measures = [{"Name": "Total Sales", "TableID": "99", "Expression": "SUM(...)"}]
+
+    md = _render_measures_md(measures, "MyDataset", {})
+
+    # Falls back to raw ID rather than silently dropping the value
+    assert "99" in md
+
+
+# ---------------------------------------------------------------------------
+# column → table join key (M5)
+# ---------------------------------------------------------------------------
+
+
+def test_table_name_by_id_uses_id_field_not_tableid():
+    """TMSCHEMA_TABLES rows use 'ID' as their own PK; 'TableID' is for cross-reference DMVs."""
+    tables = [
+        {"ID": "1", "Name": "Sales"},
+        {"ID": "2", "Name": "Date"},
+    ]
+    table_name_by_id: dict[str, str] = {}
+    for t in tables:
+        tid = t.get("ID")
+        tname = t.get("Name")
+        if tid and tname:
+            table_name_by_id[tid] = tname
+        if tname:
+            table_name_by_id[tname] = tname
+
+    # Columns report their parent via TableID (FK)
+    columns = [
+        {"Name": "Amount", "TableID": "1"},
+        {"Name": "Date", "TableID": "2"},
+    ]
+    cols_by_table: dict[str, list[dict]] = {}
+    for col in columns:
+        key = col.get("TableID") or col.get("TableName") or "unknown"
+        cols_by_table.setdefault(key, []).append(col)
+
+    # Simulate the join as done in sync_powerbi_xmla
+    for table in tables:
+        table_id = table.get("ID") or table.get("Name")
+        resolved = cols_by_table.get(table_id, [])
+        assert len(resolved) == 1, f"Expected 1 column for table {table['Name']}, got {len(resolved)}"

--- a/cli/tests/nao_core/config/test_powerbi_xmla.py
+++ b/cli/tests/nao_core/config/test_powerbi_xmla.py
@@ -37,21 +37,24 @@ def test_resolve_env_vars_expands_credentials():
     assert config.client_secret == "s3cr3t"
 
 
-def test_resolve_env_vars_missing_env_becomes_empty():
+def test_resolve_env_vars_missing_env_raises():
+    """A ${VAR} placeholder whose env var is unset must raise immediately (fail-fast)."""
+    import pytest
+    from pydantic import ValidationError
+
     from nao_core.config.databases.powerbi_xmla import PowerBIXmlaConfig
 
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("MISSING_VAR", None)
-        config = PowerBIXmlaConfig(
-            name="test",
-            workspace="W",
-            dataset="D",
-            tenant_id="${MISSING_VAR}",
-            client_id="cid",
-            client_secret="sec",
-        )
-
-    assert config.tenant_id == ""
+        with pytest.raises(ValidationError, match="MISSING_VAR"):
+            PowerBIXmlaConfig(
+                name="test",
+                workspace="W",
+                dataset="D",
+                tenant_id="${MISSING_VAR}",
+                client_id="cid",
+                client_secret="sec",
+            )
 
 
 def test_resolve_env_vars_literal_value_unchanged():

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -2293,8 +2293,10 @@ all = [
     { name = "certifi" },
     { name = "google-cloud" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "ibis-framework", extra = ["athena", "bigquery", "clickhouse", "databricks", "duckdb", "mssql", "mysql", "postgres", "snowflake", "trino"] },
     { name = "mistralai" },
+    { name = "msal" },
     { name = "notion-client" },
     { name = "notion2md" },
     { name = "ollama" },
@@ -2306,7 +2308,9 @@ all-databases = [
     { name = "azure-identity" },
     { name = "certifi" },
     { name = "google-cloud" },
+    { name = "httpx" },
     { name = "ibis-framework", extra = ["athena", "bigquery", "clickhouse", "databricks", "duckdb", "mssql", "mysql", "postgres", "snowflake", "trino"] },
+    { name = "msal" },
     { name = "snowflake-connector-python", extra = ["secure-local-storage"] },
     { name = "sshtunnel" },
 ]
@@ -2370,6 +2374,10 @@ openai = [
 postgres = [
     { name = "ibis-framework", extra = ["postgres"] },
 ]
+powerbi-xmla = [
+    { name = "httpx" },
+    { name = "msal" },
+]
 redshift = [
     { name = "ibis-framework", extra = ["postgres"] },
     { name = "sshtunnel" },
@@ -2401,6 +2409,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "google-cloud", marker = "extra == 'bigquery'", specifier = ">=0.34.0" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.61.0" },
+    { name = "httpx", marker = "extra == 'powerbi-xmla'", specifier = ">=0.27.0,<1" },
     { name = "ibis-framework", specifier = ">=9.0.0" },
     { name = "ibis-framework", extras = ["athena"], marker = "extra == 'athena'", specifier = ">=9.0.0" },
     { name = "ibis-framework", extras = ["bigquery"], marker = "extra == 'bigquery'", specifier = ">=9.0.0" },
@@ -2416,9 +2425,10 @@ requires-dist = [
     { name = "ibis-framework", extras = ["trino"], marker = "extra == 'trino'", specifier = ">=9.0.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.11.1,<2.0.0" },
+    { name = "msal", marker = "extra == 'powerbi-xmla'", specifier = ">=1.28.0,<2" },
     { name = "nao-core", extras = ["all-databases", "all-llms", "notion"], marker = "extra == 'all'" },
     { name = "nao-core", extras = ["openai", "anthropic", "mistral", "gemini", "ollama"], marker = "extra == 'all-llms'" },
-    { name = "nao-core", extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric"], marker = "extra == 'all-databases'" },
+    { name = "nao-core", extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "powerbi-xmla"], marker = "extra == 'all-databases'" },
     { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.7.0" },
     { name = "notion2md", marker = "extra == 'notion'", specifier = ">=2.9.0" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -2440,7 +2450,7 @@ requires-dist = [
     { name = "sshtunnel", marker = "extra == 'redshift'", specifier = ">=0.4.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
-provides-extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "openai", "anthropic", "mistral", "gemini", "ollama", "notion", "all-databases", "all-llms", "all", "dev"]
+provides-extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "openai", "anthropic", "mistral", "gemini", "ollama", "powerbi-xmla", "notion", "all-databases", "all-llms", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/example/nao_config.yaml
+++ b/example/nao_config.yaml
@@ -11,6 +11,23 @@ databases:
   exclude: []
   type: duckdb
   path: ./jaffle_shop.duckdb
+# Power BI Semantic Model via XMLA (requires nao-core[powerbi_xmla] + Power BI Premium/Fabric)
+# Uncomment and fill in to enable. Enable execute_dax tool in agent settings (powerbi.xmlaEnabled: true).
+#
+# - name: sales-model
+#   type: powerbi_xmla
+#   workspace: "My Analytics Workspace"      # exact name from Power BI Service
+#   dataset: "Sales Semantic Model"          # dataset / semantic model name
+#   tenant_id: ${AZURE_TENANT_ID}            # Azure AD tenant ID (env var reference)
+#   client_id: ${AZURE_CLIENT_ID}            # service principal client ID
+#   client_secret: ${AZURE_CLIENT_SECRET}    # service principal secret (never inline)
+#   row_limit: 5000                          # max rows per DAX query (default 5000)
+#   timeout_seconds: 30                      # query timeout (default 30)
+#   include_hidden: false                    # set true to include hidden tables/columns
+#   accessors:
+#     - columns                              # generates columns.md per table
+#   # Also generates measures.md and relations.md at dataset level
+
 repos:
 - name: dbt
   url: https://github.com/dbt-labs/jaffle_shop_duckdb.git

--- a/scripts/spike_powerbi_xmla.py
+++ b/scripts/spike_powerbi_xmla.py
@@ -15,6 +15,7 @@ Usage:
 
 from __future__ import annotations
 
+import html
 import os
 import sys
 from xml.etree import ElementTree as ET
@@ -80,7 +81,7 @@ def xmla_discover(token: str, workspace: str, dataset: str, request_type: str) -
     from urllib.parse import quote
 
     url = f"https://api.powerbi.com/v1.0/myorg/{quote(workspace, safe='')}"
-    soap = _DISCOVER_SOAP.format(request_type=request_type, dataset=dataset)
+    soap = _DISCOVER_SOAP.format(request_type=html.escape(request_type), dataset=html.escape(dataset))
 
     response = httpx.post(
         url,

--- a/scripts/spike_powerbi_xmla.py
+++ b/scripts/spike_powerbi_xmla.py
@@ -1,0 +1,147 @@
+"""
+Phase-0 spike: authenticate with MSAL (service principal) and list tables via XMLA DMV.
+
+Prerequisites (install in a venv):
+    pip install msal httpx
+
+Required env vars:
+    AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
+    POWERBI_WORKSPACE  — exact workspace name as shown in Power BI Service
+    POWERBI_DATASET    — dataset / semantic model name
+
+Usage:
+    AZURE_TENANT_ID=xxx ... python scripts/spike_powerbi_xmla.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from xml.etree import ElementTree as ET
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        print(f"[error] Missing required env var: {name}")
+        sys.exit(1)
+    return value
+
+
+def acquire_token(tenant_id: str, client_id: str, client_secret: str) -> str:
+    try:
+        import msal
+    except ImportError:
+        print("[error] Run: pip install msal")
+        sys.exit(1)
+
+    app = msal.ConfidentialClientApplication(
+        client_id,
+        authority=f"https://login.microsoftonline.com/{tenant_id}",
+        client_credential=client_secret,
+    )
+    result = app.acquire_token_for_client(
+        scopes=["https://analysis.windows.net/powerbi/api/.default"]
+    )
+    if "error" in result:
+        print(f"[error] MSAL: {result.get('error_description', result['error'])}")
+        sys.exit(1)
+    return result["access_token"]  # type: ignore[return-value]
+
+
+_DISCOVER_SOAP = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <xmla:Discover xmlns:xmla="urn:schemas-microsoft-com:xml-analysis">
+      <xmla:RequestType>{request_type}</xmla:RequestType>
+      <xmla:Restrictions>
+        <xmla:RestrictionList>
+          <DatabaseName>{dataset}</DatabaseName>
+        </xmla:RestrictionList>
+      </xmla:Restrictions>
+      <xmla:Properties>
+        <xmla:PropertyList>
+          <Catalog>{dataset}</Catalog>
+        </xmla:PropertyList>
+      </xmla:Properties>
+    </xmla:Discover>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>"""
+
+
+def xmla_discover(token: str, workspace: str, dataset: str, request_type: str) -> list[dict]:
+    try:
+        import httpx
+    except ImportError:
+        print("[error] Run: pip install httpx")
+        sys.exit(1)
+
+    from urllib.parse import quote
+
+    url = f"https://api.powerbi.com/v1.0/myorg/{quote(workspace, safe='')}"
+    soap = _DISCOVER_SOAP.format(request_type=request_type, dataset=dataset)
+
+    response = httpx.post(
+        url,
+        content=soap.encode("utf-8"),
+        headers={
+            "Content-Type": "text/xml;charset=UTF-8",
+            "SOAPAction": f"urn:schemas-microsoft-com:xml-analysis:Discover",
+            "Authorization": f"Bearer {token}",
+        },
+        timeout=30.0,
+    )
+
+    if not response.is_success:
+        print(f"[error] XMLA HTTP {response.status_code}: {response.text[:500]}")
+        sys.exit(1)
+
+    rowset_ns = "urn:schemas-microsoft-com:xml-analysis:rowset"
+    root = ET.fromstring(response.text)
+    rows = root.findall(f".//{{{rowset_ns}}}row")
+
+    results = []
+    for row in rows:
+        entry = {}
+        for child in row:
+            tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+            entry[tag] = child.text
+        results.append(entry)
+    return results
+
+
+def main() -> None:
+    tenant_id = _require_env("AZURE_TENANT_ID")
+    client_id = _require_env("AZURE_CLIENT_ID")
+    client_secret = _require_env("AZURE_CLIENT_SECRET")
+    workspace = _require_env("POWERBI_WORKSPACE")
+    dataset = _require_env("POWERBI_DATASET")
+
+    print(f"Acquiring token for tenant={tenant_id} client={client_id}...")
+    token = acquire_token(tenant_id, client_id, client_secret)
+    print("✓ Token acquired\n")
+
+    print(f"Discovering tables in dataset='{dataset}' workspace='{workspace}'...")
+    tables = xmla_discover(token, workspace, dataset, "TMSCHEMA_TABLES")
+
+    if not tables:
+        print("[warn] No tables returned — check workspace/dataset name and SP permissions.")
+        return
+
+    print(f"✓ Found {len(tables)} tables:\n")
+    for t in tables:
+        hidden = t.get("IsHidden", "false")
+        print(f"  {'(hidden) ' if hidden == 'true' else ''}{t.get('Name', '?')}")
+
+    print(f"\nDiscovering measures...")
+    measures = xmla_discover(token, workspace, dataset, "TMSCHEMA_MEASURES")
+    print(f"✓ Found {len(measures)} measures")
+
+    print(f"\nDiscovering relationships...")
+    rels = xmla_discover(token, workspace, dataset, "TMSCHEMA_RELATIONSHIPS")
+    print(f"✓ Found {len(rels)} relationships")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds powerbi_xmla as a new database source type that connects to Power BI Premium and Microsoft Fabric semantic models via the XMLA protocol using service principal authentication.

Changes:
- PowerBIXmlaConfig with env-var resolution, optional xmla_endpoint override, MSAL singleton per (tenant_id, client_id), row limit and timeout settings
- XmlaClient: SOAP client with circuit breaker, 401/503 retry, XSD column-name mapping in _parse_execute_response
- sync_powerbi_xmla: discovers tables/columns/measures/relationships via TMSCHEMA DMVs; fixed column->table join (ID not TableID); table names resolved in measures.md and relations.md instead of numeric IDs
- POST /execute_dax endpoint with EVALUATE guard, isolated from /execute_sql; GET /health/powerbi-xmla
- execute_dax agent tool gated behind agentSettings.powerbi.xmlaEnabled
- updateAgentSettings tRPC extended with powerbi field; persisted in existing agent_settings JSON column
- SettingsExperimental toggle for xmlaEnabled (admin-only)
- 11 new unit tests: env resolution, endpoint override, XML parsing with XSD fixture, measures name resolution, join key correctness
- msal>=1.28.0,<2 and httpx>=0.27.0,<1 optional extra powerbi_xmla

Feature is off by default behind powerbi.xmlaEnabled flag.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>