### PR TITLE
feat(table): sortable columns in TableDisplay

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -1,9 +1,17 @@
-import { formatCellValue, isNumericColumn } from '@nao/shared/story-table-utils';
+import { formatCellValue, inferColumnSortKind, isNumericColumn, sortRowsByColumn } from '@nao/shared/story-table-utils';
+import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
+import type { ColumnSortKind, SortDirection } from '@nao/shared/story-table-utils';
+
 import { TablePagination } from '@/components/ui/table-pagination';
 import { cn } from '@/lib/utils';
 
 type TableRow = Record<string, unknown>;
+
+interface SortState {
+	column: string;
+	direction: SortDirection;
+}
 
 interface TableDisplayProps {
 	data: TableRow[];
@@ -28,19 +36,43 @@ export function TableDisplay({
 }: TableDisplayProps) {
 	const resolvedColumns = columns && columns.length > 0 ? columns : inferColumns(data);
 	const numericColumns = new Set(resolvedColumns.filter((column) => isNumericColumn(data, column)));
+	const sortKinds = useMemo(() => {
+		const kinds = new Map<string, ColumnSortKind>();
+		for (const column of resolvedColumns) {
+			kinds.set(column, inferColumnSortKind(data, column));
+		}
+		return kinds;
+	}, [data, resolvedColumns]);
 	const hasRows = data.length > 0;
 	const needsPagination = data.length > maxRowsBeforePagination;
 
 	const [pageIndex, setPageIndex] = useState(0);
 	const [pageSize, setPageSize] = useState(maxRowsBeforePagination);
+	const [sort, setSort] = useState<SortState | null>(null);
 
-	useEffect(() => setPageIndex(0), [data]);
+	useEffect(() => {
+		setPageIndex(0);
+		setSort(null);
+	}, [data]);
 
-	const pageCount = Math.ceil(data.length / pageSize);
+	const sortedData = useMemo(() => {
+		if (!sort) {
+			return data;
+		}
+		const kind = sortKinds.get(sort.column) ?? 'string';
+		return sortRowsByColumn(data, sort.column, sort.direction, kind);
+	}, [data, sort, sortKinds]);
+
+	const pageCount = Math.ceil(sortedData.length / pageSize);
 	const pageData = useMemo(
-		() => (needsPagination ? data.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize) : data),
-		[data, pageIndex, pageSize, needsPagination],
+		() => (needsPagination ? sortedData.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize) : sortedData),
+		[sortedData, pageIndex, pageSize, needsPagination],
 	);
