### PR TITLE
feat(chart): UI to edit display_chart params and persist to db

### DIFF
--- a/apps/backend/src/queries/chart-image.ts
+++ b/apps/backend/src/queries/chart-image.ts
@@ -1,10 +1,12 @@
 import { displayChart, executeSql } from '@nao/shared/tools';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
 import dbConfig, { Dialect } from '../db/dbConfig';
 import { takeFirstOrThrow } from '../utils/queries';
+
+const DISPLAY_CHART_TOOL_TYPE = 'tool-display_chart';
 
 export const getChartById = async (id: string): Promise<string> => {
 	const result = await takeFirstOrThrow(
@@ -22,7 +24,7 @@ export const getChartConfigByToolCallId = async (toolCallId: string): Promise<di
 		db
 			.select({ toolInput: s.messagePart.toolInput })
 			.from(s.messagePart)
-			.where(eq(s.messagePart.toolCallId, toolCallId))
+			.where(getDisplayChartToolCallFilter(toolCallId))
 			.execute(),
 	);
 	return displayChart.InputSchema.parse(result.toolInput);
@@ -74,15 +76,28 @@ export const getChartOwnerInfo = async (toolCallId: string): Promise<{ projectId
 		.from(s.messagePart)
 		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
 		.innerJoin(s.chat, eq(s.chatMessage.chatId, s.chat.id))
-		.where(eq(s.messagePart.toolCallId, toolCallId))
+		.where(getDisplayChartToolCallFilter(toolCallId))
 		.execute();
 	return row ?? null;
 };
 
 /** Persists an updated `display_chart` config for the given tool call. */
 export const updateChartConfig = async (toolCallId: string, config: displayChart.Input): Promise<void> => {
-	await db.update(s.messagePart).set({ toolInput: config }).where(eq(s.messagePart.toolCallId, toolCallId)).execute();
+	await db.transaction(async (tx) => {
+		await tx
+			.update(s.messagePart)
+			.set({ toolInput: config })
+			.where(getDisplayChartToolCallFilter(toolCallId))
+			.execute();
 
-	// Invalidate any cached PNG so externally-served chart images refresh.
-	await db.delete(s.message_part_chart_image).where(eq(s.message_part_chart_image.toolCallId, toolCallId)).execute();
+		// Invalidate any cached PNG so externally-served chart images refresh.
+		await tx
+			.delete(s.message_part_chart_image)
+			.where(eq(s.message_part_chart_image.toolCallId, toolCallId))
+			.execute();
+	});
 };
+
+function getDisplayChartToolCallFilter(toolCallId: string) {
+	return and(eq(s.messagePart.toolCallId, toolCallId), eq(s.messagePart.type, DISPLAY_CHART_TOOL_TYPE));
+}

--- a/apps/backend/src/queries/chart-image.ts
+++ b/apps/backend/src/queries/chart-image.ts
@@ -66,3 +66,23 @@ export const saveChart = async (toolCallId: string, data: string): Promise<strin
 	);
 	return row.id;
 };
+
+/** Returns the project owner of the chat that contains the given chart tool call. */
+export const getChartOwnerInfo = async (toolCallId: string): Promise<{ projectId: string; userId: string } | null> => {
+	const [row] = await db
+		.select({ projectId: s.chat.projectId, userId: s.chat.userId })
+		.from(s.messagePart)
+		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
+		.innerJoin(s.chat, eq(s.chatMessage.chatId, s.chat.id))
+		.where(eq(s.messagePart.toolCallId, toolCallId))
+		.execute();
+	return row ?? null;
+};
+
+/** Persists an updated `display_chart` config for the given tool call. */
+export const updateChartConfig = async (toolCallId: string, config: displayChart.Input): Promise<void> => {
+	await db.update(s.messagePart).set({ toolInput: config }).where(eq(s.messagePart.toolCallId, toolCallId)).execute();
+
+	// Invalidate any cached PNG so externally-served chart images refresh.
+	await db.delete(s.message_part_chart_image).where(eq(s.message_part_chart_image.toolCallId, toolCallId)).execute();
+};

--- a/apps/backend/src/trpc/chart.routes.ts
+++ b/apps/backend/src/trpc/chart.routes.ts
@@ -1,8 +1,15 @@
+import { displayChart } from '@nao/shared/tools';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
 import { generateChartImage } from '../components/generate-chart';
-import { getChartConfigByToolCallId, getChartDataByQueryId } from '../queries/chart-image';
-import { projectProtectedProcedure } from './trpc';
+import {
+	getChartConfigByToolCallId,
+	getChartDataByQueryId,
+	getChartOwnerInfo,
+	updateChartConfig,
+} from '../queries/chart-image';
+import { projectProtectedProcedure, protectedProcedure } from './trpc';
 
 export const chartRoutes = {
 	download: projectProtectedProcedure
@@ -16,5 +23,30 @@ export const chartRoutes = {
 			const data = await getChartDataByQueryId(config.query_id);
 			const png = generateChartImage({ config, data });
 			return png.toString('base64');
+		}),
+
+	updateConfig: protectedProcedure
+		.input(
+			z.object({
+				toolCallId: z.string(),
+				config: z.custom<displayChart.Input>((value) => displayChart.InputSchema.safeParse(value).success, {
+					message: 'Invalid chart config',
+				}),
+			}),
+		)
+		.mutation(async ({ input, ctx }) => {
+			const owner = await getChartOwnerInfo(input.toolCallId);
+			if (!owner) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chart not found.' });
+			}
+			if (owner.userId !== ctx.user.id) {
+				throw new TRPCError({
+					code: 'FORBIDDEN',
+					message: 'You are not authorized to edit this chart.',
+				});
+			}
+
+			await updateChartConfig(input.toolCallId, input.config);
+			return { success: true as const };
 		}),
 };

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -1,8 +1,12 @@
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
+import { Pencil } from 'lucide-react';
 import type { UIMessage } from '@nao/backend/chat';
 import type { displayChart } from '@nao/shared/tools';
+import { Button } from '@/components/ui/button';
 import { useOptionalAgentContext } from '@/contexts/agent.provider';
+import { useStoryChartEdit } from '@/contexts/story-chart-edit';
 import { ChartDisplay } from '@/components/tool-calls/display-chart';
