### PR TITLE
feat: enable reasoning/thinking tokens for Vertex provider (Gemini + Claude)

### DIFF
--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -11,7 +11,7 @@ import type { LlmProvider } from '@nao/shared/types';
 import { createOpenRouter, LanguageModelV3 } from '@openrouter/ai-sdk-provider';
 import { createOllama } from 'ai-sdk-ollama';
 
-import type { LlmProvidersType, ProviderConfigMap, ProviderSettings } from '../types/llm';
+import type { LlmProvidersType, ProviderConfigMap, ProviderOptions, ProviderSettings } from '../types/llm';
 import { PROVIDER_META } from './provider-meta';
 
 export {
@@ -131,6 +131,20 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 			}
 			return createVertex(config)(modelId);
 		},
+		getProviderOptions: (modelId) => {
+			if (modelId.startsWith('claude-')) {
+				return {
+					anthropic: {
+						thinking: { type: 'adaptive', display: 'summarized', budget_tokens: 10000 },
+					}
+				};
+			}
+			return {
+				vertex: {
+					thinkingConfig: { includeThoughts: true },
+				}
+			};
+		},
 	},
 	azure: {
 		...PROVIDER_META.azure,
@@ -154,7 +168,7 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 
 export type ProviderModelResult = {
 	model: LanguageModelV3;
-	providerOptions: Partial<{ [P in LlmProvider]: ProviderConfigMap[P] }>;
+	providerOptions: Partial<ProviderOptions>;
 	contextWindow: number;
 };
 
@@ -165,15 +179,22 @@ export function createProviderModel(
 	modelId: string,
 ): ProviderModelResult {
 	const providerConfig = LLM_PROVIDERS[provider];
-	const defaultOptions = providerConfig.defaultOptions ?? {};
-	const modelConfig = getProviderModelConfig(provider, modelId);
 	const contextWindow = providerConfig.models.find((m) => m.id === modelId)?.contextWindow ?? 200_000;
+	const providerOptions = providerConfig.getProviderOptions
+		? providerConfig.getProviderOptions(modelId)
+		: (() => {
+			// Fallback: merge defaultOptions and modelConfig under the provider key
+			const defaultOptions = providerConfig.defaultOptions ?? {};
+			const modelConfig = getProviderModelConfig(provider, modelId);
+
+			return {
+				[provider]: { ...defaultOptions, ...modelConfig },
+			}
+		})();
 
 	return {
 		model: providerConfig.create(settings, modelId),
-		providerOptions: {
-			[provider]: { ...defaultOptions, ...modelConfig },
-		},
+		providerOptions,
 		contextWindow,
 	};
 }

--- a/apps/backend/src/types/llm.ts
+++ b/apps/backend/src/types/llm.ts
@@ -89,10 +89,15 @@ export type ProviderMetaMap = {
 	[P in LlmProvider]: ProviderMeta<P>;
 };
 
+export type ProviderOptions = {
+	[P in LlmProvider]: ProviderConfigMap[P];
+};
+
 /** Full provider configuration with SDK create function (backend-only) */
 type ProviderConfig<P extends LlmProvider> = ProviderMeta<P> & {
 	create: (settings: ProviderSettings, modelId: string) => LanguageModelV3;
 	defaultOptions?: ProviderConfigMap[P];
+	getProviderOptions?: (modelId: string) => Partial<ProviderOptions>;
 };
 
 /** Full providers type - each key gets its own config type */


### PR DESCRIPTION
## Related Issue

Fixes #670

## Summary

Enables reasoning/thinking tokens support for the Vertex provider (Gemini and Claude models). Claude models now use anthropic thinking with `adaptive type` and `summarized display` with a `token_budget` of 10000, while Gemini models enable Vertex thinkingConfig to include thoughts in responses. The rest of the providers continue using the exisiting logic.

## Changes

**Provider Option Handling Enhancements:**

* Extended the provider configuration (`ProviderConfig`) to allow an optional `getProviderOptions` function, enabling providers to return model-specific options.
* Implemented the `getProviderOptions` function for the `vertex` provider, which returns specific options for `claude-` models and a default for others.
* Refactored the `createProviderModel` function to use the new `getProviderOptions` logic, falling back to merging defaults and model config if not provided.

**Type Improvements:**

* Added a new `ProviderOptions` type to represent provider-specific options in a more structured way.
* Updated the `ProviderModelResult` type to use `Partial<ProviderOptions>` for the `providerOptions` field, improving type safety and consistency.

## Test
 - Ran linting for type safety: npm run lint
 - Ran unit test verifying provider options are correctly returned for Claude (anthropic thinking) and Gemini (vertex thinkingConfig) models.
 
<img width="933" height="321" alt="Screenshot 2026-05-05 185147" src="https://github.com/user-attachments/assets/bfd8ddb9-0851-43bf-90ba-015db69465f7" />

---
Code written with help of Claude Haiku 4.5