### PR TITLE
fix: pass credentials and add env fallback in resolveProviderSettings for Vertex AI

### DIFF
--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -76,13 +76,21 @@ export async function resolveProviderSettings(
 ): Promise<ProviderSettings | null> {
 	const config = await projectLlmConfigQueries.getProjectLlmConfigByProvider(projectId, provider);
 	if (config) {
-		return { apiKey: config.apiKey, ...(config.baseUrl && { baseURL: config.baseUrl }) };
+		return {
+			apiKey: config.apiKey,
+			...(config.baseUrl && { baseURL: config.baseUrl }),
+			...(config.credentials && { credentials: config.credentials }),
+		};
 	}
 
 	const envApiKey = getEnvApiKey(provider);
 	if (envApiKey) {
 		const envBaseUrl = getEnvBaseUrl(provider);
 		return { apiKey: envApiKey, ...(envBaseUrl && { baseURL: envBaseUrl }) };
+	}
+
+	if (hasEnvApiKey(provider)) {
+		return { apiKey: '' };
 	}
 
 	return null;


### PR DESCRIPTION
Closes #584

  AI summary features (title generation, memory extraction, compaction) were broken with Vertex AI because `resolveProviderSettings()` had
  two issues:

  1. The DB config path didn't pass `credentials` to the returned settings — even when Vertex was configured via the UI with
  project/location/service account, the summary model creation never received them.

  2. There was no `hasEnvApiKey()` fallback — unlike `resolveProviderModel()`, this function returned `null` when no API key env var was set,
   causing all summary operations to silently skip for Vertex AI.

  Note: This fix works alongside #585 which fixes `hasEnvApiKey()` to recognize Vertex's extra field env vars.