### PR TITLE
feat(cli): add -u/--username and --password flags to `nao test` for CI auth

### DIFF
--- a/cli/nao_core/auth.py
+++ b/cli/nao_core/auth.py
@@ -35,19 +35,11 @@ def clear_stored_cookies() -> None:
         AUTH_FILE.unlink()
 
 
-def prompt_login(backend_url: str) -> dict[str, str] | None:
-    """Prompt user for credentials and authenticate.
+def login(backend_url: str, email: str, password: str) -> dict[str, str] | None:
+    """Authenticate with email and password (non-interactive).
 
     Returns session cookies on success, None on failure.
     """
-    UI.info("\n🔐 Authentication required\n")
-
-    email = ask_text("Email:", required_field=True)
-    password = ask_text("Password:", password=True, required_field=True)
-
-    if not email or not password:
-        return None
-
     UI.print("[dim]Authenticating...[/dim]")
 
     try:
@@ -60,7 +52,6 @@ def prompt_login(backend_url: str) -> dict[str, str] | None:
         )
 
         if response.status_code == 200:
-            # Extract cookies from response
             cookies = dict(response.cookies)
             if cookies:
                 store_cookies(cookies)
@@ -85,19 +76,41 @@ def prompt_login(backend_url: str) -> dict[str, str] | None:
         return None
 
 
-def get_auth_session(backend_url: str, prompt_if_missing: bool = True) -> requests.Session:
+def prompt_login(backend_url: str) -> dict[str, str] | None:
+    """Prompt user for credentials and authenticate.
+
+    Returns session cookies on success, None on failure.
+    """
+    UI.info("\n🔐 Authentication required\n")
+
+    email = ask_text("Email:", required_field=True)
+    password = ask_text("Password:", password=True, required_field=True)
+
+    if not email or not password:
+        return None
+
+    return login(backend_url, email, password)
+
+
+def get_auth_session(
+    backend_url: str,
+    prompt_if_missing: bool = True,
+    email: str | None = None,
+    password: str | None = None,
+) -> requests.Session:
     """Get a requests session with authentication cookies.
 
-    Args:
-        backend_url: The backend URL to authenticate against.
-        prompt_if_missing: If True, prompt for login when no stored credentials.
-
-    Returns:
-        A requests.Session with cookies set (may be empty if auth failed/skipped).
+    When email and password are provided, authenticates non-interactively.
+    Otherwise falls back to stored cookies or interactive prompt.
     """
     session = requests.Session()
 
-    # Try stored cookies first
+    if email and password:
+        cookies = login(backend_url, email, password)
+        if cookies:
+            session.cookies.update(cookies)
+        return session
+
     cookies = get_stored_cookies()
 
     if cookies:

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import requests
 
-from nao_core.auth import clear_stored_cookies, get_auth_session, prompt_login
+from nao_core.auth import clear_stored_cookies, get_auth_session, login, prompt_login
 from nao_core.ui import UI
 
 from .case import TestCase
@@ -68,14 +68,25 @@ class AgentClientError(Exception):
 class AgentClient:
     """Client for interacting with the nao agent API."""
 
-    def __init__(self, backend_url: str = BACKEND_URL):
+    def __init__(
+        self,
+        backend_url: str = BACKEND_URL,
+        email: str | None = None,
+        password: str | None = None,
+    ):
         self.backend_url = backend_url
+        self._email = email
+        self._password = password
         self._session: requests.Session | None = None
 
     def _get_session(self) -> requests.Session:
         """Get or create an authenticated session."""
         if self._session is None:
-            self._session = get_auth_session(self.backend_url)
+            self._session = get_auth_session(
+                self.backend_url,
+                email=self._email,
+                password=self._password,
+            )
         return self._session
 
     def _reset_session(self) -> None:
@@ -83,12 +94,16 @@ class AgentClient:
         self._session = None
 
     def _handle_auth_retry(self) -> bool:
-        """Handle 401 by prompting for login. Returns True if re-auth succeeded."""
+        """Handle 401 by re-authenticating. Uses stored credentials when available."""
         UI.warn("Session expired or unauthorized.")
         clear_stored_cookies()
         self._reset_session()
 
-        cookies = prompt_login(self.backend_url)
+        if self._email and self._password:
+            cookies = login(self.backend_url, self._email, self._password)
+        else:
+            cookies = prompt_login(self.backend_url)
+
         if cookies:
             self._reset_session()
             return True
@@ -139,9 +154,9 @@ class AgentClient:
 _client: AgentClient | None = None
 
 
-def get_client() -> AgentClient:
+def get_client(email: str | None = None, password: str | None = None) -> AgentClient:
     """Get or create the module-level agent client."""
     global _client
     if _client is None:
-        _client = AgentClient(BACKEND_URL)
+        _client = AgentClient(BACKEND_URL, email=email, password=password)
     return _client

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -1,4 +1,5 @@
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -170,12 +171,17 @@ def check_dataframe(
     return False, "values differ", comparison
 
 
-def run_test(test_case: TestCase, model: ModelConfig) -> TestRunResult:
+def run_test(
+    test_case: TestCase,
+    model: ModelConfig,
+    email: str | None = None,
+    password: str | None = None,
+) -> TestRunResult:
     """Run a single test case with a specific model. Returns TestRunResult."""
     UI.print(f"[bold]Running:[/bold] {test_case.name} [dim]({model})[/dim]")
     UI.print(f"[dim]  Prompt: {test_case.prompt}[/dim]")
 
-    client = get_client()
+    client = get_client(email=email, password=password)
 
     try:
         result = client.run_test(test_case, provider=model.provider, model_id=model.model_id)
@@ -310,6 +316,20 @@ def test(
             help="Run only one test by name or yaml filename stem.",
         ),
     ] = None,
+    username: Annotated[
+        str | None,
+        Parameter(
+            name=["-u", "--username"],
+            help="Email for authentication. Falls back to NAO_USERNAME env var.",
+        ),
+    ] = None,
+    password: Annotated[
+        str | None,
+        Parameter(
+            name=["--password"],
+            help="Password for authentication. Falls back to NAO_PASSWORD env var.",
+        ),
+    ] = None,
 ):
     """Run tests from the tests/ folder.
 
