### PR TITLE
fix: accept --providers as alias for --provider flag in sync command

### DIFF
--- a/cli/nao_core/commands/sync/__init__.py
+++ b/cli/nao_core/commands/sync/__init__.py
@@ -28,7 +28,7 @@ def sync(
     provider: Annotated[
         list[str] | None,
         Parameter(
-            name=["-p", "--provider"],
+            name=["-p", "--provider", "--providers"],
             help=f"Provider(s) to sync. Use `-p provider:name` to sync a specific connection (e.g. databases:my-db). Or just `-p databases` to sync all connections. Options: {', '.join(PROVIDER_CHOICES)}",
         ),
     ] = None,


### PR DESCRIPTION
 Closes #592

  The `--providers` flag was not recognized by the CLI — only `--provider` (singular) worked. Users typing `nao sync --providers
  repositories:dbt` would get no filtering because the flag was silently ignored, causing all providers to sync.

  Added `--providers` as an alias alongside `-p` and `--provider` so both forms work as expected.