### PR TITLE
fix(cli): repair stale BigQuery `_partition_filter` fallback test

### DIFF
--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -779,12 +779,14 @@ class TestPartitionFilter:
         assert "DATE_SUB(CURRENT_DATE()" in ctx._partition_filter()
 
     def test_fallback_queries_information_schema_for_type(self):
-        ctx, mock_conn = _make_context(partition_metadata=None)
-        mock_conn.raw_sql.side_effect = [
-            [("event_time",)],
-            [],
-            [("TIMESTAMP",)],
-        ]
+        meta = TablePartitionMetadata(
+            partition_column="event_time",
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+        )
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+        mock_conn.raw_sql.side_effect = [[("TIMESTAMP",)]]
         assert "TIMESTAMP_SUB(CURRENT_TIMESTAMP()" in ctx._partition_filter()
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`TestPartitionFilter.test_fallback_queries_information_schema_for_type` in `cli/tests/nao_core/config/test_bigquery_context.py` has been failing on `main` since PR #603 (clustering keys support).

Failing run: https://github.com/getnao/nao/actions/runs/25157275862/job/73742246202

```
AssertionError: assert 'TIMESTAMP_SUB(CURRENT_TIMESTAMP()' in ''
  +  where '' = _partition_filter()
```

## Why

PR #672 introduced `_partition_filter()` with a 3-call sequence: (1) query partition columns, (2) query clustering columns, (3) query data type. PR #603 then removed the SQL-based `partition_columns()` fallback — when `partition_metadata=None`, `partition_columns()` now returns `[]` directly, so `_partition_filter()` short-circuits with `""` before it can exercise the type-resolution fallback this test was written to cover.

## Fix

Update the test to match the current architecture while preserving the original intent (verify `_resolve_partition_column_type` falls back to `INFORMATION_SCHEMA.COLUMNS`): pass metadata that has a partition column but a missing `partition_column_type`, which is the code path where the INFORMATION_SCHEMA type-resolution query still runs.

## Testing

- ✅ `cd cli && uv run pytest tests/nao_core/config/test_bigquery_context.py` (78 passed)
- ✅ `cd cli && uv run pytest --ignore=tests/nao_core/commands/sync/integration/test_mssql.py` (529 passed, 186 skipped — `test_mssql.py` excluded only due to local VM missing `libodbc.so.2`; CI has it)
- ✅ `cd cli && make lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f66ec548-d74e-43ed-b1f5-fb35c630b778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f66ec548-d74e-43ed-b1f5-fb35c630b778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