@@ -319,7 +339,11 @@ def test(
         nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
         nao test --threads 4
         nao test -s test_name
+        nao test -u user@example.com --password secret
     """
+    email = username or os.environ.get("NAO_USERNAME")
+    pwd = password or os.environ.get("NAO_PASSWORD")
+
     UI.info("\n🧪 Running nao tests...\n")
 
     config = NaoConfig.try_load(exit_on_error=True)
@@ -361,15 +385,13 @@ def test(
 
     results: list[TestRunResult] = []
     if threads == 1:
-        # Sequential execution
         for test_case, model in test_runs:
-            result = run_test(test_case, model)
+            result = run_test(test_case, model, email=email, password=pwd)
             results.append(result)
             UI.print("")
     else:
-        # Parallel execution
         with ThreadPoolExecutor(max_workers=threads) as executor:
-            futures = {executor.submit(run_test, tc, m): (tc, m) for tc, m in test_runs}
+            futures = {executor.submit(run_test, tc, m, email=email, password=pwd): (tc, m) for tc, m in test_runs}
             for future in as_completed(futures):
                 result = future.result()
                 results.append(result)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds non-interactive authentication support to `nao test` so it can run in CI pipelines without interactive prompts.

Closes #565

## Changes

### `cli/nao_core/auth.py`
- Extracted core HTTP login logic into a new `login(backend_url, email, password)` function for programmatic (non-interactive) use
- `prompt_login()` now delegates to `login()` after gathering credentials interactively
- `get_auth_session()` accepts optional `email`/`password` params — when provided, authenticates non-interactively

### `cli/nao_core/commands/test/client.py`
- `AgentClient` accepts optional `email`/`password` in constructor
- `_get_session()` passes credentials to `get_auth_session()`
- `_handle_auth_retry()` uses stored credentials for non-interactive retry on 401
- `get_client()` accepts and forwards `email`/`password`

### `cli/nao_core/commands/test/runner.py`
- Added `-u`/`--username` flag (falls back to `NAO_USERNAME` env var)
- Added `--password` flag (falls back to `NAO_PASSWORD` env var)
- Credentials are threaded through to `run_test()` → `get_client()`

## Usage

```bash
# CLI flags
nao test -u user@example.com --password secret

# Environment variables (recommended for CI — password never appears in command line)
export NAO_USERNAME=user@example.com
export NAO_PASSWORD=secret
nao test
```

The password is never printed to stdout/stderr at any point in the flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d9a10f-a56c-4607-950f-9f2820e60cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d9a10f-a56c-4607-950f-9f2820e60cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

