### PR TITLE
feat(cli): ask about profiling during `nao init`

### DIFF
--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -63,6 +63,8 @@ class NaoConfig(BaseModel):
             return cls._prompt_extend(existing)
 
         databases = cls._prompt_databases()
+        enable_profiling = cls._prompt_enable_profiling(databases)
+        databases = cls._configure_profiling_templates(databases, enable_profiling)
         llm, enable_ai_summary = cls._prompt_llm(databases=databases)
         databases = cls._configure_ai_summary_templates(databases, llm, enable_ai_summary)
 
@@ -107,7 +109,11 @@ class NaoConfig(BaseModel):
         UI.print()
 
         # Prompt for additions
-        databases.extend(cls._prompt_databases(has_existing=bool(existing.databases)))
+        new_databases = cls._prompt_databases(has_existing=bool(existing.databases))
+        if new_databases:
+            enable_profiling = cls._prompt_enable_profiling(new_databases)
+            new_databases = cls._configure_profiling_templates(new_databases, enable_profiling)
+        databases.extend(new_databases)
         repos.extend(cls._prompt_repos(has_existing=bool(existing.repos)))
 
         if llm:
@@ -213,6 +219,32 @@ class NaoConfig(BaseModel):
         for db in databases:
             if DatabaseTemplate.AI_SUMMARY not in db.templates:
                 db.templates.append(DatabaseTemplate.AI_SUMMARY)
+
+        return databases
+
+    @staticmethod
+    def _prompt_enable_profiling(databases: list[AnyDatabaseConfig]) -> bool:
+        """Prompt whether column profiling should be enabled for configured databases."""
+        if not databases:
+            return False
+
+        return ask_confirm(
+            "Enable `profiling` template for all configured databases? (can be costly on large datasets)",
+            default=False,
+        )
+
+    @staticmethod
+    def _configure_profiling_templates(
+        databases: list[AnyDatabaseConfig],
+        enable_profiling: bool,
+    ) -> list[AnyDatabaseConfig]:
+        """Enable profiling template for configured databases when requested."""
+        if not databases or not enable_profiling:
+            return databases
+
+        for db in databases:
+            if DatabaseTemplate.PROFILING not in db.templates:
+                db.templates.append(DatabaseTemplate.PROFILING)
 
         return databases
 

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -91,12 +91,11 @@ class DatabaseConfig(BaseModel, ABC):
             DatabaseTemplate.COLUMNS,
             DatabaseTemplate.HOW_TO_USE,
             DatabaseTemplate.PREVIEW,
-            DatabaseTemplate.PROFILING,
         ],
         description=(
             "Which default templates to render per table "
-            "(e.g., ['columns', 'how_to_use', 'ai_summary']). "
-            "Defaults to ['columns', 'how_to_use', 'preview', 'profiling']."
+            "(e.g., ['columns', 'how_to_use', 'profiling', 'ai_summary']). "
+            "Defaults to ['columns', 'how_to_use', 'preview']."
         ),
     )
     query_history_days: int | None = Field(

--- a/cli/tests/nao_core/commands/sync/integration/conftest.py
+++ b/cli/tests/nao_core/commands/sync/integration/conftest.py
@@ -14,6 +14,7 @@ from rich.progress import Progress  # noqa: E402
 
 import nao_core.templates.engine as engine_module  # noqa: E402
 from nao_core.commands.sync.providers.databases.provider import sync_database  # noqa: E402
+from nao_core.config.databases.base import DatabaseTemplate  # noqa: E402
 
 # Auto-load .env sitting next to this conftest so env vars are available
 # before pytest collects test modules (where skipif reads them).
@@ -30,7 +31,14 @@ def reset_template_engine():
 
 @pytest.fixture(scope="module")
 def synced(tmp_path_factory, db_config):
-    """Run sync once for the whole module and return (state, output_path, config)."""
+    """Run sync once for the whole module and return (state, output_path, config).
+
+    Profiling is explicitly enabled so that integration tests cover the full
+    template surface (profiling is opt-in during ``nao init``).
+    """
+    if DatabaseTemplate.PROFILING not in db_config.templates:
+        db_config.templates.append(DatabaseTemplate.PROFILING)
+
     output = tmp_path_factory.mktemp(f"{db_config.type}_sync")
 
     with Progress(transient=True) as progress:

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -164,3 +164,60 @@ def test_how_to_use_template_variant():
     )
     assert DatabaseTemplate.HOW_TO_USE in db.templates
     assert db.query_history_days == 14
