### PR TITLE
Fix/623 download x axis chart legend

### DIFF
--- a/apps/backend/scripts/db.seed-cloud.ts
+++ b/apps/backend/scripts/db.seed-cloud.ts
@@ -373,13 +373,17 @@ async function insertMessage(tx: Tx, chatId: string, role: 'user' | 'assistant',
 
 async function upsertOrg(tx: Tx, values: { name: string; slug: string }) {
 	const existing = await tx.query.organization.findFirst({ where: (o, { eq }) => eq(o.slug, values.slug) });
-	if (existing) return [existing] as const;
+	if (existing) {
+		return [existing] as const;
+	}
 	return tx.insert(s.organization).values(values).returning().execute();
 }
 
 async function upsertProject(tx: Tx, values: { name: string; type: 'local'; path: string; orgId: string }) {
 	const existing = await tx.query.project.findFirst({ where: (p, { eq }) => eq(p.path, values.path) });
-	if (existing) return [existing] as const;
+	if (existing) {
+		return [existing] as const;
+	}
 	return tx.insert(s.project).values(values).returning().execute();
 }
 

--- a/apps/backend/src/components/generate-chart.tsx
+++ b/apps/backend/src/components/generate-chart.tsx
@@ -41,6 +41,7 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		showGrid: true,
 		margin,
 		title: config.title,
+		maxXAxisTicks: Math.floor(width / 80),
 	});
 
 	const html = renderToString(React.cloneElement(chart, { width, height }));

--- a/apps/backend/src/components/generate-chart.tsx
+++ b/apps/backend/src/components/generate-chart.tsx
@@ -31,6 +31,8 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		return series?.color || defaultColorFor(key, index);
 	};
 
+	const maxLabelWidth = estimateMaxLabelWidth(data, config.x_axis_key);
+
 	const chart = buildChart({
 		data,
 		chartType: config.chart_type,
@@ -41,7 +43,7 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		showGrid: true,
 		margin,
 		title: config.title,
-		maxXAxisTicks: Math.floor(width / 80),
+		maxXAxisTicks: Math.floor(width / maxLabelWidth),
 	});
 
 	const html = renderToString(React.cloneElement(chart, { width, height }));
@@ -55,4 +57,16 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		: [];
 
 	return createSvg(html, width, height, legend);
+}
+
+const CHAR_WIDTH_PX = 7;
+const TICK_PADDING_PX = 16;
+const MIN_TICK_WIDTH_PX = 40;
+
+function estimateMaxLabelWidth(data: Record<string, unknown>[], xAxisKey: string): number {
+	const maxCharCount = data.reduce((max, row) => {
+		const formatted = labelize(String(row[xAxisKey] ?? ''));
+		return Math.max(max, formatted.length);
+	}, 0);
+	return Math.max(maxCharCount * CHAR_WIDTH_PX + TICK_PADDING_PX, MIN_TICK_WIDTH_PX);
 }

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -66,6 +66,7 @@ export interface BuildChartProps {
 	children?: React.ReactNode[];
 	margin?: { top?: number; right?: number; bottom?: number; left?: number };
 	title?: string;
+	maxXAxisTicks?: number;
 }
 
 /**
@@ -119,17 +120,24 @@ function buildResolved(props: BuildChartProps) {
 		/>
 	) : null;
 
+	const xAxisInterval =
+		props.maxXAxisTicks && props.data.length > props.maxXAxisTicks
+			? Math.ceil(props.data.length / props.maxXAxisTicks) - 1
+			: undefined;
+
 	const resolved: ResolvedProps = {
 		...props,
 		colorFor,
 		labelFormatter,
+		xAxisInterval,
 		margin: props.title ? { ...props.margin, top: (props.margin?.top ?? 0) + 30 } : props.margin,
 		children: titleChild ? [titleChild, ...(props.children ?? [])] : props.children,
 	};
 	return resolved;
 }
 
-type ResolvedProps = BuildChartProps & Required<Pick<BuildChartProps, 'colorFor' | 'labelFormatter'>>;
+type ResolvedProps = BuildChartProps &
+	Required<Pick<BuildChartProps, 'colorFor' | 'labelFormatter'>> & { xAxisInterval?: number };
 
 function buildKpiCard(props: ResolvedProps) {
 	const { data, series } = props;
@@ -170,8 +178,19 @@ function KpiCard({ value, displayName }: { value: unknown; displayName: string }
 }
 
 function buildBarChart(props: ResolvedProps) {
-	const { data, chartType, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } =
-		props;
+	const {
+		data,
+		chartType,
+		xAxisKey,
+		xAxisType,
+		series,
+		colorFor,
+		labelFormatter,
+		showGrid,
+		children,
+		margin,
+		xAxisInterval,
+	} = props;
 	const isStacked = chartType === 'stacked_bar';
 
 	return (
@@ -187,6 +206,7 @@ function buildBarChart(props: ResolvedProps) {
 				tickMargin={10}
 				axisLine={false}
 				minTickGap={12}
+				interval={xAxisInterval}
 				tickFormatter={labelFormatter}
 			/>
 			{children}
@@ -205,8 +225,19 @@ function buildBarChart(props: ResolvedProps) {
 }
 
 function buildAreaChart(props: ResolvedProps) {
-	const { data, chartType, xAxisKey, xAxisType, series, colorFor, labelFormatter, showGrid, children, margin } =
-		props;
+	const {
+		data,
+		chartType,
+		xAxisKey,
+		xAxisType,
+		series,
+		colorFor,
+		labelFormatter,
+		showGrid,
+		children,
+		margin,
+		xAxisInterval,
+	} = props;
 	const isStacked = chartType === 'stacked_area';
 
 	return (
@@ -234,6 +265,7 @@ function buildAreaChart(props: ResolvedProps) {
 				tickMargin={10}
 				axisLine={false}
 				minTickGap={12}
+				interval={xAxisInterval}
 				tickFormatter={labelFormatter}
 			/>
 			{children}


### PR DESCRIPTION
## Summary

Problem : 
Recharts' minTickGap relies on DOM text measurement to auto-skip overlapping x-axis labels. During server-side rendering (renderToString for PNG/HTML/PDF export), there's no DOM, so every label is rendered — causing them to pile up and become illegible.

Solution :
Estimate the pixel width of the longest x-axis tick label (character count * approximate char width), then compute a maxXAxisTicks value so labels don't overlap. This is passed as the interval prop to Recharts' <XAxis>, effectively replacing the DOM-based minTickGap logic for SSR contexts.

## Related issue

#623 