### PR TITLE
fix: resolve trino connector failure when password is configured

### DIFF
--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -28,6 +28,12 @@ def _is_excluded_schema(value: object) -> bool:
     return not schema or schema in {"none", "null"} or schema in EXCLUDED_SCHEMAS or schema.startswith("pg_")
 
 
+def _build_basic_auth(user: str, password: str):
+    from trino.auth import BasicAuthentication
+
+    return BasicAuthentication(user, password)
+
+
 class TrinoDatabaseContext(DatabaseContext):
     def _array_unnest_join(self, table_sql: str, col_sql: str, alias: str) -> str:
         return f"{table_sql} CROSS JOIN UNNEST({col_sql}) AS t({alias})"
@@ -123,7 +129,7 @@ class TrinoConfig(DatabaseConfig):
             kwargs["schema"] = self.schema_name
 
         if self.password:
-            kwargs["password"] = self.password
+            kwargs["auth"] = _build_basic_auth(self.user, self.password)
 
         return ibis.trino.connect(**kwargs)
 

--- a/cli/tests/nao_core/config/test_trino.py
+++ b/cli/tests/nao_core/config/test_trino.py
@@ -1,0 +1,67 @@
+"""Unit tests for Trino database config."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from trino.auth import BasicAuthentication
+
+from nao_core.config.databases.trino import TrinoConfig
+
+
+@pytest.fixture
+def base_config() -> TrinoConfig:
+    return TrinoConfig(
+        name="t",
+        host="trino.example",
+        port=8080,
+        catalog="hive",
+        user="alice",
+        password=None,
+        schema_name=None,
+    )
+
+
+def test_connect_passes_user_without_password(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        base_config.connect()
+
+    mock_connect.assert_called_once()
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["host"] == "trino.example"
+    assert call_kw["port"] == 8080
+    assert call_kw["user"] == "alice"
+    assert call_kw["database"] == "hive"
+    assert "auth" not in call_kw
+
+
+def test_connect_uses_basic_auth_when_password_set(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"password": "secret"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    mock_connect.assert_called_once()
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["user"] == "alice"
+    assert "password" not in call_kw
+    auth = call_kw.get("auth")
+    assert isinstance(auth, BasicAuthentication)
+
+
+def test_connect_includes_schema_when_set(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"schema_name": "analytics"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    assert mock_connect.call_args.kwargs["schema"] == "analytics"


### PR DESCRIPTION
### Summary

- Ibis / Trino expects authenticated sessions via the auth argument (e.g. trino.auth.BasicAuthentication), not a legacy-style password kwarg passed through to ibis.trino.connect.
- Passing only password could fail or behave incorrectly depending on Ibis and trino client versions, breaking Trino connections that require HTTP basic auth (sync, profiling, nao debug, etc.).
- Unit tests did not previously assert how TrinoConfig.connect() maps config into ibis.trino.connect, so regressions were easy to miss.

### What changed
`cli/nao_core/config/databases/trino.py`

- Added _build_basic_auth(user, password) (lazy import of BasicAuthentication from trino.auth).
- When password is set, connect() now passes auth=BasicAuthentication(user, password) into ibis.trino.connect instead of password=....
- user (and the rest of the existing kwargs) stay unchanged so passwordless and authenticated flows both keep the correct Trino principal.

`cli/tests/nao_core/config/test_trino.py (new)`

- Mocks ibis.trino.connect and checks:
- No password: user / database / host / port; no auth kwarg.
- With password: user present, auth is a BasicAuthentication, no password key.
- Optional schema_name: schema is forwarded.

### Test plan

- cd cli && .venv/bin/pytest tests/nao_core/config/test_trino.py -v — 3 tests pass (or equivalent with your venv).
- cd cli && make lint — ty + ruff clean (or rely on CI if local dev extras block mysqlclient).
- Manual (optional): nao debug / nao sync against Trino with username + password and confirm connectivity.

This PR was written using Cursor.