+
+	const toggleSort = (column: string) => {
+		setSort((current) => nextSortState(current, column));
+		setPageIndex(0);
+	};
 
 	return (
 		<div className={cn('flex min-h-0 flex-col gap-2', className)}>
@@ -50,17 +82,44 @@ export function TableDisplay({
 				<table className='w-full min-w-max border-collapse text-xs'>
 					<thead className='sticky top-0 z-10 border-b bg-panel'>
 						<tr>
-							{resolvedColumns.map((column) => (
-								<th
-									key={column}
-									className={cn(
-										'px-3 py-2 text-left font-medium whitespace-nowrap text-muted-foreground last:border-r-0',
-										numericColumns.has(column) && 'text-right tabular-nums',
-									)}
-								>
-									{column}
-								</th>
-							))}
+							{resolvedColumns.map((column) => {
+								const isNumeric = numericColumns.has(column);
+								const isSorted = sort?.column === column;
+								const SortIcon = isSorted
+									? sort.direction === 'asc'
+										? ChevronUp
+										: ChevronDown
+									: ChevronsUpDown;
+								return (
+									<th
+										key={column}
+										className={cn(
+											'px-3 py-2 font-medium whitespace-nowrap text-muted-foreground last:border-r-0',
+											isNumeric ? 'text-right tabular-nums' : 'text-left',
+										)}
+										aria-sort={
+											isSorted ? (sort.direction === 'asc' ? 'ascending' : 'descending') : 'none'
+										}
+									>
+										<button
+											type='button'
+											onClick={() => toggleSort(column)}
+											className={cn(
+												'group inline-flex items-center gap-1 select-none hover:text-foreground focus-visible:outline-none focus-visible:text-foreground',
+												isNumeric && 'flex-row-reverse',
+											)}
+										>
+											<span>{column}</span>
+											<SortIcon
+												className={cn(
+													'size-3 shrink-0 transition-opacity',
+													isSorted ? 'opacity-100' : 'opacity-30 group-hover:opacity-70',
+												)}
+											/>
+										</button>
+									</th>
+								);
+							})}
 						</tr>
 					</thead>
 
@@ -125,6 +184,16 @@ export function TableDisplay({
 			) : null}
 		</div>
 	);
+}
+
+function nextSortState(current: SortState | null, column: string): SortState | null {
+	if (!current || current.column !== column) {
+		return { column, direction: 'asc' };
+	}
+	if (current.direction === 'asc') {
+		return { column, direction: 'desc' };
+	}
+	return null;
 }
 
 function inferColumns(data: TableRow[]): string[] {

--- a/apps/shared/src/story-table-utils.ts
+++ b/apps/shared/src/story-table-utils.ts
@@ -30,3 +30,60 @@ export function isNumericColumn(rows: Record<string, unknown>[], column: string)
 function isNumericValue(value: unknown): boolean {
 	return typeof value === 'number' && Number.isFinite(value);
 }
+
+export type ColumnSortKind = 'numeric' | 'date' | 'string';
+
+export type SortDirection = 'asc' | 'desc';
+
+const DATE_LIKE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+export function inferColumnSortKind(rows: Record<string, unknown>[], column: string): ColumnSortKind {
+	const present = rows.filter((row) => row[column] !== null && row[column] !== undefined);
+	if (present.length === 0) {
+		return 'string';
+	}
+	if (present.every((row) => isNumericValue(row[column]))) {
+		return 'numeric';
+	}
+	if (present.every((row) => typeof row[column] === 'string' && DATE_LIKE.test(row[column] as string))) {
+		return 'date';
+	}
+	return 'string';
+}
+
+export function sortRowsByColumn<T extends Record<string, unknown>>(
+	rows: T[],
+	column: string,
+	direction: SortDirection,
+	kind: ColumnSortKind,
+): T[] {
+	const factor = direction === 'asc' ? 1 : -1;
+	return rows
+		.map((row, index) => ({ row, index }))
+		.sort((a, b) => {
+			const aNull = a.row[column] === null || a.row[column] === undefined;
+			const bNull = b.row[column] === null || b.row[column] === undefined;
+			if (aNull && bNull) {
+				return a.index - b.index;
+			}
+			if (aNull) {
+				return 1;
+			}
+			if (bNull) {
+				return -1;
+			}
+			const cmp = compareCells(a.row[column], b.row[column], kind);
+			return cmp !== 0 ? cmp * factor : a.index - b.index;
+		})
+		.map((entry) => entry.row);
+}
+
+function compareCells(a: unknown, b: unknown, kind: ColumnSortKind): number {
+	if (kind === 'numeric') {
+		return (a as number) - (b as number);
+	}
+	if (kind === 'date') {
+		return Date.parse(a as string) - Date.parse(b as string);
+	}
+	return String(a).localeCompare(String(b));
+}

--- a/apps/shared/tests/story-table-utils.test.ts
+++ b/apps/shared/tests/story-table-utils.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferColumnSortKind, sortRowsByColumn } from '../src/story-table-utils';
+
+describe('inferColumnSortKind', () => {
+	it('returns numeric when every present value is a finite number', () => {
+		const rows = [{ x: 1 }, { x: 2.5 }, { x: -3 }];
+		expect(inferColumnSortKind(rows, 'x')).toBe('numeric');
+	});
+
+	it('ignores null and undefined when inferring numeric kind', () => {
+		const rows = [{ x: 1 }, { x: null }, { x: 2 }, { x: undefined }];
+		expect(inferColumnSortKind(rows, 'x')).toBe('numeric');
+	});
+
+	it('returns date when every present value is an ISO-like date string', () => {
+		const rows = [{ d: '2024-01-01' }, { d: '2024-06-15T12:30:00Z' }, { d: '2025-12-31 23:59:59' }];
+		expect(inferColumnSortKind(rows, 'd')).toBe('date');
+	});
+
+	it('returns string when values mix numbers and strings', () => {
+		const rows = [{ x: 1 }, { x: 'two' }];
+		expect(inferColumnSortKind(rows, 'x')).toBe('string');
+	});
+
+	it('returns string when date strings are ambiguous (year-only)', () => {
+		const rows = [{ y: '2024' }, { y: '2025' }];
+		expect(inferColumnSortKind(rows, 'y')).toBe('string');
+	});
+
+	it('returns string when column is empty or all null', () => {
+		expect(inferColumnSortKind([], 'x')).toBe('string');
+		expect(inferColumnSortKind([{ x: null }, { x: undefined }], 'x')).toBe('string');
+	});
+});
+
+describe('sortRowsByColumn', () => {
+	it('sorts numeric ascending', () => {
+		const rows = [{ x: 3 }, { x: 1 }, { x: 2 }];
+		expect(sortRowsByColumn(rows, 'x', 'asc', 'numeric')).toEqual([{ x: 1 }, { x: 2 }, { x: 3 }]);
+	});
+
+	it('sorts numeric descending', () => {
+		const rows = [{ x: 3 }, { x: 1 }, { x: 2 }];
+		expect(sortRowsByColumn(rows, 'x', 'desc', 'numeric')).toEqual([{ x: 3 }, { x: 2 }, { x: 1 }]);
+	});
+
+	it('places nulls and undefined last regardless of direction', () => {
+		const rows = [{ x: 2 }, { x: null }, { x: 1 }, { x: undefined }];
+		const asc = sortRowsByColumn(rows, 'x', 'asc', 'numeric');
+		expect(asc.slice(0, 2)).toEqual([{ x: 1 }, { x: 2 }]);
+		expect(asc[2].x == null).toBe(true);
+		expect(asc[3].x == null).toBe(true);
+
+		const desc = sortRowsByColumn(rows, 'x', 'desc', 'numeric');
+		expect(desc.slice(0, 2)).toEqual([{ x: 2 }, { x: 1 }]);
+		expect(desc[2].x == null).toBe(true);
+		expect(desc[3].x == null).toBe(true);
+	});
+
+	it('sorts date strings chronologically', () => {
+		const rows = [{ d: '2024-12-01' }, { d: '2024-01-15' }, { d: '2024-06-30T10:00:00Z' }];
+		expect(sortRowsByColumn(rows, 'd', 'asc', 'date')).toEqual([
+			{ d: '2024-01-15' },
+			{ d: '2024-06-30T10:00:00Z' },
+			{ d: '2024-12-01' },
+		]);
+	});
+
+	it('sorts strings via locale compare', () => {
+		const rows = [{ s: 'banana' }, { s: 'apple' }, { s: 'cherry' }];
+		expect(sortRowsByColumn(rows, 's', 'asc', 'string')).toEqual([
+			{ s: 'apple' },
+			{ s: 'banana' },
+			{ s: 'cherry' },
+		]);
+	});
+
+	it('keeps original order for equal values (stable)', () => {
+		const rows = [
+			{ x: 1, label: 'a' },
+			{ x: 1, label: 'b' },
+			{ x: 1, label: 'c' },
+		];
+		expect(sortRowsByColumn(rows, 'x', 'asc', 'numeric')).toEqual(rows);
+		expect(sortRowsByColumn(rows, 'x', 'desc', 'numeric')).toEqual(rows);
+	});
+
+	it('does not mutate the input array', () => {
+		const rows = [{ x: 3 }, { x: 1 }, { x: 2 }];
+		const snapshot = [...rows];
+		sortRowsByColumn(rows, 'x', 'asc', 'numeric');
+		expect(rows).toEqual(snapshot);
+	});
+
+	it('treats missing column as all-null and preserves original order', () => {
+		const rows = [{ x: 1 }, { x: 2 }, { x: 3 }];
+		expect(sortRowsByColumn(rows, 'missing', 'asc', 'string')).toEqual(rows);
+	});
+});


### PR DESCRIPTION
Closes #717.

## Summary
Adds client-side column sorting to the shared `TableDisplay` component, which covers all three surfaces called out in the issue:
- inline chat tables
- `execute_sql` tool output
- tables embedded in stories

All three already render through `TableDisplay`, so a single change reaches every surface — no new component, no duplication.

## Behaviour
- Click a column header to cycle: ascending → descending → cleared
- Active column shows `ChevronUp` / `ChevronDown`; idle columns show a faint `ChevronsUpDown`
- Type-aware compare via `inferColumnSortKind`: `numeric`, `date` (ISO-like), `string` fallback (booleans sort as `false` < `true`)
- Stable sort; `null` / `undefined` always placed last, regardless of direction
- `aria-sort` on each `<th>` for accessibility
- Sort state resets when the underlying `data` prop changes
- Pure client-side over the rendered result set — no re-query

## Files
- `apps/frontend/src/components/tool-calls/display-table.tsx` — sort state, header buttons, chevron indicators
- `apps/shared/src/story-table-utils.ts` — `inferColumnSortKind`, `sortRowsByColumn`, `ColumnSortKind`, `SortDirection`
- `apps/shared/tests/story-table-utils.test.ts` — 14 unit tests (kind detection, asc/desc, null ordering, stability, immutability, missing-column safety)

## Test plan
- [x] `npm run lint` — clean across backend, frontend, shared
- [x] `vitest run` in `apps/shared` — 27/27 pass
- [x] Manual: chat → ran SQL via `execute_sql` → expanded result pill → sorted numeric (`customer_id`, `total_spend`) and string (`customer_name`) headers; verified asc → desc → clear cycle
- [ ] Reviewer: verify story table embed (open a story containing a table) — same `TableDisplay`, behaviour identical
- [ ] Reviewer: verify SQL editor side panel result table