### PR TITLE
fix: detect Vertex AI as configured when extra field env vars are set

### DIFF
--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -22,8 +22,15 @@ export function hasEnvApiKey(provider: LlmProvider): boolean {
 	if (getEnvApiKey(provider)) {
 		return true;
 	}
-	const { alternativeEnvVars } = LLM_PROVIDERS[provider].auth;
-	return alternativeEnvVars?.every((v) => process.env[v]) ?? false;
+	const { alternativeEnvVars, extraFields, apiKey } = LLM_PROVIDERS[provider].auth;
+	if (alternativeEnvVars?.every((v) => process.env[v])) {
+		return true;
+	}
+	// For providers that don't require an API key (e.g. Vertex), check if any extra field env var is set
+	if (apiKey === 'none' && extraFields?.some((f) => process.env[f.envVar])) {
+		return true;
+	}
+	return false;
 }
 
 /** Get all providers that have API keys configured via environment */


### PR DESCRIPTION
Closes #585

  The backend's `hasEnvApiKey()` function only checked the main `envVar` and `alternativeEnvVars` to determine if a provider was configured
  via environment. Vertex AI has `apiKey: 'none'` and relies on extra fields like `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION` for
  auth — none of which were checked.

  This meant that even when the CLI correctly set those env vars from `nao_config.yaml`, the backend didn't recognize Vertex AI as available
  and returned null, forcing users to configure it through the UI instead.

  The fix adds a check for `extraFields` env vars on providers that don't require an API key, so Vertex AI (and any future providers with
  similar auth patterns) are properly detected from environment configuration.