### PR TITLE
fix(backend): avoid SQL tool-output truncation by default

### DIFF
--- a/apps/backend/src/components/tool-outputs/execute-sql.tsx
+++ b/apps/backend/src/components/tool-outputs/execute-sql.tsx
@@ -4,16 +4,15 @@ import type { executeSql } from '@nao/shared/tools';
 import { Block, CodeBlock, ListItem, Span, Title, TitledList } from '../../lib/markdown';
 import { truncateMiddle } from '../../utils/utils';
 
-const MAX_ROWS = 20;
-
-export const ExecuteSqlOutput = ({ output, maxRows = MAX_ROWS }: { output: executeSql.Output; maxRows?: number }) => {
+export const ExecuteSqlOutput = ({ output, maxRows }: { output: executeSql.Output; maxRows?: number }) => {
 	if (output.data.length === 0) {
 		return <Block>The query was successfully executed and returned no rows.</Block>;
 	}
 
-	const isTruncated = output.data.length > maxRows;
-	const visibleRows = isTruncated ? output.data.slice(0, maxRows) : output.data;
-	const remainingRows = isTruncated ? output.data.length - maxRows : 0;
+	const effectiveMaxRows = maxRows ?? output.data.length;
+	const isTruncated = output.data.length > effectiveMaxRows;
+	const visibleRows = isTruncated ? output.data.slice(0, effectiveMaxRows) : output.data;
+	const remainingRows = isTruncated ? output.data.length - effectiveMaxRows : 0;
 
 	return (
 		<Block>

--- a/apps/backend/tests/tool-outputs/execute-sql.test.tsx
+++ b/apps/backend/tests/tool-outputs/execute-sql.test.tsx
@@ -118,4 +118,25 @@ name: Bob
 ...(1 more)`,
 		);
 	});
+
+	it('does not truncate rows by default', () => {
+		const data = Array.from({ length: 25 }, (_, i) => ({
+			id: i + 1,
+			name: `User ${i + 1}`,
+		}));
+
+		const result = renderToMarkdown(
+			<ExecuteSqlOutput
+				output={{
+					id: 'query_all_rows',
+					columns: ['id', 'name'],
+					row_count: data.length,
+					data,
+				}}
+			/>,
+		);
+
+		expect(result).toContain('```#25');
+		expect(result).not.toContain('...(5 more)');
+	});
 });


### PR DESCRIPTION
Closes #572

## What changed
- Removed the hardcoded default MAX_ROWS = 20 truncation in SQL tool markdown output.
- ExecuteSqlOutput now defaults to rendering all returned rows unless maxRows is explicitly provided.
- Kept explicit truncation behavior unchanged when maxRows is passed.
- Added a regression test to verify default behavior does not truncate rows.

## Why
The previous default truncation could hide rows from the model context and lead to incorrect inferences/hallucinations from partial SQL results.

## Validation
- 
px vitest run tests/tool-outputs/execute-sql.test.tsx
- 
px eslint src/components/tool-outputs/execute-sql.tsx tests/tool-outputs/execute-sql.test.tsx

Note: full backend 
pm run -w @nao/backend lint in this environment reports unrelated missing optional dependency/type setup errors outside this change scope.
