### PR TITLE
feat: add assertion-based validation for nao test

### DIFF
--- a/cli/nao_core/commands/test/case.py
+++ b/cli/nao_core/commands/test/case.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+from dataclasses import field
 
 import yaml
 
@@ -16,6 +17,7 @@ class TestCase:
     prompt: str
     file_path: Path
     sql: str
+    assertions: list[dict] = field(default_factory=list)
 
     @classmethod
     def from_yaml(cls, file_path: Path) -> "TestCase":
@@ -28,6 +30,7 @@ class TestCase:
             prompt=data["prompt"],
             sql=data.get("sql"),
             file_path=file_path,
+            assertions=data.get("assertions", [])
         )
 
 

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -20,9 +20,22 @@ from .client import AgentClientError, VerificationResult, get_client
 # Default models to test
 DEFAULT_MODELS = ["openai:gpt-4.1"]
 
+VALID_ASSERTIONS = {
+    "reference_table",
+    "contains_metric",
+    "no_hallucination",
+    "match_regex",
+}
+
 def run_assertion(assertion: dict, response: str) -> tuple[bool, str]:
     a_type= assertion.get("type")
-    val= str(assertion.get("value", ""))
+    val= assertion.get("value")
+
+    if not a_type or val is None:
+        return False, "Invalid assertion: missing type or value"
+
+    if a_type not in VALID_ASSERTIONS:
+        return False, f"Unknown assertion type: {a_type}"
 
     response_low = (response or "").lower()
     val_low= val.lower()
@@ -32,9 +45,12 @@ def run_assertion(assertion: dict, response: str) -> tuple[bool, str]:
             return False, f"Expected to use table '{val}' but it was not found in response."
         
     elif a_type == "match_regex":
-        if not re.search(val, response_low, re.IGNORECASE):
-            return False, f"Pattern not found: {val}"
-        
+        try:
+            if not re.search(val, response, re.IGNORECASE):
+                return False, f"Pattern not found: {val}"
+        except re.error:
+            return False, f"Invalid regex pattern: {val}"
+
     elif a_type == "contains_metric":
         if val_low not in response_low:
             return False, f"Missing metric: {val}"

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -18,6 +19,33 @@ from .client import AgentClientError, VerificationResult, get_client
 
 # Default models to test
 DEFAULT_MODELS = ["openai:gpt-4.1"]
+
+def run_assertion(assertion: dict, response: str) -> tuple[bool, str]:
+    a_type= assertion.get("type")
+    val= str(assertion.get("value", ""))
+
+    response_low = (response or "").lower()
+    val_low= val.lower()
+
+    if a_type == "reference_table":
+        if val_low not in response_low:
+            return False, f"Expected to use table '{val}' but it was not found in response."
+        
+    elif a_type == "match_regex":
+        if not re.search(val, response_low, re.IGNORECASE):
+            return False, f"Pattern not found: {val}"
+        
+    elif a_type == "contains_metric":
+        if val_low not in response_low:
+            return False, f"Missing metric: {val}"
+
+        
+    elif a_type == "no_hallucination":
+        if val_low in response_low:
+            return False, f"Found forbidden term: {val}"
+        
+    return True, ""
+        
 
 
 @dataclass
@@ -185,57 +213,54 @@ def run_test(
 
     try:
         result = client.run_test(test_case, provider=model.provider, model_id=model.model_id)
+        response_text = result.text or ""
 
-        if result.text:
-            UI.print(f"[dim]  Response: {result.text[:200]}...[/dim]")
+        # 1. Start with a clean slate
+        passed, msg, comparison = True, "match", None
 
-        tool_call_count = len(result.tool_calls) if result.tool_calls else 0
-        if result.tool_calls:
-            tools = [tc.get("toolName") for tc in result.tool_calls]
-            UI.print(f"[dim]  Tool calls: {tool_call_count} {tools}[/dim]")
-
-        UI.print(f"[dim]  Tokens: {result.usage.totalTokens}[/dim]")
-        UI.print(f"[dim]  Cost: ${result.cost.totalCost}[/dim]")
-        UI.print(f"[dim]  Time: {result.duration_ms}ms[/dim]")
-
+        # 2. GATE 1: THE MATH (Data Verification)
         if result.verification:
             passed, msg, comparison = check_dataframe(result.verification)
+
+        # 3. GATE 2: THE LOGIC (Behavioral Assertions)
+        # Only check logic if Gate 1 didn't already fail
+        if passed and test_case.assertions:
+            for a in test_case.assertions:
+                a_passed, a_err = run_assertion(a, response_text)
+                if not a_passed:
+                    passed = False
+                    msg = a_err
+                    break 
+
+        # 4. FINAL REPORTING (Wait until both gates finish)
+        if result.verification or test_case.assertions:
             status = "[green]✓[/green]" if passed else "[red]✗[/red]"
             UI.print(f"  {status} {msg}")
-            return TestRunResult(
-                name=test_case.name,
-                model=str(model),
-                passed=passed,
-                message=msg,
-                tokens=result.usage.totalTokens,
-                cost=result.cost.totalCost,
-                duration_ms=result.duration_ms,
-                tool_call_count=tool_call_count,
-                details=TestRunDetails(
-                    response_text=result.text,
-                    actual_data=result.verification.data,
-                    expected_data=result.verification.expectedData,
-                    comparison=comparison,
-                    tool_calls=result.tool_calls,
-                ),
-            )
+        else:
+            msg = "no verification"
+            UI.print("[yellow]  ⚠ no verification data[/yellow]")
 
-        UI.print("[yellow]  ⚠ no verification data[/yellow]")
+        # 5. SINGLE RETURN (Handles every scenario)
         return TestRunResult(
             name=test_case.name,
             model=str(model),
-            passed=True,
-            message="no verification",
+            passed=passed,
+            message=msg,
             tokens=result.usage.totalTokens,
             cost=result.cost.totalCost,
             duration_ms=result.duration_ms,
-            tool_call_count=tool_call_count,
+            tool_call_count=len(result.tool_calls) if result.tool_calls else 0,
             details=TestRunDetails(
                 response_text=result.text,
+                actual_data=result.verification.data if result.verification else None,
+                expected_data=result.verification.expectedData if result.verification else None,
+                comparison=comparison,
                 tool_calls=result.tool_calls,
             ),
         )
-
+        
+        
+        
     except AgentClientError as e:
         UI.error(str(e))
         return TestRunResult(


### PR DESCRIPTION
## What

Adds support for assertion-based validation in `nao test`.

## Features

* Supports assertion types:

  * `contains_metric`
  * `reference_table`
  * `no_hallucination`
  * `match_regex`
* Validates AI response text in addition to existing SQL/data checks
* Maintains backward compatibility for tests without assertions

## Example

```yaml
assertions:
  - type: contains_metric
    value: revenue
  - type: reference_table
    value: fact_sales
  - type: no_hallucination
    value: user_password_hash
```

## Testing

* Verified assertion logic with multiple pass/fail scenarios
* Ensured no regression in existing functionality
