### PR TITLE
fix(backend): invalidate .naoignore cache when file changes

### DIFF
--- a/apps/backend/src/utils/tools.ts
+++ b/apps/backend/src/utils/tools.ts
@@ -26,41 +26,64 @@ export const createTool = <TInput, TOutput>(
  */
 export const EXCLUDED_DIRS = ['.meta'];
 
+type NaoignoreCacheEntry = {
+	/** `mtimeMs:size` of the .naoignore file, or `null` if the file does not exist */
+	signature: string | null;
+	patterns: string[];
+};
+
 /**
  * Cache for .naoignore patterns per project folder.
+ * Entries are invalidated automatically when the underlying file changes.
  */
-const naoignoreCache = new Map<string, string[]>();
+const naoignoreCache = new Map<string, NaoignoreCacheEntry>();
+
+/**
+ * Computes a cheap fingerprint of the .naoignore file used to detect changes.
+ * Returns `null` when the file does not exist or cannot be stat-ed.
+ */
+const getNaoignoreSignature = (naoignorePath: string): string | null => {
+	try {
+		const stat = fs.statSync(naoignorePath);
+		return `${stat.mtimeMs}:${stat.size}`;
+	} catch {
+		return null;
+	}
+};
 
 /**
  * Loads and parses the .naoignore file from the project folder.
- * Returns an array of patterns. Results are cached per project folder.
+ * Returns an array of patterns. Results are cached per project folder and
+ * invalidated when the file's mtime or size changes.
  */
 export const loadNaoignorePatterns = (projectFolder: string): string[] => {
-	if (naoignoreCache.has(projectFolder)) {
-		return naoignoreCache.get(projectFolder)!;
+	const naoignorePath = path.join(projectFolder, '.naoignore');
+	const signature = getNaoignoreSignature(naoignorePath);
+
+	const cached = naoignoreCache.get(projectFolder);
+	if (cached && cached.signature === signature) {
+		return cached.patterns;
 	}
 
-	const naoignorePath = path.join(projectFolder, '.naoignore');
 	let patterns: string[] = [];
-
-	try {
-		if (fs.existsSync(naoignorePath)) {
+	if (signature !== null) {
+		try {
 			const content = fs.readFileSync(naoignorePath, 'utf-8');
 			patterns = content
 				.split('\n')
 				.map((line) => line.trim())
-				.filter((line) => line && !line.startsWith('#')); // Filter empty lines and comments
+				.filter((line) => line && !line.startsWith('#'));
+		} catch {
+			// If we can't read the file, fall back to empty patterns
 		}
-	} catch {
-		// If we can't read the file, return empty patterns
 	}
 
-	naoignoreCache.set(projectFolder, patterns);
+	naoignoreCache.set(projectFolder, { signature, patterns });
 	return patterns;
 };
 
 /**
- * Clears the naoignore cache. Useful for testing or when the .naoignore file changes.
+ * Clears the naoignore cache. Useful for testing or to force a reload.
  */
 export const clearNaoignoreCache = (): void => {
 	naoignoreCache.clear();

--- a/apps/backend/tests/tools-paths.test.ts
+++ b/apps/backend/tests/tools-paths.test.ts
@@ -10,10 +10,16 @@ async function loadTools(variant: 'posix' | 'win32') {
 	const pathModule = await import('path');
 	const impl = pathModule[variant];
 	vi.doMock('path', () => ({ ...impl, default: impl }));
+	const statSync = () => {
+		const err = new Error('ENOENT') as NodeJS.ErrnoException;
+		err.code = 'ENOENT';
+		throw err;
+	};
 	vi.doMock('fs', () => ({
-		default: { existsSync: () => false, readFileSync: () => '' },
+		default: { existsSync: () => false, readFileSync: () => '', statSync },
 		existsSync: () => false,
 		readFileSync: () => '',
+		statSync,
 	}));
 
 	const tools = await import('../src/utils/tools');
@@ -264,5 +270,78 @@ describe('isWithinProjectFolder', () => {
 				false,
 			);
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadNaoignorePatterns cache invalidation
+// ---------------------------------------------------------------------------
+
+describe('loadNaoignorePatterns cache invalidation', () => {
+	async function loadToolsWithFs(files: { content: string; mtimeMs: number; size?: number }[]) {
+		vi.resetModules();
+
+		const pathModule = await import('path');
+		const impl = pathModule.posix;
+		vi.doMock('path', () => ({ ...impl, default: impl }));
+
+		let callIndex = 0;
+		const nextFile = () => {
+			const file = files[Math.min(callIndex, files.length - 1)];
+			callIndex += 1;
+			return file;
+		};
+
+		const statSync = () => {
+			const file = nextFile();
+			return { mtimeMs: file.mtimeMs, size: file.size ?? file.content.length };
+		};
+		const readFileSync = () => nextFile().content;
+
+		vi.doMock('fs', () => ({
+			default: { existsSync: () => true, readFileSync, statSync },
+			existsSync: () => true,
+			readFileSync,
+			statSync,
+		}));
+
+		const tools = await import('../src/utils/tools');
+		tools.clearNaoignoreCache();
+		return tools;
+	}
+
+	it('returns cached patterns when the file signature is unchanged', async () => {
+		const { loadNaoignorePatterns } = await loadToolsWithFs([
+			{ content: 'templates/\n', mtimeMs: 1000 },
+			{ content: 'templates/\n', mtimeMs: 1000 },
+			{ content: 'templates/\n', mtimeMs: 1000 },
+		]);
+
+		expect(loadNaoignorePatterns('/project')).toEqual(['templates/']);
+		expect(loadNaoignorePatterns('/project')).toEqual(['templates/']);
+	});
+
+	it('reloads patterns when the file mtime changes', async () => {
+		const { loadNaoignorePatterns } = await loadToolsWithFs([
+			{ content: 'templates/\n', mtimeMs: 1000 },
+			{ content: 'templates/\n', mtimeMs: 1000 },
+			{ content: '*.j2\ntests/\n', mtimeMs: 2000 },
+			{ content: '*.j2\ntests/\n', mtimeMs: 2000 },
+		]);
+
+		expect(loadNaoignorePatterns('/project')).toEqual(['templates/']);
+		expect(loadNaoignorePatterns('/project')).toEqual(['*.j2', 'tests/']);
+	});
+
+	it('reloads patterns when the file size changes', async () => {
+		const { loadNaoignorePatterns } = await loadToolsWithFs([
+			{ content: 'templates/\n', mtimeMs: 1000, size: 11 },
+			{ content: 'templates/\n', mtimeMs: 1000, size: 11 },
+			{ content: 'tests/\n', mtimeMs: 1000, size: 7 },
+			{ content: 'tests/\n', mtimeMs: 1000, size: 7 },
+		]);
+
+		expect(loadNaoignorePatterns('/project')).toEqual(['templates/']);
+		expect(loadNaoignorePatterns('/project')).toEqual(['tests/']);
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The in-memory `.naoignore` pattern cache in `apps/backend/src/utils/tools.ts` never expired for the lifetime of the backend process. When a user edited `.naoignore` (e.g. removed `templates/` to unblock a folder), the agent continued to apply the stale rules until the backend was restarted — files that had just been unignored remained inaccessible to the agent's `list`, `read`, `search`, `grep`, etc. tools.

Reported in Slack: "there is an in-memory cache haha — we should invalidate the in-memory cache if the .naoignore hash changes."

## Fix

Track a lightweight signature of the `.naoignore` file — `mtimeMs:size` from `fs.statSync` — alongside the cached patterns. On every `loadNaoignorePatterns` call we re-stat the file (cheap) and only reuse cached patterns when the signature matches. File creation and deletion are both handled (`signature === null` when the file does not exist).

This means:
- Editing `.naoignore` is picked up on the next tool call — no restart required.
- The hot path still performs a single `statSync` instead of a full read + parse.
- The public API (`loadNaoignorePatterns`, `clearNaoignoreCache`) is unchanged.

## Tests

Added three unit tests in `apps/backend/tests/tools-paths.test.ts` covering:
- Cached patterns are reused when the signature is unchanged.
- Cache is invalidated when `mtimeMs` changes.
- Cache is invalidated when `size` changes (same mtime, different content).

All 42 tests in the `tools-paths` suite pass. `npm run lint` passes across backend / frontend / shared. The pre-commit hook (lint + format + migration checks + CLI checks) also passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b96c1f0-3199-4542-a4d0-a9297560348a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b96c1f0-3199-4542-a4d0-a9297560348a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

