### PR TITLE
all issues due to config bedrock resolved

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -43,6 +43,7 @@
 		"@ai-sdk/google-vertex": "^4.0.80",
 		"@ai-sdk/mistral": "^3.0.13",
 		"@ai-sdk/openai": "^3.0.1",
+		"@aws-sdk/credential-providers": "^3.1030.0",
 		"@azure/identity": "^4.13.0",
 		"@chat-adapter/slack": "^4.15.0",
 		"@chat-adapter/state-memory": "^4.15.0",

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -6,6 +6,7 @@ import { createVertex } from '@ai-sdk/google-vertex';
 import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { createMistral } from '@ai-sdk/mistral';
 import { createOpenAI } from '@ai-sdk/openai';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import type { LlmProvider } from '@nao/shared/types';
 import { createOpenRouter, LanguageModelV3 } from '@openrouter/ai-sdk-provider';
 import { createOllama } from 'ai-sdk-ollama';
@@ -89,12 +90,26 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 			if (settings.apiKey) {
 				config = { apiKey: settings.apiKey, region };
 			} else if (creds?.accessKeyId && creds?.secretAccessKey) {
-				config = { region, accessKeyId: creds.accessKeyId, secretAccessKey: creds.secretAccessKey };
-			} else {
+				config = {
+					region,
+					accessKeyId: creds.accessKeyId,
+					secretAccessKey: creds.secretAccessKey,
+					...(creds.sessionToken && { sessionToken: creds.sessionToken }),
+				};
+			} else if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
 				config = {
 					region,
 					accessKeyId: process.env.AWS_ACCESS_KEY_ID,
 					secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+					...(process.env.AWS_SESSION_TOKEN && { sessionToken: process.env.AWS_SESSION_TOKEN }),
+				};
+			} else {
+				config = {
+					region,
+					credentialProvider: fromNodeProviderChain({
+						profile: process.env.AWS_PROFILE,
+						ignoreCache: true,
+					}),
 				};
 			}
 
@@ -198,14 +213,16 @@ function getBedrockRegionPrefix(region: string): string {
 	return BEDROCK_REGION_PREFIXES.has(geo) ? geo : 'us';
 }
 
-/** Prepend the geographic prefix for cross-region inference models that don't already have one. */
+/** Ensure cross-region inference models use the correct geographic prefix for the target region. */
 function resolveBedrockModelId(modelId: string, region: string): string {
+	const prefix = getBedrockRegionPrefix(region);
 	const firstSegment = modelId.split('.')[0];
 	if (BEDROCK_REGION_PREFIXES.has(firstSegment)) {
-		return modelId;
+		const rest = modelId.slice(firstSegment.length + 1);
+		return firstSegment === prefix ? modelId : `${prefix}.${rest}`;
 	}
 	if (BEDROCK_CROSS_REGION_PROVIDERS.has(firstSegment)) {
-		return `${getBedrockRegionPrefix(region)}.${modelId}`;
+		return `${prefix}.${modelId}`;
 	}
 	return modelId;
 }

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -43,7 +43,13 @@ import { Provider } from '../types/messaging-provider';
 import { ToolContext } from '../types/tools';
 import { convertToCost, convertToTokenUsage, findLastUserMessage, getLastUserMessageText } from '../utils/ai';
 import { HandlerError } from '../utils/error';
-import { getDefaultModelId, getEnvModelSelections, resolveProviderModel, resolveProviderSettings } from '../utils/llm';
+import {
+	getDefaultModelId,
+	getEnvModelSelections,
+	resolveAnnotationModelId,
+	resolveProviderModel,
+	resolveProviderSettings,
+} from '../utils/llm';
 import { logger } from '../utils/logger';
 import { truncateMiddle } from '../utils/utils';
 import { compactionService } from './compaction';
