### PR TITLE
fix: exit non-zero when nao sync fails

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -334,6 +334,7 @@ class DatabaseSyncProvider(SyncProvider):
                     total_tables += state.tables_synced
                 except Exception as e:
                     console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {e}")
+                    return SyncResult.from_error(self.name, e)
 
         for state in sync_states:
             removed = cleanup_stale_paths(state, verbose=True)

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -209,6 +209,7 @@ class RepositorySyncProvider(SyncProvider):
 
         output_path.mkdir(parents=True, exist_ok=True)
         success_count = 0
+        failed_repos: list[str] = []
 
         console.print(f"\n[bold cyan]{self.emoji} Syncing {self.name}[/bold cyan]")
         console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
@@ -217,5 +218,14 @@ class RepositorySyncProvider(SyncProvider):
             if sync_repo(repo, output_path):
                 success_count += 1
                 console.print(f"  [green]✓[/green] {repo.name}")
+            else:
+                failed_repos.append(repo.name)
+
+        if failed_repos:
+            return SyncResult(
+                provider_name=self.name,
+                items_synced=success_count,
+                error=f"Failed to sync repos: {', '.join(failed_repos)}",
+            )
 
         return SyncResult(provider_name=self.name, items_synced=success_count)


### PR DESCRIPTION
Description:

## Summary
- `nao sync` now exits with non-zero code when database or repository sync fails
- This ensures CI pipelines correctly report failures instead of showing green checks

## Changes
- **databases/provider.py**: Return `SyncResult.from_error()` when database sync fails (e.g., missing ibis-framework)
- **repositories/provider.py**: Track failed repos and return error result if any fail

## Why
Previously, `nao sync` printed "✗ Failed

closes #689 