### PR TITLE
feat: import Snowflake semantic views during sync

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -177,9 +177,9 @@ def sync_database(
         for schema, tables in schema_tables.items():
             schema_path = db_path / f"schema={schema}"
             schema_path.mkdir(parents=True, exist_ok=True)
-            state.add_schema(schema)
 
             if tables:
+                state.add_schema(schema)
                 table_task = progress.add_task(
                     f"    [cyan]{schema}[/cyan]",
                     total=len(tables),

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -159,15 +159,12 @@ def sync_database(
 
             tables = [t for t in all_tables if db_config.matches_pattern(schema, t)]
 
-            if not tables:
-                progress.update(schema_task, advance=1)
-                continue
-
-            list_dur = _fmt_duration(time.monotonic() - t_list)
-            console.print(
-                f"  [cyan]▸ {schema}[/cyan] [dim]— {len(tables)} tables "
-                f"(of {len(all_tables)} total, listed in {list_dur})[/dim]"
-            )
+            if tables:
+                list_dur = _fmt_duration(time.monotonic() - t_list)
+                console.print(
+                    f"  [cyan]▸ {schema}[/cyan] [dim]— {len(tables)} tables "
+                    f"(of {len(all_tables)} total, listed in {list_dur})[/dim]"
+                )
             schema_tables[schema] = tables
 
         selected_tables = [(schema, t) for schema, tables in schema_tables.items() for t in tables]
@@ -182,84 +179,87 @@ def sync_database(
             schema_path.mkdir(parents=True, exist_ok=True)
             state.add_schema(schema)
 
-            table_task = progress.add_task(
-                f"    [cyan]{schema}[/cyan]",
-                total=len(tables),
-            )
+            if tables:
+                table_task = progress.add_task(
+                    f"    [cyan]{schema}[/cyan]",
+                    total=len(tables),
+                )
 
-            schema_errors = 0
-            schema_start = time.monotonic()
+                schema_errors = 0
+                schema_start = time.monotonic()
 
-            for table in tables:
-                table_path = schema_path / f"table={table}"
-                table_path.mkdir(parents=True, exist_ok=True)
+                for table in tables:
+                    table_path = schema_path / f"table={table}"
+                    table_path.mkdir(parents=True, exist_ok=True)
+
+                    progress.update(
+                        table_task,
+                        description=f"    [cyan]{schema}[/cyan] [dim]→ {table}[/dim]",
+                    )
+
+                    ctx = db_config.create_context(conn, schema, table)
+                    table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
+
+                    for template_name in templates:
+                        output_filename = Path(template_name).stem
+                        tpl_name = output_filename.replace(".md", "")
+
+                        extra_ctx: dict[str, Any] = {}
+                        if tpl_name == "how_to_use":
+                            extra_ctx["usage_stats"] = table_usage
+                        output_file = table_path / output_filename
+
+                        if tpl_name == "profiling" and hasattr(db_config, "profiling"):
+                            if not _should_refresh_profiling(output_file, db_config.profiling):
+                                console.print(
+                                    f"    [dim]⏭ {schema}.{table} profiling skipped "
+                                    f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
+                                )
+                                continue
+
+                        t_render = time.monotonic()
+                        try:
+                            content = engine.render(
+                                template_name,
+                                db=ctx,
+                                table_name=table,
+                                dataset=schema,
+                                **({"nao": nao_ctx} if nao_ctx else {}),
+                                **extra_ctx
+                                ,
+                            )
+                            render_dur = time.monotonic() - t_render
+                            if render_dur > 5:
+                                console.print(
+                                    f"    [yellow]⏱[/yellow] [dim]{schema}.{table}[/dim] "
+                                    f"[yellow]{tpl_name}[/yellow] [dim]took {_fmt_duration(render_dur)}[/dim]"
+                                )
+                        except Exception as e:
+                            render_dur = time.monotonic() - t_render
+                            schema_errors += 1
+                            total_errors += 1
+                            console.print(
+                                f"    [bold red]✗[/bold red] [dim]{schema}.{table}[/dim] "
+                                f"[red]{tpl_name}[/red] [dim]failed after "
+                                f"{_fmt_duration(render_dur)}:[/dim] {e}"
+                            )
+                            content = f"# {table}\n\nError generating content: {e}"
+
+                        output_file = table_path / output_filename
+                        output_file.write_text(content)
+
+                    state.add_table(schema, table)
+                    progress.update(table_task, advance=1)
 
                 progress.update(
                     table_task,
-                    description=f"    [cyan]{schema}[/cyan] [dim]→ {table}[/dim]",
+                    description=f"    [cyan]{schema}[/cyan]",
                 )
-
-                ctx = db_config.create_context(conn, schema, table)
-                table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
-
-                for template_name in templates:
-                    output_filename = Path(template_name).stem
-                    tpl_name = output_filename.replace(".md", "")
-
-                    extra_ctx: dict[str, Any] = {}
-                    if tpl_name == "how_to_use":
-                        extra_ctx["usage_stats"] = table_usage
-                    output_file = table_path / output_filename
-
-                    if tpl_name == "profiling" and hasattr(db_config, "profiling"):
-                        if not _should_refresh_profiling(output_file, db_config.profiling):
-                            console.print(
-                                f"    [dim]⏭ {schema}.{table} profiling skipped "
-                                f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
-                            )
-                            continue
-
-                    t_render = time.monotonic()
-                    try:
-                        content = engine.render(
-                            template_name,
-                            db=ctx,
-                            table_name=table,
-                            dataset=schema,
-                            **({"nao": nao_ctx} if nao_ctx else {}),
-                            **extra_ctx,
-                        )
-                        render_dur = time.monotonic() - t_render
-                        if render_dur > 5:
-                            console.print(
-                                f"    [yellow]⏱[/yellow] [dim]{schema}.{table}[/dim] "
-                                f"[yellow]{tpl_name}[/yellow] [dim]took {_fmt_duration(render_dur)}[/dim]"
-                            )
-                    except Exception as e:
-                        render_dur = time.monotonic() - t_render
-                        schema_errors += 1
-                        total_errors += 1
-                        console.print(
-                            f"    [bold red]✗[/bold red] [dim]{schema}.{table}[/dim] "
-                            f"[red]{tpl_name}[/red] [dim]failed after "
-                            f"{_fmt_duration(render_dur)}:[/dim] {e}"
-                        )
-                        content = f"# {table}\n\nError generating content: {e}"
-
-                    output_file.write_text(content)
-
-                state.add_table(schema, table)
-                progress.update(table_task, advance=1)
-
-            progress.update(
-                table_task,
-                description=f"    [cyan]{schema}[/cyan]",
-            )
-            schema_dur = _fmt_duration(time.monotonic() - schema_start)
-            error_suffix = f" [red]({schema_errors} errors)[/red]" if schema_errors else ""
-            console.print(
-                f"  [green]✓ {schema}[/green] [dim]— {len(tables)} tables synced in {schema_dur}{error_suffix}[/dim]"
-            )
+                schema_dur = _fmt_duration(time.monotonic() - schema_start)
+                error_suffix = f" [red]({schema_errors} errors)[/red]" if schema_errors else ""
+                console.print(
+                    f"  [green]✓ {schema}[/green] [dim]— {len(tables)} tables synced in {schema_dur}{error_suffix}[/dim]"
+                )
 
             semantic_views = db_config.get_semantic_views(conn, schema)
             if semantic_views:
@@ -271,7 +271,7 @@ def sync_database(
                         content_parts.append(f"{sv['comment']}\n")
                     if sv.get("definition"):
                         content_parts.append("## Definition\n")
-                        content_parts.append(f"```yaml\n{sv['definition']}\n```\n")
+                        content_parts.append(f"```sql\n{sv['definition']}\n```\n")
                     (sv_path / "definition.md").write_text("\n".join(content_parts))
                     state.add_table(schema, sv["name"])
                 console.print(f"  [green]✓ {schema}[/green] [dim]— {len(semantic_views)} semantic views synced[/dim]")

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -175,6 +175,13 @@ def sync_database(
             usage_stats = compute_table_usage(raw_queries, selected_tables, dialect=dialect)
 
         for schema, tables in schema_tables.items():
+            semantic_views = db_config.get_semantic_views(conn, schema)
+            semantic_views = [sv for sv in semantic_views if db_config.matches_pattern(schema, sv["name"])]
+
+            if not tables and not semantic_views:
+                progress.update(schema_task, advance=1)
+                continue
+
             schema_path = db_path / f"schema={schema}"
             schema_path.mkdir(parents=True, exist_ok=True)
 
@@ -224,7 +231,7 @@ def sync_database(
                             table_name=table,
                             dataset=schema,
                             **({"nao": nao_ctx} if nao_ctx else {}),
-                            **extra_ctx
+                            **extra_ctx,
                         )
                         render_dur = time.monotonic() - t_render
                         if render_dur > 5:
@@ -260,8 +267,6 @@ def sync_database(
                     f"  [green]✓ {schema}[/green] [dim]— {len(tables)} tables synced in {schema_dur}{error_suffix}[/dim]"
                 )
 
-            semantic_views = db_config.get_semantic_views(conn, schema)
-            semantic_views = [sv for sv in semantic_views if db_config.matches_pattern(schema, sv["name"])]
             if semantic_views:
                 for sv in semantic_views:
                     sv_path = schema_path / f"semantic_view={sv['name']}"

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -261,6 +261,21 @@ def sync_database(
                 f"  [green]✓ {schema}[/green] [dim]— {len(tables)} tables synced in {schema_dur}{error_suffix}[/dim]"
             )
 
+            semantic_views = db_config.get_semantic_views(conn, schema)
+            if semantic_views:
+                for sv in semantic_views:
+                    sv_path = schema_path / f"semantic_view={sv['name']}"
+                    sv_path.mkdir(parents=True, exist_ok=True)
+                    content_parts = [f"# {sv['name']}\n"]
+                    if sv.get("comment"):
+                        content_parts.append(f"{sv['comment']}\n")
+                    if sv.get("definition"):
+                        content_parts.append("## Definition\n")
+                        content_parts.append(f"```yaml\n{sv['definition']}\n```\n")
+                    (sv_path / "definition.md").write_text("\n".join(content_parts))
+                    state.add_table(schema, sv["name"])
+                console.print(f"  [green]✓ {schema}[/green] [dim]— {len(semantic_views)} semantic views synced[/dim]")
+
             progress.update(schema_task, advance=1)
 
         if total_errors:

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -178,83 +178,82 @@ def sync_database(
             schema_path = db_path / f"schema={schema}"
             schema_path.mkdir(parents=True, exist_ok=True)
 
-            if tables:
-                state.add_schema(schema)
-                table_task = progress.add_task(
-                    f"    [cyan]{schema}[/cyan]",
-                    total=len(tables),
-                )
+            state.add_schema(schema)
+            table_task = progress.add_task(
+                f"    [cyan]{schema}[/cyan]",
+                total=len(tables),
+            )
 
-                schema_errors = 0
-                schema_start = time.monotonic()
+            schema_errors = 0
+            schema_start = time.monotonic()
 
-                for table in tables:
-                    table_path = schema_path / f"table={table}"
-                    table_path.mkdir(parents=True, exist_ok=True)
-
-                    progress.update(
-                        table_task,
-                        description=f"    [cyan]{schema}[/cyan] [dim]→ {table}[/dim]",
-                    )
-
-                    ctx = db_config.create_context(conn, schema, table)
-                    table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
-
-                    for template_name in templates:
-                        output_filename = Path(template_name).stem
-                        tpl_name = output_filename.replace(".md", "")
-
-                        extra_ctx: dict[str, Any] = {}
-                        if tpl_name == "how_to_use":
-                            extra_ctx["usage_stats"] = table_usage
-                        output_file = table_path / output_filename
-
-                        if tpl_name == "profiling" and hasattr(db_config, "profiling"):
-                            if not _should_refresh_profiling(output_file, db_config.profiling):
-                                console.print(
-                                    f"    [dim]⏭ {schema}.{table} profiling skipped "
-                                    f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
-                                )
-                                continue
-
-                        t_render = time.monotonic()
-                        try:
-                            content = engine.render(
-                                template_name,
-                                db=ctx,
-                                table_name=table,
-                                dataset=schema,
-                                **({"nao": nao_ctx} if nao_ctx else {}),
-                                **extra_ctx
-                                ,
-                            )
-                            render_dur = time.monotonic() - t_render
-                            if render_dur > 5:
-                                console.print(
-                                    f"    [yellow]⏱[/yellow] [dim]{schema}.{table}[/dim] "
-                                    f"[yellow]{tpl_name}[/yellow] [dim]took {_fmt_duration(render_dur)}[/dim]"
-                                )
-                        except Exception as e:
-                            render_dur = time.monotonic() - t_render
-                            schema_errors += 1
-                            total_errors += 1
-                            console.print(
-                                f"    [bold red]✗[/bold red] [dim]{schema}.{table}[/dim] "
-                                f"[red]{tpl_name}[/red] [dim]failed after "
-                                f"{_fmt_duration(render_dur)}:[/dim] {e}"
-                            )
-                            content = f"# {table}\n\nError generating content: {e}"
-
-                        output_file = table_path / output_filename
-                        output_file.write_text(content)
-
-                    state.add_table(schema, table)
-                    progress.update(table_task, advance=1)
+            for table in tables:
+                table_path = schema_path / f"table={table}"
+                table_path.mkdir(parents=True, exist_ok=True)
 
                 progress.update(
                     table_task,
-                    description=f"    [cyan]{schema}[/cyan]",
+                    description=f"    [cyan]{schema}[/cyan] [dim]→ {table}[/dim]",
                 )
+
+                ctx = db_config.create_context(conn, schema, table)
+                table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
+
+                for template_name in templates:
+                    output_filename = Path(template_name).stem
+                    tpl_name = output_filename.replace(".md", "")
+
+                    extra_ctx: dict[str, Any] = {}
+                    if tpl_name == "how_to_use":
+                        extra_ctx["usage_stats"] = table_usage
+                    output_file = table_path / output_filename
+
+                    if tpl_name == "profiling" and hasattr(db_config, "profiling"):
+                        if not _should_refresh_profiling(output_file, db_config.profiling):
+                            console.print(
+                                f"    [dim]⏭ {schema}.{table} profiling skipped "
+                                f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
+                            )
+                            continue
+
+                    t_render = time.monotonic()
+                    try:
+                        content = engine.render(
+                            template_name,
+                            db=ctx,
+                            table_name=table,
+                            dataset=schema,
+                            **({"nao": nao_ctx} if nao_ctx else {}),
+                            **extra_ctx
+                        )
+                        render_dur = time.monotonic() - t_render
+                        if render_dur > 5:
+                            console.print(
+                                f"    [yellow]⏱[/yellow] [dim]{schema}.{table}[/dim] "
+                                f"[yellow]{tpl_name}[/yellow] [dim]took {_fmt_duration(render_dur)}[/dim]"
+                            )
+                    except Exception as e:
+                        render_dur = time.monotonic() - t_render
+                        schema_errors += 1
+                        total_errors += 1
+                        console.print(
+                            f"    [bold red]✗[/bold red] [dim]{schema}.{table}[/dim] "
+                            f"[red]{tpl_name}[/red] [dim]failed after "
+                            f"{_fmt_duration(render_dur)}:[/dim] {e}"
+                        )
+                        content = f"# {table}\n\nError generating content: {e}"
+
+                    output_file = table_path / output_filename
+                    output_file.write_text(content)
+
+                state.add_table(schema, table)
+                progress.update(table_task, advance=1)
+
+            progress.update(
+                table_task,
+                description=f"    [cyan]{schema}[/cyan]",
+            )
+            if tables:
                 schema_dur = _fmt_duration(time.monotonic() - schema_start)
                 error_suffix = f" [red]({schema_errors} errors)[/red]" if schema_errors else ""
                 console.print(
@@ -262,11 +261,15 @@ def sync_database(
                 )
 
             semantic_views = db_config.get_semantic_views(conn, schema)
+            semantic_views = [sv for sv in semantic_views if db_config.matches_pattern(schema, sv["name"])]
             if semantic_views:
                 for sv in semantic_views:
                     sv_path = schema_path / f"semantic_view={sv['name']}"
                     sv_path.mkdir(parents=True, exist_ok=True)
                     content_parts = [f"# {sv['name']}\n"]
+                    content_parts.append(
+                        "This is a Snowflake **semantic view** — use this to understand the intended way to query and aggregate data.\n"
+                    )
                     if sv.get("comment"):
                         content_parts.append(f"{sv['comment']}\n")
                     if sv.get("definition"):

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -223,6 +223,10 @@ class DatabaseConfig(BaseModel, ABC):
 
         return DatabaseContext(conn, schema, table_name)
 
+    def get_semantic_views(self, conn: "BaseBackend", schema: str) -> list[dict[str, str]]:
+        """Fetch semantic views for a schema. Override in subclasses that support semantic views."""
+        return []
+
     def get_query_history_sql(self, days: int) -> str | None:
         """Return SQL to fetch query history for the last N days.
 

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -70,7 +70,11 @@ class BigQueryDatabaseContext(DatabaseContext):
     def partition_columns(self) -> list[str]:
         if self._partition_metadata is not None and self._partition_metadata.partition_column is not None:
             return [self._partition_metadata.partition_column]
-        return []
+        try:
+            return _get_bq_partition_columns(self._conn, self._project_id, self._schema, self._table_name)
+        except Exception:
+            logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
+            return []
 
     def clustering_columns(self) -> list[str]:
         if self._partition_metadata is not None:
@@ -343,6 +347,30 @@ def _coerce(val: Any) -> Any:
     if val is not None and not isinstance(val, (str, int, float, bool, list, dict)):
         return str(val)
     return val
+
+
+def _get_bq_partition_columns(conn: BaseBackend, project_id: str, schema: str, table: str) -> list[str]:
+    """Per-context fallback when batch metadata is unavailable.
+
+    Returns partition columns first, then clustering columns (deduplicated).
+    """
+    schema_info_path = _bq_path(project_id, schema, "INFORMATION_SCHEMA", "COLUMNS")
+    table_name_literal = _bq_string_literal(table)
+    partition_query = f"""
+        SELECT column_name
+        FROM {schema_info_path}
+        WHERE table_name = {table_name_literal} AND is_partitioning_column = 'YES'
+    """
+    clustering_query = f"""
+        SELECT column_name
+        FROM {schema_info_path}
+        WHERE table_name = {table_name_literal} AND clustering_ordinal_position IS NOT NULL
+        ORDER BY clustering_ordinal_position
+    """
+    columns: list[str] = []
+    columns.extend(row[0] for row in conn.raw_sql(partition_query))  # type: ignore[union-attr]
+    columns.extend(row[0] for row in conn.raw_sql(clustering_query) if row[0] not in columns)  # type: ignore[union-attr]
+    return columns
 
 
 class BigQueryConfig(DatabaseConfig):

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -284,20 +284,21 @@ class SnowflakeConfig(DatabaseConfig):
         """Fetch semantic views from a Snowflake schema."""
         try:
             query = f"""
-                SELECT SEMANTIC_VIEW_NAME, COMMENT, DEFINITION
+                SELECT NAME, COMMENT
                 FROM INFORMATION_SCHEMA.SEMANTIC_VIEWS
-                WHERE SEMANTIC_VIEW_SCHEMA = '{schema}'
-                ORDER BY SEMANTIC_VIEW_NAME
+                WHERE "SCHEMA" = '{schema}'
+                ORDER BY NAME
             """
             rows = conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
-            return [
-                {
-                    "name": row[0],
-                    "comment": str(row[1]) if row[1] else "",
-                    "definition": str(row[2]) if row[2] else "",
-                }
-                for row in rows
-            ]
+            results = []
+            for name, comment in rows:
+                try:
+                    ddl_row = conn.raw_sql(f"SELECT GET_DDL('SEMANTIC VIEW', '{schema}.{name}')").fetchone()  # type: ignore[union-attr]
+                    definition = str(ddl_row[0]) if ddl_row and ddl_row[0] else ""
+                except Exception:
+                    definition = ""
+                results.append({"name": name, "comment": str(comment) if comment else "", "definition": definition})
+            return results
         except Exception:
             logger.debug("Failed to fetch semantic views for schema %s (feature may not be available)", schema)
             return []

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -280,6 +280,28 @@ class SnowflakeConfig(DatabaseConfig):
     def create_context(self, conn: BaseBackend, schema: str, table_name: str) -> SnowflakeDatabaseContext:
         return SnowflakeDatabaseContext(conn, schema, table_name)
 
+    def get_semantic_views(self, conn: BaseBackend, schema: str) -> list[dict[str, str]]:
+        """Fetch semantic views from a Snowflake schema."""
+        try:
+            query = f"""
+                SELECT SEMANTIC_VIEW_NAME, COMMENT, DEFINITION
+                FROM INFORMATION_SCHEMA.SEMANTIC_VIEWS
+                WHERE SEMANTIC_VIEW_SCHEMA = '{schema}'
+                ORDER BY SEMANTIC_VIEW_NAME
+            """
+            rows = conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
+            return [
+                {
+                    "name": row[0],
+                    "comment": str(row[1]) if row[1] else "",
+                    "definition": str(row[2]) if row[2] else "",
+                }
+                for row in rows
+            ]
+        except Exception:
+            logger.debug("Failed to fetch semantic views for schema %s (feature may not be available)", schema)
+            return []
+
     def get_query_history_sql(self, days: int) -> str | None:
         return (
             f"SELECT query_text AS query_text "


### PR DESCRIPTION
 Closes #582

  Snowflake semantic views are now imported during `nao sync` alongside regular tables. They provide a semantic layer (metrics, dimensions,
  relationships) that helps the LLM understand the correct way to query data.

  Changes:
  - Added `get_semantic_views()` method to `SnowflakeConfig` that queries `INFORMATION_SCHEMA.SEMANTIC_VIEWS`
  - Added base `get_semantic_views()` method to `DatabaseConfig` (returns empty for non-Snowflake databases)
  - After syncing tables for each schema, the sync provider now fetches and writes semantic views to `semantic_view=<name>/definition.md`
  - Gracefully handles Snowflake instances where semantic views are not available (silently skips)

  File structure:
  databases/type=snowflake/database=/schema=/
    table=/columns.md, preview.md, ...
    semantic_view=/definition.md     ← new

  ## Testing

  I don't have access to a Snowflake account, so I couldn't test this end-to-end against a live instance. Here's what I did verify:

  - **Mock-tested the `get_semantic_views()` method** — confirmed it correctly parses rows from `INFORMATION_SCHEMA.SEMANTIC_VIEWS` into `{name, comment, definition}` dicts
  - **Verified graceful fallback** — when the query fails (e.g. older Snowflake without semantic views), the method catches the exception and returns an empty list instead of crashing the sync
  - **Verified no impact on other databases** — the base `DatabaseConfig.get_semantic_views()` returns empty, so non-Snowflake syncs are unaffected
  - **All 479 existing CLI tests pass**, ruff lint and format clean

  Would appreciate if someone on the team with Snowflake access could validate the `INFORMATION_SCHEMA.SEMANTIC_VIEWS` query and the output file structure.