### PR TITLE
viewer role created along with cleaner protected procedure permissions

### DIFF
--- a/apps/backend/src/queries/shared-chat.queries.ts
+++ b/apps/backend/src/queries/shared-chat.queries.ts
@@ -1,4 +1,5 @@
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import type { MessageBubble } from '@nao/shared/types';
+import { and, asc, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import s, { type DBSharedChat } from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -10,10 +11,15 @@ export type SharedChatWithDetails = DBSharedChat & {
 	userId: string;
 	projectId: string;
 	forkMetadata?: ForkMetadata;
+	messageBubbles?: MessageBubble[];
 };
 
-export async function listProjectSharedChats(projectId: string, userId: string): Promise<SharedChatWithDetails[]> {
-	const allChats = await db
+export async function listUserSharedChats(projectIds: string[], userId: string): Promise<SharedChatWithDetails[]> {
+	if (projectIds.length === 0) {
+		return [];
+	}
+
+	const chats = await db
 		.select({
 			id: s.sharedChat.id,
 			projectId: s.chat.projectId,
@@ -27,35 +33,55 @@ export async function listProjectSharedChats(projectId: string, userId: string):
 		.from(s.sharedChat)
 		.innerJoin(s.chat, eq(s.sharedChat.chatId, s.chat.id))
 		.innerJoin(s.user, eq(s.chat.userId, s.user.id))
-		.where(eq(s.chat.projectId, projectId))
+		.leftJoin(
+			s.sharedChatAccess,
+			and(eq(s.sharedChatAccess.sharedChatId, s.sharedChat.id), eq(s.sharedChatAccess.userId, userId)),
+		)
+		.where(
+			and(
+				inArray(s.chat.projectId, projectIds),
+				sql`(${s.sharedChat.visibility} = 'project' OR ${s.chat.userId} = ${userId} OR ${s.sharedChatAccess.userId} IS NOT NULL)`,
+			),
+		)
 		.orderBy(desc(s.sharedChat.createdAt))
 		.execute();
 
-	const specificChatIds = allChats
-		.filter((chat) => chat.visibility === 'specific' && chat.userId !== userId)
-		.map((chat) => chat.id);
+	const bubblesMap = await fetchMessageBubbles(chats.map((c) => c.chatId));
+	return chats.map((chat) => ({ ...chat, messageBubbles: bubblesMap.get(chat.chatId) }));
+}
 
-	if (specificChatIds.length === 0) {
-		return allChats;
+async function fetchMessageBubbles(chatIds: string[]): Promise<Map<string, MessageBubble[]>> {
+	if (chatIds.length === 0) {
+		return new Map();
 	}
 
-	const accessRows = await db
-		.select({ sharedChatId: s.sharedChatAccess.sharedChatId })
-		.from(s.sharedChatAccess)
-		.where(and(eq(s.sharedChatAccess.userId, userId), inArray(s.sharedChatAccess.sharedChatId, specificChatIds)))
+	const rows = await db
+		.select({
+			chatId: s.chatMessage.chatId,
+			messageId: s.chatMessage.id,
+			role: s.chatMessage.role,
+			charCount: sql<number>`coalesce(sum(length(${s.messagePart.text})), 0)`.as('char_count'),
+		})
+		.from(s.chatMessage)
+		.leftJoin(s.messagePart, and(eq(s.messagePart.messageId, s.chatMessage.id), eq(s.messagePart.type, 'text')))
+		.where(
+			and(
+				inArray(s.chatMessage.chatId, chatIds),
+				isNull(s.chatMessage.supersededAt),
+				inArray(s.chatMessage.role, ['user', 'assistant']),
+			),
+		)
+		.groupBy(s.chatMessage.id, s.chatMessage.chatId, s.chatMessage.role, s.chatMessage.createdAt)
+		.orderBy(asc(s.chatMessage.createdAt))
 		.execute();
 
-	const accessibleIds = new Set(accessRows.map((r) => r.sharedChatId));
-
-	return allChats.filter((chat) => {
-		if (chat.visibility === 'project') {
-			return true;
-		}
-		if (chat.userId === userId) {
-			return true;
-		}
-		return accessibleIds.has(chat.id);
-	});
+	const map = new Map<string, MessageBubble[]>();
+	for (const row of rows) {
+		const bubbles = map.get(row.chatId) ?? [];
+		bubbles.push({ role: row.role as 'user' | 'assistant', charCount: Number(row.charCount) });
+		map.set(row.chatId, bubbles);
+	}
+	return map;
 }
 
 export async function createSharedChat(

--- a/apps/backend/src/queries/shared-story.queries.ts
+++ b/apps/backend/src/queries/shared-story.queries.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, max } from 'drizzle-orm';
+import { and, desc, eq, inArray, max, sql } from 'drizzle-orm';
 
 import s, { type DBSharedStory } from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -75,7 +75,11 @@ export async function canUserAccessSharedStory(sharedStoryId: string, userId: st
 	return !!row;
 }
 
-export async function listProjectSharedStories(projectId: string, userId: string): Promise<SharedStoryWithLatest[]> {
+export async function listUserSharedStories(projectIds: string[], userId: string): Promise<SharedStoryWithLatest[]> {
+	if (projectIds.length === 0) {
+		return [];
+	}
+
 	const latestVersions = db
 		.select({
 			storyId: s.storyVersion.storyId,
@@ -85,7 +89,7 @@ export async function listProjectSharedStories(projectId: string, userId: string
 		.groupBy(s.storyVersion.storyId)
 		.as('latest');
 
-	const allStories = await db
+	return db
 		.select({
 			id: s.sharedStory.id,
 			storyId: s.sharedStory.storyId,
@@ -107,35 +111,18 @@ export async function listProjectSharedStories(projectId: string, userId: string
 			s.storyVersion,
 			and(eq(s.storyVersion.storyId, s.story.id), eq(s.storyVersion.version, latestVersions.maxVersion)),
 		)
-		.where(eq(s.sharedStory.projectId, projectId))
+		.leftJoin(
+			s.sharedStoryAccess,
+			and(eq(s.sharedStoryAccess.sharedStoryId, s.sharedStory.id), eq(s.sharedStoryAccess.userId, userId)),
+		)
+		.where(
+			and(
+				inArray(s.sharedStory.projectId, projectIds),
+				sql`(${s.sharedStory.visibility} = 'project' OR ${s.sharedStory.userId} = ${userId} OR ${s.sharedStoryAccess.userId} IS NOT NULL)`,
+			),
+		)
 		.orderBy(desc(s.sharedStory.createdAt))
 		.execute();
-
-	const specificStoryIds = allStories
-		.filter((story) => story.visibility === 'specific' && story.userId !== userId)
-		.map((story) => story.id);
-
-	if (specificStoryIds.length === 0) {
-		return allStories;
-	}
-
-	const accessRows = await db
-		.select({ sharedStoryId: s.sharedStoryAccess.sharedStoryId })
-		.from(s.sharedStoryAccess)
-		.where(eq(s.sharedStoryAccess.userId, userId))
-		.execute();
-
-	const accessibleIds = new Set(accessRows.map((r) => r.sharedStoryId));
-
-	return allStories.filter((story) => {
-		if (story.visibility === 'project') {
-			return true;
-		}
-		if (story.userId === userId) {
-			return true;
-		}
-		return accessibleIds.has(story.id);
-	});
 }
 
 export async function getQueryDataFromCode(

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -19,7 +19,7 @@ export const agentRoutes = async (app: App) => {
 
 		if (projectId) {
 			const userRole = await projectQueries.getUserRoleInProject(projectId, user.id);
-			if (userRole === 'viewer') {
+			if (!userRole || userRole === 'viewer') {
 				return reply.status(403).send({ error: 'Viewers cannot send messages' });
 			}
 		}

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -3,6 +3,8 @@ import { createUIMessageStreamResponse } from 'ai';
 import type { App } from '../app';
 import { handleAgentRoute } from '../handlers/agent';
 import { authMiddleware } from '../middleware/auth';
+import * as chatQueries from '../queries/chat.queries';
+import * as projectQueries from '../queries/project.queries';
 import { posthog, PostHogEvent } from '../services/posthog';
 import { AgentRequestSchema } from '../types/chat';
 
@@ -11,8 +13,16 @@ const DEBUG_CHUNKS = false;
 export const agentRoutes = async (app: App) => {
 	app.addHook('preHandler', authMiddleware);
 
-	app.post('/', { schema: { body: AgentRequestSchema } }, async ({ user, project, body, headers }) => {
-		const projectId = project?.id;
+	app.post('/', { schema: { body: AgentRequestSchema } }, async (request, reply) => {
+		const { user, project, body, headers } = request;
+		const projectId = body.chatId ? await chatQueries.getChatProjectId(body.chatId) : project?.id;
+
+		if (projectId) {
+			const userRole = await projectQueries.getUserRoleInProject(projectId, user.id);
+			if (userRole === 'viewer') {
+				return reply.status(403).send({ error: 'Viewers cannot send messages' });
+			}
+		}
 
 		const result = await handleAgentRoute({
 			userId: user.id,

--- a/apps/backend/src/trpc/chat-fork.routes.ts
+++ b/apps/backend/src/trpc/chat-fork.routes.ts
@@ -8,7 +8,7 @@ import * as sharedStoryQueries from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
 import { compactionService } from '../services/compaction';
 import type { ForkMetadata, UIMessage, UIMessagePart } from '../types/chat';
-import { protectedProcedure } from './trpc';
+import { canSendProcedure, protectedProcedure } from './trpc';
 
 const shareTypeSchema = z.enum(['chat', 'story']);
 const selectionSchema = z.object({ start: z.number(), end: z.number(), text: z.string() });
@@ -20,7 +20,7 @@ export interface SelectionInfo {
 }
 
 export const chatForkRoutes = {
-	fork: protectedProcedure
+	fork: canSendProcedure
 		.input(
 			z.object({
 				shareId: z.string(),

--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -70,20 +70,22 @@ export const sharedChatRoutes = {
 			return created;
 		}),
 
-	getSharedChat: shareAccessProcedure
-		.input(z.object({ shareId: z.string() }))
-		.query(
-			async ({
-				ctx,
-			}): Promise<{ share: sharedChatQueries.SharedChatWithDetails; chat: UIChat; userRole: UserRole | null }> => {
-				const [chat] = await chatQueries.getChat(ctx.resource.chatId, { includeFeedback: true });
-				if (!chat) {
-					throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
-				}
+	getSharedChat: shareAccessProcedure.input(z.object({ shareId: z.string() })).query(
+		async ({
+			ctx,
+		}): Promise<{
+			share: sharedChatQueries.SharedChatWithDetails;
+			chat: UIChat;
+			userRole: UserRole | null;
+		}> => {
+			const [chat] = await chatQueries.getChat(ctx.resource.chatId, { includeFeedback: true });
+			if (!chat) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
+			}
 
-				return { share: ctx.resource, chat, userRole: ctx.userRole };
-			},
-		),
+			return { share: ctx.resource, chat, userRole: ctx.userRole };
+		},
+	),
 
 	getShareOptionsByChatId: chatProcedure.input(z.object({ chatId: z.string() })).query(async ({ input, ctx }) => {
 		const share = await sharedChatQueries.getShareIdByChatId(input.chatId, ctx.user.id);

--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -1,3 +1,4 @@
+import type { UserRole } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
@@ -6,17 +7,31 @@ import * as projectQueries from '../queries/project.queries';
 import * as sharedChatQueries from '../queries/shared-chat.queries';
 import { type UIChat } from '../types/chat';
 import { notifySharedItemRecipients } from '../utils/email';
-import { projectProtectedProcedure, resourceProjectProcedure } from './trpc';
+import { canSendProcedure, protectedProcedure, resourceProjectProcedure } from './trpc';
 
 const chatProcedure = resourceProjectProcedure('chatId', chatQueries.getChatInfo, 'Chat');
 const shareProcedure = resourceProjectProcedure('shareId', sharedChatQueries.getSharedChatInfo, 'Shared chat');
+const shareAccessProcedure = resourceProjectProcedure(
+	'shareId',
+	sharedChatQueries.getSharedChatInfo,
+	'Shared chat',
+	async (share, userId) => {
+		if (share.visibility !== 'specific') {
+			return true;
+		}
+		const isOwner = (await chatQueries.getChatOwnerId(share.chatId)) === userId;
+		return isOwner || sharedChatQueries.canUserAccessSharedChat(share.id, userId);
+	},
+);
 
 export const sharedChatRoutes = {
-	list: projectProtectedProcedure.query(async ({ ctx }) => {
-		return sharedChatQueries.listProjectSharedChats(ctx.project.id, ctx.user.id);
+	list: protectedProcedure.query(async ({ ctx }) => {
+		const projects = await projectQueries.listUserProjects(ctx.user.id);
+		const projectIds = projects.map((p) => p.id);
+		return sharedChatQueries.listUserSharedChats(projectIds, ctx.user.id);
 	}),
 
-	create: chatProcedure
+	create: canSendProcedure
 		.input(
 			z.object({
 				chatId: z.string(),
@@ -25,6 +40,14 @@ export const sharedChatRoutes = {
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
+			const chatInfo = await chatQueries.getChatInfo(input.chatId);
+			if (!chatInfo) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
+			}
+			if (chatInfo.projectId !== ctx.project.id) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
+			}
+
 			const created = await sharedChatQueries.createSharedChat(
 				{
 					chatId: input.chatId,
@@ -34,12 +57,12 @@ export const sharedChatRoutes = {
 			);
 
 			notifySharedItemRecipients({
-				projectId: ctx.resource.projectId,
+				projectId: ctx.project.id,
 				sharerId: ctx.user.id,
 				sharerName: ctx.user.name,
 				shareId: created.id,
 				itemLabel: 'chat',
-				itemTitle: ctx.resource.title,
+				itemTitle: chatInfo.title,
 				visibility: input.visibility,
 				allowedUserIds: input.allowedUserIds,
 			}).catch((err) => console.error('Failed to notify shared chat recipients', err));
@@ -47,26 +70,20 @@ export const sharedChatRoutes = {
 			return created;
 		}),
 
-	getSharedChat: shareProcedure
+	getSharedChat: shareAccessProcedure
 		.input(z.object({ shareId: z.string() }))
-		.query(async ({ ctx }): Promise<{ share: sharedChatQueries.SharedChatWithDetails; chat: UIChat }> => {
-			if (ctx.resource.visibility === 'specific') {
-				const isOwner = (await chatQueries.getChatOwnerId(ctx.resource.chatId)) === ctx.user.id;
-				if (!isOwner) {
-					const hasAccess = await sharedChatQueries.canUserAccessSharedChat(ctx.resource.id, ctx.user.id);
-					if (!hasAccess) {
-						throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this chat.' });
-					}
+		.query(
+			async ({
+				ctx,
+			}): Promise<{ share: sharedChatQueries.SharedChatWithDetails; chat: UIChat; userRole: UserRole | null }> => {
+				const [chat] = await chatQueries.getChat(ctx.resource.chatId, { includeFeedback: true });
+				if (!chat) {
+					throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
 				}
-			}
 
-			const [chat] = await chatQueries.getChat(ctx.resource.chatId, { includeFeedback: true });
-			if (!chat) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat not found.' });
-			}
-
-			return { share: ctx.resource, chat };
-		}),
+				return { share: ctx.resource, chat, userRole: ctx.userRole };
+			},
+		),
 
 	getShareOptionsByChatId: chatProcedure.input(z.object({ chatId: z.string() })).query(async ({ input, ctx }) => {
 		const share = await sharedChatQueries.getShareIdByChatId(input.chatId, ctx.user.id);

--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -3,20 +3,32 @@ import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
 import * as chatQueries from '../queries/chat.queries';
+import * as projectQueries from '../queries/project.queries';
 import * as sharedStoryQueries from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
 import { executeLiveQuery, getStoryQueryData, refreshStoryData } from '../services/live-story';
 import { notifySharedItemRecipients } from '../utils/email';
 import { buildDownloadResponse } from '../utils/story-download';
 import { extractStorySummary } from '../utils/story-summary';
-import { projectProtectedProcedure, resourceProjectProcedure } from './trpc';
+import { canSendProcedure, projectProtectedProcedure, protectedProcedure, resourceProjectProcedure } from './trpc';
 
-const shareProcedure = resourceProjectProcedure('shareId', sharedStoryQueries.getSharedStory, 'Shared story');
 const chatProcedure = resourceProjectProcedure('chatId', chatQueries.getChatInfo, 'Chat');
+const shareProcedure = resourceProjectProcedure('shareId', sharedStoryQueries.getSharedStory, 'Shared story');
+const shareAccessProcedure = resourceProjectProcedure(
+	'shareId',
+	sharedStoryQueries.getSharedStory,
+	'Shared story',
+	async (item, userId) =>
+		item.visibility !== 'specific' ||
+		item.userId === userId ||
+		sharedStoryQueries.canUserAccessSharedStory(item.id, userId),
+);
 
 export const sharedStoryRoutes = {
-	list: projectProtectedProcedure.query(async ({ ctx }) => {
-		const stories = await sharedStoryQueries.listProjectSharedStories(ctx.project.id, ctx.user.id);
+	list: protectedProcedure.query(async ({ ctx }) => {
+		const projects = await projectQueries.listUserProjects(ctx.user.id);
+		const projectIds = projects.map((p) => p.id);
+		const stories = await sharedStoryQueries.listUserSharedStories(projectIds, ctx.user.id);
 		return stories.map((story) => ({
 			...story,
 			storySlug: story.slug,
@@ -24,7 +36,7 @@ export const sharedStoryRoutes = {
 		}));
 	}),
 
-	create: chatProcedure
+	create: canSendProcedure
 		.input(
 			z.object({
 				chatId: z.string(),
@@ -42,15 +54,15 @@ export const sharedStoryRoutes = {
 			const created = await sharedStoryQueries.createSharedStory(
 				{
 					storyId: story.id,
-					projectId: ctx.resource.projectId,
+					projectId: ctx.project.id,
 					userId: ctx.user.id,
 					visibility: input.visibility,
 				},
 				input.allowedUserIds,
 			);
 
-			await notifySharedItemRecipients({
-				projectId: ctx.resource.projectId,
+			notifySharedItemRecipients({
+				projectId: ctx.project.id,
 				sharerId: ctx.user.id,
 				sharerName: ctx.user.name,
 				shareId: created.id,
@@ -58,20 +70,13 @@ export const sharedStoryRoutes = {
 				itemTitle: story.title,
 				visibility: input.visibility,
 				allowedUserIds: input.allowedUserIds,
-			});
+			}).catch((err) => console.error('Failed to notify shared story recipients', err));
 
 			return created;
 		}),
 
-	get: shareProcedure.input(z.object({ shareId: z.string() })).query(async ({ ctx }) => {
+	get: shareAccessProcedure.input(z.object({ shareId: z.string() })).query(async ({ ctx }) => {
 		const shared = ctx.resource;
-
-		if (shared.visibility === 'specific' && shared.userId !== ctx.user.id) {
-			const hasAccess = await sharedStoryQueries.canUserAccessSharedStory(shared.id, ctx.user.id);
-			if (!hasAccess) {
-				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
-			}
-		}
 
 		const storyRow = await storyQueries.getStoryByChatAndSlug(shared.chatId, shared.slug);
 		const isLive = storyRow?.isLive ?? false;
@@ -96,6 +101,7 @@ export const sharedStoryRoutes = {
 			cacheSchedule,
 			cacheScheduleDescription,
 			cachedAt,
+			userRole: ctx.userRole,
 		};
 	}),
 
@@ -105,16 +111,8 @@ export const sharedStoryRoutes = {
 			return executeLiveQuery(input.chatId, input.queryId);
 		}),
 
-	refreshData: shareProcedure.input(z.object({ shareId: z.string() })).mutation(async ({ ctx }) => {
+	refreshData: shareAccessProcedure.input(z.object({ shareId: z.string() })).mutation(async ({ ctx }) => {
 		const shared = ctx.resource;
-
-		if (shared.visibility === 'specific' && shared.userId !== ctx.user.id) {
-			const hasAccess = await sharedStoryQueries.canUserAccessSharedStory(shared.id, ctx.user.id);
-			if (!hasAccess) {
-				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
-			}
-		}
-
 		const { queryData } = await refreshStoryData(shared.chatId, shared.slug);
 		return { queryData, cachedAt: new Date() };
 	}),
@@ -173,7 +171,7 @@ export const sharedStoryRoutes = {
 		await sharedStoryQueries.deleteSharedStory(input.shareId);
 	}),
 
-	download: shareProcedure
+	download: shareAccessProcedure
 		.input(
 			z.object({
 				shareId: z.string(),
@@ -183,13 +181,6 @@ export const sharedStoryRoutes = {
 		)
 		.query(async ({ input, ctx }) => {
 			const shared = ctx.resource;
-
-			if (shared.visibility === 'specific' && shared.userId !== ctx.user.id) {
-				const hasAccess = await sharedStoryQueries.canUserAccessSharedStory(shared.id, ctx.user.id);
-				if (!hasAccess) {
-					throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
-				}
-			}
 
 			const version = input.versionNumber
 				? await storyQueries.getVersionByNumber(shared.chatId, shared.slug, input.versionNumber)

--- a/apps/backend/src/trpc/trpc.ts
+++ b/apps/backend/src/trpc/trpc.ts
@@ -97,7 +97,10 @@ export function resourceProjectProcedure<T extends { projectId: string }>(
 		if (checkAccess) {
 			const canAccess = await checkAccess(resource, ctx.user.id);
 			if (!canAccess) {
-				throw new TRPCError({ code: 'FORBIDDEN', message: `You do not have access to this ${label.toLowerCase()}.` });
+				throw new TRPCError({
+					code: 'FORBIDDEN',
+					message: `You do not have access to this ${label.toLowerCase()}.`,
+				});
 			}
 		}
 

--- a/apps/backend/src/trpc/trpc.ts
+++ b/apps/backend/src/trpc/trpc.ts
@@ -64,7 +64,7 @@ export const projectProtectedProcedure = protectedProcedure.use(async ({ ctx, ne
 });
 
 export const canSendProcedure = projectProtectedProcedure.use(async ({ ctx, next }) => {
-	if (ctx.userRole === 'viewer') {
+	if (ctx.userRole !== 'admin' && ctx.userRole !== 'user') {
 		throw new TRPCError({ code: 'FORBIDDEN', message: 'Viewers cannot perform this action' });
 	}
 

--- a/apps/backend/src/trpc/trpc.ts
+++ b/apps/backend/src/trpc/trpc.ts
@@ -63,26 +63,42 @@ export const projectProtectedProcedure = protectedProcedure.use(async ({ ctx, ne
 	return next({ ctx: { project, userRole } });
 });
 
+export const canSendProcedure = projectProtectedProcedure.use(async ({ ctx, next }) => {
+	if (ctx.userRole === 'viewer') {
+		throw new TRPCError({ code: 'FORBIDDEN', message: 'Viewers cannot perform this action' });
+	}
+
+	return next({ ctx });
+});
+
 export function resourceProjectProcedure<T extends { projectId: string }>(
-	fieldName: string,
-	resolve: (id: string) => Promise<T | null>,
-	resourceLabel: string,
+	inputField: string,
+	fetch: (id: string) => Promise<T | null>,
+	label: string,
+	checkAccess?: (resource: T, userId: string) => Promise<boolean>,
 ) {
 	return protectedProcedure.use(async ({ ctx, getRawInput, next }) => {
 		const rawInput = (await getRawInput()) as Record<string, unknown>;
-		const resourceId = rawInput[fieldName];
+		const resourceId = rawInput[inputField];
 		if (typeof resourceId !== 'string') {
-			throw new TRPCError({ code: 'BAD_REQUEST', message: `${fieldName} is required.` });
+			throw new TRPCError({ code: 'BAD_REQUEST', message: `${inputField} is required.` });
 		}
 
-		const resource = await resolve(resourceId);
+		const resource = await fetch(resourceId);
 		if (!resource) {
-			throw new TRPCError({ code: 'NOT_FOUND', message: `${resourceLabel} not found.` });
+			throw new TRPCError({ code: 'NOT_FOUND', message: `${label} not found.` });
 		}
 
 		const userRole: UserRole | null = await projectQueries.getUserRoleInProject(resource.projectId, ctx.user.id);
 		if (!userRole) {
 			throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this project.' });
+		}
+
+		if (checkAccess) {
+			const canAccess = await checkAccess(resource, ctx.user.id);
+			if (!canAccess) {
+				throw new TRPCError({ code: 'FORBIDDEN', message: `You do not have access to this ${label.toLowerCase()}.` });
+			}
 		}
 
 		return next({ ctx: { resource, userRole } });

--- a/apps/backend/src/trpc/user.routes.ts
+++ b/apps/backend/src/trpc/user.routes.ts
@@ -25,7 +25,7 @@ export const userRoutes = {
 		return user;
 	}),
 
-	modify: projectProtectedProcedure
+	modify: adminProtectedProcedure
 		.input(
 			z.object({
 				userId: z.string(),
@@ -47,10 +47,10 @@ export const userRoutes = {
 			}
 			const previousName = await userQueries.getUserName(input.userId);
 
-			if (ctx.project && input.newRole && input.newRole !== previousRole) {
+			if (input.newRole && input.newRole !== previousRole) {
 				await projectQueries.updateProjectMemberRole(ctx.project.id, input.userId, input.newRole);
 			}
-			if (ctx.project && input.name && input.name !== previousName) {
+			if (input.name && input.name !== previousName) {
 				await userQueries.updateUser(input.userId, input.name);
 			}
 		}),

--- a/apps/frontend/src/components/command-menu.tsx
+++ b/apps/frontend/src/components/command-menu.tsx
@@ -16,6 +16,7 @@ import { useTheme } from '@/contexts/theme.provider';
 import { useRegisterCommandMenuCallback } from '@/contexts/command-menu-callback';
 import { useSearchChatsQuery } from '@/queries/use-search-chats-query';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
+import { usePermissions } from '@/hooks/use-permissions';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 
 type CommandConfig = {
@@ -34,6 +35,7 @@ export function CommandMenu() {
 	const debouncedSearch = useDebouncedValue(searchValue, 300);
 	const navigate = useNavigate();
 	const { theme, setTheme } = useTheme();
+	const { canStartNewChat } = usePermissions();
 
 	const toggleOpen = useCallback(() => setOpen((prev) => !prev), []);
 	useRegisterCommandMenuCallback(toggleOpen, [toggleOpen]);
@@ -55,6 +57,7 @@ export function CommandMenu() {
 				action: () => navigate({ to: '/' }),
 				shortcut: '⇧⌘O',
 				group: 'Jump to',
+				visible: canStartNewChat,
 			},
 			{
 				id: 'open-settings',
@@ -73,10 +76,13 @@ export function CommandMenu() {
 				group: 'Actions',
 			},
 		],
-		[navigate, theme, setTheme],
+		[navigate, theme, setTheme, canStartNewChat],
 	);
 
-	const jumpToCommands = useMemo(() => commands.filter((cmd) => cmd.group === 'Jump to'), [commands]);
+	const jumpToCommands = useMemo(
+		() => commands.filter((cmd) => cmd.group === 'Jump to' && (cmd.visible ?? true)),
+		[commands],
+	);
 	const actionCommands = useMemo(() => commands.filter((cmd) => cmd.group === 'Actions'), [commands]);
 
 	useEffect(() => {

--- a/apps/frontend/src/components/permission-gate.tsx
+++ b/apps/frontend/src/components/permission-gate.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import type { PermissionKey } from '@/hooks/use-permissions';
+import { usePermissions } from '@/hooks/use-permissions';
+
+interface PermissionGateProps {
+	permission: PermissionKey;
+	children: ReactNode;
+	fallback?: ReactNode;
+}
+
+export function PermissionGate({ permission, children, fallback = null }: PermissionGateProps) {
+	const permissions = usePermissions();
+	return permissions[permission] ? children : fallback;
+}

--- a/apps/frontend/src/components/settings/memories.tsx
+++ b/apps/frontend/src/components/settings/memories.tsx
@@ -22,18 +22,18 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { SettingsMemoryItem, SettingsMemorySkeleton } from '@/components/settings/memory-item';
 import { useMemoriesQuery, useMemoryMutations, useMemorySettingsQuery } from '@/queries/use-memories';
+import { usePermissions } from '@/hooks/use-permissions';
 import { trpc } from '@/main';
 import { cn } from '@/lib/utils';
 
 export function SettingsMemories() {
 	const projectMemorySettings = useQuery(trpc.project.getMemorySettings.queryOptions());
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const memorySettings = useMemorySettingsQuery();
+	const { isAdmin } = usePermissions();
 
 	const { updateMemorySettingsMutation, updateMutation, deleteMutation } = useMemoryMutations();
 
 	const projectMemoryEnabled = projectMemorySettings.data?.memoryEnabled ?? true;
-	const isAdmin = project.data?.userRole === 'admin';
 	const userMemoryEnabled = memorySettings.data?.memoryEnabled ?? true;
 	const isProjectDisabled = !projectMemoryEnabled;
 	const isUserDisabled = !userMemoryEnabled;

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -131,7 +131,9 @@ export function SidebarSettingsNav({
 	const [query, setQuery] = useState('');
 
 	const navItems = settingsNavItems.filter(
-		(item) => item.visible?.({ isAdmin, isCloud, isViewer, isInMultipleProjects: projects.length > 1, hasLicense }) ?? true,
+		(item) =>
+			item.visible?.({ isAdmin, isCloud, isViewer, isInMultipleProjects: projects.length > 1, hasLicense }) ??
+			true,
 	);
 	const canSwitchProjects = projects.length > 1 && !!currentProjectId;
 

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -15,12 +15,15 @@ interface NavContext {
 	isAdmin: boolean;
 	isCloud: boolean;
 	hasLicense: boolean;
+	isViewer: boolean;
+	isInMultipleProjects: boolean;
 }
 
 interface NavItem {
 	label: string;
 	to?: string;
 	visible?: (ctx: NavContext) => boolean;
+	disabled?: (ctx: NavContext) => boolean;
 	type?: 'divider' | 'item';
 }
 
@@ -36,10 +39,13 @@ const settingsNavItems: NavItem[] = [
 	{
 		label: 'Organization',
 		to: '/settings/organization',
+		visible: ({ isViewer }) => !isViewer,
 	},
 	{
 		label: 'Project',
 		to: '/settings/project',
+		visible: ({ isInMultipleProjects }) => isInMultipleProjects,
+		disabled: ({ isViewer }) => isViewer,
 	},
 	{
 		label: 'Observability',
@@ -74,10 +80,12 @@ const settingsNavItems: NavItem[] = [
 	{
 		label: 'Context',
 		type: 'divider',
+		visible: ({ isViewer }) => !isViewer,
 	},
 	{
 		label: 'Memory',
 		to: '/settings/memory',
+		visible: ({ isViewer }) => !isViewer,
 	},
 	{
 		label: 'File Explorer',
@@ -89,6 +97,7 @@ const settingsNavItems: NavItem[] = [
 interface SidebarSettingsNavProps {
 	isCollapsed: boolean;
 	isAdmin: boolean;
+	isViewer: boolean;
 	isCloud: boolean;
 	hasLicense: boolean;
 	projects: ProjectOption[];
@@ -110,6 +119,7 @@ function dedupeByPage(results: FuseResult<SettingsSearchEntry>[]) {
 export function SidebarSettingsNav({
 	isCollapsed,
 	isAdmin,
+	isViewer,
 	isCloud,
 	hasLicense,
 	projects,
@@ -120,12 +130,14 @@ export function SidebarSettingsNav({
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [query, setQuery] = useState('');
 
-	const navItems = settingsNavItems.filter((item) => item.visible?.({ isAdmin, isCloud, hasLicense }) ?? true);
+	const navItems = settingsNavItems.filter(
+		(item) => item.visible?.({ isAdmin, isCloud, isViewer, isInMultipleProjects: projects.length > 1, hasLicense }) ?? true,
+	);
 	const canSwitchProjects = projects.length > 1 && !!currentProjectId;
 
 	useEffect(() => {
 		const handleSlashKey = (e: KeyboardEvent) => {
-			if (e.key !== '/' || isCollapsed) {
+			if (e.key !== '/' || isCollapsed || isViewer) {
 				return;
 			}
 			const tag = (e.target as HTMLElement)?.tagName;
@@ -137,7 +149,7 @@ export function SidebarSettingsNav({
 		};
 		document.addEventListener('keydown', handleSlashKey);
 		return () => document.removeEventListener('keydown', handleSlashKey);
-	}, [isCollapsed]);
+	}, [isCollapsed, isViewer]);
 
 	const fuse = useMemo(() => {
 		const entries = settingsSearchIndex.filter(
@@ -176,42 +188,44 @@ export function SidebarSettingsNav({
 
 	return (
 		<div className={cn('flex flex-col gap-1', hideIf(isCollapsed))}>
-			<div className='px-2 pt-2'>
-				<div className='relative'>
-					<Search className='absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none' />
-					<input
-						ref={inputRef}
-						type='text'
-						placeholder='Search settings...'
-						value={query}
-						onChange={(e) => setQuery(e.target.value)}
-						onKeyDown={handleKeyDown}
-						className={cn(
-							'w-full rounded-lg border border-input bg-transparent py-1.5 pl-8 pr-8 text-sm',
-							'placeholder:text-muted-foreground',
-							'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+			{!isViewer && (
+				<div className='px-2 pt-2'>
+					<div className='relative'>
+						<Search className='absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none' />
+						<input
+							ref={inputRef}
+							type='text'
+							placeholder='Search settings...'
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							onKeyDown={handleKeyDown}
+							className={cn(
+								'w-full rounded-lg border border-input bg-transparent py-1.5 pl-8 pr-8 text-sm',
+								'placeholder:text-muted-foreground',
+								'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+							)}
+						/>
+						{query ? (
+							<button
+								type='button'
+								onClick={() => {
+									setQuery('');
+									inputRef.current?.focus();
+								}}
+								className='absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'
+							>
+								<X className='size-3.5' />
+							</button>
+						) : (
+							<kbd className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-[10px] font-mono text-muted-foreground border border-border rounded px-1'>
+								/
+							</kbd>
 						)}
-					/>
-					{query ? (
-						<button
-							type='button'
-							onClick={() => {
-								setQuery('');
-								inputRef.current?.focus();
-							}}
-							className='absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'
-						>
-							<X className='size-3.5' />
-						</button>
-					) : (
-						<kbd className='absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-[10px] font-mono text-muted-foreground border border-border rounded px-1'>
-							/
-						</kbd>
-					)}
+					</div>
 				</div>
-			</div>
+			)}
 
-			{isSearching ? (
+			{isSearching && !isViewer ? (
 				<div className='flex flex-col gap-0.5 px-2 pt-1'>
 					{results.length === 0 ? (
 						<div className='px-3 py-4 text-xs text-muted-foreground text-center'>No results found</div>
@@ -250,23 +264,40 @@ export function SidebarSettingsNav({
 						}
 
 						const isProjectItem = item.to === '/settings/project';
+						const isDisabled =
+							item.disabled?.({
+								isAdmin,
+								isCloud,
+								isViewer,
+								isInMultipleProjects: projects.length > 1,
+								hasLicense,
+							}) ?? false;
 
 						return (
 							<div key={item.to} className='flex flex-col'>
-								<Link
-									to={item.to}
-									className={cn(
-										'flex items-center gap-3 px-3 py-2 text-sm rounded-md transition-colors whitespace-nowrap',
-									)}
-									activeProps={{
-										className: cn('bg-sidebar-accent text-foreground font-medium'),
-									}}
-									inactiveProps={{
-										className: cn('hover:bg-sidebar-accent hover:text-foreground'),
-									}}
-								>
-									{item.label}
-								</Link>
+								{isDisabled ? (
+									<span
+										className='flex items-center gap-3 px-3 py-2 text-sm rounded-md whitespace-nowrap cursor-not-allowed'
+										aria-disabled='true'
+									>
+										{item.label}
+									</span>
+								) : (
+									<Link
+										to={item.to}
+										className={cn(
+											'flex items-center gap-3 px-3 py-2 text-sm rounded-md transition-colors whitespace-nowrap',
+										)}
+										activeProps={{
+											className: cn('bg-sidebar-accent text-foreground font-medium'),
+										}}
+										inactiveProps={{
+											className: cn('hover:bg-sidebar-accent hover:text-foreground'),
+										}}
+									>
+										{item.label}
+									</Link>
+								)}
 								{isProjectItem && canSwitchProjects && currentProjectId && (
 									<ProjectSwitcherSubItem
 										projects={projects}

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -48,7 +48,7 @@ export function Sidebar() {
 		}
 	}, [locationPath]); // eslint-disable-line react-hooks/exhaustive-deps
 
-	const handleStartNewChat = useCallback(() => {
+	const handleNavigateHome = useCallback(() => {
 		navigate({ to: '/' });
 		if (isMobile) {
 			closeMobile();
@@ -76,13 +76,13 @@ export function Sidebar() {
 			}
 			if (e.shiftKey && e.metaKey && e.key.toLowerCase() === 'o') {
 				e.preventDefault();
-				handleStartNewChat();
+				handleNavigateHome();
 			}
 		};
 
 		window.addEventListener('keydown', handleKeyDown);
 		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [handleStartNewChat, isViewer]);
+	}, [handleNavigateHome, isViewer]);
 
 	useEffect(() => {
 		if (!project.data?.id) {
@@ -158,8 +158,8 @@ export function Sidebar() {
 						<div className='flex items-center relative'>
 							<button
 								type='button'
-								onClick={handleStartNewChat}
-								aria-label='New chat'
+								onClick={handleNavigateHome}
+								aria-label={isViewer ? 'View shared items' : 'New chat'}
 								className={cn(
 									'flex items-center justify-center p-2 mr-auto absolute left-0 z-0 rounded-md cursor-pointer hover:bg-sidebar-accent transition-[opacity,visibility,background-color] duration-300',
 									hideIf(effectiveIsCollapsed),
@@ -199,7 +199,7 @@ export function Sidebar() {
 								label='New chat'
 								shortcut='⇧⌘O'
 								isCollapsed={effectiveIsCollapsed}
-								onClick={handleStartNewChat}
+								onClick={handleNavigateHome}
 							/>
 						)}
 						<SidebarMenuButton

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -232,7 +232,12 @@ export function Sidebar() {
 					onProjectChange={handleProjectChange}
 				/>
 			) : (
-				<SidebarNav isCollapsed={effectiveIsCollapsed} groupBy={groupBy} filters={filters}  isViewer={isViewer} />
+				<SidebarNav
+					isCollapsed={effectiveIsCollapsed}
+					groupBy={groupBy}
+					filters={filters}
+					isViewer={isViewer}
+				/>
 			)}
 
 			<div className={cn('mt-auto transition-[padding] duration-300', effectiveIsCollapsed ? 'p-1' : 'p-2')}>
@@ -340,9 +345,9 @@ function SidebarNav({
 						'No chats shared with you.'
 					) : (
 						<>
-					No chats yet.
-					<br />
-					Start a new chat!
+							No chats yet.
+							<br />
+							Start a new chat!
 						</>
 					)}
 				</p>

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -21,6 +21,7 @@ import { useTimeAgo } from '@/hooks/use-time-ago';
 import { getActiveProjectId, setActiveProjectId } from '@/lib/active-project';
 import { cn, hideIf } from '@/lib/utils';
 import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export function Sidebar() {
 	const navigate = useNavigate();
@@ -32,7 +33,7 @@ export function Sidebar() {
 	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
 	const license = useQuery(trpc.license.getStatus.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin, isViewer } = usePermissions();
 	const isCloud = config.data?.naoMode === 'cloud';
 	const { groupBy, filters, setGroupBy, toggleFilter } = useChatViewPreferences();
 	const hasLicense = license.data?.tokenProvided === true;
@@ -70,6 +71,9 @@ export function Sidebar() {
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
+			if (isViewer) {
+				return;
+			}
 			if (e.shiftKey && e.metaKey && e.key.toLowerCase() === 'o') {
 				e.preventDefault();
 				handleStartNewChat();
@@ -78,7 +82,7 @@ export function Sidebar() {
 
 		window.addEventListener('keydown', handleKeyDown);
 		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [handleStartNewChat]);
+	}, [handleStartNewChat, isViewer]);
 
 	useEffect(() => {
 		if (!project.data?.id) {
@@ -189,13 +193,15 @@ export function Sidebar() {
 							)}
 						</div>
 
-						<SidebarMenuButton
-							icon={PlusIcon}
-							label='New chat'
-							shortcut='⇧⌘O'
-							isCollapsed={effectiveIsCollapsed}
-							onClick={handleStartNewChat}
-						/>
+						{!isViewer && (
+							<SidebarMenuButton
+								icon={PlusIcon}
+								label='New chat'
+								shortcut='⇧⌘O'
+								isCollapsed={effectiveIsCollapsed}
+								onClick={handleStartNewChat}
+							/>
+						)}
 						<SidebarMenuButton
 							icon={SearchIcon}
 							label='Search chats'
@@ -218,6 +224,7 @@ export function Sidebar() {
 				<SidebarSettingsNav
 					isCollapsed={effectiveIsCollapsed}
 					isAdmin={isAdmin}
+					isViewer={isViewer}
 					isCloud={isCloud}
 					hasLicense={hasLicense}
 					projects={projects.data ?? []}
@@ -225,7 +232,7 @@ export function Sidebar() {
 					onProjectChange={handleProjectChange}
 				/>
 			) : (
-				<SidebarNav isCollapsed={effectiveIsCollapsed} groupBy={groupBy} filters={filters} />
+				<SidebarNav isCollapsed={effectiveIsCollapsed} groupBy={groupBy} filters={filters}  isViewer={isViewer} />
 			)}
 
 			<div className={cn('mt-auto transition-[padding] duration-300', effectiveIsCollapsed ? 'p-1' : 'p-2')}>
@@ -303,18 +310,19 @@ function SidebarNav({
 	isCollapsed,
 	groupBy,
 	filters,
+	isViewer,
 }: {
 	isCollapsed: boolean;
 	groupBy: ChatGroupBy;
 	filters: ChatFilterType[];
+	isViewer: boolean;
 }) {
 	const groupedChats = useQuery({
 		...trpc.chat.listGrouped.queryOptions({ groupBy, filters }),
 		placeholderData: keepPreviousData,
 	});
 	const groups = groupedChats.data?.groups;
-	const isEmpty = groups && groups.every((g) => g.chats.length === 0);
-
+	const isEmpty = groups?.every((group) => group.chats.length === 0);
 	return (
 		<div
 			className={cn(
@@ -328,9 +336,15 @@ function SidebarNav({
 
 			{isEmpty && (
 				<p className='text-sm text-muted-foreground text-center p-4'>
+					{isViewer ? (
+						'No chats shared with you.'
+					) : (
+						<>
 					No chats yet.
 					<br />
 					Start a new chat!
+						</>
+					)}
 				</p>
 			)}
 		</div>

--- a/apps/frontend/src/components/viewer-home.tsx
+++ b/apps/frontend/src/components/viewer-home.tsx
@@ -1,0 +1,139 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState, useMemo, useCallback } from 'react';
+import type { DisplayMode, GroupBy, SharedItem } from '@/lib/viewer-home';
+import { MobileHeader } from '@/components/mobile-header';
+import { ProjectSelector } from '@/components/project-selector';
+import { ViewerToolbarControls } from '@/components/viewer-toolbar-controls';
+import { ViewerEmptyState, ViewerGroups, ViewerNoResults } from '@/components/viewer-shared-items';
+import { Spinner } from '@/components/ui/spinner';
+import { VIEWER_DISPLAY_KEY, VIEWER_GROUP_KEY, filterItems, getStoredSetting, groupItems } from '@/lib/viewer-home';
+import { setActiveProjectId } from '@/lib/active-project';
+import { trpc } from '@/main';
+
+export function ViewerHome() {
+	const queryClient = useQueryClient();
+	const project = useQuery(trpc.project.getCurrent.queryOptions());
+	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
+	const sharedChats = useQuery(trpc.sharedChat.list.queryOptions());
+	const sharedStories = useQuery(trpc.storyShare.list.queryOptions());
+	const [searchQuery, setSearchQuery] = useState('');
+	const [displayMode, setDisplayMode] = useState<DisplayMode>(() =>
+		getStoredSetting(VIEWER_DISPLAY_KEY, ['grid', 'lines'], 'grid'),
+	);
+	const [groupBy, setGroupBy] = useState<GroupBy>(() =>
+		getStoredSetting(VIEWER_GROUP_KEY, ['type', 'date', 'author'], 'type'),
+	);
+	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
+
+	const handleProjectChange = useCallback(
+		async (projectId: string) => {
+			if (!project.data || projectId === project.data.id) {
+				return;
+			}
+			setActiveProjectId(projectId);
+			await queryClient.invalidateQueries();
+		},
+		[project.data, queryClient],
+	);
+
+	function handleDisplayChange(mode: DisplayMode) {
+		setDisplayMode(mode);
+		localStorage.setItem(VIEWER_DISPLAY_KEY, mode);
+	}
+
+	function handleGroupChange(value: GroupBy) {
+		setGroupBy(value);
+		localStorage.setItem(VIEWER_GROUP_KEY, value);
+	}
+
+	const projectId = project.data?.id;
+
+	const allItems: SharedItem[] = useMemo(() => {
+		const storyItems: SharedItem[] = (sharedStories.data ?? [])
+			.filter((s) => s.projectId === projectId)
+			.map((s) => ({
+				id: s.id,
+				kind: 'story',
+				title: s.title,
+				authorName: s.authorName,
+				createdAt: new Date(s.createdAt),
+				summary: s.summary,
+			}));
+		const chatItems: SharedItem[] = (sharedChats.data ?? [])
+			.filter((c) => c.projectId === projectId)
+			.map((c) => ({
+				id: c.id,
+				kind: 'chat',
+				title: c.title,
+				authorName: c.authorName,
+				createdAt: new Date(c.createdAt),
+				messageBubbles: c.messageBubbles,
+			}));
+		return [...storyItems, ...chatItems];
+	}, [sharedStories.data, sharedChats.data, projectId]);
+
+	const filteredItems = useMemo(() => filterItems(allItems, searchQuery), [allItems, searchQuery]);
+	const groups = useMemo(() => groupItems(filteredItems, groupBy), [filteredItems, groupBy]);
+
+	const isLoading = sharedChats.isLoading || sharedStories.isLoading || project.isLoading;
+	const isEmpty = allItems.length === 0 && !isLoading;
+
+	const projectSelector = project.data && isInMultipleProjects && (
+		<div className='-ml-2 px-4 pt-3 md:px-8 md:pt-4 max-md:hidden'>
+			<ProjectSelector
+				projects={projects.data ?? []}
+				currentProjectId={project.data.id}
+				onChange={handleProjectChange}
+				triggerVariant='ghost'
+			/>
+		</div>
+	);
+
+	if (isLoading) {
+		return (
+			<div className='flex flex-col flex-1 bg-panel min-w-72 overflow-hidden'>
+				<MobileHeader />
+				{projectSelector}
+				<div className='flex flex-1 items-center justify-center'>
+					<Spinner />
+				</div>
+			</div>
+		);
+	}
+
+	if (isEmpty) {
+		return (
+			<div className='flex flex-col flex-1 bg-panel min-w-72 overflow-hidden'>
+				<MobileHeader />
+				{projectSelector}
+				<ViewerEmptyState />
+			</div>
+		);
+	}
+
+	return (
+		<div className='flex flex-col flex-1 h-full overflow-auto bg-panel min-w-72'>
+			<MobileHeader />
+			{projectSelector}
+			<div className='w-full px-4 py-6 md:px-8 md:py-10'>
+				<div className='flex items-center justify-between mb-6 md:mb-8 gap-3 flex-wrap'>
+					<h1 className='text-xl font-semibold tracking-tight'>Shared with me</h1>
+					<ViewerToolbarControls
+						searchQuery={searchQuery}
+						onSearchQueryChange={setSearchQuery}
+						groupBy={groupBy}
+						onGroupByChange={handleGroupChange}
+						displayMode={displayMode}
+						onDisplayModeChange={handleDisplayChange}
+					/>
+				</div>
+
+				{filteredItems.length === 0 && searchQuery.trim() ? (
+					<ViewerNoResults query={searchQuery} />
+				) : (
+					<ViewerGroups groups={groups} displayMode={displayMode} />
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/src/components/viewer-shared-items.tsx
+++ b/apps/frontend/src/components/viewer-shared-items.tsx
@@ -1,0 +1,183 @@
+import { BookOpen, MessageSquare } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import type { ReactNode } from 'react';
+import type { DisplayMode, SharedGroup, SharedItem } from '@/lib/viewer-home';
+import type { MessageBubble } from '@nao/shared/types';
+import { StoryThumbnail } from '@/components/story-thumbnail';
+import StoryIcon from '@/components/ui/story-icon';
+import { formatRelativeDate } from '@/lib/time-ago';
+import { cn } from '@/lib/utils';
+
+export function ViewerGroups({ groups, displayMode }: { groups: SharedGroup[]; displayMode: DisplayMode }) {
+	return (
+		<>
+			{groups.map((group, index) => (
+				<ViewerSection
+					key={group.label}
+					title={group.label}
+					className={index < groups.length - 1 ? 'mb-10' : undefined}
+				>
+					<ViewerItemsList displayMode={displayMode}>
+						{group.items.map((item) =>
+							item.kind === 'story' ? (
+								<SharedStoryCard key={item.id} item={item} displayMode={displayMode} />
+							) : (
+								<SharedChatCard key={item.id} item={item} displayMode={displayMode} />
+							),
+						)}
+					</ViewerItemsList>
+				</ViewerSection>
+			))}
+		</>
+	);
+}
+
+export function ViewerEmptyState() {
+	return (
+		<div className='flex flex-col items-center justify-center flex-1 py-24 text-center'>
+			<StoryIcon className='size-10 text-muted-foreground/40 mb-4' />
+			<p className='text-muted-foreground text-sm'>No shared content yet.</p>
+			<p className='text-muted-foreground/60 text-sm mt-1'>Stories and chats shared with you will appear here.</p>
+		</div>
+	);
+}
+
+export function ViewerNoResults({ query }: { query: string }) {
+	return (
+		<p className='text-muted-foreground text-sm py-12 text-center'>
+			No results matching &ldquo;{query.trim()}&rdquo;
+		</p>
+	);
+}
+
+function ViewerSection({ title, className, children }: { title: string; className?: string; children: ReactNode }) {
+	return (
+		<section className={className}>
+			<div className='flex items-center justify-between mb-4'>
+				<h2 className='text-sm font-medium text-muted-foreground'>{title}</h2>
+			</div>
+			{children}
+		</section>
+	);
+}
+
+function ViewerItemsList({ displayMode, children }: { displayMode: DisplayMode; children: ReactNode }) {
+	return (
+		<div
+			className={cn(
+				displayMode === 'grid' &&
+					'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3',
+				displayMode === 'lines' && 'flex flex-col gap-1',
+			)}
+		>
+			{children}
+		</div>
+	);
+}
+
+function SharedStoryCard({ item, displayMode }: { item: SharedItem; displayMode: DisplayMode }) {
+	const meta = `${item.authorName} · ${formatRelativeDate(item.createdAt)}`;
+
+	if (displayMode === 'lines') {
+		return (
+			<Link
+				to='/stories/shared/$shareId'
+				params={{ shareId: item.id }}
+				className='group flex items-center gap-3 rounded-md px-3 py-2 hover:bg-sidebar-accent'
+			>
+				<BookOpen className='size-3.5 text-muted-foreground shrink-0' />
+				<span className='text-sm font-medium truncate'>{item.title}</span>
+				<span className='ml-auto text-xs text-muted-foreground whitespace-nowrap'>{meta}</span>
+			</Link>
+		);
+	}
+
+	return (
+		<Link
+			to='/stories/shared/$shareId'
+			params={{ shareId: item.id }}
+			className='group relative aspect-[3/4] rounded-lg border bg-background overflow-hidden'
+		>
+			<div className='absolute inset-0 p-3 pb-14'>
+				<StoryThumbnail summary={item.summary as Parameters<typeof StoryThumbnail>[0]['summary']} />
+			</div>
+			<div className='absolute inset-x-0 -bottom-2 bg-gradient-to-t from-background from-45% to-transparent px-3 pb-5 pt-8 transition-transform duration-200 ease-out group-hover:-translate-y-1'>
+				<span className='text-sm font-medium leading-snug line-clamp-2'>{item.title}</span>
+				<span className='block text-[11px] text-muted-foreground mt-0.5 truncate'>{meta}</span>
+			</div>
+		</Link>
+	);
+}
+
+function SharedChatCard({ item, displayMode }: { item: SharedItem; displayMode: DisplayMode }) {
+	const meta = `${item.authorName} · ${formatRelativeDate(item.createdAt)}`;
+
+	if (displayMode === 'lines') {
+		return (
+			<Link
+				to='/shared-chat/$shareId'
+				params={{ shareId: item.id }}
+				className='group flex items-center gap-3 rounded-md px-3 py-2 hover:bg-sidebar-accent'
+			>
+				<MessageSquare className='size-3.5 text-muted-foreground shrink-0' />
+				<span className='text-sm font-medium truncate'>{item.title}</span>
+				<span className='ml-auto text-xs text-muted-foreground whitespace-nowrap'>{meta}</span>
+			</Link>
+		);
+	}
+
+	return (
+		<Link
+			to='/shared-chat/$shareId'
+			params={{ shareId: item.id }}
+			className='group relative aspect-[3/4] rounded-lg border bg-background overflow-hidden'
+		>
+			<div className='absolute inset-0 p-3 pb-14'>
+				<ChatThumbnail bubbles={item.messageBubbles} />
+			</div>
+			<div className='absolute inset-x-0 -bottom-2 bg-gradient-to-t from-background from-45% to-transparent px-3 pb-5 pt-8 transition-transform duration-200 ease-out group-hover:-translate-y-1'>
+				<span className='text-sm font-medium leading-snug line-clamp-2'>{item.title}</span>
+				<span className='block text-[11px] text-muted-foreground mt-0.5 truncate'>{meta}</span>
+			</div>
+		</Link>
+	);
+}
+
+function ChatThumbnail({ bubbles }: { bubbles?: MessageBubble[] }) {
+	if (!bubbles || bubbles.length === 0) {
+		return (
+			<div className='flex h-full items-center justify-center text-muted-foreground/20'>
+				<MessageSquare className='size-10' strokeWidth={1} />
+			</div>
+		);
+	}
+
+	const maxChars = Math.max(...bubbles.map((b) => b.charCount), 1);
+
+	return (
+		<div className='flex flex-col gap-[5px] h-full w-full overflow-hidden'>
+			{bubbles.map((bubble, i) => {
+				const ratio = Math.max(bubble.charCount / maxChars, 0.15);
+				const widthPercent = 30 + ratio * 65;
+				const scale = bubble.role === 'user' ? 1 : 1.6;
+				const heightPx = (14 + Math.min(bubble.charCount / 80, 5) * 10) * scale;
+
+				return (
+					<div
+						key={i}
+						className={cn(
+							'rounded-lg shrink-0',
+							bubble.role === 'user'
+								? 'self-end bg-primary/[0.08] dark:bg-primary/15'
+								: 'self-start bg-muted/70',
+						)}
+						style={{
+							width: `${Math.round(widthPercent)}%`,
+							height: `${Math.round(heightPx)}px`,
+						}}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/frontend/src/components/viewer-toolbar-controls.tsx
+++ b/apps/frontend/src/components/viewer-toolbar-controls.tsx
@@ -1,0 +1,123 @@
+import { LayoutGrid, List, Search, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import type { DisplayMode, GroupBy } from '@/lib/viewer-home';
+import { GROUP_BY_LABELS } from '@/lib/viewer-home';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+export function ViewerToolbarControls({
+	searchQuery,
+	onSearchQueryChange,
+	groupBy,
+	onGroupByChange,
+	displayMode,
+	onDisplayModeChange,
+}: {
+	searchQuery: string;
+	onSearchQueryChange: (value: string) => void;
+	groupBy: GroupBy;
+	onGroupByChange: (value: GroupBy) => void;
+	displayMode: DisplayMode;
+	onDisplayModeChange: (value: DisplayMode) => void;
+}) {
+	return (
+		<div className='flex items-center gap-1'>
+			<SearchInput value={searchQuery} onChange={onSearchQueryChange} />
+			<GroupBySelect value={groupBy} onChange={onGroupByChange} />
+			<DisplayModeToggle value={displayMode} onChange={onDisplayModeChange} />
+		</div>
+	);
+}
+
+function SearchInput({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+	const [open, setOpen] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (open) {
+			inputRef.current?.focus();
+		}
+	}, [open]);
+
+	function handleClose() {
+		setOpen(false);
+		onChange('');
+	}
+
+	function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+		if (event.key === 'Escape') {
+			handleClose();
+		}
+	}
+
+	if (!open) {
+		return (
+			<Button variant='ghost' size='icon-xs' onClick={() => setOpen(true)} aria-label='Search shared content'>
+				<Search className='size-4' strokeWidth={1.5} />
+			</Button>
+		);
+	}
+
+	return (
+		<div className='flex items-center gap-1 rounded-md border px-2 py-0.5'>
+			<Search className='size-3.5 text-muted-foreground shrink-0' />
+			<input
+				ref={inputRef}
+				type='text'
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				onKeyDown={handleKeyDown}
+				placeholder='Search...'
+				className='bg-transparent text-sm outline-none placeholder:text-muted-foreground w-40'
+			/>
+			<button type='button' onClick={handleClose} className='text-muted-foreground hover:text-foreground'>
+				<X className='size-3.5' />
+			</button>
+		</div>
+	);
+}
+
+function GroupBySelect({ value, onChange }: { value: GroupBy; onChange: (value: GroupBy) => void }) {
+	return (
+		<Select value={value} onValueChange={(v) => onChange(v as GroupBy)}>
+			<SelectTrigger variant='ghost' size='sm'>
+				<span className='text-muted-foreground'>Group by</span>
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{(Object.keys(GROUP_BY_LABELS) as GroupBy[]).map((key) => (
+					<SelectItem key={key} value={key}>
+						{GROUP_BY_LABELS[key]}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function DisplayModeToggle({ value, onChange }: { value: DisplayMode; onChange: (value: DisplayMode) => void }) {
+	return (
+		<div className='flex items-center gap-0.5 rounded-md border p-0.5'>
+			<Button
+				variant={value === 'grid' ? 'ghost' : 'ghost-muted'}
+				size='icon-xs'
+				onClick={() => onChange('grid')}
+				className={cn(value === 'grid' && 'bg-accent')}
+				aria-label='Grid view'
+			>
+				<LayoutGrid />
+			</Button>
+			<Button
+				variant={value === 'lines' ? 'ghost' : 'ghost-muted'}
+				size='icon-xs'
+				onClick={() => onChange('lines')}
+				className={cn(value === 'lines' && 'bg-accent')}
+				aria-label='List view'
+			>
+				<List />
+			</Button>
+		</div>
+	);
+}

--- a/apps/frontend/src/hooks/use-permissions.ts
+++ b/apps/frontend/src/hooks/use-permissions.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import type { UserRole } from '@nao/shared/types';
+import { trpc } from '@/main';
+
+export function usePermissions() {
+	const project = useQuery(trpc.project.getCurrent.queryOptions());
+	const org = useQuery(trpc.organization.get.queryOptions());
+	const role = project.data?.userRole as UserRole | undefined;
+
+	return useMemo(
+		() => ({
+			role,
+			isAdmin: role === 'admin',
+			isUser: role === 'user',
+			isViewer: role === 'viewer',
+			isOrgAdmin: org.data?.role === 'admin',
+			canSendMessages: role === 'admin' || role === 'user',
+			canShare: role === 'admin' || role === 'user',
+			canEditSettings: role === 'admin',
+			canInvite: role === 'admin',
+			canViewUsage: role === 'admin',
+			canViewChatReplay: role === 'admin',
+			canStartNewChat: role !== 'viewer' && !!role,
+			canViewSharedObjects: !!role,
+		}),
+		[role, org.data?.role],
+	);
+}
+
+export type Permissions = ReturnType<typeof usePermissions>;
+export type PermissionKey = keyof Omit<Permissions, 'role'>;

--- a/apps/frontend/src/lib/require-admin.ts
+++ b/apps/frontend/src/lib/require-admin.ts
@@ -23,3 +23,10 @@ export async function requireAdminNonCloudWithLicense() {
 		throw redirect({ to: '/settings/account' });
 	}
 }
+
+export async function requireNonViewer() {
+	const project = await queryClient.ensureQueryData(trpc.project.getCurrent.queryOptions());
+	if (!project || project.userRole === 'viewer') {
+		throw redirect({ to: '/settings/account' });
+	}
+}

--- a/apps/frontend/src/lib/viewer-home.ts
+++ b/apps/frontend/src/lib/viewer-home.ts
@@ -1,0 +1,119 @@
+import type { MessageBubble } from '@nao/shared/types';
+
+export type DisplayMode = 'grid' | 'lines';
+export type GroupBy = 'type' | 'date' | 'author';
+
+export const VIEWER_DISPLAY_KEY = 'viewer-home-display-mode';
+export const VIEWER_GROUP_KEY = 'viewer-home-group-by';
+
+export const GROUP_BY_LABELS: Record<GroupBy, string> = {
+	type: 'Type',
+	date: 'Date',
+	author: 'Author',
+};
+
+export type SharedItem = {
+	id: string;
+	kind: 'story' | 'chat';
+	title: string;
+	authorName: string;
+	createdAt: Date;
+	summary?: unknown;
+	messageBubbles?: MessageBubble[];
+};
+
+export type SharedGroup = { label: string; items: SharedItem[] };
+
+export function getStoredSetting<T extends string>(key: string, allowed: T[], fallback: T): T {
+	const stored = localStorage.getItem(key);
+	return allowed.includes(stored as T) ? (stored as T) : fallback;
+}
+
+export function filterItems(items: SharedItem[], query: string): SharedItem[] {
+	const q = query.trim().toLowerCase();
+	if (!q) {
+		return items;
+	}
+	return items.filter((item) => item.title.toLowerCase().includes(q) || item.authorName.toLowerCase().includes(q));
+}
+
+export function groupItems(items: SharedItem[], groupBy: GroupBy): SharedGroup[] {
+	if (items.length === 0) {
+		return [];
+	}
+
+	switch (groupBy) {
+		case 'type':
+			return groupByType(items);
+		case 'date':
+			return groupByDate(items);
+		case 'author':
+			return groupByAuthor(items);
+	}
+}
+
+function groupByType(items: SharedItem[]): SharedGroup[] {
+	const storyItems = items.filter((i) => i.kind === 'story');
+	const chatItems = items.filter((i) => i.kind === 'chat');
+	const groups: SharedGroup[] = [];
+
+	if (storyItems.length > 0) {
+		groups.push({ label: 'Stories', items: storyItems });
+	}
+	if (chatItems.length > 0) {
+		groups.push({ label: 'Chats', items: chatItems });
+	}
+
+	return groups;
+}
+
+function groupByDate(items: SharedItem[]): SharedGroup[] {
+	const now = new Date();
+	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
+	const weekStart = new Date(todayStart.getTime() - todayStart.getDay() * 86_400_000);
+	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+	const buckets: Record<string, SharedItem[]> = {
+		Today: [],
+		Yesterday: [],
+		'This Week': [],
+		'This Month': [],
+		Older: [],
+	};
+
+	const sorted = [...items].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+	for (const item of sorted) {
+		const ts = item.createdAt.getTime();
+		if (ts >= todayStart.getTime()) {
+			buckets['Today'].push(item);
+		} else if (ts >= yesterdayStart.getTime()) {
+			buckets['Yesterday'].push(item);
+		} else if (ts >= weekStart.getTime()) {
+			buckets['This Week'].push(item);
+		} else if (ts >= monthStart.getTime()) {
+			buckets['This Month'].push(item);
+		} else {
+			buckets['Older'].push(item);
+		}
+	}
+
+	return Object.entries(buckets)
+		.filter(([, bucket]) => bucket.length > 0)
+		.map(([label, bucket]) => ({ label, items: bucket }));
+}
+
+function groupByAuthor(items: SharedItem[]): SharedGroup[] {
+	const map = new Map<string, SharedItem[]>();
+
+	for (const item of items) {
+		const group = map.get(item.authorName);
+		if (group) {
+			group.push(item);
+		} else {
+			map.set(item.authorName, [item]);
+		}
+	}
+
+	return [...map.entries()].map(([label, group]) => ({ label, items: group }));
+}

--- a/apps/frontend/src/lib/viewer-home.ts
+++ b/apps/frontend/src/lib/viewer-home.ts
@@ -70,8 +70,10 @@ function groupByType(items: SharedItem[]): SharedGroup[] {
 function groupByDate(items: SharedItem[]): SharedGroup[] {
 	const now = new Date();
 	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-	const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
-	const weekStart = new Date(todayStart.getTime() - todayStart.getDay() * 86_400_000);
+	const yesterdayStart = new Date(todayStart);
+	yesterdayStart.setDate(todayStart.getDate() - 1);
+	const weekStart = new Date(todayStart);
+	weekStart.setDate(todayStart.getDate() - todayStart.getDay());
 	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
 	const buckets: Record<string, SharedItem[]> = {

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Folder, GitFork, Globe, Upload } from 'lucide-react';
 import type { ForkMetadata } from '@nao/backend/chat';
 import type { SelectionData } from '@/components/highlight-bubble';
+import { NEW_CHAT_ID } from '@/lib/ai';
 import { StoryOpenButton } from '@/components/story-open-button';
 import { StoryViewer } from '@/components/side-panel/story-viewer';
 import { ChatInput } from '@/components/chat-input';
@@ -20,6 +21,7 @@ import { SidePanelProvider } from '@/contexts/side-panel';
 import { EditableChatTitle } from '@/components/editable-chat-title';
 import { useChatQuery } from '@/queries/use-chat-query';
 import { ShareChatDialog } from '@/components/share-dialog.chat';
+import { usePermissions } from '@/hooks/use-permissions';
 import { trpc } from '@/main';
 import { SelectionProvider } from '@/contexts/text-selection';
 import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
@@ -30,7 +32,25 @@ export const Route = createFileRoute('/_sidebar-layout/_chat-layout/$chatId')({
 	component: RouteComponent,
 });
 
-export function RouteComponent() {
+function RouteComponent() {
+	const { chatId } = Route.useParams();
+	const { isViewer } = usePermissions();
+	const router = useRouter();
+
+	useEffect(() => {
+		if (isViewer && chatId === NEW_CHAT_ID) {
+			router.navigate({ to: '/' });
+		}
+	}, [isViewer, chatId, router]);
+
+	if (isViewer && chatId === NEW_CHAT_ID) {
+		return null;
+	}
+
+	return <ChatPage />;
+}
+
+function ChatPage() {
 	const { isLoadingMessages, isRunning } = useAgentContext();
 	const router = useRouter();
 	const { chatId } = Route.useParams();
@@ -39,8 +59,8 @@ export function RouteComponent() {
 	const shareQuery = useQuery(trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId: chatId ?? '' }));
 	const isShared = !!shareQuery.data?.shareId;
 	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
-	const hasMultipleProjects = (projects.data?.length ?? 0) > 1;
-	const chatProject = hasMultipleProjects ? projects.data?.find((p) => p.id === chat.data?.projectId) : undefined;
+	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
+	const chatProject = isInMultipleProjects ? projects.data?.find((p) => p.id === chat.data?.projectId) : undefined;
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const sidePanelRef = useRef<HTMLDivElement>(null);

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.index.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.index.tsx
@@ -6,7 +6,9 @@ import { useSession } from '@/lib/auth-client';
 import { capitalize } from '@/lib/utils';
 import { setActiveProjectId } from '@/lib/active-project';
 import { ChatMessages } from '@/components/chat-messages/chat-messages';
+import { ViewerHome } from '@/components/viewer-home';
 import { useAgentContext } from '@/contexts/agent.provider';
+import { usePermissions } from '@/hooks/use-permissions';
 import { SavedPromptSuggestions } from '@/components/chat-saved-prompt-suggestions';
 import { ChatInput } from '@/components/chat-input';
 import { Button } from '@/components/ui/button';
@@ -20,6 +22,14 @@ export const Route = createFileRoute('/_sidebar-layout/_chat-layout/')({
 });
 
 function RouteComponent() {
+	const { isViewer } = usePermissions();
+	if (isViewer) {
+		return <ViewerHome />;
+	}
+	return <HomePage />;
+}
+
+function HomePage() {
 	const { data: session } = useSession();
 	const username = session?.user?.name;
 	const { messages } = useAgentContext();
@@ -29,7 +39,7 @@ function RouteComponent() {
 		retry: false,
 	});
 	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
-	const hasMultipleProjects = (projects.data?.length ?? 0) > 1;
+	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
 	const showProjectSetupCue = project.error?.message === 'No project configured';
 	const emptyStateTitle = showProjectSetupCue
 		? 'Set up a project to start analyzing data'
@@ -47,10 +57,10 @@ function RouteComponent() {
 	);
 
 	return (
-		<div className='flex flex-col h-full flex-1 bg-panel min-w-72 overflow-hidden justify-center relative'>
+		<div className='flex flex-col h-full flex-1 bg-panel min-w-72 overflow-hidden justify-center'>
 			<MobileHeader />
-			{project.data && hasMultipleProjects && (
-				<div className='absolute top-3 left-4 z-10 max-md:hidden'>
+			{project.data && isInMultipleProjects && (
+				<div className='-ml-2 px-4 pt-3 md:px-8 md:pt-4 max-md:hidden'>
 					<ProjectSelector
 						projects={projects.data ?? []}
 						currentProjectId={project.data.id}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import type { UserRole } from '@nao/shared/types';
 
@@ -8,6 +8,7 @@ import { EditMemberDialog } from '@/components/settings/team';
 import { signOut, useSession } from '@/lib/auth-client';
 import { SettingsVersionInfo } from '@/components/settings/version-info';
 import { useAuthRoute } from '@/hooks/use-auth-route';
+import { usePermissions } from '@/hooks/use-permissions';
 import { UserProfileCard } from '@/components/settings/profile-card';
 import { useLocalStorage } from '@/hooks/use-local-storage';
 import { soundNotificationStorage } from '@/hooks/use-stream-end-sound';
@@ -26,10 +27,9 @@ function GeneralPage() {
 	const { data: session, refetch } = useSession();
 	const user = session?.user;
 	const queryClient = useQueryClient();
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
+	const { isAdmin, role } = usePermissions();
 	const [soundEnabled, setSoundEnabled] = useLocalStorage(soundNotificationStorage);
 
-	const isAdmin = project.data?.userRole === 'admin';
 	const navigation = useAuthRoute();
 
 	const [editOpen, setEditOpen] = useState(false);
@@ -42,7 +42,7 @@ function GeneralPage() {
 					id: user.id,
 					name: user.name,
 					email: user.email,
-					role: project.data?.userRole ?? 'user',
+					role: role ?? 'user',
 				}
 			: null;
 

--- a/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
@@ -27,7 +27,7 @@ function GeneralPage() {
 	const { data: session, refetch } = useSession();
 	const user = session?.user;
 	const queryClient = useQueryClient();
-	const { isAdmin, role } = usePermissions();
+	const { isAdmin, isViewer, role } = usePermissions();
 	const [soundEnabled, setSoundEnabled] = useLocalStorage(soundNotificationStorage);
 
 	const navigation = useAuthRoute();
@@ -94,7 +94,7 @@ function GeneralPage() {
 				<SettingsControlRow label='Theme' description='Choose how nao looks.' control={<ThemeSelector />} />
 			</SettingsCard>
 
-			<DangerZone />
+			{!isViewer && <DangerZone />}
 
 			{isAdmin && <SettingsVersionInfo />}
 		</SettingsPageWrapper>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.memory.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.memory.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { SettingsMemories } from '@/components/settings/memories';
+import { requireNonViewer } from '@/lib/require-admin';
 import { SettingsPageWrapper } from '@/components/ui/settings-card';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/memory')({
+	beforeLoad: requireNonViewer,
 	component: MemoryPage,
 });
 

--- a/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
@@ -21,10 +21,13 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { usePermissions } from '@/hooks/use-permissions';
 import { useSession } from '@/lib/auth-client';
+import { requireNonViewer } from '@/lib/require-admin';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/organization')({
+	beforeLoad: requireNonViewer,
 	component: OrganizationPage,
 });
 
@@ -34,7 +37,7 @@ function OrganizationPage() {
 	const org = useQuery(trpc.organization.get.queryOptions());
 	const projectsQuery = useQuery(trpc.organization.getProjects.queryOptions());
 	const membersQuery = useQuery(trpc.organization.getMembers.queryOptions());
-	const isAdmin = org.data?.role === 'admin';
+	const { isOrgAdmin } = usePermissions();
 
 	const githubAvailable = useQuery(trpc.github.isAvailable.queryOptions());
 	const githubStatus = useQuery({
@@ -137,7 +140,7 @@ function OrganizationPage() {
 					title='Members'
 					divide
 					action={
-						isAdmin ? (
+						isOrgAdmin ? (
 							<Button variant='secondary' size='sm' onClick={() => setIsAddOpen(true)}>
 								<Plus />
 								Add Member
@@ -151,7 +154,7 @@ function OrganizationPage() {
 						<TeamMembersList
 							members={members}
 							currentUserId={session?.user?.id}
-							isAdmin={isAdmin}
+							isAdmin={isOrgAdmin}
 							onEdit={setEditMember}
 							onRemove={setRemoveMember}
 							extraActions={(member) => (
@@ -191,7 +194,7 @@ function OrganizationPage() {
 						</div>
 					)}
 				</SettingsCard>
-				<OrgApiKeys isAdmin={isAdmin} />
+				<OrgApiKeys isAdmin={isOrgAdmin} />
 			</div>
 
 			<AddMemberDialog
@@ -205,7 +208,7 @@ function OrganizationPage() {
 				open={!!editMember}
 				onOpenChange={(open) => !open && setEditMember(null)}
 				member={editMember}
-				isAdmin={isAdmin}
+				isAdmin={isOrgAdmin}
 				availableRoles={USER_ROLES}
 				onSubmit={handleEdit}
 			/>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.agent.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.agent.tsx
@@ -1,18 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { SavedPrompts } from '@/components/settings/saved-prompts';
 import { SettingsExperimental } from '@/components/settings/experimental';
 import { SettingsProjectMemory } from '@/components/settings/project-memory';
 import { SettingsWebSearch } from '@/components/settings/web-search';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/agent')({
 	component: ProjectAgentTabPage,
 });
 
 function ProjectAgentTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return (
 		<>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { SettingsCard } from '@/components/ui/settings-card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useLlmProviders } from '@/hooks/use-llm-providers';
+import { usePermissions } from '@/hooks/use-permissions';
 import { toLocalDateString } from '@/lib/utils';
 import { trpc } from '@/main';
 
@@ -36,8 +37,7 @@ function buildFormState(data: { provider: string; limitUsd: number; period: stri
 }
 
 function RouteComponent() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	const { projectConfigs, envProviders } = useLlmProviders();
 	const allConfiguredProviders = useMemo(

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.index.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.index.tsx
@@ -7,6 +7,7 @@ import { GoogleConfigSection } from '@/components/settings/google-credentials-se
 import { SettingsCard } from '@/components/ui/settings-card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
+import { usePermissions } from '@/hooks/use-permissions';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/')({
@@ -15,7 +16,7 @@ export const Route = createFileRoute('/_sidebar-layout/settings/project/')({
 
 function ProjectTabPage() {
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return (
 		<>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.mcp-servers.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.mcp-servers.tsx
@@ -1,15 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { McpSettings } from '@/components/settings/display-mcp';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/mcp-servers')({
 	component: ProjectMcpServersTabPage,
 });
 
 function ProjectMcpServersTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return <McpSettings isAdmin={isAdmin} />;
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.models.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.models.tsx
@@ -1,17 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { LlmProvidersSection } from '@/components/settings/llm-providers-section';
 import { SettingsCard } from '@/components/ui/settings-card';
-import { trpc } from '@/main';
 import { SettingsTranscribe } from '@/components/settings/settings-transcribe';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/models')({
 	component: ProjectModelsTabPage,
 });
 
 function ProjectModelsTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return (
 		<>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.slack.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.slack.tsx
@@ -1,15 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { SlackConfigSection } from '@/components/settings/slack-config-section';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/slack')({
 	component: ProjectSlackTabPage,
 });
 
 function ProjectSlackTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return <SlackConfigSection isAdmin={isAdmin} />;
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
@@ -17,6 +17,7 @@ import { SettingsCard } from '@/components/ui/settings-card';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { usePermissions } from '@/hooks/use-permissions';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/main';
 
@@ -27,9 +28,8 @@ export const Route = createFileRoute('/_sidebar-layout/settings/project/team')({
 function ProjectTeamTabPage() {
 	const { data: session } = useSession();
 	const queryClient = useQueryClient();
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const usersWithRoles = useQuery(trpc.project.listAllUsersWithRoles.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	const [isAddOpen, setIsAddOpen] = useState(false);
 	const [editMember, setEditMember] = useState<TeamMember | null>(null);

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.teams.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.teams.tsx
@@ -1,15 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { TeamsConfigSection } from '@/components/settings/teams-config-section';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/teams')({
 	component: ProjectTeamsTabPage,
 });
 
 function ProjectTeamsTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return <TeamsConfigSection isAdmin={isAdmin} />;
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.telegram.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.telegram.tsx
@@ -1,16 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { TelegramConfigSection } from '@/components/settings/telegram-config-section';
 import { LinkingCodesCard } from '@/components/settings/linking-code-section';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/telegram')({
 	component: ProjectTelegramTabPage,
 });
 
 function ProjectTelegramTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return (
 		<>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
@@ -5,24 +5,23 @@ import { Github } from 'lucide-react';
 import { GitHubRepoPicker } from '@/components/settings/github-repo-picker';
 import { OrgApiKeys } from '@/components/settings/org-api-keys';
 import { SettingsProjectNav } from '@/components/settings/project-nav';
+import { usePermissions } from '@/hooks/use-permissions';
+import { requireNonViewer } from '@/lib/require-admin';
 import { trpc } from '@/main';
 import { Button } from '@/components/ui/button';
 import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
 import { Empty } from '@/components/ui/empty';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project')({
+	beforeLoad: requireNonViewer,
 	component: ProjectPage,
 });
 
 function ProjectPage() {
 	const project = useQuery(trpc.project.getCurrent.queryOptions());
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
-	const org = useQuery({
-		...trpc.organization.get.queryOptions(),
-		enabled: !project.data,
-	});
+	const { isOrgAdmin } = usePermissions();
 	const isCloud = config.data?.naoMode === 'cloud';
-	const isOrgAdmin = org.data?.role === 'admin';
 	const isProjectlessCloud = !project.data && isCloud;
 
 	const emptyMessage = isCloud

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.tsx
@@ -1,19 +1,23 @@
 import { useState } from 'react';
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { Github } from 'lucide-react';
 import { GitHubRepoPicker } from '@/components/settings/github-repo-picker';
 import { OrgApiKeys } from '@/components/settings/org-api-keys';
 import { SettingsProjectNav } from '@/components/settings/project-nav';
 import { usePermissions } from '@/hooks/use-permissions';
-import { requireNonViewer } from '@/lib/require-admin';
-import { trpc } from '@/main';
+import { queryClient, trpc } from '@/main';
 import { Button } from '@/components/ui/button';
 import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
 import { Empty } from '@/components/ui/empty';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project')({
-	beforeLoad: requireNonViewer,
+	beforeLoad: async () => {
+		const project = await queryClient.ensureQueryData(trpc.project.getCurrent.queryOptions());
+		if (project?.userRole === 'viewer') {
+			throw redirect({ to: '/settings/account' });
+		}
+	},
 	component: ProjectPage,
 });
 

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.whatsapp.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.whatsapp.tsx
@@ -1,16 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
 import { WhatsappConfigSection } from '@/components/settings/whatsapp-config-section';
 import { LinkingCodesCard } from '@/components/settings/linking-code-section';
-import { trpc } from '@/main';
+import { usePermissions } from '@/hooks/use-permissions';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/project/whatsapp')({
 	component: ProjectWhatsappTabPage,
 });
 
 function ProjectWhatsappTabPage() {
-	const project = useQuery(trpc.project.getCurrent.queryOptions());
-	const isAdmin = project.data?.userRole === 'admin';
+	const { isAdmin } = usePermissions();
 
 	return (
 		<>

--- a/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
@@ -26,6 +26,7 @@ function SharedChatPage() {
 
 	const queryClient = useQueryClient();
 	const chatQuery = useQuery(trpc.sharedChat.getSharedChat.queryOptions({ shareId }));
+	const isViewer = chatQuery.data?.userRole === 'viewer';
 	const forkMutation = useMutation(
 		trpc.chatFork.fork.mutationOptions({
 			onSuccess: (data) => {
@@ -82,26 +83,28 @@ function SharedChatPage() {
 								</Link>
 							</Button>
 						) : (
-							<Button
-								variant='outline'
-								size='sm'
-								className='ml-auto gap-1.5 shrink-0'
-								onClick={() => forkMutation.mutate({ shareId, type: 'chat' })}
-								disabled={forkMutation.isPending}
-							>
-								{forkMutation.isPending ? (
-									<Spinner className='size-3.5' />
-								) : (
-									<MessageSquare className='size-3.5' />
-								)}
-								<span>Continue chat</span>
-							</Button>
+							!isViewer && (
+								<Button
+									variant='outline'
+									size='sm'
+									className='ml-auto gap-1.5 shrink-0'
+									onClick={() => forkMutation.mutate({ shareId, type: 'chat' })}
+									disabled={forkMutation.isPending}
+								>
+									{forkMutation.isPending ? (
+										<Spinner className='size-3.5' />
+									) : (
+										<MessageSquare className='size-3.5' />
+									)}
+									<span>Continue chat</span>
+								</Button>
+							)
 						)}
 					</header>
 
 					<SelectionProvider key={shareId} persistenceConfig={{ shareId, contentType: 'chat' }}>
-						<ForkBubble shareId={shareId} contentType='chat' />
-						<SelectionChatPanel contentAreaRef={contentAreaRef} />
+						{!isViewer && <ForkBubble shareId={shareId} contentType='chat' />}
+						{!isViewer && <SelectionChatPanel contentAreaRef={contentAreaRef} />}
 						<div className='flex flex-1 min-h-0 min-w-0'>
 							<div ref={contentAreaRef} className='flex-1 min-w-0'>
 								<ChatMessagesReadonly

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -32,6 +32,7 @@ function SharedStoryPage() {
 	const navigate = useNavigate();
 
 	const { data: story, isLoading } = useSuspenseQuery(trpc.storyShare.get.queryOptions({ shareId }));
+	const isViewer = story?.userRole === 'viewer';
 
 	const containerRef = useRef<HTMLDivElement>(null);
 	const sidePanelRef = useRef<HTMLDivElement>(null);
@@ -133,27 +134,29 @@ function SharedStoryPage() {
 								</Link>
 							</Button>
 						) : (
-							<Button
-								variant='outline'
-								size='sm'
-								className='ml-auto gap-1.5 shrink-0'
-								onClick={() => forkMutation.mutate({ shareId, type: 'story' })}
-								disabled={forkMutation.isPending}
-							>
-								{forkMutation.isPending ? (
-									<Loader2 className='size-3.5 animate-spin' />
-								) : (
-									<MessageSquare className='size-3.5' />
-								)}
-								<span>Discuss story</span>
-							</Button>
+							!isViewer && (
+								<Button
+									variant='outline'
+									size='sm'
+									className='ml-auto gap-1.5 shrink-0'
+									onClick={() => forkMutation.mutate({ shareId, type: 'story' })}
+									disabled={forkMutation.isPending}
+								>
+									{forkMutation.isPending ? (
+										<Loader2 className='size-3.5 animate-spin' />
+									) : (
+										<MessageSquare className='size-3.5' />
+									)}
+									<span>Discuss story</span>
+								</Button>
+							)
 						)}
 					</div>
 				</header>
 
 				<SelectionProvider key={shareId} persistenceConfig={{ shareId, contentType: 'story' }}>
-					<ForkBubble shareId={shareId} contentType='story' />
-					<SelectionChatPanel contentAreaRef={contentAreaRef} />
+					{!isViewer && <ForkBubble shareId={shareId} contentType='story' />}
+					{!isViewer && <SelectionChatPanel contentAreaRef={contentAreaRef} />}
 					<div className='flex flex-1 min-h-0 min-w-0'>
 						<div ref={contentAreaRef} className='flex flex-col flex-1 min-w-0 min-h-0'>
 							<SharedStoryContent

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -110,6 +110,8 @@ export interface CitationData {
 	storySlug?: string;
 }
 
+export type MessageBubble = { role: 'user' | 'assistant'; charCount: number };
+
 export const CHAT_GROUP_BY_OPTIONS = ['star', 'date', 'project', 'ownership', 'sourcePlatform', 'none'];
 export const CHAT_FILTER_OPTIONS = ['all', 'mine', 'starred', 'shared', 'shared_with_me'];
 


### PR DESCRIPTION
## Summary

- `Viewer` role implemented 
- `usePermissions` hooks were created to make it easier to determine which components should be displayed based on the user's role
- cleaning of all procedure on backend routes

### New `Viewer` home

<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/37c699a5-eed3-47ab-9d38-036bd2d0a406" />
<img width="1512" height="852" alt="image" src="https://github.com/user-attachments/assets/6c19a55b-c675-4496-9c67-c0b45ac6860d" />

### Setting view with one project

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/a3f1b1ec-9e68-4e19-a2ac-76fb54cce736" />

### Setting view with multiple projects

<img width="1509" height="860" alt="image" src="https://github.com/user-attachments/assets/c74a22a9-7178-4acd-b677-cff715b153f4" />
<img width="1505" height="859" alt="image" src="https://github.com/user-attachments/assets/bf161ec2-30d5-405b-a0b9-a5384f3d472d" />

