### PR TITLE
Fix all cubic code review comments from PR #618

### DIFF
--- a/.github/workflows/deploy-app-preview.yml
+++ b/.github/workflows/deploy-app-preview.yml
@@ -50,12 +50,13 @@ jobs:
                   cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
                   cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
                   build-args: |
-                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
                       APP_VERSION=${{ github.ref_name }}
                       APP_COMMIT=${{ steps.sha.outputs.short_sha }}
+                  secrets: |
+                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
             - name: Deploy to preview server
-              uses: appleboy/ssh-action@master
+              uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
               with:
                   host: ${{ secrets.VM_HOST }}
                   username: github-actions-demo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,10 +74,11 @@ jobs:
                   cache-from: type=registry,ref=${{ env.CACHE_REGISTRY }}/${{ env.CACHE_IMAGE }}:${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
                   cache-to: type=registry,ref=${{ env.CACHE_REGISTRY }}/${{ env.CACHE_IMAGE }}:${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }},mode=max
                   build-args: |
-                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
                       APP_VERSION=${{ github.ref_name }}
                       APP_COMMIT=${{ steps.sha.outputs.short_sha }}
                       APP_BUILD_DATE=${{ steps.build_date.outputs.value }}
+                  secrets: |
+                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
             - name: Export digest
               run: |
@@ -159,7 +160,7 @@ jobs:
 
         steps:
             - name: Deploy with remote ssh commands using ssh key
-              uses: appleboy/ssh-action@master
+              uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
               with:
                   host: ${{ secrets.VM_HOST }}
                   username: github-actions-demo

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -62,17 +62,18 @@ jobs:
                       type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
                   cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
                   build-args: |
-                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
                       APP_VERSION=pr-${{ github.event.pull_request.number }}
                       APP_COMMIT=${{ steps.sha.outputs.short_sha }}
+                  secrets: |
+                      GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
             - name: Deploy to preview server
-              uses: appleboy/ssh-action@master
+              uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
               with:
                   host: ${{ secrets.VM_HOST }}
                   username: github-actions-demo
                   key: ${{ secrets.PRIVATE_KEY }}
-                  envs: PREVIEW_NAME,PREVIEW_PORT,PREVIEW_IMAGE,GITHUB_TOKEN
+                  envs: PREVIEW_NAME,PREVIEW_PORT,PREVIEW_IMAGE
                   script: |
                       export PREVIEW_NAME="${{ steps.preview.outputs.name }}"
                       export PREVIEW_PORT="${{ steps.preview.outputs.port }}"
@@ -183,7 +184,7 @@ jobs:
                   echo "name=${PREVIEW_NAME}" >> $GITHUB_OUTPUT
 
             - name: Remove preview deployment
-              uses: appleboy/ssh-action@master
+              uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
               with:
                   host: ${{ secrets.VM_HOST }}
                   username: github-actions-demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ RUN npm install -g bun
 FROM base AS deps
 WORKDIR /app
 
-# GitHub token for downloading @vscode/ripgrep binaries (avoids rate limits)
-ARG GITHUB_TOKEN
-
 COPY package.json package-lock.json bun.lock ./
 COPY apps/frontend/package.json ./apps/frontend/
 COPY apps/backend/package.json ./apps/backend/
@@ -22,9 +19,13 @@ COPY apps/shared/package.json ./apps/shared/
 
 # Single install for all workspaces. --ignore-scripts skips prepare (husky);
 # @vscode/ripgrep needs its postinstall to download the platform binary.
+# GITHUB_TOKEN is injected via BuildKit secret to avoid baking it into layers.
 RUN --mount=type=cache,target=/root/.bun/install/cache \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN 2>/dev/null || true)" \
     bun install --ignore-scripts \
-    && cd node_modules/@vscode/ripgrep && npm run postinstall
+    && GITHUB_TOKEN="$(cat /run/secrets/GITHUB_TOKEN 2>/dev/null || true)" \
+    cd node_modules/@vscode/ripgrep && npm run postinstall
 
 # =============================================================================
 # STAGE 3: Frontend builder