+import { ChartConfigEditDialog } from '@/components/tool-calls/display-chart-edit-dialog';
 import { sortByDateKey } from '@/lib/charts.utils';
 
 interface ChartBlock {
@@ -12,6 +16,7 @@ interface ChartBlock {
 	xAxisType: string | null;
 	series: Array<{ data_key: string; color: string; label?: string }>;
 	title: string;
+	rawTag?: string;
 }
 
 export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart: ChartBlock }) {
@@ -59,7 +64,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart:
 	const xAxisType = chart.xAxisType === 'number' ? 'number' : ('category' as const);
 
 	return (
-		<div className={`my-2 ${chart.chartType != 'kpi_card' ? 'aspect-3/2' : ''} `}>
+		<StoryChartEmbedShell chart={chart} availableColumns={sourceData.columns ?? []}>
 			<ChartDisplay
 				data={data}
 				chartType={chart.chartType as displayChart.ChartType}
@@ -68,6 +73,66 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart:
 				series={chart.series}
 				title={chart.title}
 			/>
-		</div>
+		</StoryChartEmbedShell>
 	);
 });
+
+interface StoryChartEmbedShellProps {
+	chart: ChartBlock;
+	availableColumns: string[];
+	children: React.ReactNode;
+}
+
+/**
+ * Wraps a rendered chart with an "Edit chart" button when the surrounding story
+ * context provides a save handler.
+ */
+export function StoryChartEmbedShell({ chart, availableColumns, children }: StoryChartEmbedShellProps) {
+	const edit = useStoryChartEdit();
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const canEdit = Boolean(edit && chart.rawTag);
+
+	const config = useMemo<displayChart.Input>(
+		() => ({
+			query_id: chart.queryId,
+			chart_type: chart.chartType as displayChart.ChartType,
+			x_axis_key: chart.xAxisKey,
+			x_axis_type: (chart.xAxisType || null) as displayChart.XAxisType | null,
+			series: chart.series.map((s) => ({
+				data_key: s.data_key,
+				color: s.color || undefined,
+				label: s.label,
+			})),
+			title: chart.title,
+		}),
+		[chart],
+	);
+
+	return (
+		<div className={`my-2 relative ${chart.chartType != 'kpi_card' ? 'aspect-3/2' : ''}`}>
+			{canEdit && (
+				<Button
+					variant='ghost-muted'
+					size='icon-xs'
+					onClick={() => setIsEditOpen(true)}
+					title='Edit chart'
+					className='absolute top-1 right-1 z-10 bg-background/80 backdrop-blur hover:bg-accent'
+				>
+					<Pencil className='size-3.5' />
+				</Button>
+			)}
+			{children}
+			{canEdit && edit && chart.rawTag && (
+				<ChartConfigEditDialog
+					open={isEditOpen}
+					onOpenChange={setIsEditOpen}
+					config={config}
+					availableColumns={availableColumns}
+					isSaving={edit.isSaving}
+					onSave={(next) => edit.saveChart(chart.rawTag!, next)}
+					description='Tweak the chart parameters. Changes are saved to the story as a new version.'
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -68,7 +68,8 @@ function ChartBlockView({ node }: ReactNodeViewProps) {
 		if (!attrMatch) {
 			return null;
 		}
-		return parseChartBlock(attrMatch[1]);
+		const parsed = parseChartBlock(attrMatch[1]);
+		return parsed ? { ...parsed, rawTag } : null;
 	}, [rawTag]);
 
 	if (!chart) {

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -21,6 +21,7 @@ import type { Editor as TiptapEditor } from '@tiptap/react';
 import type { StoryCodeViewHandle } from './story-code-view';
 import { useSidePanel } from '@/contexts/side-panel';
 import { ReadonlyAgentMessagesProvider, useOptionalAgentContext } from '@/contexts/agent.provider';
+import { StoryChartEditProvider } from '@/contexts/story-chart-edit';
 import { Spinner } from '@/components/ui/spinner';
 import { chatActivityStore } from '@/stores/chat-activity';
 import { trpc } from '@/main';
@@ -184,25 +185,34 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp }:
 			{Boolean(archivedAt) && <ArchivedBanner chatId={chatId} storySlug={resolvedStorySlug} />}
 
 			<div ref={scrollContainerRef} className='flex-1 min-h-0 overflow-auto'>
-				{viewMode === 'preview' ? (
-					<StoryPreview
-						code={storyCode}
-						cacheSchedule={cacheSchedule}
-						queryData={queryData ?? null}
-						chatId={chatId}
-						versionKey={`${currentVersionNumber}-${cachedAt ?? ''}`}
-					/>
-				) : viewMode === 'edit' ? (
-					<StoryEditor code={storyCode} editorRef={tiptapEditorRef} onSave={handleSave} />
-				) : (
-					<StoryCodeView
-						code={storyCode}
-						readOnly={isReadonlyMode}
-						codeRef={codeViewRef}
-						onDirtyChange={setIsCodeDirty}
-						onValidChange={setIsCodeValid}
-						onSave={handleSave}
-					/>
+				{renderWithEditProvider(
+					!isReadonlyMode && isViewingLatest && !archivedAt && !isAgentRunning && viewMode !== 'edit',
+					{
+						chatId,
+						storySlug: resolvedStorySlug,
+						storyTitle,
+						storyCode,
+					},
+					viewMode === 'preview' ? (
+						<StoryPreview
+							code={storyCode}
+							cacheSchedule={cacheSchedule}
+							queryData={queryData ?? null}
+							chatId={chatId}
+							versionKey={`${currentVersionNumber}-${cachedAt ?? ''}`}
+						/>
+					) : viewMode === 'edit' ? (
+						<StoryEditor code={storyCode} editorRef={tiptapEditorRef} onSave={handleSave} />
+					) : (
+						<StoryCodeView
+							code={storyCode}
+							readOnly={isReadonlyMode}
+							codeRef={codeViewRef}
+							onDirtyChange={setIsCodeDirty}
+							onValidChange={setIsCodeValid}
+							onSave={handleSave}
+						/>
+					),
 				)}
 			</div>
 
@@ -231,4 +241,24 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp }:
 	}
 
 	return <ReadonlyAgentMessagesProvider messages={chatMessages}>{content}</ReadonlyAgentMessagesProvider>;
+}
+
+function renderWithEditProvider(
+	enabled: boolean,
+	params: { chatId: string; storySlug: string; storyTitle: string; storyCode: string },
+	children: React.ReactNode,
+) {
+	if (!enabled) {
+		return children;
+	}
+	return (
+		<StoryChartEditProvider
+			chatId={params.chatId}
+			storySlug={params.storySlug}
+			storyTitle={params.storyTitle}
+			storyCode={params.storyCode}
+		>
+			{children}
+		</StoryChartEditProvider>
+	);
 }

--- a/apps/frontend/src/components/story-embeds.tsx
+++ b/apps/frontend/src/components/story-embeds.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { ParsedChartBlock, ParsedTableBlock } from '@nao/shared/story-segments';
 import type { displayChart } from '@nao/shared/tools';
 
+import { StoryChartEmbedShell } from '@/components/side-panel/story-chart-embed';
 import { ChartDisplay } from '@/components/tool-calls/display-chart';
 import { TableDisplay } from '@/components/tool-calls/display-table';
 
@@ -54,9 +55,11 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 }) {
 	const noCacheFetch = useLiveQueryData(chart.queryId, liveQuery);
 
-	const resolvedData = liveQuery
-		? (noCacheFetch.data as { data: Record<string, unknown>[]; columns: string[] } | undefined)?.data
-		: queryData?.[chart.queryId]?.data;
+	const resolved = liveQuery
+		? (noCacheFetch.data as { data: Record<string, unknown>[]; columns: string[] } | undefined)
+		: queryData?.[chart.queryId];
+	const resolvedData = resolved?.data;
+	const resolvedColumns = resolved?.columns ?? [];
 
 	if (liveQuery && noCacheFetch.isLoading) {
 		return <EmbedLoading />;
@@ -71,7 +74,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 	}
 
 	return (
-		<div className={`my-2 ${chart.chartType !== 'kpi_card' ? 'aspect-3/2' : ''}`}>
+		<StoryChartEmbedShell chart={chart} availableColumns={resolvedColumns}>
 			<ChartDisplay
 				data={resolvedData}
 				chartType={chart.chartType as displayChart.ChartType}
@@ -80,7 +83,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 				series={chart.series}
 				title={chart.title}
 			/>
-		</div>
+		</StoryChartEmbedShell>
 	);
 });
 

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -29,17 +29,26 @@ const X_AXIS_TYPE_OPTIONS: { value: NonNullable<displayChart.XAxisType> | 'auto'
 	{ value: 'number', label: 'Number' },
 ];
 
