### PR TITLE
fix the view of prohect in settings

### DIFF
--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -44,8 +44,7 @@ const settingsNavItems: NavItem[] = [
 	{
 		label: 'Project',
 		to: '/settings/project',
-		visible: ({ isInMultipleProjects }) => isInMultipleProjects,
-		disabled: ({ isViewer }) => isViewer,
+		visible: ({ isViewer, isInMultipleProjects }) => !isViewer || isInMultipleProjects,
 	},
 	{
 		label: 'Observability',


### PR DESCRIPTION
## Summary

### Viewer in 1 project
<img width="1507" height="859" alt="image" src="https://github.com/user-attachments/assets/21593ba7-396c-4b76-b7ed-205318b7313f" />

### Viewer in several projects
<img width="1509" height="857" alt="image" src="https://github.com/user-attachments/assets/2df35e34-c8a2-493e-8335-31e3ba0ef893" />
<img width="1506" height="858" alt="image" src="https://github.com/user-attachments/assets/6394218d-d61d-42f3-81f1-7a3445cd4e16" />

### User in 1 project
<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/9fc05249-9634-469b-bc25-4f3ef4e6b207" />

### Admin in 1 project
<img width="1509" height="853" alt="image" src="https://github.com/user-attachments/assets/8679d343-7be8-40f9-9cc5-4af35ab74018" />

### Admin in several projects
<img width="1509" height="854" alt="image" src="https://github.com/user-attachments/assets/1301a1e2-7f6b-44c8-bd90-624720ee6d1e" />