--- a/apps/backend/migrations-postgres/0036_cloud.sql
+++ b/apps/backend/migrations-postgres/0036_cloud.sql
@@ -14,5 +14,4 @@ ALTER TABLE "project" ADD COLUMN "env_vars" jsonb DEFAULT '{}'::jsonb NOT NULL;-
 ALTER TABLE "user" ADD COLUMN "github_access_token" text;--> statement-breakpoint
 ALTER TABLE "api_key" ADD CONSTRAINT "api_key_org_id_organization_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "api_key" ADD CONSTRAINT "api_key_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "api_key_orgId_idx" ON "api_key" USING btree ("org_id");--> statement-breakpoint
-CREATE INDEX "api_key_keyHash_idx" ON "api_key" USING btree ("key_hash");
+CREATE INDEX "api_key_orgId_idx" ON "api_key" USING btree ("org_id");

--- a/apps/backend/migrations-postgres/meta/0036_snapshot.json
+++ b/apps/backend/migrations-postgres/meta/0036_snapshot.json
@@ -195,21 +195,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "api_key_keyHash_idx": {
-          "name": "api_key_keyHash_idx",
-          "columns": [
-            {
-              "expression": "key_hash",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {

--- a/apps/backend/migrations-sqlite/0036_cloud.sql
+++ b/apps/backend/migrations-sqlite/0036_cloud.sql
@@ -13,6 +13,5 @@ CREATE TABLE `api_key` (
 --> statement-breakpoint
 CREATE UNIQUE INDEX `api_key_key_hash_unique` ON `api_key` (`key_hash`);--> statement-breakpoint
 CREATE INDEX `api_key_orgId_idx` ON `api_key` (`org_id`);--> statement-breakpoint
-CREATE INDEX `api_key_keyHash_idx` ON `api_key` (`key_hash`);--> statement-breakpoint
 ALTER TABLE `project` ADD `env_vars` text DEFAULT '{}' NOT NULL;--> statement-breakpoint
 ALTER TABLE `user` ADD `github_access_token` text;

--- a/apps/backend/migrations-sqlite/meta/0036_snapshot.json
+++ b/apps/backend/migrations-sqlite/meta/0036_snapshot.json
@@ -203,13 +203,6 @@
             "org_id"
           ],
           "isUnique": false
-        },
-        "api_key_keyHash_idx": {
-          "name": "api_key_keyHash_idx",
-          "columns": [
-            "key_hash"
-          ],
-          "isUnique": false
         }
       },
       "foreignKeys": {

--- a/apps/backend/src/db/pg-schema.ts
+++ b/apps/backend/src/db/pg-schema.ts
@@ -639,7 +639,7 @@ export const apiKey = pgTable(
 		lastUsedAt: timestamp('last_used_at'),
 		createdAt: timestamp('created_at').defaultNow().notNull(),
 	},
-	(t) => [index('api_key_orgId_idx').on(t.orgId), index('api_key_keyHash_idx').on(t.keyHash)],
+	(t) => [index('api_key_orgId_idx').on(t.orgId)],
 );
 
 export const log = pgTable(

--- a/apps/backend/src/db/sqlite-schema.ts
+++ b/apps/backend/src/db/sqlite-schema.ts
@@ -683,7 +683,7 @@ export const apiKey = sqliteTable(
 			.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
 			.notNull(),
 	},
-	(t) => [index('api_key_orgId_idx').on(t.orgId), index('api_key_keyHash_idx').on(t.keyHash)],
+	(t) => [index('api_key_orgId_idx').on(t.orgId)],
 );
 
 export const log = sqliteTable(

--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -195,7 +195,7 @@ export const initializePersonalOrganization = async (userId: string): Promise<vo
 
 	const user = await userQueries.get({ id: userId });
 	const orgName = user ? `${user.name}'s Organization` : 'Personal Organization';
-	const orgSlug = `org-${userId.slice(0, 8)}`;
+	const orgSlug = `org-${userId.replace(/-/g, '').slice(0, 16)}`;
 
 	await db.transaction(async (tx) => {
 		const [org] = await tx.insert(s.organization).values({ name: orgName, slug: orgSlug }).returning().execute();

--- a/apps/backend/src/routes/deploy.ts
+++ b/apps/backend/src/routes/deploy.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -40,7 +40,7 @@ export const deployRoutes = async (app: App) => {
 
 			const extractDir = path.join(tmpDir, 'extracted');
 			fs.mkdirSync(extractDir, { recursive: true });
-			execSync(`tar xzf ${tarPath} -C ${extractDir}`, { timeout: 30_000 });
+			execFileSync('tar', ['xzf', tarPath, '-C', extractDir], { timeout: 30_000 });
 
 			const configPath = path.join(extractDir, 'nao_config.yaml');
 			if (!fs.existsSync(configPath)) {

--- a/apps/backend/src/routes/github.ts
+++ b/apps/backend/src/routes/github.ts
@@ -1,8 +1,15 @@
+import crypto from 'node:crypto';
+
 import type { App } from '../app';
 import { getAuth } from '../auth';
+import { env } from '../env';
 import * as userQueries from '../queries/user.queries';
 import * as githubService from '../services/github';
 import { convertHeaders } from '../utils/utils';
+
+function signState(payload: string): string {
+	return crypto.createHmac('sha256', env.BETTER_AUTH_SECRET).update(payload).digest('base64url');
+}
 
 export const githubRoutes = async (app: App) => {
 	app.get('/connect', async (request, reply) => {
@@ -16,7 +23,9 @@ export const githubRoutes = async (app: App) => {
 			return reply.status(401).send({ error: 'Unauthorized' });
 		}
 
-		const state = Buffer.from(JSON.stringify({ userId: session.user.id })).toString('base64url');
+		const payload = Buffer.from(JSON.stringify({ userId: session.user.id })).toString('base64url');
+		const signature = signState(payload);
+		const state = `${payload}.${signature}`;
 		const url = githubService.buildAuthorizationUrl(state);
 		return reply.redirect(url);
 	});
@@ -27,12 +36,30 @@ export const githubRoutes = async (app: App) => {
 			return reply.redirect('/settings/organization?github=error&reason=missing_params');
 		}
 
+		const auth = await getAuth();
+		const session = await auth.api.getSession({ headers: convertHeaders(request.headers) });
+		if (!session?.user) {
+			return reply.redirect('/settings/organization?github=error&reason=unauthorized');
+		}
+
 		let userId: string;
 		try {
-			const decoded = JSON.parse(Buffer.from(state, 'base64url').toString());
+			const [payload, signature] = state.split('.');
+			if (!payload || !signature) {
+				throw new Error('malformed state');
+			}
+			const expectedSignature = signState(payload);
+			if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expectedSignature))) {
+				throw new Error('invalid signature');
+			}
+			const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString());
 			userId = decoded.userId;
 		} catch {
 			return reply.redirect('/settings/organization?github=error&reason=invalid_state');
+		}
+
+		if (session.user.id !== userId) {
+			return reply.redirect('/settings/organization?github=error&reason=user_mismatch');
 		}
 
 		try {

--- a/apps/backend/src/services/context-explorer.service.ts
+++ b/apps/backend/src/services/context-explorer.service.ts
@@ -2,7 +2,7 @@ import type { FileTreeEntry } from '@nao/shared/types';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { isExcludedEntry } from '../utils/tools';
+import { shouldExcludeEntry } from '../utils/tools';
 
 export async function getFileTree(projectFolder: string): Promise<FileTreeEntry[]> {
 	return readDirectoryRecursive(projectFolder, projectFolder);
@@ -23,7 +23,8 @@ export async function readFileContent(filePath: string, projectFolder: string): 
 async function readDirectoryRecursive(dirPath: string, projectFolder: string): Promise<FileTreeEntry[]> {
 	const dirEntries = await fs.readdir(dirPath, { withFileTypes: true });
 
-	const filtered = dirEntries.filter((entry) => !isExcludedEntry(entry.name));
+	const parentRelativePath = path.relative(projectFolder, dirPath);
+	const filtered = dirEntries.filter((entry) => !shouldExcludeEntry(entry.name, parentRelativePath, projectFolder));
 
 	const entries: FileTreeEntry[] = [];
 

--- a/apps/backend/src/services/github.ts
+++ b/apps/backend/src/services/github.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 import { env } from '../env';
 
@@ -151,7 +151,7 @@ async function searchRepos(
 
 export function cloneRepo(token: string, fullName: string, targetDir: string): void {
 	const cloneUrl = `https://x-access-token:${token}@github.com/${fullName}.git`;
-	execSync(`git clone --depth 1 ${cloneUrl} ${targetDir}`, {
+	execFileSync('git', ['clone', '--depth', '1', cloneUrl, targetDir], {
 		timeout: 120_000,
 		stdio: 'pipe',
 	});
@@ -203,15 +203,17 @@ export function pullRepo(token: string, repoFullName: string, projectDir: string
 	const opts = { cwd: projectDir, stdio: 'pipe' as const, timeout: 120_000 };
 
 	const authenticatedUrl = `https://x-access-token:${token}@github.com/${repoFullName}.git`;
-	execSync(`git remote set-url origin ${authenticatedUrl}`, opts);
+	execFileSync('git', ['remote', 'set-url', 'origin', authenticatedUrl], opts);
 
 	try {
-		execSync('git fetch --depth 1 origin', opts);
-		const branch = execSync('git rev-parse --abbrev-ref HEAD', opts).toString().trim();
-		const output = execSync(`git reset --hard origin/${branch}`, opts).toString().trim();
+		execFileSync('git', ['fetch', '--depth', '1', 'origin'], opts);
+		const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], opts).toString().trim();
+		const output = execFileSync('git', ['reset', '--hard', `origin/${branch}`], opts)
+			.toString()
+			.trim();
 		return output;
 	} finally {
 		const cleanUrl = `https://github.com/${repoFullName}.git`;
-		execSync(`git remote set-url origin ${cleanUrl}`, { ...opts, timeout: 5_000 });
+		execFileSync('git', ['remote', 'set-url', 'origin', cleanUrl], { ...opts, timeout: 5_000 });
 	}
 }

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -33,7 +33,13 @@ export const projectRoutes = {
 	listForCurrentUser: protectedProcedure.query(async ({ ctx }) => {
 		const projects = await projectQueries.listUserProjectsWithRoles(ctx.user.id);
 		return projects.map(({ project, userRole }) => ({
-			...project,
+			id: project.id,
+			orgId: project.orgId,
+			name: project.name,
+			type: project.type,
+			path: project.path,
+			createdAt: project.createdAt,
+			updatedAt: project.updatedAt,
 			userRole,
 		}));
 	}),

--- a/apps/frontend/src/components/settings/env-vars-section.tsx
+++ b/apps/frontend/src/components/settings/env-vars-section.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, Eye, EyeOff, Loader2 } from 'lucide-react';
 
@@ -15,17 +15,19 @@ export function EnvVarsSection({ isAdmin }: { isAdmin: boolean }) {
 	const [localValues, setLocalValues] = useState<Record<string, string>>({});
 	const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
 	const [hasChanges, setHasChanges] = useState(false);
+	const initializedRef = useRef(false);
 
 	useEffect(() => {
-		if (envVarsQuery.data) {
+		if (envVarsQuery.data && !initializedRef.current) {
 			setLocalValues(envVarsQuery.data.values);
-			setHasChanges(false);
+			initializedRef.current = true;
 		}
 	}, [envVarsQuery.data]);
 
 	const updateMutation = useMutation({
 		...trpc.project.updateEnvVars.mutationOptions(),
 		onSuccess: () => {
+			initializedRef.current = false;
 			queryClient.invalidateQueries({ queryKey: trpc.project.getEnvVars.queryKey() });
 			setHasChanges(false);
 		},

--- a/apps/frontend/src/components/settings/team/add-member-dialog.tsx
+++ b/apps/frontend/src/components/settings/team/add-member-dialog.tsx
@@ -20,6 +20,10 @@ export function AddMemberDialog({ open, onOpenChange, title = 'Add Member', onSu
 		defaultValues: { email: '', name: '' },
 		onSubmit: async ({ value }) => {
 			setError('');
+			if (needsName && !value.name.trim()) {
+				setError('Name is required to create a new user.');
+				return;
+			}
 			try {
 				const result = await onSubmit({
 					email: value.email,

--- a/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
@@ -48,7 +48,10 @@ function GeneralPage() {
 
 	const handleEdit = async (data: { userId: string; name?: string; newRole?: UserRole }) => {
 		await modifyUser.mutateAsync(data);
-		await queryClient.invalidateQueries({ queryKey: trpc.project.getAllUsersWithRoles.queryKey() });
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: trpc.project.getAllUsersWithRoles.queryKey() }),
+			queryClient.invalidateQueries({ queryKey: trpc.project.getCurrent.queryKey() }),
+		]);
 		await refetch();
 	};
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses all 13 issues identified by the cubic code review on #618.

### Security fixes

- **P0: OAuth CSRF vulnerability** (`github.ts`): The `/callback` endpoint now verifies the caller's session and validates an HMAC signature on the state parameter. An attacker can no longer forge a state containing an arbitrary userId.
- **P1: Shell injection** (`deploy.ts`, `github.ts`): Replaced `execSync` string interpolation with `execFileSync` array arguments to prevent shell interpretation of paths/tokens.
- **P2: GITHUB_TOKEN in image layers** (`Dockerfile`, all workflow files): Moved GITHUB_TOKEN from `build-args` to BuildKit `--mount=type=secret` so it is never persisted in Docker layers.
- **P1: Supply-chain risk** (`deploy-app-preview.yml`, `pr-preview.yml`, `docker.yml`): Pinned `appleboy/ssh-action` from `@master` to commit SHA `@0ff4204d` (v1.2.5).

### Data exposure fixes

- **P1: Sensitive project data leak** (`project.routes.ts`): `listForCurrentUser` now returns a sanitized shape excluding `envVars`, channel settings, and other internal config.
- **P1: `.naoignore` not applied** (`context-explorer.service.ts`): Replaced `isExcludedEntry` (name-only check) with `shouldExcludeEntry` (also applies `.naoignore` patterns).

### Schema & migration fixes

- **P2/P3: Redundant indexes** (`pg-schema.ts`, `sqlite-schema.ts`, both migration files + snapshots): Removed duplicate non-unique `api_key_keyHash_idx` since the column already has a unique constraint/index.

### Frontend fixes

- **P2: Stale `isAdmin` after role change** (`settings.account.tsx`): Now invalidates `project.getCurrent` alongside `getAllUsersWithRoles` after editing a member.
- **P2: Unsaved edits lost on refetch** (`env-vars-section.tsx`): Local form values are only initialized from the server once; background refetches no longer clobber in-progress edits.
- **P2: Empty name submission** (`add-member-dialog.tsx`): Validates that name is non-empty when `needsName` is true before submitting.

### Other

- **P2: Org slug collision** (`organization.queries.ts`): Increased slug uniqueness from 8 to 16 hex chars of the userId (dashes stripped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cf648dd-c74e-4de8-9fef-02864424873e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cf648dd-c74e-4de8-9fef-02864424873e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

