### PR TITLE
feat: multi-org multi-project architecture with cloud mode

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -6,10 +6,27 @@ import dbConfig, { Dialect } from './db/dbConfig';
 import { env } from './env';
 import * as orgQueries from './queries/organization.queries';
 import { emailService } from './services/email';
+import { isSelfHosted } from './utils/deployment-mode';
 import { buildForgotPasswordEmail } from './utils/email-builders';
 import { buildGithubAllowlist, isEmailDomainAllowed } from './utils/utils';
 
 type GoogleConfig = Awaited<ReturnType<typeof orgQueries.getGoogleConfig>>;
+
+async function onUserCreated(user: { id: string; name: string; email: string }, isSocial: boolean) {
+	if (isSelfHosted()) {
+		await orgQueries.initializeDefaultOrganizationForFirstUser(user.id);
+		if (isSocial) {
+			await orgQueries.addUserToDefaultProjectIfExists(user.id);
+		}
+		return;
+	}
+
+	await orgQueries.acceptPendingInvitationsForUser(user.id, user.email);
+	const memberships = await orgQueries.listUserOrganizations(user.id);
+	if (memberships.length === 0) {
+		await orgQueries.createPersonalOrganization(user.id, user.name);
+	}
+}
 
 function createAuthInstance(googleConfig: GoogleConfig) {
 	const githubAllowlist = buildGithubAllowlist(env.GITHUB_ALLOWED_USERS);
@@ -83,10 +100,7 @@ function createAuthInstance(googleConfig: GoogleConfig) {
 					},
 					async after(user, ctx) {
 						const isSocial = ctx?.params?.id === 'google' || ctx?.params?.id === 'github';
-						await orgQueries.initializeDefaultOrganizationForFirstUser(user.id);
-						if (isSocial) {
-							await orgQueries.addUserToDefaultProjectIfExists(user.id);
-						}
+						await onUserCreated(user, isSocial);
 					},
 				},
 			},

--- a/apps/backend/src/db/abstractSchema.ts
+++ b/apps/backend/src/db/abstractSchema.ts
@@ -42,6 +42,9 @@ export type NewOrganization = typeof sqliteSchema.organization.$inferInsert;
 export type DBOrgMember = typeof sqliteSchema.orgMember.$inferSelect;
 export type NewOrgMember = typeof sqliteSchema.orgMember.$inferInsert;
 
+export type DBInvitation = typeof sqliteSchema.invitation.$inferSelect;
+export type NewInvitation = typeof sqliteSchema.invitation.$inferInsert;
+
 export type DBProjectSavedPrompt = typeof sqliteSchema.projectSavedPrompt.$inferSelect;
 export type NewProjectSavedPrompt = typeof sqliteSchema.projectSavedPrompt.$inferInsert;
 

--- a/apps/backend/src/db/pg-schema.ts
+++ b/apps/backend/src/db/pg-schema.ts
@@ -1,5 +1,5 @@
 import type { LlmProvider } from '@nao/shared/types';
