### PR TITLE
fix: show full error messages in debug table instead of truncating to 80 chars

### DIFF
--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -163,13 +163,11 @@ def debug():
                 )
             else:
                 console.print("[bold red]✗[/bold red]")
-                # Truncate long error messages
-                short_msg = message[:80] + "..." if len(message) > 80 else message
                 db_table.add_row(
                     db.name,
                     db.type,
                     "[red]Failed[/red]",
-                    short_msg,
+                    f"[red]{message}[/red]",
                 )
 
         console.print()
@@ -199,11 +197,10 @@ def debug():
             )
         else:
             console.print("[bold red]✗[/bold red]")
-            short_msg = message[:80] + "..." if len(message) > 80 else message
             llm_table.add_row(
                 config.llm.provider.value,
                 "[red]Failed[/red]",
-                short_msg,
+                f"[red]{message}[/red]",
             )
 
         console.print()


### PR DESCRIPTION
Closes #580

  Previously, error messages in `nao debug` were truncated to 80 characters, which often cut off the most useful part of the error. This
  change removes the truncation and highlights errors in red so they stand out in the table.

  Changes:
  - Removed 80-char truncation on error messages for both database and LLM tables
  - Styled error text in red for better visibility
  - Rich table handles wrapping naturally for long messages