### PR TITLE
Resolve PR #629 conflicts and cubic follow-ups

### DIFF
--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -95,19 +95,39 @@ class SlackService {
 		});
 
 		this._bot.onAction('stop_generation', async (event) => {
-			const existingChat = await chatQueries.getChatBySlackThread(event.thread?.id || '');
-			if (existingChat) {
-				agentService.get(existingChat.id)?.stop();
+			try {
+				const existingChat = await chatQueries.getChatBySlackThread(event.threadId);
+				if (!existingChat) {
+					logger.warn('stop_generation: no chat found for thread', {
+						source: 'system',
+						context: { threadId: event.threadId },
+					});
+					return;
+				}
+				const agent = agentService.get(existingChat.id);
+				if (!agent) {
+					logger.warn('stop_generation: no active agent for chat', {
+						source: 'system',
+						context: { chatId: existingChat.id },
+					});
+					return;
+				}
+				agent.stop();
+			} catch (error) {
+				logger.error(`stop_generation failed: ${String(error)}`, {
+					source: 'system',
+					context: { threadId: event.threadId },
+				});
 			}
 		});
 
 		this._bot.onAction('feedback_positive', async (event) => {
-			const messageId = await this._getLastAssistantMessageId(event.thread?.id || '');
+			const messageId = await this._getLastAssistantMessageId(event.threadId);
 			if (!messageId) {
 				return;
 			}
 			await feedbackQueries.upsertFeedback({ messageId, vote: 'up' });
-			const completion = this._lastCompletionCard.get(event.thread?.id || '');
+			const completion = this._lastCompletionCard.get(event.threadId);
 			if (completion) {
 				await completion.card.edit(createCompletionCard(completion.chatUrl, 'up'));
 			}
@@ -116,7 +136,7 @@ class SlackService {
 		this._bot.onAction('feedback_negative', async (event) => {
 			await event.openModal({
 				...createFeedbackModal(),
-				privateMetadata: event.thread?.id || '',
+				privateMetadata: event.threadId,
 			});
 		});
 
@@ -255,13 +275,65 @@ class SlackService {
 			ctx.chatId = existingChat.id;
 			ctx.isNewChat = false;
 		} else {
+			const threadContext = await this._getSlackThreadContext(ctx.thread.id);
+			const messageText = threadContext
+				? `[Previous messages in this Slack thread]\n${threadContext}\n\n[Your message]\n${text}`
+				: text;
+
 			const title = createChatTitle({ text });
 			const [createdChat] = await chatQueries.createChat(
 				{ title, userId: ctx.user!.id, projectId: this._projectId, slackThreadId: ctx.thread.id },
-				{ text, source: 'slack' },
+				{ text: messageText, source: 'slack' },
 			);
 			ctx.chatId = createdChat.id;
 			ctx.isNewChat = true;
+		}
+	}
+
+	private async _getSlackThreadContext(threadId: string): Promise<string | null> {
+		const [, channelId, threadTs] = threadId.split(':');
+		if (!channelId || !threadTs) {
+			return null;
+		}
+
+		try {
+			const result = await this._slackClient?.conversations.replies({
+				channel: channelId,
+				ts: threadTs,
+			});
+
+			const allMessages = result?.messages ?? [];
+			const userMessages = allMessages.filter(
+				(msg) => !msg.bot_id && (msg as Record<string, unknown>).subtype !== 'bot_message',
+			);
+
+			const priorMessages = userMessages.slice(0, -1);
+			if (priorMessages.length === 0) {
+				return null;
+			}
+
+			const userIds = [...new Set(priorMessages.map((msg) => msg.user).filter(Boolean))] as string[];
+			const userNames = new Map<string, string>();
+			await Promise.all(
+				userIds.map(async (userId) => {
+					const slackUser = await this._getSlackUser(userId);
+					userNames.set(userId, slackUser?.real_name || slackUser?.name || userId);
+				}),
+			);
+
+			return priorMessages
+				.map((msg) => {
+					const name = msg.user ? userNames.get(msg.user) || msg.user : 'Unknown';
+					const text = (msg.text || '').replace(/(?:<@|@)([A-Z0-9]+)(?:\|[^>]+)?>?\s*/g, '').trim();
+					return `${name}: ${text}`;
+				})
+				.join('\n');
+		} catch (error) {
+			logger.error(`Failed to fetch Slack thread history: ${String(error)}`, {
+				source: 'system',
+				context: { threadId },
+			});
+			return null;
 		}
 	}
 
@@ -269,10 +341,21 @@ class SlackService {
 		const stream = await this._createAgentStream(chat, ctx);
 		const stopCard = await ctx.thread.post(createStopButtonCard());
 
-		const state = await this._readStreamAndUpdateSlackMessage(stream, ctx);
+		let state: StreamState | undefined;
+		try {
+			state = await this._readStreamAndUpdateSlackMessage(stream, ctx);
+		} catch (error) {
+			logger.error(`Stream interrupted: ${String(error)}`, {
+				source: 'system',
+				context: { chatId: ctx.chatId },
+			});
+		} finally {
+			await stopCard.delete().catch(() => {});
+		}
 
-		await stopCard.delete();
-		await this._uploadLastSqlResultAsCsv(state, ctx);
+		if (state) {
+			await this._uploadLastSqlResultAsCsv(state, ctx);
+		}
 		await this._lastCompletionCard.get(ctx.thread.id)?.card.delete();
 		const chatUrl = new URL(ctx.chatId, this._redirectUrl).toString();
 		const card = await ctx.thread.post(createCompletionCard(chatUrl));

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -35,6 +35,10 @@ import { posthog, PostHogEvent } from './posthog';
 
 const UPDATE_INTERVAL_MS = 200;
 
+const SLACK_MENTION_REGEX = /(?:<@|@)([A-Z0-9]+)(?:\|[^>]+)?>?\s*/g;
+
+type SlackReplyMessage = NonNullable<Awaited<ReturnType<WebClient['conversations']['replies']>>['messages']>[number];
+
 class SlackService {
 	private _bot: Chat | null = null;
 	private _slackClient: WebClient | null = null;
@@ -86,15 +90,19 @@ class SlackService {
 		});
 
 		this._bot.onNewMention(async (thread, message) => {
-			await thread.subscribe();
-			await this._handleWorkFlow(thread, message);
+			const startsThread = await this._isThreadStarter(thread.id);
+			if (startsThread) {
+				await thread.subscribe();
+			}
+			await this._handleWorkFlow(thread, message, { fetchUnseenMessages: true });
 		});
 
 		this._bot.onSubscribedMessage(async (thread, message) => {
-			await this._handleWorkFlow(thread, message);
+			await this._handleWorkFlow(thread, message, { fetchUnseenMessages: false });
 		});
 
 		this._bot.onAction('stop_generation', async (event) => {
+			console.log('stop_generation', event);
 			try {
 				const existingChat = await chatQueries.getChatBySlackThread(event.threadId);
 				if (!existingChat) {
@@ -182,8 +190,12 @@ class SlackService {
 		});
 	}
 
-	private async _handleWorkFlow(thread: Thread, userMessage: Message): Promise<void> {
-		userMessage.text = userMessage.text.replace(/(?:<@|@)([A-Z0-9]+)(?:\|[^>]+)?>?\s*/g, '').trim();
+	private async _handleWorkFlow(
+		thread: Thread,
+		userMessage: Message,
+		options: { fetchUnseenMessages: boolean },
+	): Promise<void> {
+		userMessage.text = userMessage.text.replace(SLACK_MENTION_REGEX, '').trim();
 
 		const ctx: ConversationContext = {
 			thread,
@@ -202,7 +214,7 @@ class SlackService {
 
 		try {
 			ctx.convMessage = await ctx.thread.post('✨ nao is answering...');
-			await this._saveOrUpdateUserMessage(ctx);
+			await this._saveOrUpdateUserMessage(ctx, options.fetchUnseenMessages);
 
 			const [chat] = await chatQueries.loadChat(ctx.chatId);
 			if (!chat) {
@@ -261,36 +273,38 @@ class SlackService {
 		}
 	}
 
-	private async _saveOrUpdateUserMessage(ctx: ConversationContext): Promise<void> {
+	private async _saveOrUpdateUserMessage(ctx: ConversationContext, fetchUnseenMessages: boolean): Promise<void> {
 		const text = ctx.userMessage.text;
+		const unseenMessages = fetchUnseenMessages
+			? await this._getUnseenSlackMessages(ctx.thread.id, ctx.userMessage.id)
+			: null;
+		const messageText = unseenMessages
+			? `[Previous messages in this Slack thread]\n${unseenMessages}\n\n[Your message]\n${text}`
+			: text;
 
 		const existingChat = await chatQueries.getChatBySlackThread(ctx.thread.id);
 		if (existingChat) {
 			await chatQueries.upsertMessage({
 				role: 'user',
-				parts: [{ type: 'text', text }],
+				parts: [{ type: 'text', text: messageText }],
 				chatId: existingChat.id,
 				source: 'slack',
 			});
 			ctx.chatId = existingChat.id;
 			ctx.isNewChat = false;
-		} else {
-			const threadContext = await this._getSlackThreadContext(ctx.thread.id);
-			const messageText = threadContext
-				? `[Previous messages in this Slack thread]\n${threadContext}\n\n[Your message]\n${text}`
-				: text;
-
-			const title = createChatTitle({ text });
-			const [createdChat] = await chatQueries.createChat(
-				{ title, userId: ctx.user!.id, projectId: this._projectId, slackThreadId: ctx.thread.id },
-				{ text: messageText, source: 'slack' },
-			);
-			ctx.chatId = createdChat.id;
-			ctx.isNewChat = true;
+			return;
 		}
+
+		const title = createChatTitle({ text });
+		const [createdChat] = await chatQueries.createChat(
+			{ title, userId: ctx.user!.id, projectId: this._projectId, slackThreadId: ctx.thread.id },
+			{ text: messageText, source: 'slack' },
+		);
+		ctx.chatId = createdChat.id;
+		ctx.isNewChat = true;
 	}
 
-	private async _getSlackThreadContext(threadId: string): Promise<string | null> {
+	private async _getUnseenSlackMessages(threadId: string, currentMessageId: string): Promise<string | null> {
 		const [, channelId, threadTs] = threadId.split(':');
 		if (!channelId || !threadTs) {
 			return null;
@@ -301,39 +315,82 @@ class SlackService {
 				channel: channelId,
 				ts: threadTs,
 			});
-
-			const allMessages = result?.messages ?? [];
-			const userMessages = allMessages.filter(
-				(msg) => !msg.bot_id && (msg as Record<string, unknown>).subtype !== 'bot_message',
-			);
-
-			const priorMessages = userMessages.slice(0, -1);
-			if (priorMessages.length === 0) {
+			const messages = this._extractUnseenUserMessages(result?.messages ?? [], currentMessageId);
+			if (messages.length === 0) {
 				return null;
 			}
-
-			const userIds = [...new Set(priorMessages.map((msg) => msg.user).filter(Boolean))] as string[];
-			const userNames = new Map<string, string>();
-			await Promise.all(
-				userIds.map(async (userId) => {
-					const slackUser = await this._getSlackUser(userId);
-					userNames.set(userId, slackUser?.real_name || slackUser?.name || userId);
-				}),
-			);
-
-			return priorMessages
-				.map((msg) => {
-					const name = msg.user ? userNames.get(msg.user) || msg.user : 'Unknown';
-					const text = (msg.text || '').replace(/(?:<@|@)([A-Z0-9]+)(?:\|[^>]+)?>?\s*/g, '').trim();
-					return `${name}: ${text}`;
-				})
-				.join('\n');
+			const userNames = await this._resolveUserNames(messages);
+			return this._formatThreadMessages(messages, userNames);
 		} catch (error) {
 			logger.error(`Failed to fetch Slack thread history: ${String(error)}`, {
 				source: 'system',
 				context: { threadId },
 			});
 			return null;
+		}
+	}
+
+	private _extractUnseenUserMessages(
+		allMessages: SlackReplyMessage[],
+		currentMessageId: string,
+	): SlackReplyMessage[] {
+		const currentIndex = allMessages.findIndex((msg) => msg.ts === currentMessageId);
+		if (currentIndex === -1) {
+			return [];
+		}
+		const priorMessages = allMessages.slice(0, currentIndex);
+		const lastBotIndex = this._findLastBotMessageIndex(priorMessages);
+		return priorMessages.slice(lastBotIndex + 1).filter((msg) => !this._isBotMessage(msg));
+	}
+
+	private _findLastBotMessageIndex(messages: SlackReplyMessage[]): number {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			if (this._isBotMessage(messages[i])) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private _isBotMessage(message: SlackReplyMessage): boolean {
+		return !!message.bot_id || (message as { subtype?: string }).subtype === 'bot_message';
+	}
+
+	private async _resolveUserNames(messages: SlackReplyMessage[]): Promise<Map<string, string>> {
+		const userIds = [...new Set(messages.map((m) => m.user).filter((u): u is string => !!u))];
+		const entries = await Promise.all(
+			userIds.map(async (userId): Promise<[string, string]> => {
+				const slackUser = await this._getSlackUser(userId);
+				return [userId, slackUser?.real_name || slackUser?.name || userId];
+			}),
+		);
+		return new Map(entries);
+	}
+
+	private _formatThreadMessages(messages: SlackReplyMessage[], userNames: Map<string, string>): string {
+		return messages
+			.map((msg) => {
+				const name = msg.user ? userNames.get(msg.user) || msg.user : 'Unknown';
+				const text = (msg.text || '').replace(SLACK_MENTION_REGEX, '').trim();
+				return `${name}: ${text}`;
+			})
+			.join('\n');
+	}
+
+	private async _isThreadStarter(threadId: string): Promise<boolean> {
+		const [, channelId, threadTs] = threadId.split(':');
+		if (!channelId || !threadTs) {
+			return false;
+		}
+		try {
+			const result = await this._slackClient?.conversations.replies({
+				channel: channelId,
+				ts: threadTs,
+				limit: 2,
+			});
+			return (result?.messages?.length ?? 0) <= 1;
+		} catch {
+			return false;
 		}
 	}
 
@@ -344,11 +401,6 @@ class SlackService {
 		let state: StreamState | undefined;
 		try {
 			state = await this._readStreamAndUpdateSlackMessage(stream, ctx);
-		} catch (error) {
-			logger.error(`Stream interrupted: ${String(error)}`, {
-				source: 'system',
-				context: { chatId: ctx.chatId },
-			});
 		} finally {
 			await stopCard.delete().catch(() => {});
 		}

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -8,12 +8,12 @@ import { BudgetExceededError } from './error';
 export const EXCLUDED_TOOLS = ['tool-suggest_follow_ups', 'tool-display_chart'];
 
 export const createLiveToolCall = (toolGroup: Map<string, ToolCallEntry>): CardChild => {
-	const countByType = new Map<string, number>();
+	const countByNoun = new Map<string, number>();
 	for (const entry of toolGroup.values()) {
-		countByType.set(entry.type, (countByType.get(entry.type) ?? 0) + 1);
+		const noun = TOOL_LABELS[entry.type] ?? entry.type.replace('tool-', '');
+		countByNoun.set(noun, (countByNoun.get(noun) ?? 0) + 1);
 	}
-	const parts = [...countByType.entries()].map(([type, count]) => {
-		const noun = TOOL_LABELS[type] ?? type.replace('tool-', '');
+	const parts = [...countByNoun.entries()].map(([noun, count]) => {
 		return `*${count} ${pluralize(noun, count)}*`;
 	});
 	return CardText(`_Exploring ${parts.join(', ')}..._`);

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -7,19 +7,16 @@ import { BudgetExceededError } from './error';
 
 export const EXCLUDED_TOOLS = ['tool-suggest_follow_ups', 'tool-display_chart'];
 
-const TOOL_LIVE_LABELS: Record<string, (input: Record<string, string>) => string> = {
-	'tool-read': (input) => `_reading **${input['file_path'] ?? '...'}**_`,
-	'tool-search': (input) => `_searching **${input['pattern'] ?? '...'}**_`,
-	'tool-grep': (input) => `_grepping **${input['pattern'] ?? '...'}**_`,
-	'tool-list': (input) => `_listing **${input['path'] ?? '...'}**_`,
-	'tool-execute_sql': (input) => `_executing **${input['query'] ?? 'SQL query'}**_`,
-};
-
 export const createLiveToolCall = (toolGroup: Map<string, ToolCallEntry>): CardChild => {
-	const lines = [...toolGroup.values()].map(
-		(entry) => TOOL_LIVE_LABELS[entry.type]?.(entry.input) ?? `_${entry.type}_`,
-	);
-	return CardText(lines.join('\n\n'));
+	const countByType = new Map<string, number>();
+	for (const entry of toolGroup.values()) {
+		countByType.set(entry.type, (countByType.get(entry.type) ?? 0) + 1);
+	}
+	const parts = [...countByType.entries()].map(([type, count]) => {
+		const noun = TOOL_LABELS[type] ?? type.replace('tool-', '');
+		return `*${count} ${pluralize(noun, count)}*`;
+	});
+	return CardText(`_Exploring ${parts.join(', ')}..._`);
 };
 
 export const createSummaryToolCalls = (toolGroup: Map<string, ToolCallEntry>): CardChild => {

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -28,7 +28,7 @@ export const createSummaryToolCalls = (toolGroup: Map<string, ToolCallEntry>): C
 		const noun = TOOL_LABELS[type] ?? type.replace('tool-', '');
 		return `**${count} ${pluralize(noun, count)}**`;
 	});
-	return CardText(`Explored ${parts.join(', ')}`);
+	return CardText(`_Explored ${parts.join(', ')}._`, { style: 'muted' });
 };
 
 export const FEEDBACK_MODAL_CALLBACK_ID = 'feedback_negative_modal';

--- a/apps/frontend/src/components/share-dialog.chat.tsx
+++ b/apps/frontend/src/components/share-dialog.chat.tsx
@@ -24,7 +24,10 @@ interface ShareChatDialogProps {
 }
 
 export function ShareChatDialog({ open, onOpenChange, chatId }: ShareChatDialogProps) {
-	const shareQuery = useQuery(trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }));
+	const shareQuery = useQuery({
+		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
+		enabled: open,
+	});
 	const shareData = shareQuery.data;
 	const isShared = !!shareData?.shareId;
 

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -30,8 +30,8 @@ export function RouteComponent() {
 	const { chatId } = Route.useParams();
 	const chat = useChatQuery({ chatId });
 	const title = chat.data?.title;
-	const shareQuery = useQuery(trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId: chatId ?? '' }));
-	const isShared = !!shareQuery.data?.shareId;
+	const sharedChatsQuery = useQuery(trpc.sharedChat.list.queryOptions());
+	const isShared = !!sharedChatsQuery.data?.some((sc) => sc.chatId === chatId);
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const sidePanelRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- resolves the merge conflict from #629 in `apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx` by keeping the current shared-chat and project badge query behavior from `main`
- keeps the #629 share-dialog optimization (`enabled: open`) and Slack thread-history changes
- addresses cubic’s unresolved Slack issue by terminating UI stream consumption on SDK error chunks (`terminateOnError: true`) so failures go through error handling instead of success completion flow
- preserves noun-based live tool aggregation in `createLiveToolCall` to avoid duplicate `search` segments

## Validation
- `npm run lint` ✅ (passes; only pre-existing warnings in `apps/backend/scripts/db.seed-cloud.ts`)
- `npm run -w @nao/backend test` ⚠️ (fails due to unrelated existing failures in `system-prompt`, `sqlite`, and `compaction` suites)
- `node --import tsx -e "import { createLiveToolCall } from './apps/backend/src/utils/messaging-provider.ts'; ..."` ✅ (confirms combined tool-search/tool-grep renders `_Exploring *2 searches*..._`)

## Walkthrough artifacts
[pr629_conflict_cubic_frontend_walkthrough.mp4](https://cursor.com/agents/bc-ba9b980c-33c4-4b58-b7dd-3b8439ba759f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr629_conflict_cubic_frontend_walkthrough.mp4)
[Signup gate without runtime errors](https://cursor.com/agents/bc-ba9b980c-33c4-4b58-b7dd-3b8439ba759f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr629_signup_gate_no_errors.webp)
[Route redirect without runtime errors](https://cursor.com/agents/bc-ba9b980c-33c4-4b58-b7dd-3b8439ba759f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr629_route_auth_redirect_no_errors.webp)

Video shows frontend loading at `localhost:3000`, redirecting to signup auth gate, and handling route navigation without runtime crashes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba9b980c-33c4-4b58-b7dd-3b8439ba759f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba9b980c-33c4-4b58-b7dd-3b8439ba759f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

