### PR TITLE
refactor: simplify FileProvider caching and filter plumbing (re: #599)

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -27,6 +27,7 @@ from nao_core.commands.sync.providers.databases.query_history import TableUsageS
 from nao_core.config import AnyDatabaseConfig, NaoConfig
 from nao_core.config.databases.base import DatabaseConfig, DatabaseTemplate, ProfilingRefreshPolicy
 from nao_core.config.llm import LLMConfig
+from nao_core.templates.context import NaoContext, create_nao_context
 from nao_core.templates.engine import get_template_engine
 
 from ..base import SyncProvider, SyncResult
@@ -107,6 +108,7 @@ def sync_database(
     project_path: Path | None = None,
     llm_config: LLMConfig | None = None,
     db_folder: str | None = None,
+    nao_ctx: NaoContext | None = None,
 ) -> DatabaseSyncState:
     """Sync a single database by rendering all database templates for each table."""
     engine = get_template_engine(project_path, llm_config=llm_config)
@@ -219,7 +221,14 @@ def sync_database(
 
                     t_render = time.monotonic()
                     try:
-                        content = engine.render(template_name, db=ctx, table_name=table, dataset=schema, **extra_ctx)
+                        content = engine.render(
+                            template_name,
+                            db=ctx,
+                            table_name=table,
+                            dataset=schema,
+                            **({"nao": nao_ctx} if nao_ctx else {}),
+                            **extra_ctx,
+                        )
                         render_dur = time.monotonic() - t_render
                         if render_dur > 5:
                             console.print(
@@ -267,7 +276,7 @@ class DatabaseSyncProvider(SyncProvider):
     """Provider for syncing database schemas to markdown documentation."""
 
     def __init__(self) -> None:
-        self._llm_config: LLMConfig | None = None
+        self._nao_config: NaoConfig | None = None
 
     @property
     def name(self) -> str:
@@ -282,7 +291,7 @@ class DatabaseSyncProvider(SyncProvider):
         return "databases"
 
     def pre_sync(self, config: NaoConfig, output_path: Path) -> None:
-        self._llm_config = config.llm
+        self._nao_config = config
         cleanup_stale_databases(config.databases, output_path, verbose=True)
 
     def get_items(self, config: NaoConfig) -> list[AnyDatabaseConfig]:
@@ -297,6 +306,9 @@ class DatabaseSyncProvider(SyncProvider):
         total_tables = 0
         total_removed = 0
         sync_states: list[DatabaseSyncState] = []
+
+        nao_ctx = create_nao_context(self._nao_config, project_path=project_path) if self._nao_config else None
+        llm_config = self._nao_config.llm if self._nao_config else None
 
         console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
         console.print(f"[dim]Location:[/dim] {output_path.absolute()}")
@@ -326,8 +338,9 @@ class DatabaseSyncProvider(SyncProvider):
                         output_path,
                         progress,
                         project_path,
-                        self._llm_config,
+                        llm_config,
                         db_folder=db_folder,
+                        nao_ctx=nao_ctx,
                     )
                     sync_states.append(state)
                     total_datasets += state.schemas_synced

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -246,7 +246,6 @@ def sync_database(
                         )
                         content = f"# {table}\n\nError generating content: {e}"
 
-                    output_file = table_path / output_filename
                     output_file.write_text(content)
 
                 state.add_table(schema, table)

--- a/cli/nao_core/templates/context.py
+++ b/cli/nao_core/templates/context.py
@@ -45,6 +45,7 @@ class FileProvider:
 
     def __init__(self, project_path: Path):
         self._project_path = project_path
+        self._resolved_root = project_path.resolve()
         self._cache: dict[str, Any] = {}
 
     def _validate_path(self, path: str) -> Path:
@@ -54,7 +55,7 @@ class FileProvider:
             raise ValueError(f"Absolute paths are not allowed: '{path}'. Use a relative path from the project root.")
 
         resolved = (self._project_path / p).resolve()
-        if not resolved.is_relative_to(self._project_path.resolve()):
+        if not resolved.is_relative_to(self._resolved_root):
             raise ValueError(f"Path traversal is not allowed: '{path}'. Path must stay within the project directory.")
 
         return resolved
@@ -183,16 +184,19 @@ class FileProvider:
 
     def glob(self, pattern: str) -> list[str]:
         """Return matching file paths relative to the project root."""
+        cache_key = f"glob:{pattern}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
         if ".." in pattern:
             raise ValueError(f"Path traversal is not allowed in glob pattern: '{pattern}'")
 
-        resolved_root = self._project_path.resolve()
-        matches = [
-            str(p.relative_to(resolved_root))
-            for p in resolved_root.glob(pattern)
-            if p.is_file() and p.resolve().is_relative_to(resolved_root)
-        ]
-        return sorted(matches)
+        root = self._resolved_root
+        matches = sorted(
+            str(p.relative_to(root)) for p in root.glob(pattern) if p.is_file() and p.resolve().is_relative_to(root)
+        )
+        self._cache[cache_key] = matches
+        return matches
 
     def exists(self, path: str) -> bool:
         """Check if a file exists within the project root."""
@@ -237,7 +241,6 @@ class NotionPage:
             client = Client(auth=self.api_key)
             title = get_page_title(client, page_id)
 
-            # Export to markdown
             md_exporter = StringExporter(block_id=page_id, token=self.api_key)
             markdown = md_exporter.export()
             markdown = strip_images(markdown)

--- a/cli/nao_core/templates/context.py
+++ b/cli/nao_core/templates/context.py
@@ -6,16 +6,206 @@ allowing them to access data from various providers like Notion, databases, etc.
 Example template usage:
     {{ nao.notion.page('https://notion.so/...').content }}
     {{ nao.notion.page('abc123').title }}
+    {{ nao.file.yaml('metadata.yaml').description }}
+    {{ nao.file.text('README.md') }}
 """
 
 from __future__ import annotations
 
+import csv
+import io
+import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
 if TYPE_CHECKING:
+    from jinja2 import Environment
+
     from nao_core.config.base import NaoConfig
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+
+class FileProvider:
+    """Provider for reading local project files in templates.
+
+    All paths are relative to the project root. Absolute paths and
+    path traversal (e.g. `../../etc/passwd`) are rejected.
+
+    Example:
+        {{ nao.file.yaml('config/metadata.yaml').description }}
+        {{ nao.file.text('docs/intro.md') }}
+        {{ nao.file.glob('schemas/*.yaml') }}
+    """
+
+    def __init__(self, project_path: Path):
+        self._project_path = project_path
+        self._cache: dict[str, Any] = {}
+
+    def _validate_path(self, path: str) -> Path:
+        """Validate and resolve a relative path against the project root."""
+        p = Path(path)
+        if p.is_absolute():
+            raise ValueError(f"Absolute paths are not allowed: '{path}'. Use a relative path from the project root.")
+
+        resolved = (self._project_path / p).resolve()
+        if not resolved.is_relative_to(self._project_path.resolve()):
+            raise ValueError(f"Path traversal is not allowed: '{path}'. Path must stay within the project directory.")
+
+        return resolved
+
+    def _read_file(self, path: str) -> str:
+        """Read a file with size and permission checks, using cache."""
+        cache_key = f"text:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        resolved = self._validate_path(path)
+
+        if not resolved.exists():
+            suggestion = self._suggest_similar(path)
+            msg = f"File not found: '{path}'"
+            if suggestion:
+                msg += f". Did you mean: {suggestion}?"
+            raise FileNotFoundError(msg)
+
+        if resolved.is_dir():
+            raise ValueError(f"'{path}' is a directory, not a file")
+
+        size = resolved.stat().st_size
+        if size > MAX_FILE_SIZE:
+            raise ValueError(f"File exceeds 10MB limit: '{path}' ({size / 1024 / 1024:.1f}MB)")
+
+        try:
+            content = resolved.read_text(encoding="utf-8")
+        except PermissionError:
+            raise PermissionError(f"Permission denied: '{path}'") from None
+        except UnicodeDecodeError:
+            raise ValueError(f"Cannot read '{path}': file is not valid UTF-8 text") from None
+
+        self._cache[cache_key] = content
+        return content
+
+    def _suggest_similar(self, path: str) -> str | None:
+        """Find similar files to suggest on FileNotFoundError."""
+        target = Path(path)
+        parent = self._project_path / target.parent
+        if not parent.is_dir():
+            return None
+
+        suffix = target.suffix or ""
+        candidates = [
+            str(p.relative_to(self._project_path))
+            for p in parent.iterdir()
+            if p.is_file() and (not suffix or p.suffix == suffix)
+        ]
+        if not candidates:
+            return None
+
+        return ", ".join(sorted(candidates)[:3])
+
+    def _cached_parse(self, namespace: str, path: str, parser: Callable[[str], Any]) -> Any:
+        """Read a file and apply a parser, caching the result."""
+        cache_key = f"{namespace}:{path}"
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        result = parser(self._read_file(path))
+        self._cache[cache_key] = result
+        return result
+
+    def yaml(self, path: str) -> Any:
+        """Read and parse a YAML file.
+
+        Returns a dict (or list) from the YAML content.
+        Empty YAML files return an empty dict.
+        """
+
+        def _parse(content: str) -> Any:
+            try:
+                result = yaml.safe_load(content)
+            except yaml.YAMLError as e:
+                raise ValueError(f"Failed to parse YAML in '{path}': {e}") from e
+            return result if result is not None else {}
+
+        return self._cached_parse("yaml", path, _parse)
+
+    def json(self, path: str) -> Any:
+        """Read and parse a JSON file."""
+
+        def _parse(content: str) -> Any:
+            try:
+                return json.loads(content)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Failed to parse JSON in '{path}': {e}") from e
+
+        return self._cached_parse("json", path, _parse)
+
+    def csv(self, path: str) -> list[dict[str, str]]:
+        """Read a CSV file as a list of dicts (one per row)."""
+
+        def _parse(content: str) -> list[dict[str, str]]:
+            try:
+                return list(csv.DictReader(io.StringIO(content)))
+            except csv.Error as e:
+                raise ValueError(f"Failed to parse CSV in '{path}': {e}") from e
+
+        return self._cached_parse("csv", path, _parse)
+
+    def text(self, path: str) -> str:
+        """Read a file as a UTF-8 string."""
+        return self._read_file(path)
+
+    def frontmatter(self, path: str) -> dict[str, Any]:
+        """Parse YAML frontmatter from a markdown file.
+
+        Returns {'meta': dict, 'content': str}.
+        """
+
+        def _parse(content: str) -> dict[str, Any]:
+            if not content.startswith("---"):
+                return {"meta": {}, "content": content}
+            parts = content.split("---", 2)
+            if len(parts) < 3:
+                return {"meta": {}, "content": content}
+            try:
+                meta = yaml.safe_load(parts[1]) or {}
+            except yaml.YAMLError as e:
+                raise ValueError(f"Failed to parse frontmatter in '{path}': {e}") from e
+            return {"meta": meta, "content": parts[2].strip()}
+
+        return self._cached_parse("frontmatter", path, _parse)
+
+    def glob(self, pattern: str) -> list[str]:
+        """Return matching file paths relative to the project root."""
+        if ".." in pattern:
+            raise ValueError(f"Path traversal is not allowed in glob pattern: '{pattern}'")
+
+        resolved_root = self._project_path.resolve()
+        matches = [
+            str(p.relative_to(resolved_root))
+            for p in resolved_root.glob(pattern)
+            if p.is_file() and p.resolve().is_relative_to(resolved_root)
+        ]
+        return sorted(matches)
+
+    def exists(self, path: str) -> bool:
+        """Check if a file exists within the project root."""
+        try:
+            resolved = self._validate_path(path)
+            return resolved.exists()
+        except ValueError:
+            return False
+
+    def register_filters(self, env: Environment) -> None:
+        """Register read_yaml and read_text as Jinja filters on the given environment."""
+        env.filters["read_yaml"] = self.yaml
+        env.filters["read_text"] = self.text
 
 
 @dataclass
@@ -153,8 +343,25 @@ class NaoContext:
         {{ nao.config.project_name }}
     """
 
-    def __init__(self, config: NaoConfig):
+    def __init__(self, config: NaoConfig, project_path: Path | None = None):
         self._config = config
+        self._project_path = project_path
+
+    @cached_property
+    def file(self) -> FileProvider:
+        """Access local project files.
+
+        Example:
+            {{ nao.file.yaml('metadata.yaml') }}
+            {{ nao.file.text('README.md') }}
+        """
+        if self._project_path is None:
+            raise RuntimeError(
+                "File reading requires a project path. "
+                "This context was created without a project_path — "
+                "ensure nao sync is run from a valid nao project directory."
+            )
+        return FileProvider(self._project_path)
 
     @cached_property
     def notion(self) -> NotionProvider:
@@ -174,25 +381,15 @@ class NaoContext:
         """
         return self._config
 
-    # Future providers can be added here:
-    # @cached_property
-    # def database(self) -> DatabaseProvider:
-    #     """Access database tables and schemas."""
-    #     return DatabaseProvider(self._config)
-    #
-    # @cached_property
-    # def repo(self) -> RepoProvider:
-    #     """Access git repository files."""
-    #     return RepoProvider(self._config)
 
-
-def create_nao_context(config: NaoConfig) -> NaoContext:
+def create_nao_context(config: NaoConfig, project_path: Path | None = None) -> NaoContext:
     """Create a NaoContext for template rendering.
 
     Args:
         config: The nao configuration.
+        project_path: Path to the nao project root (enables file reading).
 
     Returns:
         A NaoContext instance to be used as `nao` in templates.
     """
-    return NaoContext(config)
+    return NaoContext(config, project_path=project_path)

--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -77,6 +77,11 @@ class TemplateEngine:
         self.env.filters["to_json"] = to_json
         self.env.filters["truncate_middle"] = truncate_middle
 
+        if self.project_path:
+            from .context import FileProvider
+
+            FileProvider(self.project_path).register_filters(self.env)
+
     def _register_globals(self) -> None:
         """Register template global helper functions."""
         self.env.globals["prompt"] = self._prompt  # type: ignore[assignment]

--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -80,7 +80,8 @@ class TemplateEngine:
         if self.project_path:
             from .context import FileProvider
 
-            FileProvider(self.project_path).register_filters(self.env)
+            self._file_provider = FileProvider(self.project_path)
+            self._file_provider.register_filters(self.env)
 
     def _register_globals(self) -> None:
         """Register template global helper functions."""

--- a/cli/nao_core/templates/render.py
+++ b/cli/nao_core/templates/render.py
@@ -100,7 +100,8 @@ def render_template(
     Raises:
         TemplateError: If template rendering fails.
     """
-    # Create Jinja environment with project as the loader path
+    import json
+
     env = Environment(
         loader=FileSystemLoader(str(project_path)),
         autoescape=False,
@@ -109,28 +110,15 @@ def render_template(
         keep_trailing_newline=True,
     )
 
-    # Register custom filters
-    import json
-
     nao = create_nao_context(config, project_path=project_path)
-
     env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str, ensure_ascii=False)
+    nao.file.register_filters(env)
 
-    file_provider = getattr(nao, "file", None)
-    if file_provider is not None:
-        file_provider.register_filters(env)
-
-    # Load and render the template
     template = env.get_template(str(template_path))
     rendered = template.render(nao=nao)
 
-    # Determine output path (remove .j2 extension)
-    output_path = project_path / str(template_path)[:-3]  # Remove .j2
-
-    # Ensure parent directory exists
+    output_path = project_path / str(template_path)[:-3]
     output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write rendered content
     output_path.write_text(rendered)
 
     return output_path

--- a/cli/nao_core/templates/render.py
+++ b/cli/nao_core/templates/render.py
@@ -112,10 +112,13 @@ def render_template(
     # Register custom filters
     import json
 
+    nao = create_nao_context(config, project_path=project_path)
+
     env.filters["to_json"] = lambda v, indent=None: json.dumps(v, indent=indent, default=str, ensure_ascii=False)
 
-    # Create the nao context
-    nao = create_nao_context(config)
+    file_provider = getattr(nao, "file", None)
+    if file_provider is not None:
+        file_provider.register_filters(env)
 
     # Load and render the template
     template = env.get_template(str(template_path))

--- a/cli/tests/nao_core/templates/test_file_provider.py
+++ b/cli/tests/nao_core/templates/test_file_provider.py
@@ -1,0 +1,195 @@
+"""Unit tests for the FileProvider class."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nao_core.templates.context import FileProvider
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    """Create a temporary project directory with test files."""
+    # YAML file
+    (tmp_path / "metadata.yaml").write_text(yaml.dump({"name": "test", "version": 2}))
+
+    # Empty YAML file
+    (tmp_path / "empty.yaml").write_text("")
+
+    # JSON file
+    (tmp_path / "config.json").write_text(json.dumps({"key": "value", "items": [1, 2]}))
+
+    # CSV file
+    (tmp_path / "data.csv").write_text("name,age\nAlice,30\nBob,25\n")
+
+    # Text file
+    (tmp_path / "readme.txt").write_text("Hello, world!")
+
+    # Markdown with frontmatter
+    (tmp_path / "doc.md").write_text("---\ntitle: Test\ntags:\n  - a\n  - b\n---\n\nBody content here.")
+
+    # Markdown without frontmatter
+    (tmp_path / "plain.md").write_text("Just plain markdown.")
+
+    # Subdirectory with files
+    sub = tmp_path / "schemas"
+    sub.mkdir()
+    (sub / "users.yaml").write_text(yaml.dump({"table": "users"}))
+    (sub / "orders.yaml").write_text(yaml.dump({"table": "orders"}))
+
+    return tmp_path
+
+
+@pytest.fixture()
+def provider(project_dir: Path) -> FileProvider:
+    return FileProvider(project_dir)
+
+
+class TestYaml:
+    def test_reads_yaml(self, provider: FileProvider):
+        result = provider.yaml("metadata.yaml")
+        assert result == {"name": "test", "version": 2}
+
+    def test_empty_yaml_returns_empty_dict(self, provider: FileProvider):
+        result = provider.yaml("empty.yaml")
+        assert result == {}
+
+    def test_invalid_yaml_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "bad.yaml").write_text(":\n  - :\n    invalid: [")
+        with pytest.raises(ValueError, match="Failed to parse YAML"):
+            provider.yaml("bad.yaml")
+
+    def test_caches_result(self, provider: FileProvider):
+        result1 = provider.yaml("metadata.yaml")
+        result2 = provider.yaml("metadata.yaml")
+        assert result1 is result2
+
+
+class TestJson:
+    def test_reads_json(self, provider: FileProvider):
+        result = provider.json("config.json")
+        assert result == {"key": "value", "items": [1, 2]}
+
+    def test_invalid_json_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "bad.json").write_text("{not valid json")
+        with pytest.raises(ValueError, match="Failed to parse JSON"):
+            provider.json("bad.json")
+
+
+class TestCsv:
+    def test_reads_csv(self, provider: FileProvider):
+        result = provider.csv("data.csv")
+        assert len(result) == 2
+        assert result[0] == {"name": "Alice", "age": "30"}
+        assert result[1] == {"name": "Bob", "age": "25"}
+
+
+class TestText:
+    def test_reads_text(self, provider: FileProvider):
+        result = provider.text("readme.txt")
+        assert result == "Hello, world!"
+
+    def test_binary_file_raises(self, provider: FileProvider, project_dir: Path):
+        (project_dir / "binary.bin").write_bytes(b"\x00\x01\x80\xff" * 100)
+        with pytest.raises(ValueError, match="not valid UTF-8"):
+            provider.text("binary.bin")
+
+
+class TestFrontmatter:
+    def test_parses_frontmatter(self, provider: FileProvider):
+        result = provider.frontmatter("doc.md")
+        assert result["meta"] == {"title": "Test", "tags": ["a", "b"]}
+        assert result["content"] == "Body content here."
+
+    def test_no_frontmatter(self, provider: FileProvider):
+        result = provider.frontmatter("plain.md")
+        assert result["meta"] == {}
+        assert result["content"] == "Just plain markdown."
+
+
+class TestGlob:
+    def test_glob_pattern(self, provider: FileProvider):
+        result = provider.glob("schemas/*.yaml")
+        assert "schemas/orders.yaml" in result
+        assert "schemas/users.yaml" in result
+
+    def test_glob_no_matches(self, provider: FileProvider):
+        result = provider.glob("*.nonexistent")
+        assert result == []
+
+
+class TestExists:
+    def test_existing_file(self, provider: FileProvider):
+        assert provider.exists("metadata.yaml") is True
+
+    def test_missing_file(self, provider: FileProvider):
+        assert provider.exists("nope.yaml") is False
+
+    def test_traversal_returns_false(self, provider: FileProvider):
+        assert provider.exists("../../etc/passwd") is False
+
+
+class TestPathSecurity:
+    def test_absolute_path_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Absolute paths are not allowed"):
+            provider.text("/etc/passwd")
+
+    def test_traversal_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Path traversal is not allowed"):
+            provider.text("../../etc/passwd")
+
+    def test_subdirectory_allowed(self, provider: FileProvider):
+        result = provider.yaml("schemas/users.yaml")
+        assert result == {"table": "users"}
+
+    def test_directory_path_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="is a directory"):
+            provider.text("schemas")
+
+    def test_glob_traversal_rejected(self, provider: FileProvider):
+        with pytest.raises(ValueError, match="Path traversal is not allowed"):
+            provider.glob("../../**/*")
+
+
+class TestMissingFile:
+    def test_file_not_found_with_suggestion(self, provider: FileProvider):
+        with pytest.raises(FileNotFoundError, match="Did you mean"):
+            provider.text("readmee.txt")
+
+    def test_file_not_found_no_suggestion(self, provider: FileProvider):
+        with pytest.raises(FileNotFoundError, match="File not found"):
+            provider.text("nonexistent/deep/path.txt")
+
+
+class TestFileSizeLimit:
+    def test_large_file_rejected(self, provider: FileProvider, project_dir: Path):
+        big = project_dir / "huge.txt"
+        big.write_bytes(b"x" * (10 * 1024 * 1024 + 1))
+        with pytest.raises(ValueError, match="exceeds 10MB"):
+            provider.text("huge.txt")
+
+
+class TestPermissionError:
+    def test_permission_denied(self, provider: FileProvider, project_dir: Path):
+        restricted = project_dir / "secret.txt"
+        restricted.write_text("secret")
+        restricted.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError, match="Permission denied"):
+                provider.text("secret.txt")
+        finally:
+            restricted.chmod(0o644)
+
+
+class TestNoProjectPath:
+    def test_nao_context_file_without_project_path(self):
+        from unittest.mock import MagicMock
+
+        from nao_core.templates.context import NaoContext
+
+        config = MagicMock()
+        ctx = NaoContext(config, project_path=None)
+        with pytest.raises(RuntimeError, match="File reading requires a project path"):
+            _ = ctx.file

--- a/cli/tests/nao_core/templates/test_file_provider.py
+++ b/cli/tests/nao_core/templates/test_file_provider.py
@@ -12,28 +12,14 @@ from nao_core.templates.context import FileProvider
 @pytest.fixture()
 def project_dir(tmp_path: Path) -> Path:
     """Create a temporary project directory with test files."""
-    # YAML file
     (tmp_path / "metadata.yaml").write_text(yaml.dump({"name": "test", "version": 2}))
-
-    # Empty YAML file
     (tmp_path / "empty.yaml").write_text("")
-
-    # JSON file
     (tmp_path / "config.json").write_text(json.dumps({"key": "value", "items": [1, 2]}))
-
-    # CSV file
     (tmp_path / "data.csv").write_text("name,age\nAlice,30\nBob,25\n")
-
-    # Text file
     (tmp_path / "readme.txt").write_text("Hello, world!")
-
-    # Markdown with frontmatter
     (tmp_path / "doc.md").write_text("---\ntitle: Test\ntags:\n  - a\n  - b\n---\n\nBody content here.")
-
-    # Markdown without frontmatter
     (tmp_path / "plain.md").write_text("Just plain markdown.")
 
-    # Subdirectory with files
     sub = tmp_path / "schemas"
     sub.mkdir()
     (sub / "users.yaml").write_text(yaml.dump({"table": "users"}))

--- a/cli/tests/nao_core/templates/test_render.py
+++ b/cli/tests/nao_core/templates/test_render.py
@@ -2,24 +2,25 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from nao_core.templates.render import render_template
 
 
-class TestRenderTemplateToJsonFilter:
-    """Tests for the to_json filter inside render_template."""
+def _make_mock_nao(attrs: dict) -> MagicMock:
+    mock = MagicMock()
+    for k, v in attrs.items():
+        setattr(mock, k, v)
+    return mock
 
+
+class TestRenderTemplateToJsonFilter:
     def test_to_json_preserves_non_ascii(self, tmp_path: Path):
-        """to_json filter in render_template preserves non-ASCII characters."""
         template = tmp_path / "test.md.j2"
         template.write_text("{{ nao.data | to_json }}")
 
-        mock_context = {"data": {"name": "テスト", "emoji": "🎉"}}
-
         with patch("nao_core.templates.render.create_nao_context") as mock_create:
-            mock_nao = type("Nao", (), mock_context)()
-            mock_create.return_value = mock_nao
+            mock_create.return_value = _make_mock_nao({"data": {"name": "テスト", "emoji": "🎉"}})
 
             output_path = render_template(
                 template_path=Path("test.md.j2"),
@@ -35,7 +36,6 @@ class TestRenderTemplateToJsonFilter:
         assert parsed == {"name": "テスト", "emoji": "🎉"}
 
     def test_to_json_non_ascii_roundtrips(self, tmp_path: Path):
-        """Non-ASCII data round-trips through to_json correctly."""
         template = tmp_path / "test.md.j2"
         template.write_text("{{ nao.rows | to_json(indent=2) }}")
 
@@ -44,11 +44,9 @@ class TestRenderTemplateToJsonFilter:
             {"id": 2, "city": "서울"},
             {"id": 3, "city": "القاهرة"},
         ]
-        mock_context = {"rows": rows}
 
         with patch("nao_core.templates.render.create_nao_context") as mock_create:
-            mock_nao = type("Nao", (), mock_context)()
-            mock_create.return_value = mock_nao
+            mock_create.return_value = _make_mock_nao({"rows": rows})
 
             output_path = render_template(
                 template_path=Path("test.md.j2"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refactors the code introduced in #599 to reduce duplication, improve efficiency, and simplify the plumbing.

## Changes

### `context.py` — DRY caching + perf
- Extracted `_cached_parse(namespace, path, parser)` helper to eliminate repeated cache-check/parse/store boilerplate from `yaml()`, `json()`, `csv()`, and `frontmatter()`.
- Added `register_filters(env)` to `FileProvider` — single source of truth for `read_yaml`/`read_text` Jinja filter registration.
- Resolve project root once in `__init__` (`_resolved_root`) instead of calling `.resolve()` on every `_validate_path` and `glob` call.
- Cache `glob` results like other parsed file types.
- Removed low-information comment in `NotionPage._load`.

### `engine.py` — Simplified filter registration
- Replaced hand-written `FileProvider` instantiation + closure wrappers with `FileProvider.register_filters(env)`.
- Store the `FileProvider` on the engine (`_file_provider`) for potential cache sharing.

### `render.py` — Cleaned up
- Removed defensive `getattr(nao, "file", None)` guard — `NaoContext` always defines `file` as a `cached_property`; the guard only existed for brittle test mocks.
- Removed 6 low-information comments that restated the code.
- Calls `nao.file.register_filters(env)` directly.

### `provider.py` — Simplified state
- Removed redundant `_llm_config` field — derived from `_nao_config.llm`.
- `NaoContext` created once in `sync()` and shared across all databases.
- `sync_database()` accepts `nao_ctx: NaoContext` directly instead of `nao_config`.
- Removed duplicate `output_file` assignment.

### Tests
- Fixed `test_render.py` mocks to use `MagicMock` instead of bare `type()` — properly supports attribute access including `file.register_filters()`.
- Removed low-information section comments from test fixture.

## Skipped recommendations (larger refactors)
- **Unify `render.py`'s standalone `Environment` with `TemplateEngine`** — would deduplicate `to_json` filter registration but is an architectural change.
- **Narrow broad `except Exception` catches** in provider.py — pre-existing pattern, not introduced by #599.
- **Type aliases for `Any` returns** on yaml/json — YAML/JSON are inherently dynamic.

## Testing
- All 63 template tests pass (26 FileProvider + 35 engine + 2 render)
- All 515 CLI tests pass
- Python lint clean (`ty check`, `ruff check`, `ruff format --check`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b7dc364-a609-4911-9d3b-4881126e40c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b7dc364-a609-4911-9d3b-4881126e40c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

