### PR TITLE
feat: add notification for admins when they are not on latest nao version

### DIFF
--- a/apps/backend/src/services/version-check.service.ts
+++ b/apps/backend/src/services/version-check.service.ts
@@ -1,0 +1,77 @@
+import { env } from '../env';
+
+const GITHUB_RELEASES_URL = 'https://api.github.com/repos/getnao/nao/releases/latest';
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+interface VersionCheckResult {
+	currentVersion: string;
+	latestVersion: string | null;
+	updateAvailable: boolean;
+}
+
+let cachedResult: VersionCheckResult | null = null;
+let cachedAt = 0;
+
+export async function checkForUpdate(): Promise<VersionCheckResult> {
+	const now = Date.now();
+	if (cachedResult && now - cachedAt < CACHE_TTL_MS) {
+		return cachedResult;
+	}
+
+	const currentVersion = env.APP_VERSION;
+	const latestVersion = await fetchLatestVersion();
+	const updateAvailable = latestVersion !== null && isNewerVersion(currentVersion, latestVersion);
+
+	cachedResult = { currentVersion, latestVersion, updateAvailable };
+	cachedAt = now;
+	return cachedResult;
+}
+
+async function fetchLatestVersion(): Promise<string | null> {
+	try {
+		const response = await fetch(GITHUB_RELEASES_URL, {
+			headers: { Accept: 'application/vnd.github.v3+json' },
+			signal: AbortSignal.timeout(5000),
+		});
+		if (!response.ok) {
+			return null;
+		}
+		const data = (await response.json()) as { tag_name?: string };
+		return data.tag_name?.replace(/^v/, '') ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function isNewerVersion(current: string, latest: string): boolean {
+	if (current === 'dev' || current === 'unknown') {
+		return true;
+	}
+
+	const currentParts = parseVersion(current);
+	const latestParts = parseVersion(latest);
+	if (!currentParts || !latestParts) {
+		return current !== latest;
+	}
+
+	for (let i = 0; i < 3; i++) {
+		if (latestParts[i] > currentParts[i]) {
+			return true;
+		}
+		if (latestParts[i] < currentParts[i]) {
+			return false;
+		}
+	}
+	if (currentParts[3] && !latestParts[3]) {
+		return true;
+	}
+	return false;
+}
+
+function parseVersion(version: string): [number, number, number, string] | null {
+	const match = version.match(/^(\d+)\.(\d+)\.(\d+)(.*)/);
+	if (!match) {
+		return null;
+	}
+	return [Number(match[1]), Number(match[2]), Number(match[3]), match[4]];
+}

--- a/apps/backend/src/trpc/system.routes.ts
+++ b/apps/backend/src/trpc/system.routes.ts
@@ -1,4 +1,5 @@
 import { env } from '../env';
+import { checkForUpdate } from '../services/version-check.service';
 import { adminProtectedProcedure, publicProcedure } from './trpc';
 
 export const systemRoutes = {
@@ -11,4 +12,13 @@ export const systemRoutes = {
 		commit: env.APP_COMMIT,
 		buildDate: env.APP_BUILD_DATE,
 	})),
+
+	checkUpdate: adminProtectedProcedure.query(async () => {
+		const result = await checkForUpdate();
+		return {
+			currentVersion: result.currentVersion,
+			latestVersion: result.latestVersion,
+			updateAvailable: result.updateAvailable,
+		};
+	}),
 };

