### PR TITLE
ci(docker): skip `latest` tag for release candidates

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -161,7 +161,7 @@ jobs:
                   flavor: |
                       latest=false
                   tags: |
-                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
                       type=raw,value=alpha,enable=${{ github.ref == 'refs/heads/main' }}
                       type=ref,event=branch
                       type=semver,pattern={{version}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prevents the `latest` Docker image tag from being applied when pushing a release candidate tag (e.g. `v1.2.3rc1`).

## Change

In `.github/workflows/docker.yml`, the `latest` raw tag is now only enabled for tag pushes that don't contain `rc`:

```yaml
type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'rc') }}
```

## Behavior

- `v1.2.3` → builds and pushes `getnao/nao:1.2.3`, `getnao/nao:1.2`, and `getnao/nao:latest` (unchanged).
- `v1.2.3rc1` → builds and pushes the version-specific tags but **no longer** moves `latest`.
- Branch pushes (`main`, `**docker`, `**cloud`) are unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16abf0b1-a7e4-4ff3-a6e6-362794513b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16abf0b1-a7e4-4ff3-a6e6-362794513b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

