### PR TITLE
fix: handle LLM quota errors gracefully instead of crashing the UI

### DIFF
--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -1,12 +1,18 @@
-import { createUIMessageStreamResponse } from 'ai';
+import { createUIMessageStream, createUIMessageStreamResponse } from 'ai';
 
 import type { App } from '../app';
 import { handleAgentRoute } from '../handlers/agent';
 import { authMiddleware } from '../middleware/auth';
 import { posthog, PostHogEvent } from '../services/posthog';
 import { AgentRequestSchema } from '../types/chat';
+import { logger } from '../utils/logger';
 
 const DEBUG_CHUNKS = false;
+
+const STREAM_RESPONSE_HEADERS = {
+	'X-Accel-Buffering': 'no',
+	'Cache-Control': 'no-cache, no-transform',
+};
 
 export const agentRoutes = async (app: App) => {
 	app.addHook('preHandler', authMiddleware);
@@ -14,11 +20,23 @@ export const agentRoutes = async (app: App) => {
 	app.post('/', { schema: { body: AgentRequestSchema } }, async ({ user, project, body, headers }) => {
 		const projectId = project?.id;
 
-		const result = await handleAgentRoute({
-			userId: user.id,
-			projectId,
-			...body,
-		});
+		let result;
+		try {
+			result = await handleAgentRoute({
+				userId: user.id,
+				projectId,
+				...body,
+			});
+		} catch (err) {
+			logger.error(`Agent route error: ${String(err)}`, { source: 'agent', projectId });
+			const stream = createUIMessageStream({
+				execute: async () => {
+					throw err;
+				},
+				onError: (e) => String(e),
+			});
+			return createUIMessageStreamResponse({ stream, headers: STREAM_RESPONSE_HEADERS });
+		}
 
 		posthog.capture(user.id, PostHogEvent.MessageSent, {
 			project_id: projectId,
@@ -45,12 +63,7 @@ export const agentRoutes = async (app: App) => {
 
 		return createUIMessageStreamResponse({
 			stream,
-			headers: {
-				// Disable nginx buffering for streaming responses
-				// This is critical for proper stream termination behind reverse proxies
-				'X-Accel-Buffering': 'no',
-				'Cache-Control': 'no-cache, no-transform',
-			},
+			headers: STREAM_RESPONSE_HEADERS,
 		});
 	});
 };

--- a/apps/frontend/src/components/chat-messages/chat-messages.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-messages.tsx
@@ -1,6 +1,7 @@
-import { memo, useMemo, useRef } from 'react';
+import { Component, memo, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useParams, useRouterState } from '@tanstack/react-router';
+import { AlertCircleIcon } from 'lucide-react';
 import { TextShimmer } from '../ui/text-shimmer';
 import { ChatError } from './chat-error';
 import { FollowUpSuggestions } from './follow-up-suggestions';
@@ -30,6 +31,32 @@ import { trpc } from '@/main';
 
 const DEBUG_MESSAGES = false;
 
+class ChatErrorBoundary extends Component<
+	{ children: React.ReactNode },
+	{ hasError: boolean; error?: Error }
+> {
+	state = { hasError: false, error: undefined as Error | undefined };
+
+	static getDerivedStateFromError(error: Error) {
+		return { hasError: true, error };
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return (
+				<div className='flex items-start gap-2.5 px-4 py-3 text-red-500 m-4'>
+					<AlertCircleIcon className='size-4 shrink-0 mt-1' />
+					<div className='text-sm'>
+						<span className='font-medium'>Something went wrong</span>
+						<p className='text-red-400 mt-1 leading-relaxed'>{this.state.error?.message}</p>
+					</div>
+				</div>
+			);
+		}
+		return this.props.children;
+	}
+}
+
 export function ChatMessages() {
 	const chatId = useParams({ strict: false }).chatId;
 	const contentRef = useRef<HTMLDivElement>(null);
@@ -47,7 +74,9 @@ export function ChatMessages() {
 		>
 			<Conversation>
 				<ConversationContent className='max-w-3xl mx-auto gap-0 pt-15 max-md:pt-0'>
-					<ChatMessagesContent />
+					<ChatErrorBoundary>
+						<ChatMessagesContent />
+					</ChatErrorBoundary>
 				</ConversationContent>
 
 				<ConversationScrollButton />


### PR DESCRIPTION
Closes #581

  When an LLM provider returns a quota or rate limit error, the UI was crashing instead of showing a friendly error message. Two issues were
  causing this:

  1. **Backend**: If `handleAgentRoute()` threw before creating a stream (e.g. model resolution failure, quota error), Fastify returned a
  JSON error response instead of an SSE stream. The frontend's SSE parser couldn't handle this and threw an unhandled error.

  2. **Frontend**: No React Error Boundary existed anywhere in the app. Any unhandled rendering error during error state processing would
  crash the entire component tree.

  Changes:
  - Backend: Wrapped the agent route handler with try/catch that returns a proper SSE error stream on failure, so the frontend always
  receives a parseable response
  - Frontend: Added a ChatErrorBoundary around the chat messages component to catch rendering errors and show a fallback UI instead of
  crashing