--- a/apps/frontend/src/components/sidebar-version-notice.tsx
+++ b/apps/frontend/src/components/sidebar-version-notice.tsx
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query';
+import { TriangleAlert } from 'lucide-react';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn, hideIf } from '@/lib/utils';
+import { trpc } from '@/main';
+
+interface SidebarVersionNoticeProps {
+	isCollapsed: boolean;
+}
+
+export function SidebarVersionNotice({ isCollapsed }: SidebarVersionNoticeProps) {
+	const { data } = useQuery({
+		...trpc.system.checkUpdate.queryOptions(),
+		staleTime: 60 * 60 * 1000,
+		retry: false,
+	});
+
+	if (!data?.updateAvailable || !data.latestVersion) {
+		return null;
+	}
+
+	const label = `v${data.latestVersion} available`;
+
+	if (isCollapsed) {
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<div className='flex items-center justify-center p-2 mb-1 rounded-md text-amber-500'>
+						<TriangleAlert className='size-4' />
+					</div>
+				</TooltipTrigger>
+				<TooltipContent side='right'>{label}</TooltipContent>
+			</Tooltip>
+		);
+	}
+
+	return (
+		<a
+			href={`https://github.com/getnao/nao/releases/tag/v${data.latestVersion}`}
+			target='_blank'
+			rel='noopener noreferrer'
+			className='flex items-center gap-2 px-3 py-2 mb-1 rounded-md text-xs text-amber-500 hover:bg-sidebar-accent transition-colors'
+		>
+			<TriangleAlert className='size-3.5 shrink-0' />
+			<span className={cn('truncate transition-[opacity,visibility] duration-300', hideIf(isCollapsed))}>
+				{label}
+			</span>
+		</a>
+	);
+}

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -7,6 +7,7 @@ import { ChatListItem } from './sidebar-chat-list-item';
 import { SidebarCommunity } from './sidebar-community';
 import { SidebarSettingsNav } from './sidebar-settings-nav';
 import { SidebarUserMenu } from './sidebar-user-menu';
+import { SidebarVersionNotice } from './sidebar-version-notice';
 import { Spinner } from './ui/spinner';
 import StoryIcon from './ui/story-icon';
 import type { ChatFilterType, ChatGroup, ChatGroupBy, GroupedChatItem } from '@nao/shared/types';
@@ -242,6 +243,7 @@ export function Sidebar() {
 
 			<div className={cn('mt-auto transition-[padding] duration-300', effectiveIsCollapsed ? 'p-1' : 'p-2')}>
 				{isInSettings && <SidebarCommunity isCollapsed={effectiveIsCollapsed} />}
+				{isAdmin && <SidebarVersionNotice isCollapsed={effectiveIsCollapsed} />}
 				<SidebarUserMenu
 					isCollapsed={effectiveIsCollapsed}
 					chatFilterMenu={


### PR DESCRIPTION
Closes #569

## Summary
- Adds a backend endpoint (`system.checkUpdate`) that fetches the latest nao release from GitHub and compares it with the current `APP_VERSION`
- Shows a small amber warning notification at the bottom of the left sidebar when the deployed version is outdated — links to the release page
- Admin-only: non-admin users don't see the notification and can't call the endpoint
- Works for both CLI (`APP_VERSION=dev` by default) and Docker deployments (version set via build arg)
- Backend caches the GitHub check for 1 hour to avoid rate limiting

## Changed files
- **`apps/backend/src/services/version-check.service.ts`** — new service: fetches latest GitHub release, semver comparison with rc support, 1-hour in-memory cache
- **`apps/backend/src/trpc/system.routes.ts`** — new `checkUpdate` admin-protected route
- **`apps/frontend/src/components/sidebar-version-notice.tsx`** — new component: amber warning with tooltip when collapsed
- **`apps/frontend/src/components/sidebar.tsx`** — wires the notice into the sidebar bottom section (admin-only)

## Notes
The original issue also mentioned showing release notes in the admin panel — this PR ships the floating notification only. Release notes in settings can be a follow-up if useful.

## Test plan
- [ ] Deploy with an older `APP_VERSION` and verify the notification appears for admin users
- [ ] Verify the notification does NOT appear for non-admin users
- [ ] Verify the notification links to the correct GitHub release page
- [ ] Verify the collapsed sidebar shows a tooltip on hover
- [ ] Test with `APP_VERSION=dev` (default local development) — should show the notice
- [ ] Test with the latest version — notification should not appear
- [ ] Verify no GitHub API errors when offline (graceful failure, no notification shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