@@ -448,7 +454,11 @@ class AgentManager {
 
 	private async _generateTitle(userMessageText: string): Promise<void> {
 		const provider = this._modelSelection.provider;
-		const summaryModelId = LLM_PROVIDERS[provider].summaryModelId;
+		const summaryModelId = await resolveAnnotationModelId(
+			this.chat.projectId,
+			provider,
+			LLM_PROVIDERS[provider].summaryModelId,
+		);
 		const modelResult = await resolveProviderModel(this.chat.projectId, provider, summaryModelId);
 		if (!modelResult) {
 			return;

--- a/apps/backend/src/services/compaction.ts
+++ b/apps/backend/src/services/compaction.ts
@@ -14,7 +14,7 @@ import {
 	findLastUserMessageIndex,
 } from '../utils/ai';
 import { debugCompaction } from '../utils/debug';
-import { resolveProviderModel } from '../utils/llm';
+import { resolveAnnotationModelId, resolveProviderModel } from '../utils/llm';
 import { scheduleSaveLlmInferenceRecord } from '../utils/schedule-task';
 import { ITokenCounter, TokenCounter } from './token-counter';
 
@@ -170,7 +170,7 @@ export class CompactionService {
 	}
 
 	private async _resolveCompactionLLM(projectId: string, provider: LlmProvider) {
-		const modelId = LLM_PROVIDERS[provider].extractorModelId;
+		const modelId = await resolveAnnotationModelId(projectId, provider, LLM_PROVIDERS[provider].extractorModelId);
 		const model = await resolveProviderModel(projectId, provider, modelId);
 		if (!model) {
 			return undefined;

--- a/apps/backend/src/services/memory.ts
+++ b/apps/backend/src/services/memory.ts
@@ -14,7 +14,7 @@ import type {
 	UserMemory,
 	UserProfile,
 } from '../types/memory';
-import { resolveProviderModel } from '../utils/llm';
+import { resolveAnnotationModelId, resolveProviderModel } from '../utils/llm';
 import { logger } from '../utils/logger';
 import { posthog, PostHogEvent } from './posthog';
 
@@ -61,7 +61,7 @@ class MemoryService {
 			return;
 		}
 
-		const modelId = this._getExtractorModelId(opts.provider);
+		const modelId = await this._getExtractorModelId(opts.projectId, opts.provider);
 		const model = await this._resolveModel(opts.projectId, opts.provider, modelId);
 		if (!model) {
 			return;
@@ -104,9 +104,8 @@ class MemoryService {
 		return resolveProviderModel(projectId, provider, modelId);
 	}
 
-	private _getExtractorModelId(provider: LlmProvider): string {
-		const providerConfig = LLM_PROVIDERS[provider];
-		return providerConfig.extractorModelId;
+	private async _getExtractorModelId(projectId: string, provider: LlmProvider): Promise<string> {
+		return resolveAnnotationModelId(projectId, provider, LLM_PROVIDERS[provider].extractorModelId);
 	}
 
 	private async _persistExtractedMemories(opts: {

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -127,6 +127,29 @@ export async function resolveProviderModel(
 	return null;
 }
 
+/**
+ * Resolve the model to use for background tasks (memory extraction, compaction, title generation).
+ * Priority: NAO_ANNOTATION_MODEL env var > first enabled model in project config > provider default.
+ */
+export async function resolveAnnotationModelId(
+	projectId: string,
+	provider: LlmProvider,
+	fallbackModelId: string,
+): Promise<string> {
+	const envOverride = process.env.NAO_ANNOTATION_MODEL;
+	if (envOverride) {
+		return envOverride;
+	}
+
+	const config = await projectLlmConfigQueries.getProjectLlmConfigByProvider(projectId, provider);
+	const enabledModels = config?.enabledModels ?? [];
+	if (enabledModels.length > 0) {
+		return enabledModels[0];
+	}
+
+	return fallbackModelId;
+}
+
 export const getProjectAvailableModels = async (
 	projectId: string,
 ): Promise<Array<{ provider: LlmProvider; modelId: string; name: string }>> => {

--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -229,6 +229,14 @@ def chat(
                 if config.llm.secret_key:
                     env["AWS_SECRET_ACCESS_KEY"] = config.llm.secret_key
                     console.print("[bold green]✓[/bold green] Set AWS_SECRET_ACCESS_KEY from config")
+                aws_profile = config.llm.aws_profile or os.environ.get("AWS_PROFILE")
+                if aws_profile:
+                    env["AWS_PROFILE"] = aws_profile
+                    console.print("[bold green]✓[/bold green] Set AWS_PROFILE from config")
+                session_token = os.environ.get("AWS_SESSION_TOKEN")
+                if session_token:
+                    env["AWS_SESSION_TOKEN"] = session_token
+                    console.print("[bold green]✓[/bold green] Set AWS_SESSION_TOKEN from environment")
                 if config.llm.aws_region:
                     env["AWS_REGION"] = config.llm.aws_region
                     console.print("[bold green]✓[/bold green] Set AWS_REGION from config")
@@ -248,6 +256,10 @@ def chat(
                     console.print("[bold green]✓[/bold green] Set VERTEX_GOOGLE_APPLICATION_CREDENTIALS from config")
 
         env["NAO_DEFAULT_PROJECT_PATH"] = str(Path.cwd())
+
+        if config and config.llm and config.llm.annotation_model:
+            env["NAO_ANNOTATION_MODEL"] = config.llm.annotation_model
+            console.print("[bold green]✓[/bold green] Set NAO_ANNOTATION_MODEL from config")
 
         if ngrok:
             ngrok_url = start_ngrok_tunnel(port)

--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -66,7 +66,9 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
 
         import boto3
 
-        client = boto3.client("bedrock", region_name=region)
+        profile = llm_config.aws_profile or os.environ.get("AWS_PROFILE")
+        session = boto3.Session(profile_name=profile, region_name=region)
+        client = session.client("bedrock")
         response = client.list_foundation_models()
         models = response.get("modelSummaries", [])
     elif provider == "vertex":

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -88,6 +88,9 @@ class LLMConfig(BaseModel):
     access_key: str | None = Field(default=None, description="AWS access key (only for Bedrock)")
     secret_key: str | None = Field(default=None, description="AWS secret key (only for Bedrock)")
     aws_region: str | None = Field(default=None, description="AWS region (only for Bedrock)")
+    aws_profile: str | None = Field(
+        default=None, description="AWS CLI profile name (only for Bedrock, e.g. SSO profile)"
+    )
     gcp_project: str | None = Field(default=None, description="GCP project ID (only for Vertex)")
     gcp_location: str | None = Field(default=None, description="GCP location (only for Vertex)")
     service_account_json: str | None = Field(default=None, description="Service account JSON (only for Vertex)")
@@ -146,6 +149,8 @@ class LLMConfig(BaseModel):
         service_account_json = None
         key_file = None
 
+        aws_profile = None
+
         if auth.api_key == "required":
             api_key = ask_text(f"Enter your {llm_provider.upper()} API key:", password=True, required_field=True)
         elif llm_provider == "bedrock":
@@ -157,7 +162,13 @@ class LLMConfig(BaseModel):
                     questionary.Choice("Bearer token", value="bearer"),
                 ],
             )
-            if bedrock_auth_mode == "keys":
+            if bedrock_auth_mode == "env":
+                aws_profile = ask_text(
+                    "Enter AWS profile name (leave blank for default):",
+                    password=False,
+                    required_field=False,
+                )
+            elif bedrock_auth_mode == "keys":
                 access_key = ask_text("Enter AWS access key:", password=False, required_field=True)
                 secret_key = ask_text("Enter AWS secret key:", password=True, required_field=True)
             elif bedrock_auth_mode == "bearer":
@@ -193,6 +204,7 @@ class LLMConfig(BaseModel):
             access_key=access_key,
             secret_key=secret_key,
             aws_region=aws_region or None,
+            aws_profile=aws_profile or None,
             gcp_project=gcp_project or None,
             gcp_location=gcp_location or None,
             service_account_json=service_account_json or None,

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"@ai-sdk/google-vertex": "^4.0.80",
 				"@ai-sdk/mistral": "^3.0.13",
 				"@ai-sdk/openai": "^3.0.1",
+				"@aws-sdk/credential-providers": "^3.1030.0",
 				"@azure/identity": "^4.13.0",
 				"@chat-adapter/slack": "^4.15.0",
 				"@chat-adapter/state-memory": "^4.15.0",
@@ -748,6 +749,82 @@
 				"node": ">=16.0.0"
 			}
 		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
 		"node_modules/@aws-crypto/util": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
@@ -797,6 +874,432 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/client-cognito-identity": {
+			"version": "3.1030.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1030.0.tgz",
+			"integrity": "sha512-PD9RIT5eJEXsP+Dq8fncTXOFAOI+EP3fRa/z1te2xehAVawixEpAJkjEE03A4msqPWGJ2S0TM2bb6zDbP66w3g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/credential-provider-node": "^3.972.30",
+				"@aws-sdk/middleware-host-header": "^3.972.9",
+				"@aws-sdk/middleware-logger": "^3.972.9",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.10",
+				"@aws-sdk/middleware-user-agent": "^3.972.29",
+				"@aws-sdk/region-config-resolver": "^3.972.11",
+				"@aws-sdk/types": "^3.973.7",
+				"@aws-sdk/util-endpoints": "^3.996.6",
+				"@aws-sdk/util-user-agent-browser": "^3.972.9",
+				"@aws-sdk/util-user-agent-node": "^3.973.15",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/core": "^3.23.14",
+				"@smithy/fetch-http-handler": "^5.3.16",
+				"@smithy/hash-node": "^4.2.13",
+				"@smithy/invalid-dependency": "^4.2.13",
+				"@smithy/middleware-content-length": "^4.2.13",
+				"@smithy/middleware-endpoint": "^4.4.29",
+				"@smithy/middleware-retry": "^4.5.0",
+				"@smithy/middleware-serde": "^4.2.17",
+				"@smithy/middleware-stack": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/node-http-handler": "^4.5.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.45",
+				"@smithy/util-defaults-mode-node": "^4.2.49",
+				"@smithy/util-endpoints": "^3.3.4",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-retry": "^4.3.0",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+			"integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@aws-sdk/xml-builder": "^3.972.17",
+				"@smithy/core": "^3.23.14",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/signature-v4": "^5.3.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
+			"version": "3.972.22",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.22.tgz",
+			"integrity": "sha512-ih6ORpme4i2qJqGckOQ9Lt2iiZ+5tm3bnfsT5TwoPyFnuDURXv3OdhYa3Nr/m0iJr38biqKYKdGKb5GR1KB2hw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+			"integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+			"integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/fetch-http-handler": "^5.3.16",
+				"@smithy/node-http-handler": "^4.5.2",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-stream": "^4.5.22",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+			"integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/credential-provider-env": "^3.972.25",
+				"@aws-sdk/credential-provider-http": "^3.972.27",
+				"@aws-sdk/credential-provider-login": "^3.972.29",
+				"@aws-sdk/credential-provider-process": "^3.972.25",
+				"@aws-sdk/credential-provider-sso": "^3.972.29",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.29",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+			"integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.30",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+			"integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.25",
+				"@aws-sdk/credential-provider-http": "^3.972.27",
+				"@aws-sdk/credential-provider-ini": "^3.972.29",
+				"@aws-sdk/credential-provider-process": "^3.972.25",
+				"@aws-sdk/credential-provider-sso": "^3.972.29",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.29",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+			"integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+			"integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/token-providers": "3.1026.0",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+			"integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers": {
+			"version": "3.1030.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1030.0.tgz",
+			"integrity": "sha512-hQhRax7MzsG40mc6Es2Muvfai+jfWt1j1odqP4UQtUok6Fu4qbJNRGgQ/EAi7Sb6VAL0EdY5JGGMevHz2oO+AA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/client-cognito-identity": "3.1030.0",
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/credential-provider-cognito-identity": "^3.972.22",
+				"@aws-sdk/credential-provider-env": "^3.972.25",
+				"@aws-sdk/credential-provider-http": "^3.972.27",
+				"@aws-sdk/credential-provider-ini": "^3.972.29",
+				"@aws-sdk/credential-provider-login": "^3.972.29",
+				"@aws-sdk/credential-provider-node": "^3.972.30",
+				"@aws-sdk/credential-provider-process": "^3.972.25",
+				"@aws-sdk/credential-provider-sso": "^3.972.29",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.29",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/core": "^3.23.14",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+			"integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+			"integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+			"integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.29",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+			"integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/types": "^3.973.7",
+				"@aws-sdk/util-endpoints": "^3.996.6",
+				"@smithy/core": "^3.23.14",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-retry": "^4.3.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.996.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+			"integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/middleware-host-header": "^3.972.9",
+				"@aws-sdk/middleware-logger": "^3.972.9",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.10",
+				"@aws-sdk/middleware-user-agent": "^3.972.29",
+				"@aws-sdk/region-config-resolver": "^3.972.11",
+				"@aws-sdk/types": "^3.973.7",
+				"@aws-sdk/util-endpoints": "^3.996.6",
+				"@aws-sdk/util-user-agent-browser": "^3.972.9",
+				"@aws-sdk/util-user-agent-node": "^3.973.15",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/core": "^3.23.14",
+				"@smithy/fetch-http-handler": "^5.3.16",
+				"@smithy/hash-node": "^4.2.13",
+				"@smithy/invalid-dependency": "^4.2.13",
+				"@smithy/middleware-content-length": "^4.2.13",
+				"@smithy/middleware-endpoint": "^4.4.29",
+				"@smithy/middleware-retry": "^4.5.0",
+				"@smithy/middleware-serde": "^4.2.17",
+				"@smithy/middleware-stack": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/node-http-handler": "^4.5.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.45",
+				"@smithy/util-defaults-mode-node": "^4.2.49",
+				"@smithy/util-endpoints": "^3.3.4",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-retry": "^4.3.0",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+			"integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/config-resolver": "^4.4.14",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1026.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+			"integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.27",
+				"@aws-sdk/nested-clients": "^3.996.19",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/types": {
 			"version": "3.973.7",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
@@ -808,6 +1311,94 @@
 			},
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+			"integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-endpoints": "^3.3.4",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+			"integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/types": "^4.14.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+			"integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.29",
+				"@aws-sdk/types": "^3.973.7",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+			"integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@azure/abort-controller": {
@@ -6763,12 +7354,283 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.16",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+			"integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+			"integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+			"integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@smithy/is-array-buffer": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
 			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+			"integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.29",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+			"integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-serde": "^4.2.17",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"@smithy/url-parser": "^4.2.13",
+				"@smithy/util-middleware": "^4.2.13",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
+			"integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.14",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/service-error-classification": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-retry": "^4.3.1",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.17",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+			"integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.14",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+			"integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+			"integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/shared-ini-file-loader": "^4.4.8",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+			"integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/querystring-builder": "^4.2.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+			"integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+			"integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+			"integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+			"integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.13",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+			"integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+			"integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.13",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+			"integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.13",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.9",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+			"integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.23.14",
+				"@smithy/middleware-endpoint": "^4.4.29",
+				"@smithy/middleware-stack": "^4.2.13",
+				"@smithy/protocol-http": "^5.3.13",
+				"@smithy/types": "^4.14.0",
+				"@smithy/util-stream": "^4.5.22",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -6800,6 +7662,65 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.45",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+			"integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.50",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.50.tgz",
+			"integrity": "sha512-xpjncL5XozFA3No7WypTsPU1du0fFS8flIyO+Wh2nhCy7bpEapvU7BR55Bg+wrfw+1cRA+8G8UsTjaxgzrMzXg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.15",
+				"@smithy/credential-provider-imds": "^4.2.13",
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/property-provider": "^4.2.13",
+				"@smithy/smithy-client": "^4.12.9",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.0.tgz",
+			"integrity": "sha512-QQHGPKkw6NPcU6TJ1rNEEa201srPtZiX4k61xL163vvs9sTqW/XKz+UEuJ00uvPqoN+5Rs4Ka1UJ7+Mp03IXJw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.13",
+				"@smithy/types": "^4.14.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@smithy/util-hex-encoding": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
@@ -6819,6 +7740,18 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -14603,6 +15536,41 @@
 			],
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fastify": {
 			"version": "5.8.4",
 			"resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
@@ -19815,6 +20783,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -22790,6 +23773,18 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
 			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/strnum": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
 			"license": "MIT"
 		},
 		"node_modules/style-to-js": {


### PR DESCRIPTION
## Summary

- [x]  **Fix SSO authentication for Bedrock** — AWS SSO credentials (profile, session token) were not propagated to subprocesses, causing auth failures. Added fromNodeProviderChain as a fallback so SSO, IAM roles, and named profiles work out of the box.

- [x] **Fix background tasks (memory, compaction, title) failing with 403** — These tasks used a hardcoded model ID that restrictive IAM policies don't allow. They now resolve the model from NAO_ANNOTATION_MODEL env var or the project's enabled models before falling back to the provider default.

- [x] **Fix wrong regional prefix for cross-region inference** — resolveBedrockModelId now replaces an incorrect geographic prefix (e.g. us. → eu.) instead of keeping it as-is.

## Related issue

#560 