### PR TITLE
fix: resolve chatId via context in display-chart Add to story (#641)

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -149,9 +149,10 @@ export const DisplayChartToolCall = ({
 			return;
 		}
 
-		const data = await queryClient.fetchQuery(
-			trpc.story.listVersions.queryOptions({ chatId, storySlug: targetId }),
-		);
+		const data = await queryClient.fetchQuery({
+			...trpc.story.listVersions.queryOptions({ chatId, storySlug: targetId }),
+			staleTime: 0,
+		});
 		const latest = data.versions.at(-1);
 		if (!latest) {
 			return;

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -144,7 +144,14 @@ export const DisplayChartToolCall = ({
 	}
 
 	const handleAddToStory = async () => {
-		const targetId = isVisible && currentStorySlug ? currentStorySlug : storyIds[storyIds.length - 1];
+		const latestStoryId = storyIds[storyIds.length - 1];
+		// Prefer the currently-visible story slug, but only if it's a real story
+		// from this chat — the side panel's currentStorySlug can lag behind (e.g.
+		// it was set from a partial streamed slug during the story tool's
+		// input-streaming phase) and would otherwise point to a non-existent
+		// story.
+		const targetId =
+			isVisible && currentStorySlug && storyIds.includes(currentStorySlug) ? currentStorySlug : latestStoryId;
 		if (!targetId || !config || !chatId) {
 			return;
 		}

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -2,7 +2,6 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import { buildChart, labelize } from '@nao/shared';
 import { Download, FilePlus } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
 import { useOptionalAgentContext } from '../../contexts/agent.provider';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '../ui/chart';
 import { TextShimmer } from '../ui/text-shimmer';
@@ -17,6 +16,7 @@ import type { UIMessage } from '@nao/backend/chat';
 import type { DateRange } from '@/lib/charts.utils';
 import { filterByDateRange, sortByDateKey, DATE_RANGE_OPTIONS, toKey } from '@/lib/charts.utils';
 import { findStoryIds } from '@/lib/story.utils';
+import { useChatId } from '@/hooks/use-chat-id';
 import { useSidePanel } from '@/contexts/side-panel';
 import { StoryViewer } from '@/components/side-panel/story-viewer';
 import { trpc } from '@/main';
@@ -32,7 +32,7 @@ export const DisplayChartToolCall = ({
 }: ToolCallComponentProps<'display_chart'>) => {
 	const agent = useOptionalAgentContext();
 	const messages = agent?.messages ?? EMPTY_MESSAGES;
-	const { chatId } = useParams({ strict: false });
+	const chatId = useChatId();
 	const queryClient = useQueryClient();
 	const { open: openSidePanel, currentStorySlug, isVisible } = useSidePanel();
 	const config = state !== 'input-streaming' ? input : undefined;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #641

## Repro

1. Ask for a chart.
2. Ask the agent to create a simple story.
3. Click "Add to story" on the chart → nothing happens.
4. Reload the page → works.

## Root cause

Three compounding bugs broke the button in this exact flow:

1. **Wrong `chatId` source.** `DisplayChartToolCall` resolved `chatId` with `useParams({ strict: false }).chatId`, which is `undefined` in any chat surface where the route doesn't expose `chatId` (home, shared chats, selection chat panel). `handleAddToStory` then exited at its early `!chatId` guard.

2. **Stale react-query cache.** When the `story` tool runs with `action: 'create'`, `StoryToolCall` auto-opens the `StoryViewer` during `input-streaming`. The viewer's `useQuery` fires `story.listVersions` before the story is persisted and caches `{ versions: [] }` under the default 5-minute `staleTime`. `handleAddToStory` read from that cached empty response and exited because `data.versions.at(-1)` was `undefined`.

3. **Stale side-panel slug (the actual user-hit bug).** The story tool's `input.id` is streamed progressively; the first value that makes it into `StoryToolCall` is often a *partial* slug like `"test"` when the final slug is `"test-story"`. The auto-open captures that partial value into the side panel's `currentStorySlug` and it's never resynced. `handleAddToStory` preferred `currentStorySlug` over the slug from the conversation messages, so it queried `listVersions` for the non-existent `"test"` and silently exited. Reloading cleared the side-panel state, which is why the button worked only after a refresh.

Observed in a real-LLM run (headless Chrome):

```
listVersions cache entries:
  key: [..., "storySlug":"test"]         → title=test, versions=0          ← partial streamed slug
  key: [..., "storySlug":"test-story"]   → title=Test Story, versions=1    ← committed slug
```

## Fix

- `display-chart.tsx`: resolve `chatId` via `useChatId()` (falls back to `ChatIdContext` set by `AgentProvider` / `SelectionChatPanel`).
- `display-chart.tsx`: pass `staleTime: 0` to `fetchQuery` so the handler always hits the server after a story commit.
- `display-chart.tsx`: only trust the side panel's `currentStorySlug` when it actually exists in the conversation's story IDs; otherwise fall back to the last story slug from the agent messages. This handles the partial-slug-from-streaming case.

## Walkthrough

Reproduction: seeded chat with a chart + committed story, then manually set `currentStorySlug` to a partial slug (`"revenue-analy"` vs. `"revenue-analysis"`) — exactly what the auto-open does during `input-streaming`.

Before fix:
```
=== API calls ===
200 story.listVersions
createVersion fired? false    ← bug
```

After fix:
```
=== API calls ===
200 story.listVersions
200 story.createVersion
createVersion fired? true     ← fixed
```

[Chart](https://cursor.com/agents/bc-839c293d-9a8b-4937-bbd0-ebf3a3412b3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_partial_slug_after_click.png)

## Testing

- ✅ `npm run lint` (tsc + eslint across backend, frontend, shared)
- ✅ Headless Chrome repro with an injected empty `listVersions` cache — confirms `staleTime: 0` bypasses the stale cache.
- ✅ Headless Chrome repro with a partial `currentStorySlug` — confirms the fallback to `storyIds[storyIds.length - 1]` picks up the real story and `createVersion` fires.
- ✅ Regular happy-path click still works and opens the side panel with the new story version.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-839c293d-9a8b-4937-bbd0-ebf3a3412b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-839c293d-9a8b-4937-bbd0-ebf3a3412b3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

