### PR TITLE
resolve parition filter to match any of the 3 possible types

### DIFF
--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -274,9 +274,35 @@ class BigQueryDatabaseContext(DatabaseContext):
 
     def _partition_filter(self) -> str:
         cols = self.partition_columns()
-        if cols:
-            return f"`{cols[0]}` >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
-        return ""
+        if not cols:
+            return ""
+        col = cols[0]
+        col_type = self._resolve_partition_column_type(col)
+        if "TIMESTAMP" in col_type:
+            return f"`{col}` >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)"
+        if "DATETIME" in col_type:
+            return f"`{col}` >= DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 30 DAY)"
+        return f"`{col}` >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
+
+    def _resolve_partition_column_type(self, col_name: str) -> str:
+        """Return the uppercase data type of the partition column."""
+        if self._partition_metadata and self._partition_metadata.partition_column_type:
+            return self._partition_metadata.partition_column_type.upper()
+        try:
+            table_literal = _bq_string_literal(self._table_name)
+            col_literal = _bq_string_literal(col_name)
+            info_path = _bq_path(self._project_id, self._schema, "INFORMATION_SCHEMA", "COLUMNS")
+            query = f"""
+                SELECT data_type FROM {info_path}
+                WHERE table_name = {table_literal} AND column_name = {col_literal}
+                LIMIT 1
+            """
+            row = next(iter(self._conn.raw_sql(query)), None)  # type: ignore[union-attr]
+            if row:
+                return str(row[0]).upper()
+        except Exception:
+            logger.debug("Failed to resolve partition column type for %s.%s", self._schema, self._table_name)
+        return "DATE"
 
     def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
         return f"{table_sql}, UNNEST({col_sql}) AS {alias}"

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -722,6 +722,70 @@ class TestActivePartitionFilter:
         assert result == "DATE(`server_received_at`) = DATE('2026-03-11')"
 
 
+class TestPartitionFilter:
+    """_partition_filter() must generate type-appropriate SQL for DATE, TIMESTAMP, and DATETIME."""
+
+    def test_date_partition_uses_date_sub(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_date",
+            partition_column_type="DATE",
+            last_partition_id="20260310",
+            total_rows=100,
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+        assert ctx._partition_filter() == "`event_date` >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)"
+
+    def test_timestamp_partition_uses_timestamp_sub(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_time",
+            partition_column_type="TIMESTAMP",
+            last_partition_id="20260310",
+            total_rows=100,
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+        assert ctx._partition_filter() == "`event_time` >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)"
+
+    def test_datetime_partition_uses_datetime_sub(self):
+        meta = TablePartitionMetadata(
+            partition_column="created_at",
+            partition_column_type="DATETIME",
+            last_partition_id="20260310",
+            total_rows=100,
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+        assert ctx._partition_filter() == "`created_at` >= DATETIME_SUB(CURRENT_DATETIME(), INTERVAL 30 DAY)"
+
+    def test_no_partition_returns_empty_string(self):
+        meta = TablePartitionMetadata(
+            partition_column=None,
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+        assert ctx._partition_filter() == ""
+
+    def test_unknown_type_defaults_to_date(self):
+        meta = TablePartitionMetadata(
+            partition_column="event_date",
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+        )
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+        mock_conn.raw_sql.return_value = []
+        assert "DATE_SUB(CURRENT_DATE()" in ctx._partition_filter()
+
+    def test_fallback_queries_information_schema_for_type(self):
+        ctx, mock_conn = _make_context(partition_metadata=None)
+        mock_conn.raw_sql.side_effect = [
+            [("event_time",)],
+            [],
+            [("TIMESTAMP",)],
+        ]
+        assert "TIMESTAMP_SUB(CURRENT_TIMESTAMP()" in ctx._partition_filter()
+
+
 class TestTablePartitionMetadata:
     def test_require_partition_filter_defaults_to_false(self):
         meta = TablePartitionMetadata(


### PR DESCRIPTION
## Summary

**Issue** - `profiling.md` generation was failing when the partition wasn't type `DATE` but type `TIMESTAMP` or `DATETIME`
**Solution** - handle the 3 possible types of partition in BigQuery warehouse

## Related issue

#640 
