### PR TITLE
feat: add clustering keys support for BigQuery provider

### DIFF
--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, PrivateAttr, field_validator
@@ -28,6 +28,7 @@ class TablePartitionMetadata:
     last_partition_id: str | None  # e.g. "20260310" for DATE partitions
     total_rows: int | None  # from INFORMATION_SCHEMA.PARTITIONS
     require_partition_filter: bool = False
+    clustering_columns: list[str] = field(default_factory=list)
 
 
 def _bq_escape_quoted_identifier(name: object) -> str:
@@ -69,11 +70,12 @@ class BigQueryDatabaseContext(DatabaseContext):
     def partition_columns(self) -> list[str]:
         if self._partition_metadata is not None and self._partition_metadata.partition_column is not None:
             return [self._partition_metadata.partition_column]
-        try:
-            return _get_bq_partition_columns(self._conn, self._schema, self._table_name)
-        except Exception:
-            logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
-            return []
+        return []
+
+    def clustering_columns(self) -> list[str]:
+        if self._partition_metadata is not None:
+            return self._partition_metadata.clustering_columns
+        return []
 
     def description(self) -> str | None:
         try:
@@ -317,28 +319,6 @@ def _coerce(val: Any) -> Any:
     return val
 
 
-def _get_bq_partition_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
-    schema_info_path = _bq_path(schema, "INFORMATION_SCHEMA", "COLUMNS")
-    table_name_literal = _bq_string_literal(table)
-    partition_query = f"""
-        SELECT column_name
-        FROM {schema_info_path}
-        WHERE table_name = {table_name_literal} AND is_partitioning_column = 'YES'
-    """
-    clustering_query = f"""
-        SELECT column_name
-        FROM {schema_info_path}
-        WHERE table_name = {table_name_literal} AND clustering_ordinal_position IS NOT NULL
-        ORDER BY clustering_ordinal_position
-    """
-    columns: list[str] = []
-
-    columns.extend(row[0] for row in conn.raw_sql(partition_query))  # type: ignore[union-attr]
-    columns.extend(row[0] for row in conn.raw_sql(clustering_query) if row[0] not in columns)  # type: ignore[union-attr]
-
-    return columns
-
-
 class BigQueryConfig(DatabaseConfig):
     """BigQuery-specific configuration."""
 
@@ -557,11 +537,12 @@ class BigQueryConfig(DatabaseConfig):
 def _fetch_schema_partition_metadata(
     conn: BaseBackend, project_id: str, schema: str
 ) -> dict[str, TablePartitionMetadata]:
-    """Fetch partition metadata for all tables in a schema in three batch queries."""
+    """Fetch partition and clustering metadata for all tables in a schema in batch queries."""
     partition_columns: dict[str, tuple[str, str]] = {}  # table -> (column_name, column_type)
     last_partition_ids: dict[str, str] = {}
     total_rows_map: dict[str, int] = {}
     require_filter_tables: set[str] = set()