-import { SHARE_VISIBILITY, USER_ROLES } from '@nao/shared/types';
+import { INVITATION_SCOPES, INVITATION_STATUSES, SHARE_VISIBILITY, USER_ROLES } from '@nao/shared/types';
 import { type ProviderMetadata } from 'ai';
 import { sql } from 'drizzle-orm';
 import {
@@ -128,6 +128,34 @@ export const orgMember = pgTable(
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 	},
 	(t) => [primaryKey({ columns: [t.orgId, t.userId] }), index('org_member_userId_idx').on(t.userId)],
+);
+
+export const invitation = pgTable(
+	'invitation',
+	{
+		id: text('id')
+			.$defaultFn(() => crypto.randomUUID())
+			.primaryKey(),
+		orgId: text('org_id')
+			.notNull()
+			.references(() => organization.id, { onDelete: 'cascade' }),
+		projectId: text('project_id'),
+		email: text('email').notNull(),
+		role: text('role', { enum: USER_ROLES }).notNull(),
+		scope: text('scope', { enum: INVITATION_SCOPES }).notNull(),
+		invitedBy: text('invited_by')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		token: text('token').notNull().unique(),
+		status: text('status', { enum: INVITATION_STATUSES }).notNull().default('pending'),
+		expiresAt: timestamp('expires_at').notNull(),
+		createdAt: timestamp('created_at').defaultNow().notNull(),
+	},
+	(t) => [
+		index('invitation_orgId_idx').on(t.orgId),
+		index('invitation_email_idx').on(t.email),
+		index('invitation_token_idx').on(t.token),
+	],
 );
 
 export const project = pgTable(

--- a/apps/backend/src/db/sqlite-schema.ts
+++ b/apps/backend/src/db/sqlite-schema.ts
@@ -1,5 +1,5 @@
 import type { LlmProvider } from '@nao/shared/types';
-import { SHARE_VISIBILITY, USER_ROLES } from '@nao/shared/types';
+import { INVITATION_SCOPES, INVITATION_STATUSES, SHARE_VISIBILITY, USER_ROLES } from '@nao/shared/types';
 import { type ProviderMetadata } from 'ai';
 import { sql } from 'drizzle-orm';
 import { check, index, integer, primaryKey, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
@@ -134,6 +134,36 @@ export const orgMember = sqliteTable(
 			.notNull(),
 	},
 	(t) => [primaryKey({ columns: [t.orgId, t.userId] }), index('org_member_userId_idx').on(t.userId)],
+);
+
+export const invitation = sqliteTable(
+	'invitation',
+	{
+		id: text('id')
+			.$defaultFn(() => crypto.randomUUID())
+			.primaryKey(),
+		orgId: text('org_id')
+			.notNull()
+			.references(() => organization.id, { onDelete: 'cascade' }),
+		projectId: text('project_id'),
+		email: text('email').notNull(),
+		role: text('role', { enum: USER_ROLES }).notNull(),
+		scope: text('scope', { enum: INVITATION_SCOPES }).notNull(),
+		invitedBy: text('invited_by')
+			.notNull()
+			.references(() => user.id, { onDelete: 'cascade' }),
+		token: text('token').notNull().unique(),
+		status: text('status', { enum: INVITATION_STATUSES }).notNull().default('pending'),
+		expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
+		createdAt: integer('created_at', { mode: 'timestamp_ms' })
+			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+			.notNull(),
+	},
+	(t) => [
+		index('invitation_orgId_idx').on(t.orgId),
+		index('invitation_email_idx').on(t.email),
+		index('invitation_token_idx').on(t.token),
+	],
 );
 
 export const project = sqliteTable(

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -11,6 +11,7 @@ dotenv.config({
 
 const envSchema = z.object({
 	MODE: z.enum(['dev', 'prod', 'test']).default('dev'),
+	NAO_MODE: z.enum(['self-hosted', 'cloud']).optional(),
 
 	DB_URI: z.string().default('sqlite:./db.sqlite'),
 	DB_SSL: z
@@ -67,6 +68,11 @@ if (!result.success) {
 		const path = issue.path.join('.');
 		console.error(`${path}: ${issue.message}`);
 	}
+	process.exit(1);
+}
+
+if (result.data.NAO_DEFAULT_PROJECT_PATH && result.data.NAO_MODE === 'cloud') {
+	console.error('NAO_DEFAULT_PROJECT_PATH and NAO_MODE=cloud cannot be set at the same time.');
 	process.exit(1);
 }
 

--- a/apps/backend/src/queries/invitation.queries.ts
+++ b/apps/backend/src/queries/invitation.queries.ts
@@ -1,0 +1,51 @@
+import { and, eq, gt } from 'drizzle-orm';
+
+import s, { DBInvitation, NewInvitation } from '../db/abstractSchema';
+import { db } from '../db/db';
+
+const INVITATION_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const createInvitation = async (
+	invitation: Omit<NewInvitation, 'token' | 'expiresAt'>,
+): Promise<DBInvitation> => {
+	const token = crypto.randomUUID();
+	const expiresAt = new Date(Date.now() + INVITATION_EXPIRY_MS);
+	const [created] = await db
+		.insert(s.invitation)
+		.values({ ...invitation, token, expiresAt })
+		.returning()
+		.execute();
+	return created;
+};
+
+export const getInvitationByToken = async (token: string): Promise<DBInvitation | null> => {
+	const [inv] = await db.select().from(s.invitation).where(eq(s.invitation.token, token)).execute();
+	return inv ?? null;
+};
+
+export const getInvitationById = async (id: string): Promise<DBInvitation | null> => {
+	const [inv] = await db.select().from(s.invitation).where(eq(s.invitation.id, id)).execute();
+	return inv ?? null;
+};
+
+export const listPendingInvitationsForOrg = async (orgId: string): Promise<DBInvitation[]> => {
+	return db
+		.select()
+		.from(s.invitation)
+		.where(
+			and(
+				eq(s.invitation.orgId, orgId),
+				eq(s.invitation.status, 'pending'),
+				gt(s.invitation.expiresAt, new Date()),
+			),
+		)
+		.execute();
+};
+
+export const markAccepted = async (invitationId: string): Promise<void> => {
+	await db.update(s.invitation).set({ status: 'accepted' }).where(eq(s.invitation.id, invitationId)).execute();
+};
+
+export const revokeInvitation = async (invitationId: string): Promise<void> => {
+	await db.delete(s.invitation).where(eq(s.invitation.id, invitationId)).execute();
+};

--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -1,11 +1,26 @@
+import type { UserRole } from '@nao/shared/types';
 import { and, eq, isNull } from 'drizzle-orm';
 
 import s, { DBOrganization, DBOrgMember, NewOrganization, NewOrgMember } from '../db/abstractSchema';
 import { db } from '../db/db';
 import { env } from '../env';
-import { OrgRole } from '../types/organization';
+import type { OrgRole } from '../types/organization';
+import { isCloud, isSelfHosted } from '../utils/deployment-mode';
+import { generateSlug } from '../utils/utils';
 import * as projectQueries from './project.queries';
 import * as userQueries from './user.queries';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toOrgRole(role: UserRole): OrgRole {
+	return role === 'viewer' ? 'user' : role;
+}
+
+// ---------------------------------------------------------------------------
+// Core CRUD
+// ---------------------------------------------------------------------------
 
 export const getOrganizationById = async (id: string): Promise<DBOrganization | null> => {
 	const [org] = await db.select().from(s.organization).where(eq(s.organization.id, id)).execute();
@@ -22,6 +37,56 @@ export const createOrganization = async (org: NewOrganization): Promise<DBOrgani
 	return created;
 };
 
+export const updateOrganization = async (
+	orgId: string,
+	values: Partial<Pick<DBOrganization, 'name' | 'slug'>>,
+): Promise<DBOrganization> => {
+	const [updated] = await db
+		.update(s.organization)
+		.set(values)
+		.where(eq(s.organization.id, orgId))
+		.returning()
+		.execute();
+	return updated;
+};
+
+export const listUserOrganizations = async (
+	userId: string,
+): Promise<(DBOrgMember & { organization: DBOrganization })[]> => {
+	return db
+		.select({
+			orgId: s.orgMember.orgId,
+			userId: s.orgMember.userId,
+			role: s.orgMember.role,
+			createdAt: s.orgMember.createdAt,
+			organization: s.organization,
+		})
+		.from(s.orgMember)
+		.innerJoin(s.organization, eq(s.orgMember.orgId, s.organization.id))
+		.where(eq(s.orgMember.userId, userId))
+		.execute();
+};
+
+export const listOrgMembers = async (
+	orgId: string,
+): Promise<{ userId: string; role: OrgRole; name: string; email: string }[]> => {
+	return db
+		.select({
+			userId: s.orgMember.userId,
+			role: s.orgMember.role,
+			name: s.user.name,
+			email: s.user.email,
+		})
+		.from(s.orgMember)
+		.innerJoin(s.user, eq(s.orgMember.userId, s.user.id))
+		.where(eq(s.orgMember.orgId, orgId))
+		.execute();
+};
+
+// ---------------------------------------------------------------------------
+// Org members
+// ---------------------------------------------------------------------------
+
 export const getOrgMember = async (orgId: string, userId: string): Promise<DBOrgMember | null> => {
 	const [member] = await db
 		.select()
@@ -36,22 +101,25 @@ export const addOrgMember = async (member: NewOrgMember): Promise<DBOrgMember> =
 	return created;
 };
 
+export const removeOrgMember = async (orgId: string, userId: string): Promise<void> => {
+	await db
+		.delete(s.orgMember)
+		.where(and(eq(s.orgMember.orgId, orgId), eq(s.orgMember.userId, userId)))
+		.execute();
+};
+
+export const updateOrgMemberRole = async (orgId: string, userId: string, role: OrgRole): Promise<void> => {
+	await db
+		.update(s.orgMember)
+		.set({ role })
+		.where(and(eq(s.orgMember.orgId, orgId), eq(s.orgMember.userId, userId)))
+		.execute();
+};
+
 export const getUserOrgMembership = async (
 	userId: string,
 ): Promise<(DBOrgMember & { organization: DBOrganization }) | null> => {
-	const [result] = await db
-		.select({
-			orgId: s.orgMember.orgId,
-			userId: s.orgMember.userId,
-			role: s.orgMember.role,
-			createdAt: s.orgMember.createdAt,
-			organization: s.organization,
-		})
-		.from(s.orgMember)
-		.innerJoin(s.organization, eq(s.orgMember.orgId, s.organization.id))
-		.where(eq(s.orgMember.userId, userId))
-		.limit(1)
-		.execute();
+	const [result] = await listUserOrganizations(userId);
 	return result ?? null;
 };
 
@@ -59,6 +127,10 @@ export const getUserRoleInOrg = async (orgId: string, userId: string): Promise<O
 	const member = await getOrgMember(orgId, userId);
 	return member?.role ?? null;
 };
+
+// ---------------------------------------------------------------------------
+// Google SSO config
+// ---------------------------------------------------------------------------
 
 export const updateGoogleSettings = async (
 	orgId: string,
@@ -87,6 +159,20 @@ export const getGoogleConfig = async () => {
 	};
 };
 
+export const getGoogleConfigForOrg = async (orgId: string) => {
+	const org = await getOrganizationById(orgId);
+	return {
+		clientId: org?.googleClientId || env.GOOGLE_CLIENT_ID || '',
+		clientSecret: org?.googleClientSecret || env.GOOGLE_CLIENT_SECRET || '',
+		authDomains: org?.googleAuthDomains || env.GOOGLE_AUTH_DOMAINS || '',
+		usingDbOverride: !!(org?.googleClientId && org?.googleClientSecret),
+	};
+};
+
+// ---------------------------------------------------------------------------
+// Default / personal org helpers
+// ---------------------------------------------------------------------------
+
 export const getOrCreateDefaultOrganization = async (): Promise<DBOrganization> => {
 	const existing = await getFirstOrganization();
 	if (existing) {
@@ -99,12 +185,24 @@ export const getOrCreateDefaultOrganization = async (): Promise<DBOrganization> 
 	});
 };
 
-/**
- * Initialize default organization and project for the first user.
- * Creates the organization, adds the user as admin, and creates the default project.
- * All operations are wrapped in a transaction.
- */
+export const createPersonalOrganization = async (userId: string, userName: string): Promise<DBOrganization> => {
+	const org = await createOrganization({
+		name: `${userName}'s Organization`,
+		slug: generateSlug(userName),
+	});
+	await addOrgMember({ orgId: org.id, userId, role: 'admin' });
+	return org;
+};
+
+// ---------------------------------------------------------------------------
+// Self-hosted bootstrap (first user + startup)
+// ---------------------------------------------------------------------------
+
 export const initializeDefaultOrganizationForFirstUser = async (userId: string): Promise<void> => {
+	if (isCloud()) {
+		return;
+	}
+
 	const userCount = await userQueries.countAll();
 	if (userCount !== 1) {
 		return;
@@ -116,17 +214,14 @@ export const initializeDefaultOrganizationForFirstUser = async (userId: string):
 	}
 
 	await db.transaction(async (tx) => {
-		// Create organization
 		const [org] = await tx
 			.insert(s.organization)
 			.values({ name: 'Default Organization', slug: 'default' })
 			.returning()
 			.execute();
 
-		// Add user as org admin
 		await tx.insert(s.orgMember).values({ orgId: org.id, userId, role: 'admin' }).execute();
 
-		// Create default project if path is configured
 		const projectPath = process.env.NAO_DEFAULT_PROJECT_PATH;
 		if (projectPath) {
 			const [existingProject] = await tx
@@ -149,12 +244,11 @@ export const initializeDefaultOrganizationForFirstUser = async (userId: string):
 	});
 };
 
-/**
- * Add a user to the default organization and project if they don't already exist.
- * Called when a new user signs up.
- * Idempotent: safe to call multiple times for the same user.
- */
 export const addUserToDefaultProjectIfExists = async (userId: string): Promise<void> => {
+	if (isCloud()) {
+		return;
+	}
+
 	const org = await getFirstOrganization();
 	if (!org) {
 		return;
@@ -184,58 +278,81 @@ export const addUserToDefaultProjectIfExists = async (userId: string): Promise<v
 	});
 };
 
-/**
- * Startup check: Ensures organization structure is valid.
- * - If there are users but no organization, creates one and assigns first user as org_admin
- * - If there are projects without an org, assigns them to the default org
- * - If NAO_DEFAULT_PROJECT_PATH is set, ensures a project exists for that path
- */
+// ---------------------------------------------------------------------------
+// Cloud-mode: accept pending invitations on signup
+// ---------------------------------------------------------------------------
+
+export const acceptPendingInvitationsForUser = async (userId: string, email: string): Promise<void> => {
+	const pendingInvitations = await db
+		.select()
+		.from(s.invitation)
+		.where(and(eq(s.invitation.email, email.toLowerCase()), eq(s.invitation.status, 'pending')))
+		.execute();
+
+	for (const inv of pendingInvitations) {
+		await db.transaction(async (tx) => {
+			const existingOrgMember = await tx.query.orgMember.findFirst({
+				where: and(eq(s.orgMember.orgId, inv.orgId), eq(s.orgMember.userId, userId)),
+			});
+			if (!existingOrgMember) {
+				await tx
+					.insert(s.orgMember)
+					.values({ orgId: inv.orgId, userId, role: toOrgRole(inv.role) })
+					.execute();
+			}
+
+			if (inv.projectId) {
+				const existingProjectMember = await tx.query.projectMember.findFirst({
+					where: and(eq(s.projectMember.projectId, inv.projectId), eq(s.projectMember.userId, userId)),
+				});
+				if (!existingProjectMember) {
+					await tx
+						.insert(s.projectMember)
+						.values({ projectId: inv.projectId, userId, role: inv.role })
+						.execute();
+				}
+			}
+
+			await tx.update(s.invitation).set({ status: 'accepted' }).where(eq(s.invitation.id, inv.id)).execute();
+		});
+	}
+};
+
+// ---------------------------------------------------------------------------
+// Startup setup
+// ---------------------------------------------------------------------------
+
 export const ensureOrganizationSetup = async (): Promise<void> => {
-	const firstUser = await userQueries.getFirst();
-	if (!firstUser) {
-		return; // No users yet, nothing to do
+	if (isCloud()) {
+		return;
 	}
 
-	// Check if there's an organization
+	const firstUser = await userQueries.getFirst();
+	if (!firstUser) {
+		return;
+	}
+
 	let org = await getFirstOrganization();
 
 	if (!org) {
-		// Create default organization
-		org = await createOrganization({
-			name: 'Default Organization',
-			slug: 'default',
-		});
-
-		// Add first user as org_admin
-		await addOrgMember({
-			orgId: org.id,
-			userId: firstUser.id,
-			role: 'admin',
-		});
+		org = await createOrganization({ name: 'Default Organization', slug: 'default' });
+		await addOrgMember({ orgId: org.id, userId: firstUser.id, role: 'admin' });
 	}
 
-	// Check if first user is a member of the org
 	const membership = await getOrgMember(org.id, firstUser.id);
 	if (!membership) {
-		await addOrgMember({
-			orgId: org.id,
-			userId: firstUser.id,
-			role: 'admin',
-		});
+		await addOrgMember({ orgId: org.id, userId: firstUser.id, role: 'admin' });
 	}
 
-	// Assign any orphaned projects (projects without org) to the default org
 	await db.update(s.project).set({ orgId: org.id }).where(isNull(s.project.orgId)).execute();
-
-	// Ensure a project exists for the current NAO_DEFAULT_PROJECT_PATH
 	await ensureDefaultProject(org);
 };
 
-/**
- * Ensures a project exists for the current NAO_DEFAULT_PROJECT_PATH.
- * When users change the project path and restart, the DB may not have a record for the new path.
- */
 const ensureDefaultProject = async (org: DBOrganization): Promise<void> => {
+	if (!isSelfHosted()) {
+		return;
+	}
+
 	const projectPath = env.NAO_DEFAULT_PROJECT_PATH;
 	if (!projectPath) {
 		return;
@@ -254,7 +371,6 @@ const ensureDefaultProject = async (org: DBOrganization): Promise<void> => {
 		orgId: org.id,
 	});
 
-	// Add all org members to the new project
 	const orgMembers = await db.select().from(s.orgMember).where(eq(s.orgMember.orgId, org.id)).execute();
 	for (const member of orgMembers) {
 		await projectQueries.addProjectMember({

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -109,7 +109,7 @@ export const getDefaultProject = async (): Promise<DBProject | null> => {
 	return getProjectByPath(projectPath);
 };
 
-export const getProjectByUserId = async (userId: string): Promise<DBProject | null> => {
+export const getDefaultProjectForUser = async (userId: string): Promise<DBProject | null> => {
 	const projectPath = env.NAO_DEFAULT_PROJECT_PATH;
 	if (!projectPath) {
 		return null;
@@ -120,13 +120,25 @@ export const getProjectByUserId = async (userId: string): Promise<DBProject | nu
 		return null;
 	}
 
-	const userProject = await getProjectMember(project.id, userId);
+	const membership = await getProjectMember(project.id, userId);
+	return membership ? project : null;
+};
 
-	if (!userProject) {
+export const getProjectForUser = async (projectId: string, userId: string): Promise<DBProject | null> => {
+	const project = await getProjectById(projectId);
+	if (!project) {
 		return null;
 	}
 
-	return project;
+	const membership = await getProjectMember(project.id, userId);
+	return membership ? project : null;
+};
+
+/** @deprecated Use getDefaultProjectForUser instead */
+export const getProjectByUserId = getDefaultProjectForUser;
+
+export const listProjectsByOrgId = async (orgId: string): Promise<DBProject[]> => {
+	return db.select().from(s.project).where(eq(s.project.orgId, orgId)).execute();
 };
 
 export const checkProjectHasMoreThanOneAdmin = async (projectId: string): Promise<boolean> => {

--- a/apps/backend/src/trpc/invitation.routes.ts
+++ b/apps/backend/src/trpc/invitation.routes.ts
@@ -1,0 +1,124 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod/v4';
+
+import * as invitationQueries from '../queries/invitation.queries';
+import * as orgQueries from '../queries/organization.queries';
+import * as projectQueries from '../queries/project.queries';
+import { emailService } from '../services/email';
+import type { OrgRole } from '../types/organization';
+import { buildInvitationEmail } from '../utils/email-builders';
+import { orgAdminProcedure, protectedProcedure } from './trpc';
+
+function toOrgRole(role: string): OrgRole {
+	return role === 'viewer' ? 'user' : (role as OrgRole);
+}
+
+export const invitationRoutes = {
+	send: orgAdminProcedure
+		.input(
+			z.object({
+				orgId: z.string(),
+				email: z.string().email(),
+				role: z.enum(['admin', 'user', 'viewer']),
+				projectId: z.string().optional(),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const scope = input.projectId ? 'project' : 'org';
+
+			if (input.projectId) {
+				const project = await projectQueries.getProjectById(input.projectId);
+				if (!project || project.orgId !== ctx.org.id) {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Project not found in this organization' });
+				}
+			}
+
+			const invitation = await invitationQueries.createInvitation({
+				orgId: ctx.org.id,
+				projectId: input.projectId ?? null,
+				email: input.email.toLowerCase(),
+				role: input.role,
+				scope,
+				invitedBy: ctx.user.id,
+				status: 'pending',
+			});
+
+			if (emailService.isEnabled()) {
+				await emailService.sendEmail(
+					invitation.email,
+					buildInvitationEmail({
+						orgName: ctx.org.name,
+						inviterName: ctx.user.name,
+						token: invitation.token,
+					}),
+				);
+			}
+
+			return invitation;
+		}),
+
+	listForOrg: orgAdminProcedure.input(z.object({ orgId: z.string() })).query(async ({ ctx }) => {
+		return invitationQueries.listPendingInvitationsForOrg(ctx.org.id);
+	}),
+
+	revoke: orgAdminProcedure
+		.input(z.object({ orgId: z.string(), invitationId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const invitation = await invitationQueries.getInvitationById(input.invitationId);
+			if (!invitation || invitation.orgId !== ctx.org.id) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Invitation not found' });
+			}
+			await invitationQueries.revokeInvitation(input.invitationId);
+		}),
+
+	accept: protectedProcedure.input(z.object({ token: z.string() })).mutation(async ({ ctx, input }) => {
+		const invitation = await invitationQueries.getInvitationByToken(input.token);
+		if (!invitation) {
+			throw new TRPCError({ code: 'NOT_FOUND', message: 'Invitation not found' });
+		}
+		if (invitation.status !== 'pending') {
+			throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invitation is no longer valid' });
+		}
+		if (invitation.expiresAt < new Date()) {
+			throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invitation has expired' });
+		}
+
+		const existingOrgMember = await orgQueries.getOrgMember(invitation.orgId, ctx.user.id);
+		if (!existingOrgMember) {
+			await orgQueries.addOrgMember({
+				orgId: invitation.orgId,
+				userId: ctx.user.id,
+				role: toOrgRole(invitation.role),
+			});
+		}
+
+		if (invitation.projectId) {
+			const existingProjectMember = await projectQueries.getProjectMember(invitation.projectId, ctx.user.id);
+			if (!existingProjectMember) {
+				await projectQueries.addProjectMember({
+					projectId: invitation.projectId,
+					userId: ctx.user.id,
+					role: invitation.role,
+				});
+			}
+		}
+
+		await invitationQueries.markAccepted(invitation.id);
+		return { orgId: invitation.orgId, projectId: invitation.projectId };
+	}),
+
+	getByToken: protectedProcedure.input(z.object({ token: z.string() })).query(async ({ input }) => {
+		const invitation = await invitationQueries.getInvitationByToken(input.token);
+		if (!invitation || invitation.status !== 'pending' || invitation.expiresAt < new Date()) {
+			return null;
+		}
+		const org = await orgQueries.getOrganizationById(invitation.orgId);
+		return {
+			id: invitation.id,
+			orgName: org?.name ?? 'Unknown',
+			email: invitation.email,
+			role: invitation.role,
+			scope: invitation.scope,
+		};
+	}),
+};

--- a/apps/backend/src/trpc/organization.routes.ts
+++ b/apps/backend/src/trpc/organization.routes.ts
@@ -1,0 +1,82 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod/v4';
+
+import * as orgQueries from '../queries/organization.queries';
+import * as projectQueries from '../queries/project.queries';
+import { getDeploymentMode } from '../utils/deployment-mode';
+import { generateSlug } from '../utils/utils';
+import { orgAdminProcedure, orgProtectedProcedure, protectedProcedure } from './trpc';
+
+export const organizationRoutes = {
+	getDeploymentMode: protectedProcedure.query(() => {
+		return { mode: getDeploymentMode() };
+	}),
+
+	list: protectedProcedure.query(async ({ ctx }) => {
+		const memberships = await orgQueries.listUserOrganizations(ctx.user.id);
+		return memberships.map((m) => ({
+			id: m.organization.id,
+			name: m.organization.name,
+			slug: m.organization.slug,
+			role: m.role,
+		}));
+	}),
+
+	create: protectedProcedure.input(z.object({ name: z.string().min(1) })).mutation(async ({ ctx, input }) => {
+		const org = await orgQueries.createOrganization({
+			name: input.name,
+			slug: generateSlug(input.name),
+		});
+		await orgQueries.addOrgMember({ orgId: org.id, userId: ctx.user.id, role: 'admin' });
+		return org;
+	}),
+
+	update: orgAdminProcedure
+		.input(z.object({ orgId: z.string(), name: z.string().min(1).optional() }))
+		.mutation(async ({ ctx, input }) => {
+			const values: Parameters<typeof orgQueries.updateOrganization>[1] = {};
+			if (input.name) {
+				values.name = input.name;
+			}
+			return orgQueries.updateOrganization(ctx.org.id, values);
+		}),
+
+	listMembers: orgProtectedProcedure.input(z.object({ orgId: z.string() })).query(async ({ ctx }) => {
+		return orgQueries.listOrgMembers(ctx.org.id);
+	}),
+
+	removeMember: orgAdminProcedure
+		.input(z.object({ orgId: z.string(), userId: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			if (input.userId === ctx.user.id) {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot remove yourself from the organization' });
+			}
+			await orgQueries.removeOrgMember(ctx.org.id, input.userId);
+		}),
+
+	updateMemberRole: orgAdminProcedure
+		.input(z.object({ orgId: z.string(), userId: z.string(), role: z.enum(['admin', 'user']) }))
+		.mutation(async ({ ctx, input }) => {
+			if (input.userId === ctx.user.id) {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot change your own role' });
+			}
+			await orgQueries.updateOrgMemberRole(ctx.org.id, input.userId, input.role);
+		}),
+
+	listProjects: orgProtectedProcedure.input(z.object({ orgId: z.string() })).query(async ({ ctx }) => {
+		return projectQueries.listProjectsByOrgId(ctx.org.id);
+	}),
+
+	createProject: orgAdminProcedure
+		.input(z.object({ orgId: z.string(), name: z.string().min(1), path: z.string().min(1) }))
+		.mutation(async ({ ctx, input }) => {
+			const project = await projectQueries.createProject({
+				name: input.name,
+				type: 'local',
+				path: input.path,
+				orgId: ctx.org.id,
+			});
+			await projectQueries.addProjectMember({ projectId: project.id, userId: ctx.user.id, role: 'admin' });
+			return project;
+		}),
+};

--- a/apps/backend/src/trpc/router.ts
+++ b/apps/backend/src/trpc/router.ts
@@ -6,9 +6,11 @@ import { chatForkRoutes } from './chat-fork.routes';
 import { citationRoutes } from './citation.routes';
 import { contextExplorerRoutes } from './context-explorer.routes';
 import { feedbackRoutes } from './feedback.routes';
+import { invitationRoutes } from './invitation.routes';
 import { logRoutes } from './log.routes';
 import { mcpRoutes } from './mcp.routes';
 import { memoryRoutes } from './memory.routes';
+import { organizationRoutes } from './organization.routes';
 import { posthogRoutes } from './posthog.routes';
 import { projectRoutes } from './project.routes';
 import { sharedChatRoutes } from './shared-chat.routes';
@@ -29,7 +31,9 @@ export const trpcRouter = router({
 	citation: citationRoutes,
 	contextExplorer: contextExplorerRoutes,
 	feedback: feedbackRoutes,
+	invitation: invitationRoutes,
 	log: logRoutes,
+	organization: organizationRoutes,
 	posthog: posthogRoutes,
 	project: projectRoutes,
 	storyShare: sharedStoryRoutes,

--- a/apps/backend/src/trpc/trpc.ts
+++ b/apps/backend/src/trpc/trpc.ts
@@ -4,7 +4,10 @@ import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify'
 import superjson from 'superjson';
 
 import { getAuth } from '../auth';
+import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
+import type { OrgRole } from '../types/organization';
+import { isCloud } from '../utils/deployment-mode';
 import { HandlerError } from '../utils/error';
 import { convertHeaders } from '../utils/utils';
 
@@ -15,22 +18,19 @@ export const createContext = async (opts: CreateFastifyContextOptions) => {
 	const headers = convertHeaders(opts.req.headers);
 	const auth = await getAuth();
 	const session = await auth?.api.getSession({ headers });
+	const projectId = opts.req.headers['x-project-id'] as string | undefined;
 	return {
 		session,
+		projectId,
 	};
 };
 
-/**
- * Initialization of tRPC backend
- * Should be done only once per backend!
- */
 const t = initTRPC.context<Context>().create({
 	transformer: superjson,
 });
 
 export const router = t.router;
 
-// Map HandlerError to tRPC error
 const withHandlerErrors = t.middleware(async ({ next }) => {
 	try {
 		return await next();
@@ -52,8 +52,15 @@ export const protectedProcedure = publicProcedure.use(async ({ ctx, next }) => {
 	return next({ ctx: { user: ctx.session.user } });
 });
 
+async function resolveProject(userId: string, headerProjectId?: string) {
+	if (isCloud() && headerProjectId) {
+		return projectQueries.getProjectForUser(headerProjectId, userId);
+	}
+	return projectQueries.getDefaultProjectForUser(userId);
+}
+
 export const projectProtectedProcedure = protectedProcedure.use(async ({ ctx, next }) => {
-	const project = await projectQueries.getProjectByUserId(ctx.user.id);
+	const project = await resolveProject(ctx.user.id, ctx.projectId);
 	if (!project) {
 		throw new TRPCError({ code: 'BAD_REQUEST', message: 'No project configured' });
 	}
@@ -68,6 +75,34 @@ export const adminProtectedProcedure = projectProtectedProcedure.use(async ({ ct
 	}
 
 	return next({ ctx: { project: ctx.project, userRole: ctx.userRole } });
+});
+
+export const orgProtectedProcedure = protectedProcedure
+	.input((raw: unknown) => {
+		const parsed = raw as Record<string, unknown>;
+		if (typeof parsed?.orgId !== 'string') {
+			throw new TRPCError({ code: 'BAD_REQUEST', message: 'orgId is required' });
+		}
+		return parsed as { orgId: string; [key: string]: unknown };
+	})
+	.use(async ({ ctx, input, next }) => {
+		const orgId = (input as { orgId: string }).orgId;
+		const membership = await orgQueries.getOrgMember(orgId, ctx.user.id);
+		if (!membership) {
+			throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not a member of this organization' });
+		}
+		const org = await orgQueries.getOrganizationById(orgId);
+		if (!org) {
+			throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' });
+		}
+		return next({ ctx: { org, orgRole: membership.role as OrgRole } });
+	});
+
+export const orgAdminProcedure = orgProtectedProcedure.use(async ({ ctx, next }) => {
+	if (ctx.orgRole !== 'admin') {
+		throw new TRPCError({ code: 'FORBIDDEN', message: 'Only org admins can perform this action' });
+	}
+	return next({ ctx });
 });
 
 export function ownedResourceProcedure(

--- a/apps/backend/src/utils/deployment-mode.ts
+++ b/apps/backend/src/utils/deployment-mode.ts
@@ -1,0 +1,13 @@
+import type { DeploymentMode } from '@nao/shared/types';
+
+import { env } from '../env';
+
+export function getDeploymentMode(): DeploymentMode {
+	if (env.NAO_DEFAULT_PROJECT_PATH) {
+		return 'self-hosted';
+	}
+	return env.NAO_MODE ?? 'self-hosted';
+}
+
+export const isSelfHosted = () => getDeploymentMode() === 'self-hosted';
+export const isCloud = () => getDeploymentMode() === 'cloud';

--- a/apps/backend/src/utils/email-builders.ts
+++ b/apps/backend/src/utils/email-builders.ts
@@ -54,3 +54,10 @@ export function buildResetPasswordEmail(
 	);
 	return { subject, html };
 }
+
+export function buildInvitationEmail(opts: { orgName: string; inviterName: string; token: string }): CreatedEmail {
+	const acceptUrl = `${env.BETTER_AUTH_URL}invite/${opts.token}`;
+	const subject = `${opts.inviterName} invited you to join ${opts.orgName} on nao`;
+	const html = `<p>You've been invited to join <strong>${opts.orgName}</strong> on nao.</p><p><a href="${acceptUrl}">Accept invitation</a></p>`;
+	return { subject, html };
+}

--- a/apps/backend/src/utils/utils.ts
+++ b/apps/backend/src/utils/utils.ts
@@ -107,6 +107,16 @@ export const buildCredentialPreviews = (
 	);
 };
 
+export const generateSlug = (name: string): string => {
+	const base = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '')
+		.slice(0, 40);
+	const suffix = crypto.randomUUID().slice(0, 6);
+	return `${base}-${suffix}`;
+};
+
 export const formatSize = (bytes: number) => {
 	if (bytes < 1024) {
 		return `${bytes} B`;

--- a/apps/frontend/src/components/org-switcher.tsx
+++ b/apps/frontend/src/components/org-switcher.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { Building2, ChevronsUpDown, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveProject } from '@/contexts/active-project';
+import { cn } from '@/lib/utils';
+
+interface OrgSwitcherProps {
+	isCollapsed: boolean;
+}
+
+export function OrgSwitcher({ isCollapsed }: OrgSwitcherProps) {
+	const { orgs, activeOrgId, setActiveOrg } = useActiveProject();
+	const activeOrg = orgs.find((o) => o.id === activeOrgId);
+
+	const handleSelect = useCallback(
+		(orgId: string) => {
+			setActiveOrg(orgId);
+		},
+		[setActiveOrg],
+	);
+
+	if (orgs.length === 0) {
+		return null;
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant='ghost'
+					className={cn(
+						'w-full justify-start gap-2 px-2 py-1.5 h-auto',
+						isCollapsed && 'justify-center px-0',
+					)}
+				>
+					<Building2 className='size-4 shrink-0' />
+					{!isCollapsed && (
+						<>
+							<span className='truncate text-sm font-medium'>{activeOrg?.name ?? 'Select org'}</span>
+							<ChevronsUpDown className='ml-auto size-3.5 text-muted-foreground shrink-0' />
+						</>
+					)}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align='start' className='w-56'>
+				{orgs.map((org) => (
+					<DropdownMenuItem
+						key={org.id}
+						onSelect={() => handleSelect(org.id)}
+						className={cn(org.id === activeOrgId && 'bg-accent')}
+					>
+						<Building2 className='mr-2 size-4' />
+						<span className='truncate'>{org.name}</span>
+					</DropdownMenuItem>
+				))}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem>
+					<Plus className='mr-2 size-4' />
+					Create organization
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/frontend/src/components/project-switcher.tsx
+++ b/apps/frontend/src/components/project-switcher.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronsUpDown, FolderOpen, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveProject } from '@/contexts/active-project';
+import { cn } from '@/lib/utils';
+import { trpc } from '@/main';
+
+interface ProjectSwitcherProps {
+	isCollapsed: boolean;
+}
+
+export function ProjectSwitcher({ isCollapsed }: ProjectSwitcherProps) {
+	const { activeOrgId, activeProjectId, setActiveProject } = useActiveProject();
+
+	const projectsQuery = useQuery({
+		...trpc.organization.listProjects.queryOptions({ orgId: activeOrgId ?? '' }),
+		enabled: !!activeOrgId,
+	});
+
+	const projects = useMemo(() => projectsQuery.data ?? [], [projectsQuery.data]);
+	const activeProject = projects.find((p) => p.id === activeProjectId);
+
+	useEffect(() => {
+		if (projects.length > 0 && !activeProject) {
+			setActiveProject(projects[0].id);
+		}
+	}, [projects, activeProject, setActiveProject]);
+
+	const handleSelect = useCallback(
+		(projectId: string) => {
+			setActiveProject(projectId);
+		},
+		[setActiveProject],
+	);
+
+	if (!activeOrgId) {
+		return null;
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant='ghost'
+					className={cn(
+						'w-full justify-start gap-2 px-2 py-1.5 h-auto',
+						isCollapsed && 'justify-center px-0',
+					)}
+				>
+					<FolderOpen className='size-4 shrink-0' />
+					{!isCollapsed && (
+						<>
+							<span className='truncate text-sm'>{activeProject?.name ?? 'Select project'}</span>
+							<ChevronsUpDown className='ml-auto size-3.5 text-muted-foreground shrink-0' />
+						</>
+					)}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align='start' className='w-56'>
+				{projects.length === 0 ? (
+					<DropdownMenuItem disabled>
+						<span className='text-muted-foreground'>No projects yet</span>
+					</DropdownMenuItem>
+				) : (
+					projects.map((project) => (
+						<DropdownMenuItem
+							key={project.id}
+							onSelect={() => handleSelect(project.id)}
+							className={cn(project.id === activeProjectId && 'bg-accent')}
+						>
+							<FolderOpen className='mr-2 size-4' />
+							<span className='truncate'>{project.name}</span>
+						</DropdownMenuItem>
+					))
+				)}
+				<DropdownMenuSeparator />
+				<DropdownMenuItem>
+					<Plus className='mr-2 size-4' />
+					Create project
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -1,49 +1,38 @@
 import { Link } from '@tanstack/react-router';
 import { cn, hideIf } from '@/lib/utils';
+import { useIsCloud } from '@/hooks/use-deployment-mode';
+
+type NavItemVisibility = 'always' | 'admin' | 'cloud' | 'cloud-admin';
 
 interface NavItem {
 	label: string;
 	to: string;
-	visible?: boolean;
+	visibility: NavItemVisibility;
 }
 
 const settingsNavItems: NavItem[] = [
-	{
-		label: 'General',
-		to: '/settings/general',
-		visible: undefined,
-	},
-	{
-		label: 'Memory',
-		to: '/settings/memory',
-		visible: undefined,
-	},
-	{
-		label: 'Project',
-		to: '/settings/project',
-		visible: undefined,
-	},
-	{
-		label: 'Usage & costs',
-		to: '/settings/usage',
-		visible: true,
-	},
-	{
-		label: 'Chats Replay',
-		to: '/settings/chats-replay',
-		visible: true,
-	},
-	{
-		label: 'Logs',
-		to: '/settings/logs',
-		visible: true,
-	},
-	{
-		label: 'File Explorer',
-		to: '/settings/context-explorer',
-		visible: true,
-	},
+	{ label: 'General', to: '/settings/general', visibility: 'always' },
+	{ label: 'Memory', to: '/settings/memory', visibility: 'always' },
+	{ label: 'Organization', to: '/settings/organization', visibility: 'cloud' },
+	{ label: 'Project', to: '/settings/project', visibility: 'always' },
+	{ label: 'Usage & costs', to: '/settings/usage', visibility: 'admin' },
+	{ label: 'Chats Replay', to: '/settings/chats-replay', visibility: 'admin' },
+	{ label: 'Logs', to: '/settings/logs', visibility: 'admin' },
+	{ label: 'File Explorer', to: '/settings/context-explorer', visibility: 'admin' },
 ];
+
+function isItemVisible(item: NavItem, isAdmin: boolean, isCloudMode: boolean): boolean {
+	switch (item.visibility) {
+		case 'always':
+			return true;
+		case 'admin':
+			return isAdmin;
+		case 'cloud':
+			return isCloudMode;
+		case 'cloud-admin':
+			return isCloudMode && isAdmin;
+	}
+}
 
 interface SidebarSettingsNavProps {
 	isCollapsed: boolean;
@@ -51,29 +40,28 @@ interface SidebarSettingsNavProps {
 }
 
 export function SidebarSettingsNav({ isCollapsed, isAdmin }: SidebarSettingsNavProps) {
-	const navItems = settingsNavItems.filter((item) => (item.visible === undefined ? true : item.visible === isAdmin));
+	const isCloudMode = useIsCloud();
+	const navItems = settingsNavItems.filter((item) => isItemVisible(item, isAdmin, isCloudMode));
 
 	return (
 		<nav className={cn('flex flex-col gap-1 px-2', hideIf(isCollapsed))}>
-			{navItems.map((item) => {
-				return (
-					<Link
-						key={item.to}
-						to={item.to}
-						className={cn(
-							'flex items-center gap-3 px-3 py-2 text-sm rounded-md transition-colors whitespace-nowrap',
-						)}
-						activeProps={{
-							className: cn('bg-sidebar-accent text-foreground font-medium'),
-						}}
-						inactiveProps={{
-							className: cn('hover:bg-sidebar-accent hover:text-foreground'),
-						}}
-					>
-						{item.label}
-					</Link>
-				);
-			})}
+			{navItems.map((item) => (
+				<Link
+					key={item.to}
+					to={item.to}
+					className={cn(
+						'flex items-center gap-3 px-3 py-2 text-sm rounded-md transition-colors whitespace-nowrap',
+					)}
+					activeProps={{
+						className: cn('bg-sidebar-accent text-foreground font-medium'),
+					}}
+					inactiveProps={{
+						className: cn('hover:bg-sidebar-accent hover:text-foreground'),
+					}}
+				>
+					{item.label}
+				</Link>
+			))}
 		</nav>
 	);
 }

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -4,6 +4,8 @@ import { Link, useNavigate, useMatchRoute, useRouterState } from '@tanstack/reac
 import { ArrowLeftFromLine, ArrowRightToLine, PlusIcon, ArrowLeft, ChevronRight, SearchIcon, X } from 'lucide-react';
 import { ChatList } from './sidebar-chat-list';
 import { ChatListItem } from './sidebar-chat-list-item';
+import { OrgSwitcher } from './org-switcher';
+import { ProjectSwitcher } from './project-switcher';
 import { SharedChatListItem } from './shared-chat-list-item';
 import { SidebarUserMenu } from './sidebar-user-menu';
 import { SidebarSettingsNav } from './sidebar-settings-nav';
@@ -20,6 +22,7 @@ import { useChatListQuery } from '@/queries/use-chat-list-query';
 import { useSidebar } from '@/contexts/sidebar';
 import { useCommandMenuCallback } from '@/contexts/command-menu-callback';
 import { useSectionActivity } from '@/hooks/use-chat-activity';
+import { useIsCloud } from '@/hooks/use-deployment-mode';
 import NaoLogo from '@/components/icons/nao-logo.svg';
 import { trpc } from '@/main';
 
@@ -35,6 +38,7 @@ export function Sidebar() {
 	const { fire: openCommandMenu } = useCommandMenuCallback();
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const isAdmin = project.data?.userRole === 'admin';
+	const isCloud = useIsCloud();
 
 	const locationPath = useRouterState({ select: (s) => s.location.pathname });
 	const isInSettings = matchRoute({ to: '/settings', fuzzy: true });
@@ -193,6 +197,12 @@ export function Sidebar() {
 
 			<div className={cn('mt-auto transition-[padding] duration-300', effectiveIsCollapsed ? 'p-1' : 'p-2')}>
 				{isInSettings && <SidebarCommunity isCollapsed={effectiveIsCollapsed} />}
+				{isCloud && (
+					<div className='flex flex-col gap-0.5 mb-1'>
+						<OrgSwitcher isCollapsed={effectiveIsCollapsed} />
+						<ProjectSwitcher isCollapsed={effectiveIsCollapsed} />
+					</div>
+				)}
 				<SidebarUserMenu isCollapsed={effectiveIsCollapsed} />
 			</div>
 		</div>

--- a/apps/frontend/src/contexts/active-project.tsx
+++ b/apps/frontend/src/contexts/active-project.tsx
@@ -1,0 +1,82 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { trpc } from '@/main';
+import { useIsCloud } from '@/hooks/use-deployment-mode';
+import { getActiveProjectId, setActiveProjectId } from '@/lib/active-project';
+
+interface OrgSummary {
+	id: string;
+	name: string;
+	slug: string;
+	role: string;
+}
+
+interface ActiveProjectContextValue {
+	orgs: OrgSummary[];
+	activeOrgId: string | null;
+	activeProjectId: string | null;
+	setActiveOrg: (orgId: string) => void;
+	setActiveProject: (projectId: string) => void;
+}
+
+const ActiveProjectContext = createContext<ActiveProjectContextValue>({
+	orgs: [],
+	activeOrgId: null,
+	activeProjectId: null,
+	setActiveOrg: () => {},
+	setActiveProject: () => {},
+});
+
+export function useActiveProject() {
+	return useContext(ActiveProjectContext);
+}
+
+export function ActiveProjectProvider({ children }: { children: React.ReactNode }) {
+	const isCloud = useIsCloud();
+	const orgsQuery = useQuery({
+		...trpc.organization.list.queryOptions(),
+		enabled: isCloud,
+	});
+
+	const [activeOrgId, setActiveOrgIdState] = useState<string | null>(() => localStorage.getItem('nao-active-org-id'));
+
+	const [projectId, setProjectIdState] = useState<string | null>(() => getActiveProjectId());
+
+	const orgs = useMemo(() => orgsQuery.data ?? [], [orgsQuery.data]);
+
+	useEffect(() => {
+		if (!isCloud || orgs.length === 0) {
+			return;
+		}
+		if (activeOrgId && orgs.some((o) => o.id === activeOrgId)) {
+			return;
+		}
+		setActiveOrgIdState(orgs[0].id);
+		localStorage.setItem('nao-active-org-id', orgs[0].id);
+	}, [isCloud, orgs, activeOrgId]);
+
+	const setActiveOrg = useCallback((orgId: string) => {
+		setActiveOrgIdState(orgId);
+		localStorage.setItem('nao-active-org-id', orgId);
+		setProjectIdState(null);
+		setActiveProjectId(null);
+	}, []);
+
+	const setActiveProject = useCallback((id: string) => {
+		setProjectIdState(id);
+		setActiveProjectId(id);
+	}, []);
+
+	const value = useMemo(
+		() => ({
+			orgs,
+			activeOrgId,
+			activeProjectId: projectId,
+			setActiveOrg,
+			setActiveProject,
+		}),
+		[orgs, activeOrgId, projectId, setActiveOrg, setActiveProject],
+	);
+
+	return <ActiveProjectContext.Provider value={value}>{children}</ActiveProjectContext.Provider>;
+}

--- a/apps/frontend/src/hooks/use-auth-route.ts
+++ b/apps/frontend/src/hooks/use-auth-route.ts
@@ -1,8 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { trpc } from '@/main';
+import { useIsCloud } from '@/hooks/use-deployment-mode';
 
 export function useAuthRoute(): string {
 	const userCount = useQuery(trpc.user.countAll.queryOptions());
-	const navigation = userCount.data ? '/login' : '/signup';
-	return navigation;
+	const isCloud = useIsCloud();
+
+	if (isCloud) {
+		return '/login';
+	}
+
+	return userCount.data ? '/login' : '/signup';
 }

--- a/apps/frontend/src/hooks/use-deployment-mode.ts
+++ b/apps/frontend/src/hooks/use-deployment-mode.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import type { DeploymentMode } from '@nao/shared/types';
+import { trpc } from '@/main';
+
+export function useDeploymentMode(): DeploymentMode | undefined {
+	const query = useQuery(trpc.organization.getDeploymentMode.queryOptions());
+	return query.data?.mode;
+}
+
+export function useIsCloud(): boolean {
+	return useDeploymentMode() === 'cloud';
+}
+
+export function useIsSelfHosted(): boolean {
+	const mode = useDeploymentMode();
+	return mode === undefined || mode === 'self-hosted';
+}

--- a/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
+++ b/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
@@ -1,30 +1,36 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
 
 import { useSession } from '@/lib/auth-client';
 import { useAuthRoute } from '@/hooks/use-auth-route';
+import { useIsCloud } from '@/hooks/use-deployment-mode';
 
 const AUTH_ROUTES = ['/login', '/forgot-password', '/reset-password'];
+const CLOUD_AUTH_ROUTES = [...AUTH_ROUTES, '/signup'];
 
 export const useSessionOrNavigateToIndexPage = () => {
 	const navigate = useNavigate();
 	const session = useSession();
 	const navigation = useAuthRoute();
 	const pathname = useRouterState({ select: (s) => s.location.pathname });
+	const isCloud = useIsCloud();
+
+	const isInvitePage = pathname.startsWith('/invite/');
+	const allAuthRoutes = useMemo(() => (isCloud ? CLOUD_AUTH_ROUTES : AUTH_ROUTES), [isCloud]);
 
 	useEffect(() => {
 		if (session.isPending) {
 			return;
 		}
 
-		if (!session.data && !AUTH_ROUTES.includes(pathname)) {
+		if (!session.data && !allAuthRoutes.includes(pathname) && !isInvitePage) {
 			navigate({ to: navigation });
 		}
 
-		if (session.data && (AUTH_ROUTES.includes(pathname) || pathname === '/signup')) {
+		if (session.data && (allAuthRoutes.includes(pathname) || (!isCloud && pathname === '/signup'))) {
 			navigate({ to: '/' });
 		}
-	}, [session.isPending, session.data, navigate, navigation, pathname]);
+	}, [session.isPending, session.data, navigate, navigation, pathname, allAuthRoutes, isCloud, isInvitePage]);
 
 	return session;
 };

--- a/apps/frontend/src/lib/active-project.ts
+++ b/apps/frontend/src/lib/active-project.ts
@@ -1,0 +1,24 @@
+let activeProjectId: string | null = null;
+
+export function getActiveProjectId(): string | null {
+	return activeProjectId;
+}
+
+export function setActiveProjectId(id: string | null) {
+	activeProjectId = id;
+	if (id) {
+		localStorage.setItem('nao-active-project-id', id);
+	} else {
+		localStorage.removeItem('nao-active-project-id');
+	}
+}
+
+export function restoreActiveProjectId(): string | null {
+	const stored = localStorage.getItem('nao-active-project-id');
+	if (stored) {
+		activeProjectId = stored;
+	}
+	return activeProjectId;
+}
+
+restoreActiveProjectId();

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -6,11 +6,13 @@ import { RouterProvider, createRouter } from '@tanstack/react-router';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import superjson from 'superjson';
+import { ActiveProjectProvider } from './contexts/active-project';
 import { PostHogProvider } from './contexts/posthog.provider';
 import { ThemeProvider } from './contexts/theme.provider';
 import { McpProvider } from './contexts/mcp';
 import { routeTree } from './routeTree.gen';
 import reportWebVitals from './reportWebVitals';
+import { getActiveProjectId } from './lib/active-project';
 import type { TrpcRouter } from '@nao/backend/trpc';
 
 // Register the router instance for type safety
@@ -51,6 +53,10 @@ export const trpcClient = createTRPCClient<TrpcRouter>({
 		httpBatchLink({
 			url: '/api/trpc',
 			transformer: superjson,
+			headers: () => {
+				const projectId = getActiveProjectId();
+				return projectId ? { 'x-project-id': projectId } : {};
+			},
 		}),
 	],
 });
@@ -69,11 +75,13 @@ if (!rootElement.innerHTML) {
 		<StrictMode>
 			<ThemeProvider>
 				<QueryClientProvider client={queryClient}>
-					<McpProvider>
-						<PostHogProvider>
-							<RouterProvider router={router} />
-						</PostHogProvider>
-					</McpProvider>
+					<ActiveProjectProvider>
+						<McpProvider>
+							<PostHogProvider>
+								<RouterProvider router={router} />
+							</PostHogProvider>
+						</McpProvider>
+					</ActiveProjectProvider>
 				</QueryClientProvider>
 			</ThemeProvider>
 		</StrictMode>,

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as InviteTokenRouteImport } from './routes/invite.$token'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as LoginRouteImport } from './routes/login'
@@ -27,6 +28,7 @@ import { Route as SidebarLayoutSettingsLogsRouteImport } from './routes/_sidebar
 import { Route as SidebarLayoutSettingsGeneralRouteImport } from './routes/_sidebar-layout.settings.general'
 import { Route as SidebarLayoutSettingsContextExplorerRouteImport } from './routes/_sidebar-layout.settings.context-explorer'
 import { Route as SidebarLayoutSettingsChatsReplayRouteImport } from './routes/_sidebar-layout.settings.chats-replay'
+import { Route as SidebarLayoutSettingsOrganizationRouteImport } from './routes/_sidebar-layout.settings.organization'
 import { Route as SidebarLayoutChatLayoutChatIdRouteImport } from './routes/_sidebar-layout._chat-layout.$chatId'
 import { Route as SidebarLayoutSettingsProjectIndexRouteImport } from './routes/_sidebar-layout.settings.project.index'
 import { Route as SidebarLayoutStoriesSharedShareIdRouteImport } from './routes/_sidebar-layout.stories.shared.$shareId'
@@ -40,6 +42,11 @@ import { Route as SidebarLayoutSettingsProjectMcpServersRouteImport } from './ro
 import { Route as SidebarLayoutSettingsProjectAgentRouteImport } from './routes/_sidebar-layout.settings.project.agent'
 import { Route as SidebarLayoutStoriesPreviewChatIdStoryIdRouteImport } from './routes/_sidebar-layout.stories.preview.$chatId.$storyId'
 
+const InviteTokenRoute = InviteTokenRouteImport.update({
+  id: '/invite/$token',
+  path: '/invite/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
@@ -139,6 +146,12 @@ const SidebarLayoutSettingsChatsReplayRoute =
     path: '/chats-replay',
     getParentRoute: () => SidebarLayoutSettingsRoute,
   } as any)
+const SidebarLayoutSettingsOrganizationRoute =
+  SidebarLayoutSettingsOrganizationRouteImport.update({
+    id: '/organization',
+    path: '/organization',
+    getParentRoute: () => SidebarLayoutSettingsRoute,
+  } as any)
 const SidebarLayoutChatLayoutChatIdRoute =
   SidebarLayoutChatLayoutChatIdRouteImport.update({
     id: '/$chatId',
@@ -215,6 +228,7 @@ const SidebarLayoutStoriesPreviewChatIdStoryIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof SidebarLayoutChatLayoutIndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/login': typeof LoginRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -225,6 +239,7 @@ export interface FileRoutesByFullPath {
   '/settings/general': typeof SidebarLayoutSettingsGeneralRoute
   '/settings/logs': typeof SidebarLayoutSettingsLogsRoute
   '/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
+  '/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
   '/settings/project': typeof SidebarLayoutSettingsProjectRouteWithChildren
   '/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
@@ -245,6 +260,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof SidebarLayoutChatLayoutIndexRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/login': typeof LoginRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -254,6 +270,7 @@ export interface FileRoutesByTo {
   '/settings/general': typeof SidebarLayoutSettingsGeneralRoute
   '/settings/logs': typeof SidebarLayoutSettingsLogsRoute
   '/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
+  '/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
   '/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/settings': typeof SidebarLayoutSettingsIndexRoute
@@ -274,6 +291,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_sidebar-layout': typeof SidebarLayoutRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
+  '/invite/$token': typeof InviteTokenRoute
   '/login': typeof LoginRoute
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
@@ -284,9 +302,10 @@ export interface FileRoutesById {
   '/_sidebar-layout/settings/context-explorer': typeof SidebarLayoutSettingsContextExplorerRoute
   '/_sidebar-layout/settings/general': typeof SidebarLayoutSettingsGeneralRoute
   '/_sidebar-layout/settings/logs': typeof SidebarLayoutSettingsLogsRoute
-  '/_sidebar-layout/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
-  '/_sidebar-layout/settings/project': typeof SidebarLayoutSettingsProjectRouteWithChildren
-  '/_sidebar-layout/settings/usage': typeof SidebarLayoutSettingsUsageRoute
+    '/_sidebar-layout/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
+    '/_sidebar-layout/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
+    '/_sidebar-layout/settings/project': typeof SidebarLayoutSettingsProjectRouteWithChildren
+    '/_sidebar-layout/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/_sidebar-layout/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/_sidebar-layout/_chat-layout/': typeof SidebarLayoutChatLayoutIndexRoute
   '/_sidebar-layout/settings/': typeof SidebarLayoutSettingsIndexRoute
@@ -308,6 +327,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/forgot-password'
+    | '/invite/$token'
     | '/login'
     | '/reset-password'
     | '/signup'
@@ -318,6 +338,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/settings/logs'
     | '/settings/memory'
+    | '/settings/organization'
     | '/settings/project'
     | '/settings/usage'
     | '/shared-chat/$shareId'
@@ -338,6 +359,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/forgot-password'
+    | '/invite/$token'
     | '/login'
     | '/reset-password'
     | '/signup'
@@ -347,6 +369,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/settings/logs'
     | '/settings/memory'
+    | '/settings/organization'
     | '/settings/usage'
     | '/shared-chat/$shareId'
     | '/settings'
@@ -366,6 +389,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_sidebar-layout'
     | '/forgot-password'
+    | '/invite/$token'
     | '/login'
     | '/reset-password'
     | '/signup'
@@ -377,6 +401,7 @@ export interface FileRouteTypes {
     | '/_sidebar-layout/settings/general'
     | '/_sidebar-layout/settings/logs'
     | '/_sidebar-layout/settings/memory'
+    | '/_sidebar-layout/settings/organization'
     | '/_sidebar-layout/settings/project'
     | '/_sidebar-layout/settings/usage'
     | '/_sidebar-layout/shared-chat/$shareId'
@@ -399,6 +424,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   SidebarLayoutRoute: typeof SidebarLayoutRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
+  InviteTokenRoute: typeof InviteTokenRoute
   LoginRoute: typeof LoginRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
@@ -406,6 +432,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/invite/$token': {
+      id: '/invite/$token'
+      path: '/invite/$token'
+      fullPath: '/invite/$token'
+      preLoaderRoute: typeof InviteTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup': {
       id: '/signup'
       path: '/signup'
@@ -530,6 +563,13 @@ declare module '@tanstack/react-router' {
       path: '/chats-replay'
       fullPath: '/settings/chats-replay'
       preLoaderRoute: typeof SidebarLayoutSettingsChatsReplayRouteImport
+      parentRoute: typeof SidebarLayoutSettingsRoute
+    }
+    '/_sidebar-layout/settings/organization': {
+      id: '/_sidebar-layout/settings/organization'
+      path: '/organization'
+      fullPath: '/settings/organization'
+      preLoaderRoute: typeof SidebarLayoutSettingsOrganizationRouteImport
       parentRoute: typeof SidebarLayoutSettingsRoute
     }
     '/_sidebar-layout/_chat-layout/$chatId': {
@@ -680,6 +720,7 @@ interface SidebarLayoutSettingsRouteChildren {
   SidebarLayoutSettingsGeneralRoute: typeof SidebarLayoutSettingsGeneralRoute
   SidebarLayoutSettingsLogsRoute: typeof SidebarLayoutSettingsLogsRoute
   SidebarLayoutSettingsMemoryRoute: typeof SidebarLayoutSettingsMemoryRoute
+  SidebarLayoutSettingsOrganizationRoute: typeof SidebarLayoutSettingsOrganizationRoute
   SidebarLayoutSettingsProjectRoute: typeof SidebarLayoutSettingsProjectRouteWithChildren
   SidebarLayoutSettingsUsageRoute: typeof SidebarLayoutSettingsUsageRoute
   SidebarLayoutSettingsIndexRoute: typeof SidebarLayoutSettingsIndexRoute
@@ -692,6 +733,7 @@ const SidebarLayoutSettingsRouteChildren: SidebarLayoutSettingsRouteChildren = {
   SidebarLayoutSettingsGeneralRoute: SidebarLayoutSettingsGeneralRoute,
   SidebarLayoutSettingsLogsRoute: SidebarLayoutSettingsLogsRoute,
   SidebarLayoutSettingsMemoryRoute: SidebarLayoutSettingsMemoryRoute,
+  SidebarLayoutSettingsOrganizationRoute: SidebarLayoutSettingsOrganizationRoute,
   SidebarLayoutSettingsProjectRoute:
     SidebarLayoutSettingsProjectRouteWithChildren,
   SidebarLayoutSettingsUsageRoute: SidebarLayoutSettingsUsageRoute,
@@ -730,6 +772,7 @@ const SidebarLayoutRouteWithChildren = SidebarLayoutRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   SidebarLayoutRoute: SidebarLayoutRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,
+  InviteTokenRoute: InviteTokenRoute,
   LoginRoute: LoginRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,

--- a/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
@@ -1,0 +1,155 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Building2, Mail, Trash2, UserPlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
+import { useActiveProject } from '@/contexts/active-project';
+import { trpc, trpcClient } from '@/main';
+
+export const Route = createFileRoute('/_sidebar-layout/settings/organization')({
+	component: OrganizationSettingsPage,
+});
+
+function OrganizationSettingsPage() {
+	const { activeOrgId } = useActiveProject();
+
+	if (!activeOrgId) {
+		return (
+			<SettingsPageWrapper>
+				<p className='text-muted-foreground text-sm'>No organization selected.</p>
+			</SettingsPageWrapper>
+		);
+	}
+
+	return (
+		<SettingsPageWrapper>
+			<OrgMembers orgId={activeOrgId} />
+			<OrgInvitations orgId={activeOrgId} />
+		</SettingsPageWrapper>
+	);
+}
+
+function OrgMembers({ orgId }: { orgId: string }) {
+	const membersQuery = useQuery(trpc.organization.listMembers.queryOptions({ orgId }));
+	const queryClient = useQueryClient();
+
+	const removeMember = useMutation({
+		mutationFn: (userId: string) => trpcClient.organization.removeMember.mutate({ orgId, userId }),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: trpc.organization.listMembers.queryOptions({ orgId }).queryKey,
+			}),
+	});
+
+	return (
+		<SettingsCard
+			icon={<Building2 className='size-4' />}
+			title='Organization Members'
+			description='Manage who has access to this organization.'
+		>
+			<div className='flex flex-col gap-2'>
+				{membersQuery.data?.map((member) => (
+					<div key={member.userId} className='flex items-center justify-between py-2'>
+						<div className='flex flex-col'>
+							<span className='text-sm font-medium'>{member.name}</span>
+							<span className='text-xs text-muted-foreground'>{member.email}</span>
+						</div>
+						<div className='flex items-center gap-2'>
+							<span className='text-xs bg-muted px-2 py-0.5 rounded-full capitalize'>{member.role}</span>
+							<Button
+								variant='ghost'
+								size='icon-sm'
+								onClick={() => removeMember.mutate(member.userId)}
+								disabled={removeMember.isPending}
+							>
+								<Trash2 className='size-3.5 text-destructive' />
+							</Button>
+						</div>
+					</div>
+				))}
+			</div>
+		</SettingsCard>
+	);
+}
+
+function OrgInvitations({ orgId }: { orgId: string }) {
+	const [email, setEmail] = useState('');
+	const [role, setRole] = useState<'admin' | 'user'>('user');
+	const queryClient = useQueryClient();
+
+	const invitationsQuery = useQuery(trpc.invitation.listForOrg.queryOptions({ orgId }));
+
+	const sendInvite = useMutation({
+		mutationFn: () => trpcClient.invitation.send.mutate({ orgId, email, role }),
+		onSuccess: () => {
+			setEmail('');
+			queryClient.invalidateQueries({
+				queryKey: trpc.invitation.listForOrg.queryOptions({ orgId }).queryKey,
+			});
+		},
+	});
+
+	const revokeInvite = useMutation({
+		mutationFn: (invitationId: string) => trpcClient.invitation.revoke.mutate({ orgId, invitationId }),
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: trpc.invitation.listForOrg.queryOptions({ orgId }).queryKey,
+			}),
+	});
+
+	return (
+		<SettingsCard
+			icon={<UserPlus className='size-4' />}
+			title='Invitations'
+			description='Invite users to your organization.'
+		>
+			<div className='flex gap-2'>
+				<Input
+					placeholder='Email address'
+					type='email'
+					value={email}
+					onChange={(e) => setEmail(e.target.value)}
+					className='flex-1'
+				/>
+				<select
+					value={role}
+					onChange={(e) => setRole(e.target.value as 'admin' | 'user')}
+					className='border border-border rounded-md px-2 text-sm bg-background'
+				>
+					<option value='user'>User</option>
+					<option value='admin'>Admin</option>
+				</select>
+				<Button onClick={() => sendInvite.mutate()} disabled={!email || sendInvite.isPending} size='sm'>
+					<Mail className='size-4 mr-1' />
+					Invite
+				</Button>
+			</div>
+
+			{invitationsQuery.data && invitationsQuery.data.length > 0 && (
+				<div className='flex flex-col gap-2 mt-4'>
+					<h4 className='text-xs font-medium text-muted-foreground uppercase'>Pending Invitations</h4>
+					{invitationsQuery.data.map((inv) => (
+						<div key={inv.id} className='flex items-center justify-between py-1'>
+							<div className='flex flex-col'>
+								<span className='text-sm'>{inv.email}</span>
+								<span className='text-xs text-muted-foreground capitalize'>
+									{inv.role} &middot; {inv.scope}
+								</span>
+							</div>
+							<Button
+								variant='ghost'
+								size='icon-sm'
+								onClick={() => revokeInvite.mutate(inv.id)}
+								disabled={revokeInvite.isPending}
+							>
+								<Trash2 className='size-3.5 text-destructive' />
+							</Button>
+						</div>
+					))}
+				</div>
+			)}
+		</SettingsCard>
+	);
+}

--- a/apps/frontend/src/routes/invite.$token.tsx
+++ b/apps/frontend/src/routes/invite.$token.tsx
@@ -1,0 +1,77 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { Building2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSession } from '@/lib/auth-client';
+import { trpc, trpcClient } from '@/main';
+
+export const Route = createFileRoute('/invite/$token')({
+	component: InviteAcceptPage,
+});
+
+function InviteAcceptPage() {
+	const { token } = Route.useParams();
+	const navigate = useNavigate();
+	const session = useSession();
+
+	const inviteQuery = useQuery(trpc.invitation.getByToken.queryOptions({ token }));
+
+	const acceptMutation = useMutation({
+		mutationFn: () => trpcClient.invitation.accept.mutate({ token }),
+		onSuccess: () => navigate({ to: '/' }),
+	});
+
+	if (!session.data) {
+		return (
+			<div className='flex flex-col items-center justify-center h-screen gap-4'>
+				<Building2 className='size-8 text-muted-foreground' />
+				<p className='text-muted-foreground'>Please log in or sign up to accept this invitation.</p>
+				<div className='flex gap-2'>
+					<Button variant='outline' onClick={() => navigate({ to: '/login', search: { error: undefined } })}>
+						Log In
+					</Button>
+					<Button onClick={() => navigate({ to: '/signup', search: { error: undefined } })}>Sign Up</Button>
+				</div>
+			</div>
+		);
+	}
+
+	if (inviteQuery.isLoading) {
+		return (
+			<div className='flex items-center justify-center h-screen'>
+				<p className='text-muted-foreground'>Loading invitation...</p>
+			</div>
+		);
+	}
+
+	if (!inviteQuery.data) {
+		return (
+			<div className='flex flex-col items-center justify-center h-screen gap-4'>
+				<p className='text-muted-foreground'>This invitation is invalid or has expired.</p>
+				<Button onClick={() => navigate({ to: '/' })}>Go to app</Button>
+			</div>
+		);
+	}
+
+	const invite = inviteQuery.data;
+
+	return (
+		<div className='flex flex-col items-center justify-center h-screen gap-6'>
+			<Building2 className='size-10 text-primary' />
+			<div className='text-center space-y-2'>
+				<h1 className='text-xl font-semibold'>You&apos;re invited to join</h1>
+				<p className='text-2xl font-bold'>{invite.orgName}</p>
+				<p className='text-sm text-muted-foreground'>
+					as <span className='capitalize font-medium'>{invite.role}</span>
+					{invite.scope === 'project' && ' (project-level access)'}
+				</p>
+			</div>
+			<Button size='lg' onClick={() => acceptMutation.mutate()} disabled={acceptMutation.isPending}>
+				{acceptMutation.isPending ? 'Accepting...' : 'Accept Invitation'}
+			</Button>
+			{acceptMutation.isError && (
+				<p className='text-sm text-destructive'>Failed to accept invitation. Please try again.</p>
+			)}
+		</div>
+	);
+}

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -2,6 +2,18 @@ export type UserRole = 'admin' | 'user' | 'viewer';
 
 export const USER_ROLES = ['admin', 'user', 'viewer'] as const satisfies readonly UserRole[];
 
+export type DeploymentMode = 'self-hosted' | 'cloud';
+
+export const DEPLOYMENT_MODES = ['self-hosted', 'cloud'] as const satisfies readonly DeploymentMode[];
+
+export type InvitationStatus = 'pending' | 'accepted' | 'expired';
+
+export const INVITATION_STATUSES = ['pending', 'accepted', 'expired'] as const satisfies readonly InvitationStatus[];
+
+export type InvitationScope = 'org' | 'project';
+
+export const INVITATION_SCOPES = ['org', 'project'] as const satisfies readonly InvitationScope[];
+
 export type UpdatedAtFilter = { mode: 'single'; value: string } | { mode: 'range'; start: string; end: string };
 
 export const NO_CACHE_SCHEDULE = 'no-cache';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 			"dependencies": {
 				"@boxlite-ai/boxlite": "^0.3.0",
 				"@pydantic/monty": "^0.0.7",
-				"@rollup/rollup-linux-x64-gnu": "^4.60.0",
 				"depd": "^2.0.0"
 			},
 			"devDependencies": {
@@ -43,7 +42,6 @@
 				"@duckdb/node-api": "^1.4.4-r.1",
 				"@fastify/formbody": "^8.0.2",
 				"@fastify/static": "^8.1.0",
-				"@isaacs/brace-expansion": "^5.0.1",
 				"@microsoft/microsoft-graph-client": "^3.0.7",
 				"@nao/shared": "*",
 				"@openrouter/ai-sdk-provider": "^2.2.3",
@@ -2907,23 +2905,6 @@
 				"mlly": "^1.8.0"
 			}
 		},
-		"node_modules/@isaacs/balanced-match": {
-			"version": "4.0.1",
-			"license": "MIT",
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"@isaacs/balanced-match": "^4.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
 		"node_modules/@isaacs/cliui": {
 			"version": "9.0.0",
 			"license": "BlueOak-1.0.0",
@@ -5318,18 +5299,6 @@
 			],
 			"license": "MIT",
 			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-			"integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "MIT",
 			"os": [
 				"linux"
 			]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the foundation for multi-organization, multi-project architecture alongside the existing self-hosted mode. The two modes are mutually exclusive, controlled by environment variables, and all existing self-hosted behavior is fully backward compatible.

## Deployment modes

- **Self-hosted** (`NAO_DEFAULT_PROJECT_PATH` set): unchanged behavior -- single org, single project, bootstrap on first user, social-only auto-join
- **Cloud** (`NAO_MODE=cloud`): open signup, personal org creation, invitation system, dynamic project selection via `x-project-id` header

The two modes cannot be active simultaneously (env validation rejects both being set).

## Backend changes

### New shared types (`apps/shared`)
- `DeploymentMode`, `InvitationStatus`, `InvitationScope` types and const arrays

### Environment + mode detection (`apps/backend`)
- `NAO_MODE` env var (`self-hosted` | `cloud`, optional)
- `deployment-mode.ts` utility: `getDeploymentMode()`, `isSelfHosted()`, `isCloud()`

### Schema (`apps/backend/src/db`)
- New `invitation` table (both SQLite and PostgreSQL): `id`, `orgId`, `projectId`, `email`, `role`, `scope`, `invitedBy`, `token`, `status`, `expiresAt`, `createdAt`
- New `DBInvitation` / `NewInvitation` abstract types

### tRPC middleware (`apps/backend/src/trpc/trpc.ts`)
- `projectProtectedProcedure` is now mode-aware: reads `x-project-id` header in cloud mode, falls back to env path in self-hosted
- New `orgProtectedProcedure` and `orgAdminProcedure` for org-scoped operations
- Context now includes `projectId` from request header

### Organization queries (`apps/backend/src/queries`)
- Added: `updateOrganization`, `listUserOrganizations`, `listOrgMembers`, `removeOrgMember`, `updateOrgMemberRole`, `createPersonalOrganization`, `acceptPendingInvitationsForUser`, `getGoogleConfigForOrg`
- `ensureOrganizationSetup`, `initializeDefaultOrganizationForFirstUser`, `addUserToDefaultProjectIfExists` now skip in cloud mode

### Project queries (`apps/backend/src/queries`)
- Added: `getDefaultProjectForUser`, `getProjectForUser`, `listProjectsByOrgId`
- Deprecated `getProjectByUserId` as alias

### New tRPC routes
- `organization.*`: `getDeploymentMode`, `list`, `create`, `update`, `listMembers`, `removeMember`, `updateMemberRole`, `listProjects`, `createProject`
- `invitation.*`: `send`, `listForOrg`, `revoke`, `accept`, `getByToken`

### Auth hooks (`apps/backend/src/auth.ts`)
- Extracted `onUserCreated()` -- mode-aware handler
- Cloud: accepts pending invitations, creates personal org if no memberships
- Self-hosted: unchanged behavior

## Frontend changes

### Active project system
- `lib/active-project.ts`: module-level store for active project ID (persisted in localStorage)
- `contexts/active-project.tsx`: React context for org/project selection state
- tRPC client sends `x-project-id` header from the active project store

### Mode-aware hooks
- `use-deployment-mode.ts`: `useDeploymentMode()`, `useIsCloud()`, `useIsSelfHosted()`
- `use-auth-route.ts`: cloud mode always shows `/login` (signup accessible)
- `use-session-or-navigate-to-index-page.tsx`: cloud mode allows `/signup` + `/invite/*`

### Sidebar
- `OrgSwitcher` and `ProjectSwitcher` dropdown components (cloud mode only)
- Sidebar conditionally renders switchers at bottom
- Settings nav: refactored visibility (`always` | `admin` | `cloud` | `cloud-admin`), added "Organization" item for cloud

### New pages
- `/settings/organization`: org members management + invitation sending/revoking
- `/invite/$token`: invitation acceptance page with login/signup flow for unauthenticated users

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53a9b943-4f49-401f-8904-8b5062d2a367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53a9b943-4f49-401f-8904-8b5062d2a367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