-interface Props {
+interface ChartConfigEditDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	toolCallId: string;
 	config: displayChart.Input;
 	availableColumns: string[];
+	onSave: (next: displayChart.Input) => Promise<void>;
+	isSaving?: boolean;
+	description?: string;
 }
 
-export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config, availableColumns }: Props) {
-	const queryClient = useQueryClient();
-	const { messages, setMessages } = useAgentContext();
+/** Presentational edit dialog for `display_chart` configuration. */
+export function ChartConfigEditDialog({
+	open,
+	onOpenChange,
+	config,
+	availableColumns,
+	onSave,
+	isSaving = false,
+	description = 'Tweak the chart parameters.',
+}: ChartConfigEditDialogProps) {
 	const [draft, setDraft] = useState<displayChart.Input>(config);
 	const [error, setError] = useState<string | null>(null);
 
@@ -49,14 +58,6 @@ export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config,
 			setError(null);
 		}
 	}, [open, config]);
-
-	const updateMutation = useMutation(
-		trpc.chart.updateConfig.mutationOptions({
-			onSuccess: () => {
-				queryClient.invalidateQueries({ queryKey: [['chat', 'get']] });
-			},
-		}),
-	);
 
 	const xAxisOptions = useMemo(() => {
 		if (availableColumns.length === 0) {
@@ -73,15 +74,10 @@ export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config,
 			return;
 		}
 
-		const next = parsed.data;
-		const previousMessages = messages;
-		setMessages(applyChartConfigToMessages(previousMessages, toolCallId, next));
-
 		try {
-			await updateMutation.mutateAsync({ toolCallId, config: next });
+			await onSave(parsed.data);
 			onOpenChange(false);
 		} catch (err) {
-			setMessages(previousMessages);
 			setError(err instanceof Error ? err.message : 'Failed to update chart.');
 		}
 	};
@@ -115,7 +111,7 @@ export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config,
 			<DialogContent className='sm:max-w-xl max-h-[90vh] overflow-y-auto'>
 				<DialogHeader>
 					<DialogTitle>Edit chart</DialogTitle>
-					<DialogDescription>Tweak the chart parameters. Changes are saved to the chat.</DialogDescription>
+					<DialogDescription>{description}</DialogDescription>
 				</DialogHeader>
 
 				<form onSubmit={handleSubmit} className='flex flex-col gap-4'>
@@ -239,13 +235,64 @@ export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config,
 						<Button type='button' variant='ghost' onClick={() => onOpenChange(false)}>
 							Cancel
 						</Button>
-						<Button type='submit' isLoading={updateMutation.isPending} disabled={updateMutation.isPending}>
+						<Button type='submit' isLoading={isSaving} disabled={isSaving}>
 							Save
 						</Button>
 					</DialogFooter>
 				</form>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+interface DisplayChartEditDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	toolCallId: string;
+	config: displayChart.Input;
+	availableColumns: string[];
+}
+
+/** Edit dialog bound to a `tool-display_chart` message part: persists through `chart.updateConfig`. */
+export function DisplayChartEditDialog({
+	open,
+	onOpenChange,
+	toolCallId,
+	config,
+	availableColumns,
+}: DisplayChartEditDialogProps) {
+	const queryClient = useQueryClient();
+	const { messages, setMessages } = useAgentContext();
+
+	const updateMutation = useMutation(
+		trpc.chart.updateConfig.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [['chat', 'get']] });
+			},
+		}),
+	);
+
+	const handleSave = async (next: displayChart.Input) => {
+		const previousMessages = messages;
+		setMessages(applyChartConfigToMessages(previousMessages, toolCallId, next));
+		try {
+			await updateMutation.mutateAsync({ toolCallId, config: next });
+		} catch (err) {
+			setMessages(previousMessages);
+			throw err;
+		}
+	};
+
+	return (
+		<ChartConfigEditDialog
+			open={open}
+			onOpenChange={onOpenChange}
+			config={config}
+			availableColumns={availableColumns}
+			onSave={handleSave}
+			isSaving={updateMutation.isPending}
+			description='Tweak the chart parameters. Changes are saved to the chat.'
+		/>
 	);
 }
 

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Plus, Trash2 } from 'lucide-react';
+import { displayChart } from '@nao/shared/tools';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import type { UIMessage, UIToolPart } from '@nao/backend/chat';
+import { useAgentContext } from '@/contexts/agent.provider';
+import { trpc } from '@/main';
+
+const CHART_TYPE_OPTIONS: { value: displayChart.ChartType; label: string }[] = [
+	{ value: 'bar', label: 'Bar' },
+	{ value: 'stacked_bar', label: 'Stacked bar' },
+	{ value: 'line', label: 'Line' },
+	{ value: 'area', label: 'Area' },
+	{ value: 'stacked_area', label: 'Stacked area' },
+	{ value: 'pie', label: 'Pie' },
+	{ value: 'kpi_card', label: 'KPI card' },
+	{ value: 'scatter', label: 'Scatter' },
+	{ value: 'radar', label: 'Radar' },
+];
+
+const X_AXIS_TYPE_OPTIONS: { value: NonNullable<displayChart.XAxisType> | 'auto'; label: string }[] = [
+	{ value: 'auto', label: 'Auto' },
+	{ value: 'category', label: 'Category' },
+	{ value: 'date', label: 'Date' },
+	{ value: 'number', label: 'Number' },
+];
+
+interface Props {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	toolCallId: string;
+	config: displayChart.Input;
+	availableColumns: string[];
+}
+
+export function DisplayChartEditDialog({ open, onOpenChange, toolCallId, config, availableColumns }: Props) {
+	const queryClient = useQueryClient();
+	const { messages, setMessages } = useAgentContext();
+	const [draft, setDraft] = useState<displayChart.Input>(config);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (open) {
+			setDraft(config);
+			setError(null);
+		}
+	}, [open, config]);
+
+	const updateMutation = useMutation(
+		trpc.chart.updateConfig.mutationOptions({
+			onSuccess: () => {
+				queryClient.invalidateQueries({ queryKey: [['chat', 'get']] });
+			},
+		}),
+	);
+
+	const xAxisOptions = useMemo(() => {
+		if (availableColumns.length === 0) {
+			return [config.x_axis_key];
+		}
+		return availableColumns;
+	}, [availableColumns, config.x_axis_key]);
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		const parsed = displayChart.InputSchema.safeParse(draft);
+		if (!parsed.success) {
+			setError(parsed.error.issues[0]?.message ?? 'Invalid chart configuration.');
+			return;
+		}
+
+		const next = parsed.data;
+		const previousMessages = messages;
+		setMessages(applyChartConfigToMessages(previousMessages, toolCallId, next));
+
+		try {
+			await updateMutation.mutateAsync({ toolCallId, config: next });
+			onOpenChange(false);
+		} catch (err) {
+			setMessages(previousMessages);
+			setError(err instanceof Error ? err.message : 'Failed to update chart.');
+		}
+	};
+
+	const updateSeriesAt = (index: number, patch: Partial<displayChart.SeriesConfig>) => {
+		setDraft((prev) => ({
+			...prev,
+			series: prev.series.map((s, i) => (i === index ? { ...s, ...patch } : s)),
+		}));
+	};
+
+	const removeSeriesAt = (index: number) => {
+		setDraft((prev) => ({
+			...prev,
+			series: prev.series.length <= 1 ? prev.series : prev.series.filter((_, i) => i !== index),
+		}));
+	};
+
+	const addSeries = () => {
+		const used = new Set(draft.series.map((s) => s.data_key));
+		const fallback =
+			availableColumns.find((c) => c !== draft.x_axis_key && !used.has(c)) ?? availableColumns[0] ?? '';
+		setDraft((prev) => ({
+			...prev,
+			series: [...prev.series, { data_key: fallback }],
+		}));
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className='sm:max-w-xl max-h-[90vh] overflow-y-auto'>
+				<DialogHeader>
+					<DialogTitle>Edit chart</DialogTitle>
+					<DialogDescription>Tweak the chart parameters. Changes are saved to the chat.</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={handleSubmit} className='flex flex-col gap-4'>
+					<div className='grid gap-2'>
+						<label htmlFor='chart-title' className='text-xs font-medium text-foreground'>
+							Title
+						</label>
+						<Input
+							id='chart-title'
+							value={draft.title}
+							onChange={(e) => setDraft((prev) => ({ ...prev, title: e.target.value }))}
+							placeholder='Chart title'
+						/>
+					</div>
+
+					<div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+						<div className='grid gap-2'>
+							<span className='text-xs font-medium text-foreground'>Chart type</span>
+							<Select
+								value={draft.chart_type}
+								onValueChange={(value) =>
+									setDraft((prev) => ({ ...prev, chart_type: value as displayChart.ChartType }))
+								}
+							>
+								<SelectTrigger className='w-full'>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{CHART_TYPE_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className='grid gap-2'>
+							<span className='text-xs font-medium text-foreground'>X-axis type</span>
+							<Select
+								value={draft.x_axis_type ?? 'auto'}
+								onValueChange={(value) =>
+									setDraft((prev) => ({
+										...prev,
+										x_axis_type: value === 'auto' ? null : (value as displayChart.XAxisType),
+									}))
+								}
+							>
+								<SelectTrigger className='w-full'>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{X_AXIS_TYPE_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+
+					<div className='grid gap-2'>
+						<span className='text-xs font-medium text-foreground'>X-axis column</span>
+						<ColumnSelect
+							value={draft.x_axis_key}
+							columns={xAxisOptions}
+							onChange={(value) => setDraft((prev) => ({ ...prev, x_axis_key: value }))}
+						/>
+					</div>
+
+					<div className='grid gap-2'>
+						<div className='flex items-center justify-between'>
+							<span className='text-xs font-medium text-foreground'>Series</span>
+							<Button type='button' size='sm' variant='outline' onClick={addSeries}>
+								<Plus className='size-3.5' /> Add series
+							</Button>
+						</div>
+						<div className='flex flex-col gap-3'>
+							{draft.series.map((series, index) => (
+								<div
+									key={index}
+									className='grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center rounded-md border border-border/60 p-2'
+								>
+									<ColumnSelect
+										value={series.data_key}
+										columns={availableColumns.length > 0 ? availableColumns : [series.data_key]}
+										onChange={(value) => updateSeriesAt(index, { data_key: value })}
+									/>
+									<Input
+										value={series.label ?? ''}
+										onChange={(e) => updateSeriesAt(index, { label: e.target.value || undefined })}
+										placeholder='Label (optional)'
+										className='h-9 text-sm'
+									/>
+									<input
+										type='color'
+										aria-label='Series color'
+										value={normalizeHexColor(series.color)}
+										onChange={(e) => updateSeriesAt(index, { color: e.target.value })}
+										className='h-9 w-9 cursor-pointer rounded-md border border-input bg-transparent p-0.5'
+									/>
+									<Button
+										type='button'
+										size='icon-sm'
+										variant='ghost-muted'
+										onClick={() => removeSeriesAt(index)}
+										disabled={draft.series.length <= 1}
+										title='Remove series'
+									>
+										<Trash2 className='size-3.5' />
+									</Button>
+								</div>
+							))}
+						</div>
+					</div>
+
+					{error && <p className='text-xs text-destructive'>{error}</p>}
+
+					<DialogFooter>
+						<Button type='button' variant='ghost' onClick={() => onOpenChange(false)}>
+							Cancel
+						</Button>
+						<Button type='submit' isLoading={updateMutation.isPending} disabled={updateMutation.isPending}>
+							Save
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+interface ColumnSelectProps {
+	value: string;
+	columns: string[];
+	onChange: (value: string) => void;
+}
+
+function ColumnSelect({ value, columns, onChange }: ColumnSelectProps) {
+	const items = columns.includes(value) ? columns : [value, ...columns];
+	return (
+		<Select value={value} onValueChange={onChange}>
+			<SelectTrigger className='w-full'>
+				<SelectValue placeholder='Select column' />
+			</SelectTrigger>
+			<SelectContent>
+				{items.map((column) => (
+					<SelectItem key={column} value={column}>
+						{column}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+function normalizeHexColor(color?: string): string {
+	if (color && HEX_RE.test(color)) {
+		return color;
+	}
+	return '#104e64';
+}
+
+function applyChartConfigToMessages(
+	messages: UIMessage[],
+	toolCallId: string,
+	config: displayChart.Input,
+): UIMessage[] {
+	return messages.map((message) => {
+		let changed = false;
+		const parts = message.parts.map((part) => {
+			if (part.type !== 'tool-display_chart') {
+				return part;
+			}
+			const toolPart = part as UIToolPart<'display_chart'>;
+			if (toolPart.toolCallId !== toolCallId) {
+				return part;
+			}
+			changed = true;
+			return { ...toolPart, input: config } as typeof part;
+		});
+		return changed ? { ...message, parts } : message;
+	});
+}

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -98,8 +98,14 @@ export function ChartConfigEditDialog({
 
 	const addSeries = () => {
 		const used = new Set(draft.series.map((s) => s.data_key));
-		const fallback =
-			availableColumns.find((c) => c !== draft.x_axis_key && !used.has(c)) ?? availableColumns[0] ?? '';
+		const selectableColumns = getSelectableColumns(availableColumns);
+		const fallback = selectableColumns.find((c) => c !== draft.x_axis_key && !used.has(c)) ?? selectableColumns[0];
+		if (!fallback) {
+			setError('No columns are available to add as a series.');
+			return;
+		}
+
+		setError(null);
 		setDraft((prev) => ({
 			...prev,
 			series: [...prev.series, { data_key: fallback }],
@@ -303,9 +309,10 @@ interface ColumnSelectProps {
 }
 
 function ColumnSelect({ value, columns, onChange }: ColumnSelectProps) {
-	const items = columns.includes(value) ? columns : [value, ...columns];
+	const columnsWithValues = getSelectableColumns(columns);
+	const items = value && !columnsWithValues.includes(value) ? [value, ...columnsWithValues] : columnsWithValues;
 	return (
-		<Select value={value} onValueChange={onChange}>
+		<Select value={value} onValueChange={onChange} disabled={items.length === 0}>
 			<SelectTrigger className='w-full'>
 				<SelectValue placeholder='Select column' />
 			</SelectTrigger>
@@ -318,6 +325,10 @@ function ColumnSelect({ value, columns, onChange }: ColumnSelectProps) {
 			</SelectContent>
 		</Select>
 	);
+}
+
+function getSelectableColumns(columns: string[]): string[] {
+	return Array.from(new Set(columns.filter((column) => column.length > 0)));
 }
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { buildChart, labelize } from '@nao/shared';
+import { buildChartTag } from '@nao/shared/story-segments';
 import { Download, FilePlus, Pencil } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOptionalAgentContext } from '../../contexts/agent.provider';
@@ -24,9 +25,6 @@ import { trpc } from '@/main';
 
 const Colors = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
 const EMPTY_MESSAGES: UIMessage[] = [];
-
-const escapeDoubleQuotedAttr = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-const escapeSingleQuotedAttr = (value: string) => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
 export const DisplayChartToolCall = ({
 	toolPart: { state, input, output, toolCallId },
@@ -168,8 +166,7 @@ export const DisplayChartToolCall = ({
 			return;
 		}
 
-		const seriesJson = JSON.stringify(config.series);
-		const chartBlock = `<chart query_id="${escapeDoubleQuotedAttr(config.query_id)}" chart_type="${escapeDoubleQuotedAttr(config.chart_type)}" x_axis_key="${escapeDoubleQuotedAttr(config.x_axis_key)}" x_axis_type="${escapeDoubleQuotedAttr(config.x_axis_type ?? '')}" series='${escapeSingleQuotedAttr(seriesJson)}' title="${escapeDoubleQuotedAttr(config.title ?? '')}" />`;
+		const chartBlock = buildChartTag(config);
 		const newCode = latest.code.trimEnd() + '\n\n' + chartBlock;
 
 		addToStoryMutation.mutate({

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { buildChart, labelize } from '@nao/shared';
-import { Download, FilePlus } from 'lucide-react';
+import { Download, FilePlus, Pencil } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOptionalAgentContext } from '../../contexts/agent.provider';
 import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '../ui/chart';
@@ -9,6 +9,7 @@ import { Skeleton } from '../ui/skeleton';
 import { Button } from '../ui/button';
 import { ToolCallWrapper } from './tool-call-wrapper';
 import { ChartRangeSelector } from './display-chart-range-selector';
+import { DisplayChartEditDialog } from './display-chart-edit-dialog';
 import type { ToolCallComponentProps } from '.';
 import type { ChartConfig } from '../ui/chart';
 import type { displayChart } from '@nao/shared/tools';
@@ -55,6 +56,8 @@ export const DisplayChartToolCall = ({
 	);
 
 	const [isDownloading, setIsDownloading] = useState(false);
+	const [isEditOpen, setIsEditOpen] = useState(false);
+	const isEditable = Boolean(agent && !agent.isReadonly && !agent.isRunning);
 
 	const handleDownload = async () => {
 		if (!config) {
@@ -208,6 +211,16 @@ export const DisplayChartToolCall = ({
 							onRangeSelected={(range) => setDataRange(range)}
 						/>
 					)}
+					{isEditable && (
+						<Button
+							variant='ghost-muted'
+							size='icon-xs'
+							onClick={() => setIsEditOpen(true)}
+							title='Edit chart'
+						>
+							<Pencil className='size-3.5' />
+						</Button>
+					)}
 					{config.chart_type != 'kpi_card' && (
 						<Button
 							variant='ghost-muted'
@@ -221,6 +234,16 @@ export const DisplayChartToolCall = ({
 					)}
 				</div>
 			</div>
+
+			{isEditable && (
+				<DisplayChartEditDialog
+					open={isEditOpen}
+					onOpenChange={setIsEditOpen}
+					toolCallId={toolCallId}
+					config={config}
+					availableColumns={sourceData.columns ?? []}
+				/>
+			)}
 
 			<ChartDisplay
 				data={filteredData}

--- a/apps/frontend/src/contexts/agent.provider.tsx
+++ b/apps/frontend/src/contexts/agent.provider.tsx
@@ -57,6 +57,7 @@ export const ReadonlyAgentMessagesProvider = ({
 			selectedModel: null,
 			setSelectedModel: noop,
 			setMentions: noop,
+			isReadonly: true,
 		}),
 		[chatId, messages],
 	);

--- a/apps/frontend/src/contexts/story-chart-edit-utils.test.ts
+++ b/apps/frontend/src/contexts/story-chart-edit-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { replaceUniqueChartTag } from './story-chart-edit-utils';
+
+describe('replaceUniqueChartTag', () => {
+	it('replaces the matching chart tag when it is unique', () => {
+		const rawTag = '<chart query_id="q1" chart_type="bar" x_axis_key="date" />';
+		const nextTag = '<chart query_id="q1" chart_type="line" x_axis_key="date" />';
+		const storyCode = `Intro\n\n${rawTag}\n\nOutro`;
+
+		expect(replaceUniqueChartTag(storyCode, rawTag, nextTag)).toBe(`Intro\n\n${nextTag}\n\nOutro`);
+	});
+
+	it('rejects when the chart tag is missing', () => {
+		expect(() => replaceUniqueChartTag('Intro only', '<chart query_id="q1" />', '<chart query_id="q2" />')).toThrow(
+			'Could not locate the chart in the current story version.',
+		);
+	});
+
+	it('rejects when identical chart tags make the target ambiguous', () => {
+		const rawTag = '<chart query_id="q1" chart_type="bar" x_axis_key="date" />';
+		const nextTag = '<chart query_id="q1" chart_type="line" x_axis_key="date" />';
+		const storyCode = `${rawTag}\n\nSome text\n\n${rawTag}`;
+
+		expect(() => replaceUniqueChartTag(storyCode, rawTag, nextTag)).toThrow(
+			'Could not uniquely identify the chart because the same chart tag appears more than once.',
+		);
+	});
+});

--- a/apps/frontend/src/contexts/story-chart-edit-utils.ts
+++ b/apps/frontend/src/contexts/story-chart-edit-utils.ts
@@ -1,0 +1,19 @@
+const CHART_NOT_FOUND_MESSAGE = 'Could not locate the chart in the current story version.';
+
+export function replaceUniqueChartTag(storyCode: string, rawTag: string, nextTag: string): string {
+	if (!rawTag) {
+		throw new Error(CHART_NOT_FOUND_MESSAGE);
+	}
+
+	const startIndex = storyCode.indexOf(rawTag);
+	if (startIndex === -1) {
+		throw new Error(CHART_NOT_FOUND_MESSAGE);
+	}
+
+	const nextIndex = storyCode.indexOf(rawTag, startIndex + rawTag.length);
+	if (nextIndex !== -1) {
+		throw new Error('Could not uniquely identify the chart because the same chart tag appears more than once.');
+	}
+
+	return `${storyCode.slice(0, startIndex)}${nextTag}${storyCode.slice(startIndex + rawTag.length)}`;
+}

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -1,0 +1,98 @@
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { buildChartTag } from '@nao/shared/story-segments';
+import type { displayChart } from '@nao/shared/tools';
+import { trpc } from '@/main';
+
+export interface StoryChartEditHandlers {
+	/**
+	 * Persists a new chart config by replacing `rawTag` (the original `<chart ... />` tag)
+	 * in the story's markdown and saving a new version.
+	 * Returns a promise that rejects if the save fails.
+	 */
+	saveChart: (rawTag: string, config: displayChart.Input) => Promise<void>;
+	/** Whether a save is currently in flight. */
+	isSaving: boolean;
+}
+
+const StoryChartEditContext = createContext<StoryChartEditHandlers | null>(null);
+
+export const useStoryChartEdit = () => useContext(StoryChartEditContext);
+
+interface StoryChartEditProviderProps {
+	chatId: string;
+	storySlug: string;
+	storyTitle: string;
+	storyCode: string;
+	children: React.ReactNode;
+}
+
+/**
+ * Provides a `saveChart` handler that chart embeds inside a story can call to persist
+ * edits (title/type/series/etc) back to the story via `story.createVersion`.
+ */
+export function StoryChartEditProvider({
+	chatId,
+	storySlug,
+	storyTitle,
+	storyCode,
+	children,
+}: StoryChartEditProviderProps) {
+	const queryClient = useQueryClient();
+	const latestStoryQueryKey = trpc.story.getLatest.queryKey({ chatId, storySlug });
+
+	const createVersionMutation = useMutation(
+		trpc.story.createVersion.mutationOptions({
+			onMutate: async (variables) => {
+				await queryClient.cancelQueries({ queryKey: latestStoryQueryKey });
+				const previousLatestStory = queryClient.getQueryData(latestStoryQueryKey);
+				queryClient.setQueryData(latestStoryQueryKey, (latestStory) =>
+					latestStory && typeof latestStory === 'object'
+						? { ...latestStory, code: variables.code }
+						: latestStory,
+				);
+				return { previousLatestStory };
+			},
+			onError: (_error, _variables, context) => {
+				if (context?.previousLatestStory !== undefined) {
+					queryClient.setQueryData(latestStoryQueryKey, context.previousLatestStory);
+				}
+			},
+			onSuccess: () => {
+				void queryClient.invalidateQueries({
+					queryKey: trpc.story.listVersions.queryKey({ chatId, storySlug }),
+				});
+				void queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+				void queryClient.invalidateQueries({ queryKey: latestStoryQueryKey });
+			},
+		}),
+	);
+
+	const saveChart = useCallback(
+		async (rawTag: string, config: displayChart.Input) => {
+			if (!storyCode.includes(rawTag)) {
+				throw new Error('Could not locate the chart in the current story version.');
+			}
+			const nextTag = buildChartTag(config);
+			const nextCode = storyCode.replace(rawTag, nextTag);
+			if (nextCode === storyCode) {
+				return;
+			}
+			await createVersionMutation.mutateAsync({
+				chatId,
+				storySlug,
+				title: storyTitle,
+				code: nextCode,
+				action: 'replace',
+			});
+		},
+		[chatId, storySlug, storyTitle, storyCode, createVersionMutation],
+	);
+
+	const value = useMemo<StoryChartEditHandlers>(
+		() => ({ saveChart, isSaving: createVersionMutation.isPending }),
+		[saveChart, createVersionMutation.isPending],
+	);
+
+	return <StoryChartEditContext.Provider value={value}>{children}</StoryChartEditContext.Provider>;
+}

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildChartTag } from '@nao/shared/story-segments';
+import { replaceUniqueChartTag } from './story-chart-edit-utils';
 import type { displayChart } from '@nao/shared/tools';
 import { trpc } from '@/main';
 
@@ -70,11 +71,8 @@ export function StoryChartEditProvider({
 
 	const saveChart = useCallback(
 		async (rawTag: string, config: displayChart.Input) => {
-			if (!storyCode.includes(rawTag)) {
-				throw new Error('Could not locate the chart in the current story version.');
-			}
 			const nextTag = buildChartTag(config);
-			const nextCode = storyCode.replace(rawTag, nextTag);
+			const nextCode = replaceUniqueChartTag(storyCode, rawTag, nextTag);
 			if (nextCode === storyCode) {
 				return;
 			}

--- a/apps/frontend/src/hooks/use-agent.ts
+++ b/apps/frontend/src/hooks/use-agent.ts
@@ -45,6 +45,7 @@ export interface AgentHelpers {
 	selectedModel: LlmSelectedModel | null;
 	setSelectedModel: React.Dispatch<React.SetStateAction<LlmSelectedModel | null>>;
 	setMentions: (mentions: MentionOption[]) => void;
+	isReadonly?: boolean;
 }
 
 export interface SendMessageArgs {

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -57,6 +57,7 @@ function StoryPreviewPage() {
 	);
 
 	const cachedAt = story.cachedAt ? new Date(story.cachedAt as unknown as string) : null;
+	const canEditCharts = !story.archivedAt;
 
 	return (
 		<div className='flex flex-col flex-1 h-full overflow-hidden bg-panel min-w-0'>
@@ -130,21 +131,39 @@ function StoryPreviewPage() {
 
 			<SelectionProvider key={storySlug}>
 				<HighlightBubble onAsk={handleSelectionAsk} disabled={isChatRunning} />
-				<StoryChartEditProvider
-					chatId={chatId}
-					storySlug={storySlug}
-					storyTitle={story.title}
-					storyCode={story.code}
-				>
+				{renderWithChartEditProvider(
+					canEditCharts,
+					{ chatId, storySlug, storyTitle: story.title, storyCode: story.code },
 					<PreviewContent
 						code={story.code}
 						queryData={story.queryData as QueryDataMap | null}
 						chatId={chatId}
 						cacheSchedule={story.cacheSchedule}
-					/>
-				</StoryChartEditProvider>
+					/>,
+				)}
 			</SelectionProvider>
 		</div>
+	);
+}
+
+function renderWithChartEditProvider(
+	enabled: boolean,
+	params: { chatId: string; storySlug: string; storyTitle: string; storyCode: string },
+	children: React.ReactNode,
+) {
+	if (!enabled) {
+		return children;
+	}
+
+	return (
+		<StoryChartEditProvider
+			chatId={params.chatId}
+			storySlug={params.storySlug}
+			storyTitle={params.storyTitle}
+			storyCode={params.storyCode}
+		>
+			{children}
+		</StoryChartEditProvider>
 	);
 }
 

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { trpc } from '@/main';
 import { StoryDownload } from '@/components/story-download';
 import { SelectionProvider } from '@/contexts/text-selection';
+import { StoryChartEditProvider } from '@/contexts/story-chart-edit';
 import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useChatActivity } from '@/hooks/use-chat-activity';
 
@@ -129,12 +130,19 @@ function StoryPreviewPage() {
 
 			<SelectionProvider key={storySlug}>
 				<HighlightBubble onAsk={handleSelectionAsk} disabled={isChatRunning} />
-				<PreviewContent
-					code={story.code}
-					queryData={story.queryData as QueryDataMap | null}
+				<StoryChartEditProvider
 					chatId={chatId}
-					cacheSchedule={story.cacheSchedule}
-				/>
+					storySlug={storySlug}
+					storyTitle={story.title}
+					storyCode={story.code}
+				>
+					<PreviewContent
+						code={story.code}
+						queryData={story.queryData as QueryDataMap | null}
+						chatId={chatId}
+						cacheSchedule={story.cacheSchedule}
+					/>
+				</StoryChartEditProvider>
 			</SelectionProvider>
 		</div>
 	);

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -5,6 +5,8 @@ export interface ParsedChartBlock {
 	xAxisType: string | null;
 	series: Array<{ data_key: string; color: string; label?: string }>;
 	title: string;
+	/** The original `<chart ... />` tag this block was parsed from, when available. */
+	rawTag?: string;
 }
 
 export interface ParsedTableBlock {
@@ -60,6 +62,26 @@ export function parseChartBlock(attrString: string): ParsedChartBlock | null {
 		series,
 		title: attrs.title || '',
 	};
+}
+
+const escapeDoubleQuotedAttr = (value: string) => value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+const escapeSingleQuotedAttr = (value: string) => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+/** Serializes a chart config into its `<chart ... />` tag representation used in story markdown. */
+export function buildChartTag(config: {
+	query_id: string;
+	chart_type: string;
+	x_axis_key: string;
+	x_axis_type: string | null;
+	series: Array<{ data_key: string; color?: string; label?: string }>;
+	title: string;
+}): string {
+	const seriesJson = JSON.stringify(config.series);
+	return `<chart query_id="${escapeDoubleQuotedAttr(config.query_id)}" chart_type="${escapeDoubleQuotedAttr(
+		config.chart_type,
+	)}" x_axis_key="${escapeDoubleQuotedAttr(config.x_axis_key)}" x_axis_type="${escapeDoubleQuotedAttr(
+		config.x_axis_type ?? '',
+	)}" series='${escapeSingleQuotedAttr(seriesJson)}' title="${escapeDoubleQuotedAttr(config.title ?? '')}" />`;
 }
 
 export function parseTableBlock(attrString: string): ParsedTableBlock | null {
@@ -141,7 +163,7 @@ export function splitCodeIntoSegments(code: string): Segment[] {
 		} else if (match[3] !== undefined) {
 			const chart = parseChartBlock(match[3]);
 			if (chart) {
-				segments.push({ type: 'chart', chart });
+				segments.push({ type: 'chart', chart: { ...chart, rawTag: match[0] } });
 			}
 		} else if (match[4] !== undefined) {
 			const table = parseTableBlock(match[4]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an initial edit UI for chart tool calls so users can tweak chart params after generation, with the edited config persisted back to the database — both for charts in chats and charts embedded in stories.

## Walkthrough

### Chat chart edit

[edit_chart_params_demo.mp4](https://cursor.com/agents/bc-77e4237a-d817-43de-9f38-d95abcf2f594/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_chart_params_demo.mp4)

End-to-end demo: open the edit dialog, change title/type/series label/color, save, and reload the page to confirm the changes persisted to the DB.

### Story chart edit

[Story chart with edit pencil icon at top right](https://cursor.com/agents/bc-77e4237a-d817-43de-9f38-d95abcf2f594/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_chart_before_real.png)
[Edit chart dialog open inside the story viewer](https://cursor.com/agents/bc-77e4237a-d817-43de-9f38-d95abcf2f594/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_chart_dialog_real.png)

The same dialog opens from charts embedded in a story. The save path goes through `story.createVersion`, creating a new story version with the chart tag swapped out.

## Changes

### Shared
- `apps/shared/src/story-segments.ts`: adds `rawTag` to `ParsedChartBlock` (populated by `splitCodeIntoSegments`) and a new `buildChartTag()` helper so chart config ↔ `<chart ... />` markup can round-trip consistently across chat and story flows.

### Backend
- `apps/backend/src/queries/chart-image.ts`: adds `getChartOwnerInfo(toolCallId)` (project + chat owner lookup) and `updateChartConfig(toolCallId, config)` that updates `message_part.tool_input` and invalidates the cached PNG in `chart_image`.
- `apps/backend/src/trpc/chart.routes.ts`: adds the ownership-checked `chart.updateConfig` mutation that validates with `displayChart.InputSchema` and writes the new config.

### Frontend
- `apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx` (new): exports two components.
  - `ChartConfigEditDialog` — presentational form for `title`, `chart_type`, `x_axis_type`, `x_axis_key`, and each series (`data_key`, `label`, `color`). Columns come from the linked `execute_sql` output.
  - `DisplayChartEditDialog` — chat-specific binding that wires the form to `chart.updateConfig` with optimistic `setMessages` rollback.
- `apps/frontend/src/components/tool-calls/display-chart.tsx`: adds a pencil edit button next to download; uses the new shared `buildChartTag` helper for the "Add to story" snippet.
- `apps/frontend/src/components/side-panel/story-chart-embed.tsx`: exports a `StoryChartEmbedShell` that overlays an "Edit chart" pencil on any rendered story chart when the surrounding `StoryChartEditProvider` is available.
- `apps/frontend/src/components/story-embeds.tsx`: wraps the live story chart embed with `StoryChartEmbedShell`.
- `apps/frontend/src/components/side-panel/story-editor.tsx`: threads `rawTag` into the Tiptap chart node view so edits work in the editor's preview.
- `apps/frontend/src/contexts/story-chart-edit.tsx` (new): provides a `saveChart(rawTag, config)` handler that replaces the chart tag in the current story code and saves through `story.createVersion` (with optimistic cache update + rollback).
- `apps/frontend/src/components/side-panel/story-viewer.tsx`: mounts `StoryChartEditProvider` around `StoryPreview`/`StoryCodeView` when the user owns the latest version and the story isn't archived, readonly, or being streamed. Edit is disabled in the Tiptap `edit` view to avoid conflicting with in-flight text edits.
- `apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx`: mounts the provider around the story preview route.
- `apps/frontend/src/contexts/agent.provider.tsx` + `apps/frontend/src/hooks/use-agent.ts`: adds `isReadonly` on `AgentHelpers` so the in-chat edit button is hidden in readonly views (shared chats, chat replay, story side panels).

## Notes
- Chat edits require chat ownership (`userId` check on server); story edits reuse the existing `chatOwnerProcedure` ownership guard on `story.createVersion`.
- Edit buttons are hidden while the agent is running, when viewing an old story version, when the story is archived, and in readonly views (shared chats/stories, Tiptap edit mode).
- After a chat chart save, the cached chart PNG (if any) is deleted so Slack/Teams/WhatsApp image URLs regenerate on next request.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77e4237a-d817-43de-9f38-d95abcf2f594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77e4237a-d817-43de-9f38-d95abcf2f594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