+    clustering_map: dict[str, list[str]] = {}
 
     try:
         column_query = f"""
@@ -606,7 +587,19 @@ def _fetch_schema_partition_metadata(
     except Exception:
         logger.debug("Failed to fetch require_partition_filter flags for schema %s", schema)
 
-    all_tables = set(partition_columns) | set(last_partition_ids)
+    try:
+        clustering_query = f"""
+            SELECT table_name, column_name
+            FROM `{project_id}.{schema}.INFORMATION_SCHEMA.COLUMNS`
+            WHERE clustering_ordinal_position IS NOT NULL
+            ORDER BY table_name, clustering_ordinal_position
+        """
+        for row in conn.raw_sql(clustering_query):  # type: ignore[union-attr]
+            clustering_map.setdefault(row[0], []).append(row[1])
+    except Exception:
+        logger.debug("Failed to fetch clustering columns for schema %s", schema)
+
+    all_tables = set(partition_columns) | set(last_partition_ids) | set(clustering_map)
     result: dict[str, TablePartitionMetadata] = {}
     for table in all_tables:
         col_info = partition_columns.get(table)
@@ -616,5 +609,6 @@ def _fetch_schema_partition_metadata(
             last_partition_id=last_partition_ids.get(table),
             total_rows=total_rows_map.get(table),
             require_partition_filter=table in require_filter_tables,
+            clustering_columns=clustering_map.get(table, []),
         )
     return result

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -68,7 +68,11 @@ class DatabaseContext:
         return rows
 
     def partition_columns(self) -> list[str]:
-        """Return partition/clustering column names if available."""
+        """Return partition column names if available."""
+        return []
+
+    def clustering_columns(self) -> list[str]:
+        """Return clustering column names if available."""
         return []
 
     def is_partitioned(self) -> bool:

--- a/cli/nao_core/templates/defaults/databases/description.md.j2
+++ b/cli/nao_core/templates/defaults/databases/description.md.j2
@@ -44,13 +44,25 @@ _No description available._
 
 {% set partitions = db.partition_columns() %}
 {% if partitions %}
-## Partition / Clustering columns
+## Partition columns
 
 {% for col in partitions %}
 - {{ col }}
 {% endfor %}
 
 > When querying this table, always filter on {% for col in partitions %}{{ col }}{% if not loop.last %}, {% endif %}{% endfor %} for best performance.
+
+{% endif %}
+
+{% set clustering = db.clustering_columns() %}
+{% if clustering %}
+## Clustering columns
+
+{% for col in clustering %}
+- {{ col }}
+{% endfor %}
+
+> Filtering or ordering by {% for col in clustering %}{{ col }}{% if not loop.last %}, {% endif %}{% endfor %} improves query performance.
 
 {% endif %}
 

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -604,13 +604,14 @@ class TestBuildPartitionFilter:
 
 
 class TestFetchSchemaPartitionMetadata:
-    def _mock_conn(self, column_rows, partition_rows, required_filter_table_names):
+    def _mock_conn(self, column_rows, partition_rows, required_filter_table_names, clustering_rows=None):
         """Helper: build a mock conn whose raw_sql returns appropriate rows per call."""
         mock_conn = MagicMock()
         results = [
             column_rows,
             partition_rows,
             [(name,) for name in required_filter_table_names],
+            clustering_rows or [],
         ]
         mock_conn.raw_sql.side_effect = results
         return mock_conn
@@ -659,6 +660,7 @@ class TestFetchSchemaPartitionMetadata:
             [],
             [],
             Exception("permission denied"),
+            [],
         ]
 
         result = _fetch_schema_partition_metadata(mock_conn, "my-project", "my_schema")
@@ -741,3 +743,96 @@ class TestTablePartitionMetadata:
             require_partition_filter=True,
         )
         assert meta.require_partition_filter is True
+
+    def test_clustering_columns_defaults_to_empty(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_date",
+            partition_column_type="DATE",
+            last_partition_id="20260310",
+            total_rows=100,
+        )
+        assert meta.clustering_columns == []
+
+    def test_clustering_columns_can_be_set(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_date",
+            partition_column_type="DATE",
+            last_partition_id="20260310",
+            total_rows=100,
+            clustering_columns=["user_id", "event_type"],
+        )
+        assert meta.clustering_columns == ["user_id", "event_type"]
+
+
+class TestClusteringColumns:
+    def test_clustering_columns_fetched_in_batch(self):
+        mock_conn = MagicMock()
+        mock_conn.raw_sql.side_effect = [
+            [("events_v1", "event_date", "DATE")],
+            [("events_v1", ["20260310"], 5000)],
+            [],
+            [("events_v1", "user_id"), ("events_v1", "event_type")],
+        ]
+
+        result = _fetch_schema_partition_metadata(mock_conn, "my-project", "my_schema")
+
+        assert result["events_v1"].clustering_columns == ["user_id", "event_type"]
+
+    def test_clustering_columns_empty_when_none_exist(self):
+        mock_conn = MagicMock()
+        mock_conn.raw_sql.side_effect = [
+            [("events_v1", "event_date", "DATE")],
+            [("events_v1", ["20260310"], 5000)],
+            [],
+            [],
+        ]
+
+        result = _fetch_schema_partition_metadata(mock_conn, "my-project", "my_schema")
+
+        assert result["events_v1"].clustering_columns == []
+
+    def test_clustering_query_failure_does_not_crash(self):
+        mock_conn = MagicMock()
+        mock_conn.raw_sql.side_effect = [
+            [("events_v1", "event_date", "DATE")],
+            [("events_v1", ["20260310"], 5000)],
+            [],
+            Exception("permission denied"),
+        ]
+
+        result = _fetch_schema_partition_metadata(mock_conn, "my-project", "my_schema")
+
+        assert result["events_v1"].partition_column == "event_date"
+        assert result["events_v1"].clustering_columns == []
+
+    def test_table_with_only_clustering_no_partition(self):
+        mock_conn = MagicMock()
+        mock_conn.raw_sql.side_effect = [
+            [],
+            [],
+            [],
+            [("logs", "user_id"), ("logs", "timestamp")],
+        ]
+
+        result = _fetch_schema_partition_metadata(mock_conn, "my-project", "my_schema")
+
+        assert "logs" in result
+        assert result["logs"].partition_column is None
+        assert result["logs"].clustering_columns == ["user_id", "timestamp"]
+
+    def test_context_clustering_columns_from_metadata(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_date",
+            partition_column_type="DATE",
+            last_partition_id="20260310",
+            total_rows=100,
+            clustering_columns=["user_id", "event_type"],
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+
+        assert ctx.clustering_columns() == ["user_id", "event_type"]
+
+    def test_context_clustering_columns_empty_when_no_metadata(self):
+        ctx, _ = _make_context(partition_metadata=None)
+
+        assert ctx.clustering_columns() == []


### PR DESCRIPTION
Closes #593

  BigQuery clustering columns are now fetched separately from partition columns and exposed distinctly in the LLM context. Previously they
  were mixed together, making it impossible for the agent to give proper guidance about partition filters vs clustering performance hints.

  Changes:
  - Added `clustering_columns` field to `TablePartitionMetadata` dataclass
  - Added batch query for clustering columns in `_fetch_schema_partition_metadata()` to fetch them efficiently per schema
  - Added `clustering_columns()` method to `DatabaseContext` base class and `BigQueryDatabaseContext`
  - Separated "Partition columns" and "Clustering columns" into distinct sections in the description template
  - Removed the mixed `_get_bq_partition_columns()` function that conflated both column types
  - Added 9 new tests covering batch fetch, context method, edge cases, and failure handling