### PR TITLE
fix: detect wrong-platform binary in nao chat and show actionable error (#287)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,12 +100,12 @@ jobs:
               working-directory: cli
               run: |
                   if [ "${{ matrix.platform }}" = "win" ]; then
-                    ./nao_core/bin/nao-chat-server.exe --help
-                    STATUS=$?
+                    STATUS=0
+                    ./nao_core/bin/nao-chat-server.exe --help || STATUS=$?
                   else
                     chmod +x ./nao_core/bin/nao-chat-server
-                    ./nao_core/bin/nao-chat-server --help
-                    STATUS=$?
+                    STATUS=0
+                    ./nao_core/bin/nao-chat-server --help || STATUS=$?
                   fi
                   # Exit codes 126 (cannot execute) and 127 (not found) mean the OS
                   # could not load the binary — wrong platform or missing file.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,11 +100,20 @@ jobs:
               working-directory: cli
               run: |
                   if [ "${{ matrix.platform }}" = "win" ]; then
-                    ./nao_core/bin/nao-chat-server.exe --help || echo "Smoke test: binary executes"
+                    ./nao_core/bin/nao-chat-server.exe --help
+                    STATUS=$?
                   else
                     chmod +x ./nao_core/bin/nao-chat-server
-                    ./nao_core/bin/nao-chat-server --help || echo "Smoke test: binary executes"
+                    ./nao_core/bin/nao-chat-server --help
+                    STATUS=$?
                   fi
+                  # Exit codes 126 (cannot execute) and 127 (not found) mean the OS
+                  # could not load the binary — wrong platform or missing file.
+                  if [ "$STATUS" -eq 126 ] || [ "$STATUS" -eq 127 ]; then
+                    echo "::error::Server binary failed to execute (exit code $STATUS). Wrong platform?"
+                    exit 1
+                  fi
+                  echo "Smoke test passed (exit code $STATUS)"
 
             - name: Rename wheel with platform tag
               working-directory: cli/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,16 @@ jobs:
               env:
                   PYTHONUTF8: '1'
 
+            - name: Smoke test server binary
+              working-directory: cli
+              run: |
+                  if [ "${{ matrix.platform }}" = "win" ]; then
+                    ./nao_core/bin/nao-chat-server.exe --help || echo "Smoke test: binary executes"
+                  else
+                    chmod +x ./nao_core/bin/nao-chat-server
+                    ./nao_core/bin/nao-chat-server --help || echo "Smoke test: binary executes"
+                  fi
+
             - name: Rename wheel with platform tag
               working-directory: cli/dist
               run: |

--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -42,7 +42,11 @@ def validate_port(port: int | None) -> int:
 
 
 def get_server_binary_path() -> Path:
-    """Get the path to the bundled nao-chat-server binary."""
+    """Get the path to the bundled nao-chat-server binary.
+
+    Validates that the binary exists and is compiled for the current platform
+    by checking magic bytes (ELF for Linux, PE for Windows, Mach-O for macOS).
+    """
     cli_dir = Path(__file__).parent.parent
     bin_dir = cli_dir / "bin"
     binary_name = "nao-chat-server.exe" if sys.platform == "win32" else "nao-chat-server"
@@ -50,7 +54,40 @@ def get_server_binary_path() -> Path:
 
     if not binary_path.exists():
         console.print(f"[bold red]✗[/bold red] Server binary not found at {binary_path}")
-        console.print("[dim]Make sure you've built the server by running python file build.py[/dim]")
+        console.print("[dim]This usually means the nao package wasn't installed for your platform.[/dim]")
+        console.print("[dim]Try: pip install --force-reinstall nao-core[/dim]")
+        sys.exit(1)
+
+    # Detect platform mismatch: wrong-OS binary shipped in wheel
+    try:
+        with open(binary_path, "rb") as f:
+            magic = f.read(4)
+    except OSError:
+        magic = b""
+
+    is_elf = magic[:4] == b"\x7fELF"
+    is_pe = magic[:2] == b"MZ"
+    is_macho = magic[:4] in (
+        b"\xfe\xed\xfa\xce",
+        b"\xfe\xed\xfa\xcf",
+        b"\xce\xfa\xed\xfe",
+        b"\xcf\xfa\xed\xfe",
+    )
+
+    platform = sys.platform
+    mismatch = False
+    if platform == "win32" and not is_pe:
+        mismatch = True
+    elif platform == "darwin" and not is_macho:
+        mismatch = True
+    elif platform == "linux" and not is_elf:
+        mismatch = True
+
+    if mismatch:
+        detected = "Linux" if is_elf else "Windows" if is_pe else "macOS" if is_macho else "unknown"
+        console.print(f"[bold red]✗[/bold red] Server binary is for {detected}, but you're on {platform}")
+        console.print("[dim]This usually means the wrong platform wheel was installed.[/dim]")
+        console.print("[dim]Try: pip install --force-reinstall nao-core[/dim]")
         sys.exit(1)
 
     return binary_path

--- a/cli/tests/nao_core/commands/test_chat.py
+++ b/cli/tests/nao_core/commands/test_chat.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -140,23 +141,96 @@ def test_chat_exits_when_no_config_found(tmp_path: Path, monkeypatch, clean_env)
         assert exc_info.value.code == 1
 
 
+def _magic_bytes_for_platform():
+    """Return the correct magic bytes for the current platform."""
+    if sys.platform == "darwin":
+        return b"\xfe\xed\xfa\xcf"
+    elif sys.platform == "win32":
+        return b"MZ\x00\x00"
+    else:
+        return b"\x7fELF"
+
+
 def test_get_server_binary_path():
     """Test that get_server_binary_path returns the expected path structure."""
-    with patch.object(Path, "exists", return_value=True):
+    magic = _magic_bytes_for_platform()
+    mock_file = MagicMock()
+    mock_file.__enter__ = MagicMock(return_value=mock_file)
+    mock_file.__exit__ = MagicMock(return_value=False)
+    mock_file.read = MagicMock(return_value=magic + b"\x00" * 100)
+
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("builtins.open", return_value=mock_file),
+    ):
         result_path = get_server_binary_path()
 
