### PR TITLE
Let templates read local project files via nao.file

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -27,6 +27,7 @@ from nao_core.commands.sync.providers.databases.query_history import TableUsageS
 from nao_core.config import AnyDatabaseConfig, NaoConfig
 from nao_core.config.databases.base import DatabaseConfig, DatabaseTemplate, ProfilingRefreshPolicy
 from nao_core.config.llm import LLMConfig
+from nao_core.templates.context import create_nao_context
 from nao_core.templates.engine import get_template_engine
 
 from ..base import SyncProvider, SyncResult
@@ -107,9 +108,13 @@ def sync_database(
     project_path: Path | None = None,
     llm_config: LLMConfig | None = None,
     db_folder: str | None = None,
+    nao_config: NaoConfig | None = None,
 ) -> DatabaseSyncState:
     """Sync a single database by rendering all database templates for each table."""
     engine = get_template_engine(project_path, llm_config=llm_config)
+
+    # Create nao context for templates if config is available
+    nao_ctx = create_nao_context(nao_config, project_path=project_path) if nao_config else None
     templates = _filter_templates_by_config(engine.list_templates(TEMPLATE_PREFIX), db_config)
 
     has_how_to_use = DatabaseTemplate.HOW_TO_USE in db_config.templates
@@ -219,7 +224,10 @@ def sync_database(
 
                     t_render = time.monotonic()
                     try:
-                        content = engine.render(template_name, db=ctx, table_name=table, dataset=schema, **extra_ctx)
+                        render_kwargs: dict[str, Any] = {"db": ctx, "table_name": table, "dataset": schema, **extra_ctx}
+                        if nao_ctx:
+                            render_kwargs["nao"] = nao_ctx
+                        content = engine.render(template_name, **render_kwargs)
                         render_dur = time.monotonic() - t_render
                         if render_dur > 5:
                             console.print(
@@ -268,6 +276,7 @@ class DatabaseSyncProvider(SyncProvider):
 
     def __init__(self) -> None:
         self._llm_config: LLMConfig | None = None
+        self._nao_config: NaoConfig | None = None
 
     @property
     def name(self) -> str:
@@ -283,6 +292,7 @@ class DatabaseSyncProvider(SyncProvider):
 
     def pre_sync(self, config: NaoConfig, output_path: Path) -> None:
         self._llm_config = config.llm
+        self._nao_config = config
         cleanup_stale_databases(config.databases, output_path, verbose=True)
 
     def get_items(self, config: NaoConfig) -> list[AnyDatabaseConfig]:
@@ -328,6 +338,7 @@ class DatabaseSyncProvider(SyncProvider):
                         project_path,
                         self._llm_config,
                         db_folder=db_folder,
+                        nao_config=self._nao_config,
                     )
                     sync_states.append(state)
                     total_datasets += state.schemas_synced

--- a/cli/nao_core/templates/context.py
+++ b/cli/nao_core/templates/context.py
@@ -6,16 +6,205 @@ allowing them to access data from various providers like Notion, databases, etc.
 Example template usage:
     {{ nao.notion.page('https://notion.so/...').content }}
     {{ nao.notion.page('abc123').title }}
+    {{ nao.file.yaml('metadata.yaml').description }}
+    {{ nao.file.text('README.md') }}
 """
 
 from __future__ import annotations
 
+import csv
+import io
+import json
 from dataclasses import dataclass
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import yaml
 
 if TYPE_CHECKING:
     from nao_core.config.base import NaoConfig
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+
+class FileProvider:
+    """Provider for reading local project files in templates.
+
+    All paths are relative to the project root. Absolute paths and
+    path traversal (e.g. `../../etc/passwd`) are rejected.
+
+    Example:
+        {{ nao.file.yaml('config/metadata.yaml').description }}
+        {{ nao.file.text('docs/intro.md') }}
+        {{ nao.file.glob('schemas/*.yaml') }}
+    """
+
+    def __init__(self, project_path: Path):
+        self._project_path = project_path
+        self._cache: dict[str, Any] = {}
+
+    def _validate_path(self, path: str) -> Path:
+        """Validate and resolve a relative path against the project root."""
+        p = Path(path)
+        if p.is_absolute():
+            raise ValueError(f"Absolute paths are not allowed: '{path}'. Use a relative path from the project root.")
+
+        resolved = (self._project_path / p).resolve()
+        if not resolved.is_relative_to(self._project_path.resolve()):
+            raise ValueError(f"Path traversal is not allowed: '{path}'. Path must stay within the project directory.")
+
+        return resolved
+
+    def _read_file(self, path: str) -> str:
+        """Read a file with size and permission checks, using cache."""
+        cache_key = f"text:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            suggestion = self._suggest_similar(path)
+            msg = f"File not found: '{path}'"
+            if suggestion:
+                msg += f". Did you mean: {suggestion}?"
+            raise FileNotFoundError(msg)
+
+        size = resolved.stat().st_size
+        if size > MAX_FILE_SIZE:
+            raise ValueError(f"File exceeds 10MB limit: '{path}' ({size / 1024 / 1024:.1f}MB)")
+
+        try:
+            content = resolved.read_text(encoding="utf-8")
+        except PermissionError:
+            raise PermissionError(f"Permission denied: '{path}'") from None
+        except UnicodeDecodeError:
+            raise ValueError(f"Cannot read '{path}': file is not valid UTF-8 text") from None
+
+        self._cache[cache_key] = content
+        return content
+
+    def _suggest_similar(self, path: str) -> str | None:
+        """Find similar files to suggest on FileNotFoundError."""
+        target = Path(path)
+        parent = self._project_path / target.parent
+        if not parent.exists():
+            return None
+
+        suffix = target.suffix or ""
+        candidates = [
+            str(p.relative_to(self._project_path))
+            for p in parent.iterdir()
+            if p.is_file() and (not suffix or p.suffix == suffix)
+        ]
+        if not candidates:
+            return None
+
+        return ", ".join(sorted(candidates)[:3])
+
+    def yaml(self, path: str) -> Any:
+        """Read and parse a YAML file.
+
+        Returns a dict (or list) from the YAML content.
+        Empty YAML files return an empty dict.
+        """
+        cache_key = f"yaml:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        content = self._read_file(path)
+        try:
+            result = yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Failed to parse YAML in '{path}': {e}") from e
+
+        # Normalize empty YAML (returns None) to empty dict
+        if result is None:
+            result = {}
+
+        self._cache[cache_key] = result
+        return result
+
+    def json(self, path: str) -> Any:
+        """Read and parse a JSON file."""
+        cache_key = f"json:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        content = self._read_file(path)
+        try:
+            result = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse JSON in '{path}': {e}") from e
+
+        self._cache[cache_key] = result
+        return result
+
+    def csv(self, path: str) -> list[dict[str, str]]:
+        """Read a CSV file as a list of dicts (one per row)."""
+        cache_key = f"csv:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        content = self._read_file(path)
+        try:
+            reader = csv.DictReader(io.StringIO(content))
+            result = list(reader)
+        except csv.Error as e:
+            raise ValueError(f"Failed to parse CSV in '{path}': {e}") from e
+
+        self._cache[cache_key] = result
+        return result
+
+    def text(self, path: str) -> str:
+        """Read a file as a UTF-8 string."""
+        return self._read_file(path)
+
+    def frontmatter(self, path: str) -> dict[str, Any]:
+        """Parse YAML frontmatter from a markdown file.
+
+        Returns {'meta': dict, 'content': str}.
+        """
+        cache_key = f"frontmatter:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        content = self._read_file(path)
+
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            if len(parts) >= 3:
+                try:
+                    meta = yaml.safe_load(parts[1]) or {}
+                except yaml.YAMLError as e:
+                    raise ValueError(f"Failed to parse frontmatter in '{path}': {e}") from e
+                result = {"meta": meta, "content": parts[2].strip()}
+            else:
+                result = {"meta": {}, "content": content}
+        else:
+            result = {"meta": {}, "content": content}
+
+        self._cache[cache_key] = result
+        return result
+
+    def glob(self, pattern: str) -> list[str]:
+        """Return matching file paths relative to the project root."""
+        resolved_root = self._project_path.resolve()
+        matches = [
+            str(p.relative_to(resolved_root))
+            for p in resolved_root.glob(pattern)
+            if p.is_file() and p.resolve().is_relative_to(resolved_root)
+        ]
+        return sorted(matches)
+
+    def exists(self, path: str) -> bool:
+        """Check if a file exists within the project root."""
+        try:
+            resolved = self._validate_path(path)
+            return resolved.exists()
+        except ValueError:
+            return False
 
 
 @dataclass
@@ -153,8 +342,25 @@ class NaoContext:
         {{ nao.config.project_name }}
     """
 
-    def __init__(self, config: NaoConfig):
+    def __init__(self, config: NaoConfig, project_path: Path | None = None):
         self._config = config
+        self._project_path = project_path
+
+    @cached_property
+    def file(self) -> FileProvider:
+        """Access local project files.
+
+        Example:
+            {{ nao.file.yaml('metadata.yaml') }}
+            {{ nao.file.text('README.md') }}
+        """
+        if self._project_path is None:
+            raise RuntimeError(
+                "File reading requires a project path. "
+                "This context was created without a project_path — "
+                "ensure nao sync is run from a valid nao project directory."
+            )
+        return FileProvider(self._project_path)
 
     @cached_property
     def notion(self) -> NotionProvider:
@@ -174,25 +380,15 @@ class NaoContext:
         """
         return self._config
 
-    # Future providers can be added here:
-    # @cached_property
-    # def database(self) -> DatabaseProvider:
-    #     """Access database tables and schemas."""
-    #     return DatabaseProvider(self._config)
-    #
-    # @cached_property
-    # def repo(self) -> RepoProvider:
-    #     """Access git repository files."""
-    #     return RepoProvider(self._config)
 
-
-def create_nao_context(config: NaoConfig) -> NaoContext:
+def create_nao_context(config: NaoConfig, project_path: Path | None = None) -> NaoContext:
     """Create a NaoContext for template rendering.
 
     Args:
         config: The nao configuration.
+        project_path: Path to the nao project root (enables file reading).
 
     Returns:
         A NaoContext instance to be used as `nao` in templates.
     """
-    return NaoContext(config)
+    return NaoContext(config, project_path=project_path)

--- a/cli/nao_core/templates/context.py
+++ b/cli/nao_core/templates/context.py
@@ -71,6 +71,9 @@ class FileProvider:
                 msg += f". Did you mean: {suggestion}?"
             raise FileNotFoundError(msg)
 
+        if resolved.is_dir():
+            raise ValueError(f"'{path}' is a directory, not a file")
+
         size = resolved.stat().st_size
         if size > MAX_FILE_SIZE:
             raise ValueError(f"File exceeds 10MB limit: '{path}' ({size / 1024 / 1024:.1f}MB)")
@@ -89,7 +92,7 @@ class FileProvider:
         """Find similar files to suggest on FileNotFoundError."""
         target = Path(path)
         parent = self._project_path / target.parent
-        if not parent.exists():
+        if not parent.is_dir():
             return None
 
         suffix = target.suffix or ""
@@ -190,6 +193,9 @@ class FileProvider:
 
     def glob(self, pattern: str) -> list[str]:
         """Return matching file paths relative to the project root."""
+        if ".." in pattern:
+            raise ValueError(f"Path traversal is not allowed in glob pattern: '{pattern}'")
+
         resolved_root = self._project_path.resolve()
         matches = [
             str(p.relative_to(resolved_root))

--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -74,8 +74,26 @@ class TemplateEngine:
             text = str(text)
             return text[:half] + "..." + text[-half:]
 
+        from .context import FileProvider
+
+        file_provider = FileProvider(self.project_path) if self.project_path else None
+
+        def read_yaml(path: str) -> Any:
+            """Read and parse a YAML file relative to project root."""
+            if not file_provider:
+                raise RuntimeError("read_yaml filter requires a project path.")
+            return file_provider.yaml(path)
+
+        def read_text(path: str) -> str:
+            """Read a text file relative to project root."""
+            if not file_provider:
+                raise RuntimeError("read_text filter requires a project path.")
+            return file_provider.text(path)
+
         self.env.filters["to_json"] = to_json
         self.env.filters["truncate_middle"] = truncate_middle
+        self.env.filters["read_yaml"] = read_yaml
+        self.env.filters["read_text"] = read_text
 
     def _register_globals(self) -> None:
         """Register template global helper functions."""

--- a/cli/nao_core/templates/render.py
+++ b/cli/nao_core/templates/render.py
@@ -112,10 +112,12 @@ def render_template(
     # Register custom filters
     import json
 
-    env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str, ensure_ascii=False)
+    # Create the nao context first so filters share its FileProvider cache
+    nao = create_nao_context(config, project_path=project_path)
 
-    # Create the nao context
-    nao = create_nao_context(config)
+    env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str, ensure_ascii=False)
+    env.filters["read_yaml"] = lambda path: nao.file.yaml(path)
+    env.filters["read_text"] = lambda path: nao.file.text(path)
 
     # Load and render the template
     template = env.get_template(str(template_path))

--- a/cli/tests/nao_core/templates/test_file_provider.py
+++ b/cli/tests/nao_core/templates/test_file_provider.py
@@ -1,0 +1,187 @@
+"""Unit tests for the FileProvider class."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nao_core.templates.context import FileProvider
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    """Create a temporary project directory with test files."""
+    # YAML file
+    (tmp_path / "metadata.yaml").write_text(yaml.dump({"name": "test", "version": 2}))
+
+    # Empty YAML file
+    (tmp_path / "empty.yaml").write_text("")
+
+    # JSON file
+    (tmp_path / "config.json").write_text(json.dumps({"key": "value", "items": [1, 2]}))
+
+    # CSV file
+    (tmp_path / "data.csv").write_text("name,age\nAlice,30\nBob,25\n")
+
+    # Text file
+    (tmp_path / "readme.txt").write_text("Hello, world!")
+
+    # Markdown with frontmatter
+    (tmp_path / "doc.md").write_text("---\ntitle: Test\ntags:\n  - a\n  - b\n---\n\nBody content here.")
+
+    # Markdown without frontmatter
+    (tmp_path / "plain.md").write_text("Just plain markdown.")
+
+    # Subdirectory with files
+    sub = tmp_path / "schemas"
+    sub.mkdir()
+    (sub / "users.yaml").write_text(yaml.dump({"table": "users"}))
+    (sub / "orders.yaml").write_text(yaml.dump({"table": "orders"}))
+
+    return tmp_path
+
+
+@pytest.fixture()
+def provider(project_dir: Path) -> FileProvider:
+    return FileProvider(project_dir)
+
+
+class TestYaml:
+    def test_reads_yaml(self, provider: FileProvider):
+        result = provider.yaml("metadata.yaml")
+        assert result == {"name": "test", "version": 2}
+
+    def test_empty_yaml_returns_empty_dict(self, provider: FileProvider):
+        result = provider.yaml("empty.yaml")
+        assert result == {}
+
+    def test_invalid_yaml_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "bad.yaml").write_text(":\n  - :\n    invalid: [")
+        with pytest.raises(ValueError, match="Failed to parse YAML"):
+            provider.yaml("bad.yaml")
+
+    def test_caches_result(self, provider: FileProvider):
+        result1 = provider.yaml("metadata.yaml")
+        result2 = provider.yaml("metadata.yaml")
+        assert result1 is result2
+
+
+class TestJson:
+    def test_reads_json(self, provider: FileProvider):
+        result = provider.json("config.json")
+        assert result == {"key": "value", "items": [1, 2]}
+
+    def test_invalid_json_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "bad.json").write_text("{not valid json")
+        with pytest.raises(ValueError, match="Failed to parse JSON"):
+            provider.json("bad.json")
+
+
+class TestCsv:
+    def test_reads_csv(self, provider: FileProvider):
+        result = provider.csv("data.csv")
+        assert len(result) == 2
+        assert result[0] == {"name": "Alice", "age": "30"}
+        assert result[1] == {"name": "Bob", "age": "25"}
+
+
+class TestText:
+    def test_reads_text(self, provider: FileProvider):
+        result = provider.text("readme.txt")
+        assert result == "Hello, world!"
+
+    def test_binary_file_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "binary.bin").write_bytes(b"\x00\x01\x80\xff" * 100)
+        with pytest.raises(ValueError, match="not valid UTF-8"):
+            provider.text("binary.bin")
+
+
+class TestFrontmatter:
+    def test_parses_frontmatter(self, provider: FileProvider):
+        result = provider.frontmatter("doc.md")
+        assert result["meta"] == {"title": "Test", "tags": ["a", "b"]}
+        assert result["content"] == "Body content here."
+
+    def test_no_frontmatter(self, provider: FileProvider):
+        result = provider.frontmatter("plain.md")
+        assert result["meta"] == {}
+        assert result["content"] == "Just plain markdown."
+
+
+class TestGlob:
+    def test_glob_pattern(self, provider: FileProvider):
+        result = provider.glob("schemas/*.yaml")
+        assert "schemas/orders.yaml" in result
+        assert "schemas/users.yaml" in result
+
+    def test_glob_no_matches(self, provider: FileProvider):
+        result = provider.glob("*.nonexistent")
+        assert result == []
+
+
+class TestExists:
+    def test_existing_file(self, provider: FileProvider):
+        assert provider.exists("metadata.yaml") is True
+
+    def test_missing_file(self, provider: FileProvider):
+        assert provider.exists("nope.yaml") is False
+
+    def test_traversal_returns_false(self, provider: FileProvider):
+        assert provider.exists("../../etc/passwd") is False
+
+
+class TestPathSecurity:
+    def test_absolute_path_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Absolute paths are not allowed"):
+            provider.text("/etc/passwd")
+
+    def test_traversal_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Path traversal is not allowed"):
+            provider.text("../../etc/passwd")
+
+    def test_subdirectory_allowed(self, provider: FileProvider):
+        result = provider.yaml("schemas/users.yaml")
+        assert result == {"table": "users"}
+
+
+class TestMissingFile:
+    def test_file_not_found_with_suggestion(self, provider: FileProvider):
+        with pytest.raises(FileNotFoundError, match="Did you mean"):
+            provider.text("readmee.txt")
+
+    def test_file_not_found_no_suggestion(self, provider: FileProvider):
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            provider.text("nonexistent/deep/path.txt")
+
+
+class TestFileSizeLimit:
+    def test_large_file_rejected(self, provider: FileProvider, project_dir: Path):
+        big = project_dir / "huge.txt"
+        big.write_bytes(b"x" * (10 * 1024 * 1024 + 1))
+        with pytest.raises(ValueError, match="exceeds 10MB"):
+            provider.text("huge.txt")
+
+
+class TestPermissionError:
+    def test_permission_denied(self, provider: FileProvider, project_dir: Path):
+        restricted = project_dir / "secret.txt"
+        restricted.write_text("secret")
+        restricted.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError, match="Permission denied"):
+                provider.text("secret.txt")
+        finally:
+            restricted.chmod(0o644)
+
+
+class TestNoProjectPath:
+    def test_nao_context_file_without_project_path(self):
+        from unittest.mock import MagicMock
+
+        from nao_core.templates.context import NaoContext
+
+        config = MagicMock()
+        ctx = NaoContext(config, project_path=None)
+        with pytest.raises(RuntimeError, match="File reading requires a project path"):
+            _ = ctx.file

