### PR TITLE
Add nao newsletter subscription in account settings

### DIFF
--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -38,14 +38,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 	{
 		page: '/settings/account',
 		pageLabel: 'Account',
-		section: 'General Settings',
-		title: 'nao Newsletter',
-		description: 'Get product updates and news from nao.',
-		keywords: ['newsletter', 'subscribe', 'updates', 'email', 'mailing list'],
-	},
-	{
-		page: '/settings/account',
-		pageLabel: 'Account',
 		title: 'Danger Zone',
 		description: 'Delete your account or perform other destructive actions.',
 		keywords: ['delete account', 'remove'],
@@ -388,5 +380,23 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		description: 'Browse and inspect the files and context available to the agent.',
 		keywords: ['files', 'context', 'documents', 'knowledge base'],
 		adminOnly: true,
+	},
+
+	// ── Updates ──────────────────────────────────────────────
+	{
+		page: '/settings/updates',
+		pageLabel: 'Updates',
+		section: 'Release Notes',
+		title: 'GitHub Releases',
+		description: 'See what is new in nao.',
+		keywords: ['changelog', 'releases', 'version', 'github', 'what is new'],
+	},
+	{
+		page: '/settings/updates',
+		pageLabel: 'Updates',
+		section: 'Newsletter',
+		title: 'nao Newsletter',
+		description: 'Get product updates and news from nao.',
+		keywords: ['newsletter', 'subscribe', 'updates', 'email', 'mailing list'],
 	},
 ];

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -38,6 +38,14 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 	{
 		page: '/settings/account',
 		pageLabel: 'Account',
+		section: 'General Settings',
+		title: 'nao Newsletter',
+		description: 'Get product updates and news from nao.',
+		keywords: ['newsletter', 'subscribe', 'updates', 'email', 'mailing list'],
+	},
+	{
+		page: '/settings/account',
+		pageLabel: 'Account',
 		title: 'Danger Zone',
 		description: 'Delete your account or perform other destructive actions.',
 		keywords: ['delete account', 'remove'],

--- a/apps/frontend/src/components/settings/newsletter-subscription.tsx
+++ b/apps/frontend/src/components/settings/newsletter-subscription.tsx
@@ -14,7 +14,9 @@ export function NewsletterSubscription({ email }: { email?: string }) {
 	const [message, setMessage] = useState('');
 
 	const handleSubscribe = async () => {
-		if (!email || isSubmitting) return;
+		if (!email || isSubmitting) {
+			return;
+		}
 
 		setIsSubmitting(true);
 		setMessage('');

--- a/apps/frontend/src/components/settings/newsletter-subscription.tsx
+++ b/apps/frontend/src/components/settings/newsletter-subscription.tsx
@@ -1,19 +1,41 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Loader2, Mail, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { useLocalStorage } from '@/hooks/use-local-storage';
-import { createLocalStorage } from '@/lib/local-storage';
 
 const WAITLIST_API_URL = 'https://sunshine.getnao.io/api/waitlist/';
 
+const subscribedStorageKey = (email: string | undefined) => `newsletter-subscribed:${email ?? ''}`;
+
+const readSubscribed = (email: string | undefined): boolean => {
+	try {
+		return localStorage.getItem(subscribedStorageKey(email)) === 'true';
+	} catch {
+		return false;
+	}
+};
+
+const writeSubscribed = (email: string | undefined, value: boolean) => {
+	try {
+		localStorage.setItem(subscribedStorageKey(email), String(value));
+	} catch {
+		// ignore quota / privacy-mode errors
+	}
+};
+
 export function NewsletterSubscription({ email }: { email?: string }) {
-	const subscribedStorage = useMemo(
-		() => createLocalStorage<boolean>(`newsletter-subscribed:${email ?? ''}`, false),
-		[email],
-	);
-	const [subscribed, setSubscribed] = useLocalStorage(subscribedStorage);
+	const [subscribed, setSubscribed] = useState(() => readSubscribed(email));
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [message, setMessage] = useState('');
+
+	useEffect(() => {
+		setSubscribed(readSubscribed(email));
+		setMessage('');
+	}, [email]);
+
+	const persistSubscribed = (value: boolean) => {
+		setSubscribed(value);
+		writeSubscribed(email, value);
+	};
 
 	const handleSubscribe = async () => {
 		if (!email || isSubmitting) {
@@ -46,10 +68,10 @@ export function NewsletterSubscription({ email }: { email?: string }) {
 				/exists/i.test(serverMsg);
 
 			if (response.ok || data?.success === true) {
-				setSubscribed(true);
+				persistSubscribed(true);
 				setMessage("You're subscribed!");
 			} else if (isAlready) {
-				setSubscribed(true);
+				persistSubscribed(true);
 				setMessage("You're already subscribed!");
 			} else {
 				setMessage('Something went wrong. Please try again.');

--- a/apps/frontend/src/components/settings/newsletter-subscription.tsx
+++ b/apps/frontend/src/components/settings/newsletter-subscription.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Loader2, Mail, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLocalStorage } from '@/hooks/use-local-storage';
@@ -6,10 +6,12 @@ import { createLocalStorage } from '@/lib/local-storage';
 
 const WAITLIST_API_URL = 'https://sunshine.getnao.io/api/waitlist/';
 
-const newsletterSubscribedStorage = createLocalStorage<boolean>('newsletter-subscribed', false);
-
 export function NewsletterSubscription({ email }: { email?: string }) {
-	const [subscribed, setSubscribed] = useLocalStorage(newsletterSubscribedStorage);
+	const subscribedStorage = useMemo(
+		() => createLocalStorage<boolean>(`newsletter-subscribed:${email ?? ''}`, false),
+		[email],
+	);
+	const [subscribed, setSubscribed] = useLocalStorage(subscribedStorage);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [message, setMessage] = useState('');
 

--- a/apps/frontend/src/components/settings/newsletter-subscription.tsx
+++ b/apps/frontend/src/components/settings/newsletter-subscription.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Loader2, Mail, CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useLocalStorage } from '@/hooks/use-local-storage';
+import { createLocalStorage } from '@/lib/local-storage';
+
+const WAITLIST_API_URL = 'https://sunshine.getnao.io/api/waitlist/';
+
+const newsletterSubscribedStorage = createLocalStorage<boolean>('newsletter-subscribed', false);
+
+export function NewsletterSubscription({ email }: { email?: string }) {
+	const [subscribed, setSubscribed] = useLocalStorage(newsletterSubscribedStorage);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [message, setMessage] = useState('');
+
+	const handleSubscribe = async () => {
+		if (!email || isSubmitting) return;
+
+		setIsSubmitting(true);
+		setMessage('');
+
+		try {
+			const response = await fetch(WAITLIST_API_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ email }),
+			});
+
+			let data = null;
+			try {
+				data = await response.json();
+			} catch {
+				// ignore parse errors
+			}
+
+			const serverMsg = String(data?.message || data?.error || data?.detail || '');
+			const isAlready =
+				response.status === 409 ||
+				response.status === 400 ||
+				/already/i.test(serverMsg) ||
+				/duplicate/i.test(serverMsg) ||
+				/exists/i.test(serverMsg);
+
+			if (response.ok || data?.success === true) {
+				setSubscribed(true);
+				setMessage("You're subscribed!");
+			} else if (isAlready) {
+				setSubscribed(true);
+				setMessage("You're already subscribed!");
+			} else {
+				setMessage('Something went wrong. Please try again.');
+			}
+		} catch {
+			setMessage('Could not reach the server. Please try again later.');
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<div className='flex items-center justify-between'>
+			<div className='flex flex-col gap-0.5'>
+				<p className='text-sm font-medium text-foreground h-5'>nao Newsletter</p>
+				<p className='text-xs text-muted-foreground'>
+					{message || 'Get product updates and news from nao. No spam.'}
+				</p>
+			</div>
+			{subscribed ? (
+				<div className='flex items-center gap-1.5 text-sm text-emerald-600 dark:text-emerald-400'>
+					<CheckCircle2 className='size-4' />
+					Subscribed
+				</div>
+			) : (
+				<Button variant='outline' size='sm' disabled={isSubmitting || !email} onClick={handleSubscribe}>
+					{isSubmitting ? <Loader2 className='animate-spin' /> : <Mail />}
+					{isSubmitting ? 'Subscribing...' : 'Subscribe'}
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/frontend/src/components/sidebar-community.tsx
+++ b/apps/frontend/src/components/sidebar-community.tsx
@@ -1,3 +1,5 @@
+import { Link } from '@tanstack/react-router';
+import { Mail } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import GithubIcon from '@/components/icons/github-icon.svg';
 import SlackIcon from '@/components/icons/slack.svg';
@@ -39,6 +41,15 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 				>
 					<SlackIcon className='size-3.5 grayscale brightness-0 dark:brightness-200 opacity-30' />
 				</a>
+				<Link
+					to='/settings/updates'
+					className={cn(
+						'p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
+					)}
+					title='Subscribe to updates'
+				>
+					<Mail className='size-3.5' />
+				</Link>
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -91,6 +91,14 @@ const settingsNavItems: NavItem[] = [
 		to: '/settings/context-explorer',
 		visible: ({ isAdmin }) => isAdmin,
 	},
+	{
+		label: 'nao',
+		type: 'divider',
+	},
+	{
+		label: 'Updates',
+		to: '/settings/updates',
+	},
 ];
 
 interface SidebarSettingsNavProps {

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as SidebarLayoutSettingsIndexRouteImport } from './routes/_sideba
 import { Route as SidebarLayoutChatLayoutIndexRouteImport } from './routes/_sidebar-layout._chat-layout.index'
 import { Route as SidebarLayoutSharedChatShareIdRouteImport } from './routes/_sidebar-layout.shared-chat.$shareId'
 import { Route as SidebarLayoutSettingsUsageRouteImport } from './routes/_sidebar-layout.settings.usage'
+import { Route as SidebarLayoutSettingsUpdatesRouteImport } from './routes/_sidebar-layout.settings.updates'
 import { Route as SidebarLayoutSettingsProjectRouteImport } from './routes/_sidebar-layout.settings.project'
 import { Route as SidebarLayoutSettingsOrganizationRouteImport } from './routes/_sidebar-layout.settings.organization'
 import { Route as SidebarLayoutSettingsMemoryRouteImport } from './routes/_sidebar-layout.settings.memory'
@@ -104,6 +105,12 @@ const SidebarLayoutSettingsUsageRoute =
   SidebarLayoutSettingsUsageRouteImport.update({
     id: '/usage',
     path: '/usage',
+    getParentRoute: () => SidebarLayoutSettingsRoute,
+  } as any)
+const SidebarLayoutSettingsUpdatesRoute =
+  SidebarLayoutSettingsUpdatesRouteImport.update({
+    id: '/updates',
+    path: '/updates',
     getParentRoute: () => SidebarLayoutSettingsRoute,
   } as any)
 const SidebarLayoutSettingsProjectRoute =
@@ -249,6 +256,7 @@ export interface FileRoutesByFullPath {
   '/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
   '/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
   '/settings/project': typeof SidebarLayoutSettingsProjectRouteWithChildren
+  '/settings/updates': typeof SidebarLayoutSettingsUpdatesRoute
   '/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/settings/': typeof SidebarLayoutSettingsIndexRoute
@@ -280,6 +288,7 @@ export interface FileRoutesByTo {
   '/settings/logs': typeof SidebarLayoutSettingsLogsRoute
   '/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
   '/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
+  '/settings/updates': typeof SidebarLayoutSettingsUpdatesRoute
   '/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/settings': typeof SidebarLayoutSettingsIndexRoute
@@ -315,6 +324,7 @@ export interface FileRoutesById {
   '/_sidebar-layout/settings/memory': typeof SidebarLayoutSettingsMemoryRoute
   '/_sidebar-layout/settings/organization': typeof SidebarLayoutSettingsOrganizationRoute
   '/_sidebar-layout/settings/project': typeof SidebarLayoutSettingsProjectRouteWithChildren
+  '/_sidebar-layout/settings/updates': typeof SidebarLayoutSettingsUpdatesRoute
   '/_sidebar-layout/settings/usage': typeof SidebarLayoutSettingsUsageRoute
   '/_sidebar-layout/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/_sidebar-layout/_chat-layout/': typeof SidebarLayoutChatLayoutIndexRoute
@@ -351,6 +361,7 @@ export interface FileRouteTypes {
     | '/settings/memory'
     | '/settings/organization'
     | '/settings/project'
+    | '/settings/updates'
     | '/settings/usage'
     | '/shared-chat/$shareId'
     | '/settings/'
@@ -382,6 +393,7 @@ export interface FileRouteTypes {
     | '/settings/logs'
     | '/settings/memory'
     | '/settings/organization'
+    | '/settings/updates'
     | '/settings/usage'
     | '/shared-chat/$shareId'
     | '/settings'
@@ -416,6 +428,7 @@ export interface FileRouteTypes {
     | '/_sidebar-layout/settings/memory'
     | '/_sidebar-layout/settings/organization'
     | '/_sidebar-layout/settings/project'
+    | '/_sidebar-layout/settings/updates'
     | '/_sidebar-layout/settings/usage'
     | '/_sidebar-layout/shared-chat/$shareId'
     | '/_sidebar-layout/_chat-layout/'
@@ -527,6 +540,13 @@ declare module '@tanstack/react-router' {
       path: '/usage'
       fullPath: '/settings/usage'
       preLoaderRoute: typeof SidebarLayoutSettingsUsageRouteImport
+      parentRoute: typeof SidebarLayoutSettingsRoute
+    }
+    '/_sidebar-layout/settings/updates': {
+      id: '/_sidebar-layout/settings/updates'
+      path: '/updates'
+      fullPath: '/settings/updates'
+      preLoaderRoute: typeof SidebarLayoutSettingsUpdatesRouteImport
       parentRoute: typeof SidebarLayoutSettingsRoute
     }
     '/_sidebar-layout/settings/project': {
@@ -746,6 +766,7 @@ interface SidebarLayoutSettingsRouteChildren {
   SidebarLayoutSettingsMemoryRoute: typeof SidebarLayoutSettingsMemoryRoute
   SidebarLayoutSettingsOrganizationRoute: typeof SidebarLayoutSettingsOrganizationRoute
   SidebarLayoutSettingsProjectRoute: typeof SidebarLayoutSettingsProjectRouteWithChildren
+  SidebarLayoutSettingsUpdatesRoute: typeof SidebarLayoutSettingsUpdatesRoute
   SidebarLayoutSettingsUsageRoute: typeof SidebarLayoutSettingsUsageRoute
   SidebarLayoutSettingsIndexRoute: typeof SidebarLayoutSettingsIndexRoute
 }
@@ -762,6 +783,7 @@ const SidebarLayoutSettingsRouteChildren: SidebarLayoutSettingsRouteChildren = {
     SidebarLayoutSettingsOrganizationRoute,
   SidebarLayoutSettingsProjectRoute:
     SidebarLayoutSettingsProjectRouteWithChildren,
+  SidebarLayoutSettingsUpdatesRoute: SidebarLayoutSettingsUpdatesRoute,
   SidebarLayoutSettingsUsageRoute: SidebarLayoutSettingsUsageRoute,
   SidebarLayoutSettingsIndexRoute: SidebarLayoutSettingsIndexRoute,
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
@@ -14,7 +14,6 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { soundNotificationStorage } from '@/hooks/use-stream-end-sound';
 import { ThemeSelector } from '@/components/settings/theme-selector';
 import { DangerZone } from '@/components/settings/danger-zone';
-import { NewsletterSubscription } from '@/components/settings/newsletter-subscription';
 import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
 import { SettingsControlRow, SettingsToggleRow } from '@/components/ui/settings-toggle-row';
 import { trpc } from '@/main';
@@ -93,7 +92,6 @@ function GeneralPage() {
 					onCheckedChange={setSoundEnabled}
 				/>
 				<SettingsControlRow label='Theme' description='Choose how nao looks.' control={<ThemeSelector />} />
-				<NewsletterSubscription email={user?.email} />
 			</SettingsCard>
 
 			{!isViewer && <DangerZone />}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.account.tsx
@@ -14,6 +14,7 @@ import { useLocalStorage } from '@/hooks/use-local-storage';
 import { soundNotificationStorage } from '@/hooks/use-stream-end-sound';
 import { ThemeSelector } from '@/components/settings/theme-selector';
 import { DangerZone } from '@/components/settings/danger-zone';
+import { NewsletterSubscription } from '@/components/settings/newsletter-subscription';
 import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
 import { SettingsControlRow, SettingsToggleRow } from '@/components/ui/settings-toggle-row';
 import { trpc } from '@/main';
@@ -92,6 +93,7 @@ function GeneralPage() {
 					onCheckedChange={setSoundEnabled}
 				/>
 				<SettingsControlRow label='Theme' description='Choose how nao looks.' control={<ThemeSelector />} />
+				<NewsletterSubscription email={user?.email} />
 			</SettingsCard>
 
 			{!isViewer && <DangerZone />}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.updates.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.updates.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { ExternalLink } from 'lucide-react';
+
+import { useSession } from '@/lib/auth-client';
+import { NewsletterSubscription } from '@/components/settings/newsletter-subscription';
+import { Button } from '@/components/ui/button';
+import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
+
+const RELEASES_URL = 'https://github.com/getnao/nao/releases';
+
+export const Route = createFileRoute('/_sidebar-layout/settings/updates')({
+	component: UpdatesPage,
+});
+
+function UpdatesPage() {
+	const { data: session } = useSession();
+
+	return (
+		<SettingsPageWrapper>
+			<SettingsCard title='Release Notes' description='See what is new in nao.'>
+				<div className='flex items-center justify-between'>
+					<div className='flex flex-col gap-0.5'>
+						<p className='text-sm font-medium text-foreground h-5'>GitHub Releases</p>
+						<p className='text-xs text-muted-foreground'>
+							Browse the full changelog of nao releases on GitHub.
+						</p>
+					</div>
+					<Button variant='outline' size='sm' asChild>
+						<a href={RELEASES_URL} target='_blank' rel='noopener noreferrer'>
+							<ExternalLink />
+							View releases
+						</a>
+					</Button>
+				</div>
+			</SettingsCard>
+
+			<SettingsCard title='Newsletter' description='Stay in the loop with product news from nao.'>
+				<NewsletterSubscription email={session?.user?.email} />
+			</SettingsCard>
+		</SettingsPageWrapper>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds a "nao Newsletter" row in **Settings > Account > General Settings** that lets logged-in users subscribe to the nao newsletter.
- Calls the same `https://sunshine.getnao.io/api/waitlist/` endpoint as the "Keep me updated" form on the getnao.io website footer, so signups land in the same database.
- Persists subscription state in localStorage so the row shows a "Subscribed" check after signing up.

## Changes
- New component: \`apps/frontend/src/components/settings/newsletter-subscription.tsx\`
- Wired into the Account settings page next to the Theme selector
- Added a search index entry so it shows up in settings search

## Test plan
- [ ] Visit \`/settings/account\`, click **Subscribe** — confirm "You're subscribed!" message and the row switches to a "Subscribed" check
- [ ] Click subscribe again with the same email — confirm "You're already subscribed!" handling
- [ ] Verify the entry appears when searching "newsletter" in the settings search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related issue

#570 