### PR TITLE
Fix #268: PII masking in the context provider

### DIFF
--- a/apps/backend/src/utils/chat-context-usage.ts
+++ b/apps/backend/src/utils/chat-context-usage.ts
@@ -1,5 +1,5 @@
 import type { LlmProvider } from '@nao/shared/types';
-import { convertToModelMessages, type ModelMessage, type Tool } from 'ai';
+import { convertToModelMessages, isToolUIPart, type ModelMessage, type Tool } from 'ai';
 
 import { KNOWN_MODELS } from '../agents/providers';
 import { getTools } from '../agents/tools';
@@ -10,7 +10,8 @@ import * as projectQueries from '../queries/project.queries';
 import { compactionService } from '../services/compaction';
 import { memoryService } from '../services/memory';
 import { tokenCounter } from '../services/token-counter';
-import type { ContextUsage, UIMessage } from '../types/chat';
+import type { ContextUsage, UIMessage, UIMessagePart } from '../types/chat';
+import { maskPII, maskPIIValue } from './pii';
 
 export async function getChatContextUsage(opts: {
 	chatId: string;
@@ -41,9 +42,48 @@ export async function getChatAsModelMessages(opts: {
 	const systemPrompt = renderToMarkdown(SystemPrompt({ memories }));
 	const systemMessage: Omit<UIMessage, 'id'> = {
 		role: 'system',
-		parts: [{ type: 'text', text: systemPrompt }],
+		parts: [{ type: 'text', text: maskPII(systemPrompt) }],
 	};
-	return convertToModelMessages<UIMessage>([systemMessage, ...uiMessagesWithCompaction], { tools: opts.tools });
+	const maskedUiMessages = uiMessagesWithCompaction.map((message) => ({
+		...message,
+		parts: message.parts.map(maskContextMessagePart),
+	}));
+	return convertToModelMessages<UIMessage>([systemMessage, ...maskedUiMessages], { tools: opts.tools });
+}
+
+function maskContextMessagePart(part: UIMessagePart): UIMessagePart {
+	if (part.type === 'text') {
+		return { ...part, text: maskPII(part.text) };
+	}
+
+	if (part.type === 'reasoning') {
+		return { ...part, text: maskPII(part.text) };
+	}
+
+	if (part.type === 'dynamic-tool') {
+		if (part.state === 'output-available') {
+			return {
+				...part,
+				input: maskPIIValue(part.input),
+				output: maskPIIValue(part.output),
+			} as UIMessagePart;
+		}
+
+		return {
+			...part,
+			input: maskPIIValue(part.input),
+		} as UIMessagePart;
+	}
+
+	if (isToolUIPart(part)) {
+		return {
+			...part,
+			input: maskPIIValue(part.input),
+			output: maskPIIValue(part.output),
+		} as UIMessagePart;
+	}
+
+	return part;
 }
 
 function getContextWindow({ provider, modelId }: { provider: LlmProvider; modelId: string }): number | null {

--- a/apps/backend/src/utils/pii.ts
+++ b/apps/backend/src/utils/pii.ts
@@ -1,0 +1,36 @@
+export const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+
+const ipOctet = '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)';
+export const IPV4_REGEX = new RegExp(`\\b(?:${ipOctet}\\.){3}${ipOctet}\\b`, 'g');
+
+export const PHONE_REGEX = /\b(?:\+?\d{1,3}[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g;
+
+export function maskPII(text: string): string {
+	if (!text) return text;
+
+	let masked = text;
+	masked = masked.replace(EMAIL_REGEX, '[EMAIL REDACTED]');
+	masked = masked.replace(IPV4_REGEX, '[IP REDACTED]');
+	masked = masked.replace(PHONE_REGEX, '[PHONE REDACTED]');
+
+	return masked;
+}
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function maskPIIValue(value: unknown): unknown {
+	if (typeof value === 'string') {
+		return maskPII(value);
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => maskPIIValue(item));
+	}
+
+	if (isPlainObject(value)) {
+		return Object.fromEntries(Object.entries(value).map(([key, nestedValue]) => [key, maskPIIValue(nestedValue)]));
+	}
+
+	return value;
+}


### PR DESCRIPTION
This PR implements PII masking in the context provider so we don't accidentally leak sensitive user data to the LLMs.

I wanted to make sure this was strict and type-safe rather than just forcing a blanket string replacement, so here are the exact technical details of what I did:

- Added a maskPII utility in `apps/backend/src/utils/pii.ts` with regex patterns for emails, IPv4 addresses, and standard phone numbers. (I constructed the IPv4 regex dynamically to satisfy the 120-character Prettier limit).

- Masked the parsed `systemPrompt` text before appending it to the model payload.

- To prevent tool results (like database queries) from leaking PII, I avoided unsafe `as any` casts and risky `JSON.stringify` hacks. Instead, I used the exact AI SDK type guards (`isToolUIPart` and `part.type === 'dynamic-tool'`).

- Implemented a recursive `maskPIIValue` function to safely walk through tool input/output payloads. This ensures we only mask the actual string values deeply nested inside the tools without corrupting the object structure or JSON keys.

Fixes #268

---

**This PR was written using Claude Haiku 4.5 (claude-haiku-4-5).**