### PR TITLE
feat(cli): support aliases for `nao sync -p` provider names

### DIFF
--- a/cli/nao_core/commands/sync/__init__.py
+++ b/cli/nao_core/commands/sync/__init__.py
@@ -29,7 +29,7 @@ def sync(
         list[str] | None,
         Parameter(
             name=["-p", "--provider", "--providers"],
-            help=f"Provider(s) to sync. Use `-p provider:name` to sync a specific connection (e.g. databases:my-db). Or just `-p databases` to sync all connections. Options: {', '.join(PROVIDER_CHOICES)}",
+            help=f"Provider(s) to sync. Use `-p provider:name` to sync a specific connection (e.g. databases:my-db). Or just `-p databases` to sync all connections. Options: {', '.join(PROVIDER_CHOICES)} (aliases: repo/repos/repository, db/dbs/database).",
         ),
     ] = None,
     output_dirs: Annotated[dict[str, str] | None, Parameter(show=False)] = None,

--- a/cli/nao_core/commands/sync/providers/__init__.py
+++ b/cli/nao_core/commands/sync/providers/__init__.py
@@ -14,6 +14,16 @@ PROVIDER_REGISTRY: dict[str, SyncProvider] = {
     "databases": DatabaseSyncProvider(),
 }
 
+# Aliases mapping shortcut names to canonical provider names
+PROVIDER_ALIASES: dict[str, str] = {
+    "repo": "repositories",
+    "repos": "repositories",
+    "repository": "repositories",
+    "db": "databases",
+    "dbs": "databases",
+    "database": "databases",
+}
+
 # Default providers in order of execution
 DEFAULT_PROVIDERS: list[SyncProvider] = list(PROVIDER_REGISTRY.values())
 
@@ -47,12 +57,13 @@ def parse_provider_arg(arg: str) -> ProviderSelection:
         connection_name = None
 
     provider_name_lower = provider_name.lower()
-    if provider_name_lower not in PROVIDER_REGISTRY:
+    canonical_name = PROVIDER_ALIASES.get(provider_name_lower, provider_name_lower)
+    if canonical_name not in PROVIDER_REGISTRY:
         valid = ", ".join(PROVIDER_CHOICES)
         raise ValueError(f"Unknown provider '{provider_name}'. Valid options: {valid}")
 
     return ProviderSelection(
-        provider=PROVIDER_REGISTRY[provider_name_lower],
+        provider=PROVIDER_REGISTRY[canonical_name],
         connection_name=connection_name,
     )
 
@@ -75,6 +86,7 @@ __all__ = [
     "DatabaseSyncProvider",
     "RepositorySyncProvider",
     "PROVIDER_REGISTRY",
+    "PROVIDER_ALIASES",
     "PROVIDER_CHOICES",
     "DEFAULT_PROVIDERS",
     "get_all_providers",

--- a/cli/tests/nao_core/commands/sync/test_providers.py
+++ b/cli/tests/nao_core/commands/sync/test_providers.py
@@ -1,8 +1,12 @@
 """Unit tests for sync providers base classes and utilities."""
 
+import pytest
+
 from nao_core.commands.sync.providers import (
     SyncResult,
     get_all_providers,
+    get_providers_by_names,
+    parse_provider_arg,
 )
 from nao_core.commands.sync.providers.databases.provider import DatabaseSyncProvider
 from nao_core.commands.sync.providers.notion.provider import NotionSyncProvider
@@ -57,3 +61,35 @@ class TestGetAllProviders:
         providers2 = get_all_providers()
 
         assert providers1 is not providers2
+
+
+class TestParseProviderArg:
+    def test_canonical_name(self):
+        selection = parse_provider_arg("repositories")
+        assert isinstance(selection.provider, RepositorySyncProvider)
+        assert selection.connection_name is None
+
+    @pytest.mark.parametrize("alias", ["repo", "repos", "repository", "REPO", "Repos"])
+    def test_repository_aliases(self, alias: str):
+        selection = parse_provider_arg(alias)
+        assert isinstance(selection.provider, RepositorySyncProvider)
+
+    @pytest.mark.parametrize("alias", ["db", "dbs", "database", "DB", "Database"])
+    def test_database_aliases(self, alias: str):
+        selection = parse_provider_arg(alias)
+        assert isinstance(selection.provider, DatabaseSyncProvider)
+
+    def test_alias_with_connection_name(self):
+        selection = parse_provider_arg("db:my-conn")
+        assert isinstance(selection.provider, DatabaseSyncProvider)
+        assert selection.connection_name == "my-conn"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            parse_provider_arg("unknown")
+
+    def test_get_providers_by_names_with_aliases(self):
+        selections = get_providers_by_names(["repo", "db"])
+        assert len(selections) == 2
+        assert isinstance(selections[0].provider, RepositorySyncProvider)
+        assert isinstance(selections[1].provider, DatabaseSyncProvider)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Typing `nao sync -p repositories` (or `databases`) every time is annoying. This adds shortcut aliases so users can use shorter names:

- `repo`, `repos`, `repository` → `repositories`
- `db`, `dbs`, `database` → `databases`

Aliases are case-insensitive and work with the `:connection` filter syntax too (e.g. `nao sync -p db:my-conn`).

## Changes

- `cli/nao_core/commands/sync/providers/__init__.py`: new `PROVIDER_ALIASES` mapping; `parse_provider_arg` resolves the alias to the canonical name before looking it up in the registry.
- `cli/nao_core/commands/sync/__init__.py`: updated `-p` help text to mention the available aliases.
- `cli/tests/nao_core/commands/sync/test_providers.py`: added unit tests covering canonical names, every alias, case-insensitivity, alias + connection filter, and unknown provider errors.

## Testing

- ✅ `uv run pytest tests/nao_core/commands/sync/test_providers.py` (20 passed, including 13 new tests)
- ✅ `make lint` (`ty check`, `ruff check`, `ruff format --check` all pass)
- ✅ Manual smoke test: ran `nao sync -p <alias>` for each alias against a minimal `nao_config.yaml` and confirmed each routes to the expected provider; invalid names still produce `Unknown provider 'foo'. Valid options: notion, repositories, databases`.
- ✅ `nao sync --help` shows the updated help text listing the aliases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59495fb3-6ec2-4841-8af8-abfa4a15a7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59495fb3-6ec2-4841-8af8-abfa4a15a7ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