+
+
+def test_default_templates_exclude_profiling():
+    """Default templates should not include profiling."""
+    from nao_core.config.databases.base import DatabaseTemplate
+
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    assert DatabaseTemplate.PROFILING not in db.templates
+
+
+def test_configure_profiling_templates_adds_profiling_when_enabled():
+    """Profiling template should be added when user opts in."""
+    from nao_core.config.databases.base import DatabaseTemplate
+
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    result = NaoConfig._configure_profiling_templates(databases=[db], enable_profiling=True)
+    assert DatabaseTemplate.PROFILING in result[0].templates
+
+
+def test_configure_profiling_templates_skips_when_disabled():
+    """Profiling template should not be added when user opts out."""
+    from nao_core.config.databases.base import DatabaseTemplate
+
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    result = NaoConfig._configure_profiling_templates(databases=[db], enable_profiling=False)
+    assert DatabaseTemplate.PROFILING not in result[0].templates
+
+
+def test_configure_profiling_templates_does_not_duplicate():
+    """Profiling template should only appear once."""
+    from nao_core.config.databases.base import DatabaseTemplate
+
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    db.templates.append(DatabaseTemplate.PROFILING)
+    result = NaoConfig._configure_profiling_templates(databases=[db], enable_profiling=True)
+    assert result[0].templates.count(DatabaseTemplate.PROFILING) == 1
+
+
+@patch("nao_core.config.base.ask_confirm")
+def test_prompt_enable_profiling_returns_true_when_accepted(mock_confirm):
+    """Profiling prompt should return True when user accepts."""
+    mock_confirm.return_value = True
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    assert NaoConfig._prompt_enable_profiling([db]) is True
+
+
+@patch("nao_core.config.base.ask_confirm")
+def test_prompt_enable_profiling_returns_false_when_declined(mock_confirm):
+    """Profiling prompt should return False when user declines."""
+    mock_confirm.return_value = False
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    assert NaoConfig._prompt_enable_profiling([db]) is False
+
+
+def test_prompt_enable_profiling_returns_false_without_databases():
+    """Profiling prompt should return False when no databases are configured."""
+    assert NaoConfig._prompt_enable_profiling([]) is False


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

During `nao init`, the CLI now asks the user whether they want to enable the `profiling` template for their databases. Profiling computes column-level statistics (null counts, distinct counts, min/max, top values, etc.) which can be costly on large datasets, so it defaults to **off** and is opt-in.

This follows the same pattern as `ai_summary` — an optional template that gets added to each database's template list based on user choice.

## Changes

- **`cli/nao_core/config/databases/base.py`** — Removed `PROFILING` from the default `templates` list on `DatabaseConfig`. Existing YAML configs that explicitly include `profiling` in their templates continue to work unchanged.
- **`cli/nao_core/config/base.py`** — Added `_prompt_enable_profiling()` and `_configure_profiling_templates()` methods. Wired the profiling prompt into both the fresh `promptConfig` and the `_prompt_extend` (update existing config) flows.
- **`cli/tests/nao_core/config/test_base.py`** — Added 7 new tests covering: default templates exclude profiling, enabling/disabling profiling via prompt, no-duplicate guard, and no-databases short-circuit.

## Init flow (after this change)

```
Set up database connections? (Y/n)
  → Select database type: ...
  → [per-DB prompts]
  → Add another database? (y/N)
Enable `profiling` template for all configured databases? (can be costly on large datasets) (y/N)   ← NEW
Set up LLM configuration? (Y/n)
  → Enable `ai_summary` template for all configured databases? (Y/n)
  → ...
```

## Backward compatibility

Existing `nao_config.yaml` files that already list `profiling` in their `templates` array are unaffected — the enum value still exists and is loaded as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da503fbf-fd44-450d-8c4d-bcc5f59d3c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da503fbf-fd44-450d-8c4d-bcc5f59d3c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

