### PR TITLE
feat: enable includeThoughts for Vertex provider

### DIFF
--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -131,6 +131,9 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 			}
 			return createVertex(config)(modelId);
 		},
+		// Enable reasoning token traces for Gemini models on Vertex AI.
+		// See: https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex#C27791156-L11
+		defaultOptions: { includeThoughts: true },
 	},
 	azure: {
 		...PROVIDER_META.azure,


### PR DESCRIPTION
## Summary

Adds `includeThoughts: true` to the Vertex provider's `defaultOptions` so that reasoning/thinking tokens are returned by the Vertex AI SDK and surfaced in the nao UI.

This specifically helps users running Gemini models via the Vertex provider — reasoning steps were silently dropped because the SDK requires an explicit opt-in via this flag.

> **Note:** `includeThoughts` is a Gemini-specific option. It is passed as a provider option (via `providerOptions`) and has no effect on Claude models routed through `createVertexAnthropic`, so there is no risk of breakage for Sonnet/Opus users on Vertex.

## Changes

- `apps/backend/src/agents/providers.ts` — added `defaultOptions: { includeThoughts: true }` to the `vertex` provider entry.

## Reference

- https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex#C27791156-L11