### PR TITLE
fix(sync): strip .git/ from cloned repos to fix gitlink bug

### DIFF
--- a/cli/nao_core/commands/sync/cleanup.py
+++ b/cli/nao_core/commands/sync/cleanup.py
@@ -172,6 +172,9 @@ def cleanup_stale_databases(active_databases: List, base_path: Path, verbose: bo
 def cleanup_stale_repos(config_repos: list, base_path: Path, verbose: bool = False) -> None:
     """Remove repositories that are not present in the config file."""
 
+    if not base_path.exists():
+        return
+
     repo_names = {repo.name for repo in config_repos}
     for repo_dir in base_path.iterdir():
         if repo_dir.is_dir() and repo_dir.name not in repo_names:

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -21,18 +21,25 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
 
+    # Guard against path traversal via malicious repo.name (e.g. "../other")
+    resolved_repo_path = repo_path.resolve()
+    if not resolved_repo_path.is_relative_to(base_path.resolve()):
+        console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
+        return False
+
+    tmp_path = base_path / f"{repo.name}.tmp"
+
     try:
-        if repo_path.exists():
-            console.print(f"  [dim]Re-cloning[/dim] {repo.name}")
-            shutil.rmtree(repo_path)
-        else:
-            console.print(f"  [dim]Cloning[/dim] {repo.name}")
+        console.print(f"  [dim]{'Re-cloning' if repo_path.exists() else 'Cloning'}[/dim] {repo.name}")
+
+        if tmp_path.exists():
+            shutil.rmtree(tmp_path)
 
         cmd = ["git", "clone"]
         if repo.branch:
             cmd.extend(["-b", repo.branch])
         if repo.url:
-            cmd.extend([repo.url, str(repo_path)])
+            cmd.extend([repo.url, str(tmp_path)])
 
         result = subprocess.run(
             cmd,
@@ -43,17 +50,24 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
 
         if result.returncode != 0:
             console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
+            shutil.rmtree(tmp_path, ignore_errors=True)
             return False
 
         # Strip .git/ so parent repo tracks files as regular content, not a gitlink
-        git_dir = repo_path / ".git"
+        git_dir = tmp_path / ".git"
         if git_dir.exists():
             shutil.rmtree(git_dir)
+
+        # Atomic swap: only replace existing repo after successful clone
+        if repo_path.exists():
+            shutil.rmtree(repo_path)
+        tmp_path.rename(repo_path)
 
         return True
 
     except Exception as e:
         console.print(f"  [yellow]⚠[/yellow] Error syncing {repo.name}: {e}")
+        shutil.rmtree(tmp_path, ignore_errors=True)
         return False
 
 

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -20,17 +20,16 @@ console = Console()
 def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
-
-    # Guard against path traversal via malicious repo.name (e.g. "../other")
-    resolved_repo_path = repo_path.resolve()
-    if not resolved_repo_path.is_relative_to(base_path.resolve()):
-        console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
-        return False
-
     tmp_path = base_path / f"{repo.name}.tmp"
 
     try:
-        console.print(f"  [dim]{'Re-cloning' if repo_path.exists() else 'Cloning'}[/dim] {repo.name}")
+        # Guard against path traversal via malicious repo.name (e.g. "../other")
+        if not repo_path.resolve().is_relative_to(base_path.resolve()):
+            console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
+            return False
+
+        action = "Re-cloning" if repo_path.exists() else "Cloning"
+        console.print(f"  [dim]{action}[/dim] {repo.name}")
 
         if tmp_path.exists():
             shutil.rmtree(tmp_path)

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -18,53 +18,37 @@ console = Console()
 
 
 def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
-    """Clone a repository if it doesn't exist, or pull latest changes if it does."""
+    """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
 
     try:
         if repo_path.exists():
-            console.print(f"  [dim]Pulling latest changes for[/dim] {repo.name}")
-
-            result = subprocess.run(
-                ["git", "pull"],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-
-            if result.returncode != 0:
-                console.print(f"  [yellow]⚠[/yellow] Failed to pull {repo.name}: {result.stderr.strip()}")
-                return False
-
-            if repo.branch:
-                subprocess.run(
-                    ["git", "checkout", repo.branch],
-                    cwd=repo_path,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-
+            console.print(f"  [dim]Re-cloning[/dim] {repo.name}")
+            shutil.rmtree(repo_path)
         else:
             console.print(f"  [dim]Cloning[/dim] {repo.name}")
 
-            cmd = ["git", "clone"]
-            if repo.branch:
-                cmd.extend(["-b", repo.branch])
-            if repo.url:
-                cmd.extend([repo.url, str(repo_path)])
+        cmd = ["git", "clone"]
+        if repo.branch:
+            cmd.extend(["-b", repo.branch])
+        if repo.url:
+            cmd.extend([repo.url, str(repo_path)])
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-            if result.returncode != 0:
-                console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
-                return False
+        if result.returncode != 0:
+            console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
+            return False
+
+        # Strip .git/ so parent repo tracks files as regular content, not a gitlink
+        git_dir = repo_path / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir)
 
         return True
 

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -134,19 +134,28 @@ class TestRepositorySyncProvider:
         assert provider.should_sync(mock_config) is False
 
 
+def git_clone_stub(base_path: Path, repo_name: str):
+    """subprocess.run side_effect that simulates git clone by creating the .tmp target directory."""
+
+    def _run(*_args, **_kwargs):
+        (base_path / f"{repo_name}.tmp").mkdir(exist_ok=True)
+        return MagicMock(returncode=0)
+
+    return _run
+
+
 class TestCloneOrPullRepo:
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
     def test_clones_new_repo(self, mock_console, mock_run, tmp_path: Path):
         repo = RepoConfig(name="new-repo", url="https://github.com/test/new-repo")
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "new-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
         mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        assert "clone" in call_args[0][0]
+        assert "clone" in mock_run.call_args[0][0]
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
@@ -156,7 +165,7 @@ class TestCloneOrPullRepo:
             url="https://github.com/test/new-repo",
             branch="develop",
         )
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "new-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
@@ -167,36 +176,69 @@ class TestCloneOrPullRepo:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_pulls_existing_repo(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_reclones_existing_repo(self, mock_console, mock_run, tmp_path: Path):
+        """Re-sync always re-clones fresh rather than pulling in-place."""
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(name="existing-repo", url="https://github.com/test/existing-repo")
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "existing-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
-        call_args = mock_run.call_args[0][0]
-        assert "pull" in call_args
+        assert mock_run.call_count == 1
+        assert "clone" in mock_run.call_args[0][0]
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_pulls_and_checkouts_branch(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_reclones_existing_repo_with_branch(self, mock_console, mock_run, tmp_path: Path):
+        """Re-sync with branch uses a single clone -b, not pull + checkout."""
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(
             name="existing-repo",
             url="https://github.com/test/existing-repo",
             branch="feature",
         )
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "existing-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 1
+        call_args = mock_run.call_args[0][0]
+        assert "-b" in call_args
+        assert "feature" in call_args
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_strips_git_directory_after_clone(self, mock_console, mock_run, tmp_path: Path):
+        """Core fix: .git/ must be removed so parent repo tracks files, not a gitlink."""
+        repo = RepoConfig(name="my-repo", url="https://github.com/test/my-repo")
+
+        def fake_clone_with_git_dir(*args, **kwargs):
+            cloned = tmp_path / "my-repo.tmp"
+            cloned.mkdir(exist_ok=True)
+            (cloned / ".git").mkdir()
+            (cloned / "README.md").write_text("hello")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_clone_with_git_dir
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is True
+        assert not (tmp_path / "my-repo" / ".git").exists()
+        assert (tmp_path / "my-repo" / "README.md").exists()
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_rejects_path_traversal_repo_name(self, mock_console, mock_run, tmp_path: Path):
+        """Security: repo.name like '../evil' must be rejected before any git call."""
+        repo = RepoConfig(name="../evil", url="https://github.com/test/evil")
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is False
+        mock_run.assert_not_called()
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
@@ -210,12 +252,10 @@ class TestCloneOrPullRepo:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_returns_false_on_pull_failure(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_returns_false_on_reclone_failure(self, mock_console, mock_run, tmp_path: Path):
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(name="existing-repo", url="https://github.com/test/existing-repo")
-        mock_run.return_value = MagicMock(returncode=1, stderr="Error pulling")
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error cloning")
 
         result = clone_or_pull_repo(repo, tmp_path)
 


### PR DESCRIPTION
Closes #716

## Problem

When `nao sync` clones a git repo into `repos/<name>/`, it leaves a `.git/` folder inside. Git sees this nested `.git/` and treats the whole directory as a **gitlink** (`mode 160000`) instead of regular tracked files.

So when you commit and push the context repo, Git only stores a SHA pointer, not the actual file content. Anyone who clones that repo after you, a teammate, CI pipeline, or the deployed agent, gets an **empty folder, silently, with no errors.**

The files only ever exist on the machine that ran `nao sync`.

```bash
# Before this fix, git was storing a pointer, not files
$ git ls-tree -r HEAD repos/
160000 commit bf48ed0a...    repos/dbt
```

---

## What We Changed

### `cli/nao_core/commands/sync/providers/repositories/provider.py`

- After a successful clone, we now call `shutil.rmtree(repo_path / ".git")` to strip the nested Git repo
- `repos/<name>/` becomes a plain folder, `git add` now commits actual file content, not a SHA pointer
- Since `.git/` no longer exists after first sync, `git pull` on re-sync is not possible, changed to always **re-clone fresh** (delete → clone → strip)

### `cli/nao_core/commands/sync/cleanup.py` *(bonus fix)*

- `cleanup_stale_repos` called `base_path.iterdir()` before `repos/` existed on first sync
- This crashed every first-time sync with `[Errno 2] No such file or directory: 'repos'`
- Fixed with a simple early return: `if not base_path.exists(): return`

---

## Proof

```bash
$ uv run nao sync
  Cloning dbt
  ✓ dbt

# .git/ is gone — no more gitlink
$ ls repos/dbt/.git
No such file or directory

# actual files are there and committable
$ ls repos/dbt/
Dockerfile  README.md  dbt_project.yml  models  seeds  profiles.yml ...
```

> Screenshot attached below, shows sync success, `.git/` stripped, and real files present in one run.
<img width="1919" height="1079" alt="Screenshot 2026-05-05 010608" src="https://github.com/user-attachments/assets/2a985845-2642-4efb-a890-ed06140e1c72" />


---

## Impact

- Fixes silent data loss for all teams using git repo context sources
- Fixes first-time sync crash when `repos/` doesn't exist yet
- Files in `repos/<name>/` are now portable: committable, pushable, and readable by the deployed agent