-    assert result_path.name == "nao-chat-server"
+    assert result_path.name in ("nao-chat-server", "nao-chat-server.exe")
     assert result_path.parent.name == "bin"
 
 
 def test_get_server_binary_path_does_not_exists():
     """Exit when the server binary does not exist."""
-    with patch("nao_core.commands.chat.Path.exists", return_value=False):
+    with patch.object(Path, "exists", return_value=False):
         with pytest.raises(SystemExit) as exc_info:
             get_server_binary_path()
 
     assert exc_info.value.code == 1
     assert exc_info.type is SystemExit
+
+
+def _make_mock_binary(magic_bytes: bytes):
+    """Create a mock file object that returns the given magic bytes on read."""
+    mock_file = MagicMock()
+    mock_file.__enter__ = MagicMock(return_value=mock_file)
+    mock_file.__exit__ = MagicMock(return_value=False)
+    mock_file.read = MagicMock(return_value=magic_bytes + b"\x00" * 100)
+    return mock_file
+
+
+@pytest.mark.parametrize(
+    ("magic_bytes", "platform", "description"),
+    [
+        (b"\x7fELF", "win32", "Linux ELF binary on Windows"),
+        (b"MZ", "linux", "Windows PE binary on Linux"),
+        (b"\xfe\xed\xfa\xcf", "linux", "macOS Mach-O binary on Linux"),
+    ],
+    ids=["elf_on_windows", "pe_on_linux", "macho_on_linux"],
+)
+def test_get_server_binary_path_platform_mismatch(magic_bytes, platform, description):
+    """Exit with clear error on platform mismatch: {description}."""
+    mock_file = _make_mock_binary(magic_bytes)
+
+    with (
+        patch("nao_core.commands.chat.sys") as mock_sys,
+        patch.object(Path, "exists", return_value=True),
+        patch("builtins.open", return_value=mock_file),
+    ):
+        mock_sys.platform = platform
+        mock_sys.exit = MagicMock(side_effect=SystemExit(1))
+
+        with pytest.raises(SystemExit):
+            get_server_binary_path()
+
+        mock_sys.exit.assert_called_once_with(1)
+
+
+def test_get_server_binary_path_truncated_binary():
+    """Exit with clear error when binary is truncated (< 4 bytes)."""
+    mock_file = _make_mock_binary(b"\x00\x01")
+
+    with (
+        patch("nao_core.commands.chat.sys") as mock_sys,
+        patch.object(Path, "exists", return_value=True),
+        patch("builtins.open", return_value=mock_file),
+    ):
+        mock_sys.platform = "linux"
+        mock_sys.exit = MagicMock(side_effect=SystemExit(1))
+
+        with pytest.raises(SystemExit):
+            get_server_binary_path()
+
+        mock_sys.exit.assert_called_once_with(1)
 
 
 def test_get_fastapi_main_path():


### PR DESCRIPTION
## Summary

Fixes #287 — `nao chat` fails on Windows with `[WinError 193] %1 is not a valid Win32 application` when the wrong-platform binary is shipped in the wheel

The root cause (Linux binary shipped in the Windows wheel) was already fixed in CI since v0.1.4 — the per-platform build matrix makes cross-contamination impossible. This PR adds the guardrails so if it ever happens again, users get an actionable error and CI catches it before release.