--- a/cli/tests/nao_core/templates/test_file_provider.py
+++ b/cli/tests/nao_core/templates/test_file_provider.py
@@ -144,6 +144,14 @@ class TestPathSecurity:
         result = provider.yaml("schemas/users.yaml")
         assert result == {"table": "users"}
 
+    def test_directory_path_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="is a directory"):
+            provider.text("schemas")
+
+    def test_glob_traversal_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Path traversal is not allowed"):
+            provider.glob("../../**/*")
+
 
 class TestMissingFile:
     def test_file_not_found_with_suggestion(self, provider: FileProvider):


### PR DESCRIPTION
Closes #533

## What this does

Templates can now read files from the project repo during `nao sync`. This lets users enrich their generated `columns.md` (or any template output) with metadata from YAML configs, CSV tables, or plain text docs — without copying content into `nao.yaml` by hand.

### New: `nao.file` provider

Available in any `.j2` template as `nao.file`:

```jinja
{# Read and parse structured files #}
{% set meta = nao.file.yaml('metadata/tables.yaml') %}
{% set schema = nao.file.json('schemas/users.json') %}
{% set rows = nao.file.csv('lookups/owners.csv') %}

{# Read raw text or markdown with frontmatter #}
{{ nao.file.text('docs/intro.md') }}
{% set doc = nao.file.frontmatter('docs/guide.md') %}
{{ doc.meta.title }} — {{ doc.content }}

{# List and check files #}
{% for f in nao.file.glob('schemas/*.yaml') %}
  - {{ f }}
{% endfor %}
{% if nao.file.exists('overrides.yaml') %}...{% endif %}
```

Also available as Jinja filters: `{{ 'config.yaml' | read_yaml }}` and `{{ 'notes.md' | read_text }}`.

### Safety

- Only relative paths allowed — absolute paths and `../` traversal are rejected
- 10MB file size cap
- `yaml.safe_load()` only (no arbitrary code execution)
- Parsed results cached per sync run (no repeated disk reads)

## Changes

- **`context.py`** — `FileProvider` class with 7 methods + path validation + caching, wired into `NaoContext` as `nao.file`
- **`engine.py`** — `read_yaml` / `read_text` Jinja filters backed by a shared `FileProvider`
- **`render.py`** — Same filters for user-facing template rendering, sharing cache with `nao.file`
- **`provider.py`** — Threads `nao_config` into `sync_database()` so database templates get the `nao` context

## Test plan

- [x] 24 new tests covering all methods, path security, edge cases (empty YAML, binary files, permission errors, size limits, typo suggestions)
- [x] All 53 template tests pass
- [x] Lint clean