### PR TITLE
feat(bedrock): make default model region-aware based on AWS_REGION

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -310,10 +310,17 @@ export const PROVIDER_META: ProviderMetaMap = {
 	},
 };
 
-export function getDefaultModelId(provider: LlmProvider): string {
+export function getDefaultModelId(provider: LlmProvider, region?: string): string {
 	const models = PROVIDER_META[provider].models;
 	const defaultModel = models.find((m) => m.default);
-	return defaultModel?.id ?? models[0]?.id ?? '';
+	const modelId = defaultModel?.id ?? models[0]?.id ?? '';
+	if (provider === 'bedrock') {
+		const effectiveRegion = region ?? process.env.AWS_REGION;
+		if (effectiveRegion) {
+			return resolveBedrockModelId(modelId, effectiveRegion);
+		}
+	}
+	return modelId;
 }
 
 export function getProviderAuth(provider: LlmProvider): ProviderAuth {
@@ -322,6 +329,28 @@ export function getProviderAuth(provider: LlmProvider): ProviderAuth {
 
 export function getProviderApiKeyRequirement(provider: LlmProvider): boolean {
 	return PROVIDER_META[provider].auth.apiKey === 'required';
+}
+
+export const BEDROCK_REGION_PREFIXES = new Set(['us', 'eu', 'ap']);
+const BEDROCK_CROSS_REGION_PROVIDERS = new Set(['anthropic', 'meta']);
+
+export function getBedrockRegionPrefix(region: string): string {
+	const geo = region.split('-')[0];
+	return BEDROCK_REGION_PREFIXES.has(geo) ? geo : 'us';
+}
+
+/** Ensure cross-region inference models use the correct geographic prefix for the target region. */
+export function resolveBedrockModelId(modelId: string, region: string): string {
+	const prefix = getBedrockRegionPrefix(region);
+	const firstSegment = modelId.split('.')[0];
+	if (BEDROCK_REGION_PREFIXES.has(firstSegment)) {
+		const rest = modelId.slice(firstSegment.length + 1);
+		return firstSegment === prefix ? modelId : `${prefix}.${rest}`;
+	}
+	if (BEDROCK_CROSS_REGION_PROVIDERS.has(firstSegment)) {
+		return `${prefix}.${modelId}`;
+	}
+	return modelId;
 }
 
 export const KNOWN_MODELS = Object.fromEntries(

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -207,4 +207,3 @@ function buildVertexAuthOptions(creds?: Record<string, string>) {
 
 	return undefined;
 }
-

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -12,14 +12,17 @@ import { createOpenRouter, LanguageModelV3 } from '@openrouter/ai-sdk-provider';
 import { createOllama } from 'ai-sdk-ollama';
 
 import type { LlmProvidersType, ProviderConfigMap, ProviderSettings } from '../types/llm';
-import { PROVIDER_META } from './provider-meta';
+import { PROVIDER_META, resolveBedrockModelId } from './provider-meta';
 
 export {
+	BEDROCK_REGION_PREFIXES,
+	getBedrockRegionPrefix,
 	getDefaultModelId,
 	getProviderApiKeyRequirement,
 	getProviderAuth,
 	KNOWN_MODELS,
 	PROVIDER_META,
+	resolveBedrockModelId,
 } from './provider-meta';
 
 // See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
@@ -205,24 +208,3 @@ function buildVertexAuthOptions(creds?: Record<string, string>) {
 	return undefined;
 }
 
-const BEDROCK_REGION_PREFIXES = new Set(['us', 'eu', 'ap']);
-const BEDROCK_CROSS_REGION_PROVIDERS = new Set(['anthropic', 'meta']);
-
-function getBedrockRegionPrefix(region: string): string {
-	const geo = region.split('-')[0];
-	return BEDROCK_REGION_PREFIXES.has(geo) ? geo : 'us';
-}
-
-/** Ensure cross-region inference models use the correct geographic prefix for the target region. */
-function resolveBedrockModelId(modelId: string, region: string): string {
-	const prefix = getBedrockRegionPrefix(region);
-	const firstSegment = modelId.split('.')[0];
-	if (BEDROCK_REGION_PREFIXES.has(firstSegment)) {
-		const rest = modelId.slice(firstSegment.length + 1);
-		return firstSegment === prefix ? modelId : `${prefix}.${rest}`;
-	}
-	if (BEDROCK_CROSS_REGION_PROVIDERS.has(firstSegment)) {
-		return `${prefix}.${modelId}`;
-	}
-	return modelId;
-}

--- a/apps/backend/src/queries/project-llm-config.queries.ts
+++ b/apps/backend/src/queries/project-llm-config.queries.ts
@@ -91,8 +91,8 @@ export const getProjectLlmConfigForModel = async (
 	const isModelEnabled = enabledModels.length === 0 || enabledModels.includes(modelId);
 
 	if (!isModelEnabled) {
-		// Model not enabled, use the first enabled model or default
-		const fallbackModel = enabledModels[0] ?? getDefaultModelId(provider);
+		const region = (config.credentials as Record<string, string> | null)?.region;
+		const fallbackModel = enabledModels[0] ?? getDefaultModelId(provider, region);
 		return { config, modelId: fallbackModel };
 	}
 

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -119,9 +119,10 @@ export class AgentService {
 		const configs = await llmConfigQueries.getProjectLlmConfigs(projectId);
 		const config = configs.at(0);
 		if (config) {
+			const region = (config.credentials as Record<string, string> | null)?.region;
 			return {
 				provider: config.provider,
-				modelId: getDefaultModelId(config.provider),
+				modelId: getDefaultModelId(config.provider, region),
 			};
 		}
 

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -176,8 +176,8 @@ export const getProjectAvailableModels = async (
 		const enabledModels = config.enabledModels ?? [];
 
 		if (enabledModels.length === 0) {
-			// If no models explicitly enabled, add the default
-			const defaultModelId = getDefaultModelId(provider);
+			const region = (config.credentials as Record<string, string> | null)?.region;
+			const defaultModelId = getDefaultModelId(provider, region);
 			models.push({ provider, modelId: defaultModelId, name: getModelName(provider, defaultModelId) });
 		} else {
 			for (const modelId of enabledModels) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The default Bedrock model (`us.anthropic.claude-sonnet-4-6`) was hardcoded with a `us.` prefix. When users configure `AWS_REGION` to an EU or AP region (e.g. `eu-west-1`, `ap-southeast-1`), the default model ID still used the `us.` prefix, which doesn't work for cross-region inference.

While `resolveBedrockModelId` in `providers.ts` already handled rewriting model IDs at inference time, `getDefaultModelId` (used for fallback model selection, UI display, and project config initialization) always returned the raw `us.` prefixed ID.

## Solution

- Moved `resolveBedrockModelId`, `getBedrockRegionPrefix`, and `BEDROCK_REGION_PREFIXES` from `providers.ts` to `provider-meta.ts` (no SDK imports — stays frontend-safe)
- `getDefaultModelId` now accepts an optional `region` parameter and resolves the correct geographic prefix (`us.`/`eu.`/`ap.`) for Bedrock models
- When no explicit region is passed, falls back to `process.env.AWS_REGION`
- Updated backend callers (`agent.ts`, `llm.ts`, `project-llm-config.queries.ts`) to pass the project config region where available

## How it works

| Scenario | Before | After |
|---|---|---|
| `AWS_REGION=eu-west-1`, no explicit region | `us.anthropic.claude-sonnet-4-6` | `eu.anthropic.claude-sonnet-4-6` |
| `AWS_REGION=ap-southeast-1` | `us.anthropic.claude-sonnet-4-6` | `ap.anthropic.claude-sonnet-4-6` |
| `AWS_REGION=us-east-1` or unset | `us.anthropic.claude-sonnet-4-6` | `us.anthropic.claude-sonnet-4-6` (unchanged) |
| Project config with `region: 'eu-central-1'` | `us.anthropic.claude-sonnet-4-6` | `eu.anthropic.claude-sonnet-4-6` |

## Files changed

- `apps/backend/src/agents/provider-meta.ts` — added Bedrock region helpers and region-aware `getDefaultModelId`
- `apps/backend/src/agents/providers.ts` — removed duplicate helpers, re-exports from `provider-meta.ts`
- `apps/backend/src/services/agent.ts` — passes project config region to `getDefaultModelId`
- `apps/backend/src/utils/llm.ts` — passes project config region to `getDefaultModelId`
- `apps/backend/src/queries/project-llm-config.queries.ts` — passes project config region to fallback model lookup
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54eb9f3d-9cd0-4f50-ba82-08958829cc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54eb9f3d-9cd0-4f50-ba82-08958829cc25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

