### PR TITLE
Fix nao skills so that agents can launch nao commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,21 +181,15 @@ For end-to-end self-hosted deployment (for example on Cloud Run with PostgreSQL)
 
 ## 🧩 Skills
 
-nao ships skills for Claude Code that help you set up, test, and maintain your analytics agent.
+Use nao skills to create your nao project and context with your favourite agent.
 
 Install the nao skill pack:
-
-```bash
-nao skills add getnao/nao
-```
-
-`nao skills` is a thin wrapper around the open-source [skills CLI from Vercel Labs](https://github.com/nichochar/skills), so the equivalent direct call also works:
 
 ```bash
 npx skills add getnao/nao
 ```
 
-Once installed, skills are available as slash commands in Claude Code (e.g. `/setup-context`, `/audit-context`, `/create-context-tests`).
+Docs on nao skills: https://docs.getnao.io/nao-agent/context-engineering/skills
 
 ## 👩🏻‍💻 Development
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,24 @@ See the [DockerHub page](https://hub.docker.com/r/getnao/nao) for more details.
 
 For end-to-end self-hosted deployment (for example on Cloud Run with PostgreSQL), see the [Deployment Guide](https://docs.getnao.io/nao-agent/self-hosting/deployment-guide).
 
+## 🧩 Skills
+
+nao ships skills for Claude Code that help you set up, test, and maintain your analytics agent.
+
+Install the nao skill pack:
+
+```bash
+nao skills add getnao/nao
+```
+
+`nao skills` is a thin wrapper around the open-source [skills CLI from Vercel Labs](https://github.com/nichochar/skills), so the equivalent direct call also works:
+
+```bash
+npx skills add getnao/nao
+```
+
+Once installed, skills are available as slash commands in Claude Code (e.g. `/setup-context`, `/audit-context`, `/create-context-tests`).
+
 ## 👩🏻‍💻 Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commands, and guidelines.

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -30,6 +30,12 @@ Send a single message asking for:
 
 3. **Run `nao init`** — it detects the existing yaml and offers to update; confirm. Folder scaffold gets created. Say "no" to optional providers (skills / MCPs / Notion / Slack); edit the yaml directly afterwards if needed.
 
+    Use this command (unsets leaked env vars from the parent agentic CLI — see Step 5):
+
+    ```bash
+    unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY && source ~/.zshrc 2>/dev/null; nao init 2>&1
+    ```
+
 4. **Print a summary of `nao_config.yaml` to the user** before going further. Format example:
 
     ```

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -20,7 +20,7 @@ Send a single message asking for:
     - **Broad** — gold/marts across multiple domains (exec / cross-functional agents).
     - **Deep** — silver + gold for one domain (team-specific agents).
 3. **Extra context** — dbt / ETL / BI repos, Notion, internal docs. Ask for **the SSH git URL** of each repo (e.g. `git@github.com:org/repo.git`) — sync clones them. No local paths.
-4. **LLM** — provider + model. Key comes later (Step 5).
+4. **LLM** — provider and key. The model is selected in the nao UI, not in the config. Key comes later (Step 5).
 
 ## Step 2 — Look up warehouse fields, write `nao_config.yaml`, run `nao init`
 
@@ -31,6 +31,7 @@ Send a single message asking for:
 3. **Run `nao init`** — it detects the existing yaml and offers to update; confirm. Folder scaffold gets created. Say "no" to optional providers (skills / MCPs / Notion / Slack); edit the yaml directly afterwards if needed.
 
 4. **Print a summary of `nao_config.yaml` to the user** before going further. Format example:
+
     ```
     nao_config.yaml summary
       • project: <name>
@@ -38,8 +39,11 @@ Send a single message asking for:
       • scope: include=["analytics.fct_*", "analytics.dim_*"], exclude=[]
       • templates: [columns, preview, description]
       • repos: company-dbt (git@github.com:org/company-dbt.git)
-      • llm: anthropic / claude-sonnet-4-7 (key via ${ANTHROPIC_API_KEY})
+      • llm: anthropic (key via ${ANTHROPIC_API_KEY})
     ```
+
+    The model is configured in the nao UI, not in `nao_config.yaml` — don't include a model ID in the summary or the yaml.
+
     Ask the user to confirm before continuing. This is the last cheap chance to catch a wrong project, a misspelled dataset, or a missing repo.
 
 ### Database `templates` field
@@ -85,8 +89,7 @@ Then `nao debug` to confirm.
 If `nao chat` / `nao debug` / `nao test` fails with that error and the URL is `https://api.anthropic.com/messages` (no `/v1/`), the parent agentic CLI (Claude Code, Cursor, Codex) is leaking `ANTHROPIC_BASE_URL` into the child env. Fix:
 
 ```bash
-unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY
-nao chat   # or debug / test
+unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY && source ~/.zshrc 2>/dev/null; nao chat 2>&1
 ```
 
 Regular human terminals aren't affected.


### PR DESCRIPTION
## Summary
- Remove `claude-sonnet-4-7` model ID reference from setup-context skill — model is configured in the nao UI, not in `nao_config.yaml`
- Update the `nao chat` launch command in the known-issue workaround to properly reload the shell env after unsetting leaked vars
- Add a **Skills** section to the root README explaining how to install the nao skill pack via `nao skills add` or `npx skills add`

## Test plan
- [ ] Verify setup-context skill no longer references a model ID in the summary example or Step 1
- [ ] Verify README renders the new Skills section correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)