### PR TITLE
fix: support all LLM providers in NLP cron and live story refresh

### DIFF
--- a/apps/backend/src/queries/project-llm-config.queries.ts
+++ b/apps/backend/src/queries/project-llm-config.queries.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm';
 
 import s, { DBProjectLlmConfig, NewProjectLlmConfig } from '../db/abstractSchema';
 import { db } from '../db/db';
-import { getDefaultEnvProvider, getDefaultModelId } from '../utils/llm';
+import { getDefaultModelId } from '../utils/llm';
 
 export const getProjectLlmConfigs = async (projectId: string): Promise<DBProjectLlmConfig[]> => {
 	return db.select().from(s.projectLlmConfig).where(eq(s.projectLlmConfig.projectId, projectId)).execute();
@@ -54,25 +54,6 @@ export const deleteProjectLlmConfig = async (projectId: string, provider: LlmPro
 		.delete(s.projectLlmConfig)
 		.where(and(eq(s.projectLlmConfig.projectId, projectId), eq(s.projectLlmConfig.provider, provider)))
 		.execute();
-};
-
-/** Get the provider for a project (for display purposes) */
-export const getProjectModelProvider = async (projectId: string): Promise<LlmProvider | undefined> => {
-	const configs = await getProjectLlmConfigs(projectId);
-
-	// Return first configured provider, preferring anthropic
-	const anthropicConfig = configs.find((c) => c.provider === 'anthropic');
-	if (anthropicConfig) {
-		return 'anthropic';
-	}
-
-	const openaiConfig = configs.find((c) => c.provider === 'openai');
-	if (openaiConfig) {
-		return 'openai';
-	}
-
-	// Fall back to env providers
-	return getDefaultEnvProvider();
 };
 
 /** Get the config to use for a specific model selection */

--- a/apps/backend/src/services/cron-nlp.ts
+++ b/apps/backend/src/services/cron-nlp.ts
@@ -2,9 +2,8 @@ import { generateText, Output } from 'ai';
 import { CronExpressionParser } from 'cron-parser';
 import { z } from 'zod';
 
-import { LLM_PROVIDERS, type ProviderModelResult } from '../agents/providers';
-import * as llmConfigQueries from '../queries/project-llm-config.queries';
-import { resolveProviderModel } from '../utils/llm';
+import { LLM_PROVIDERS } from '../agents/providers';
+import { resolveFirstProjectModel } from '../utils/llm';
 
 export async function naturalLanguageToCron(projectId: string, text: string): Promise<string | null> {
 	const modelConfig = await resolveModelForProject(projectId);
@@ -48,12 +47,6 @@ export async function naturalLanguageToCron(projectId: string, text: string): Pr
 	}
 }
 
-async function resolveModelForProject(projectId: string): Promise<ProviderModelResult | null> {
-	const provider = await llmConfigQueries.getProjectModelProvider(projectId);
-	if (!provider) {
-		return null;
-	}
-
-	const extractorModelId = LLM_PROVIDERS[provider].extractorModelId;
-	return resolveProviderModel(projectId, provider, extractorModelId);
+async function resolveModelForProject(projectId: string) {
+	return resolveFirstProjectModel(projectId, (provider) => LLM_PROVIDERS[provider].extractorModelId);
 }

--- a/apps/backend/src/services/live-story.ts
+++ b/apps/backend/src/services/live-story.ts
@@ -7,10 +7,9 @@ import { env } from '../env';
 import { renderToMarkdown } from '../lib/markdown';
 import * as chatQueries from '../queries/chat.queries';
 import * as projectQueries from '../queries/project.queries';
-import * as llmConfigQueries from '../queries/project-llm-config.queries';
 import { getQueryDataFromCode } from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
-import { getDefaultModelId, resolveProviderModel } from '../utils/llm';
+import { getDefaultModelId, resolveFirstProjectModel } from '../utils/llm';
 import { MAX_OUTPUT_TOKENS } from './agent';
 const MAX_RENDERED_ROWS = 60;
 
@@ -166,12 +165,7 @@ async function generateDynamicStoryCode(
 	originalCode: string,
 	queryData: Record<string, { data: unknown[]; columns: string[] }>,
 ): Promise<string | null> {
-	const provider = await llmConfigQueries.getProjectModelProvider(projectId);
-	if (!provider) {
-		return null;
-	}
-
-	const model = await resolveProviderModel(projectId, provider, getDefaultModelId(provider));
+	const model = await resolveFirstProjectModel(projectId, (provider) => getDefaultModelId(provider));
 	if (!model) {
 		return null;
 	}

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -47,15 +47,9 @@ export function getEnvBaseUrls(): Record<string, string> {
 	);
 }
 
-/** Get the first available provider from env (preferring anthropic) */
+/** Get the first available provider from env */
 export function getDefaultEnvProvider(): LlmProvider | undefined {
-	if (hasEnvApiKey('anthropic')) {
-		return 'anthropic';
-	}
-	if (hasEnvApiKey('openai')) {
-		return 'openai';
-	}
-	return undefined;
+	return getEnvProviders()[0];
 }
 
 /** Check if a model ID is known for a provider */
@@ -137,6 +131,48 @@ export async function resolveProviderModel(
 
 	if (hasEnvApiKey(provider)) {
 		return createProviderModel(provider, { apiKey: '' }, modelId);
+	}
+
+	return null;
+}
+
+/**
+ * Resolves the first available working model for a project.
+ * Tries DB-configured providers first, then env-configured fallback.
+ * Skips providers where selectModelId returns an empty string.
+ */
+export async function resolveFirstProjectModel(
+	projectId: string,
+	selectModelId: (provider: LlmProvider) => string,
+): Promise<ProviderModelResult | null> {
+	const configs = await projectLlmConfigQueries.getProjectLlmConfigs(projectId);
+
+	for (const config of configs) {
+		const provider = config.provider as LlmProvider;
+		const modelId = selectModelId(provider);
+		if (!modelId) {
+			continue;
+		}
+		const result = await resolveProviderModel(projectId, provider, modelId);
+		if (result) {
+			return result;
+		}
+	}
+
+	const configuredProviders = new Set(configs.map((c) => c.provider));
+
+	for (const provider of getEnvProviders()) {
+		if (configuredProviders.has(provider)) {
+			continue;
+		}
+		const modelId = selectModelId(provider);
+		if (!modelId) {
+			continue;
+		}
+		const result = await resolveProviderModel(projectId, provider, modelId);
+		if (result) {
+			return result;
+		}
 	}
 
 	return null;

--- a/apps/backend/tests/resolve-first-project-model.test.ts
+++ b/apps/backend/tests/resolve-first-project-model.test.ts
@@ -1,0 +1,213 @@
+import type { LlmProvider } from '@nao/shared/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Full factory mocks — avoid loading bun:sqlite or SDK packages
+const mocks = vi.hoisted(() => ({
+	getProjectLlmConfigs: vi.fn(),
+	getProjectLlmConfigByProvider: vi.fn(),
+	createProviderModel: vi.fn(),
+	getDefaultModelId: vi.fn((provider: string) => `default-model-${provider}`),
+	PROVIDER_META: {} as Record<string, unknown>,
+	KNOWN_MODELS: {} as Record<string, unknown>,
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigs: mocks.getProjectLlmConfigs,
+	getProjectLlmConfigByProvider: mocks.getProjectLlmConfigByProvider,
+}));
+
+vi.mock('../src/agents/providers', () => ({
+	createProviderModel: mocks.createProviderModel,
+	getDefaultModelId: mocks.getDefaultModelId,
+	PROVIDER_META: mocks.PROVIDER_META,
+	KNOWN_MODELS: mocks.KNOWN_MODELS,
+	LLM_PROVIDERS: {
+		anthropic: {
+			envVar: 'ANTHROPIC_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'claude-haiku-4-5',
+			models: [],
+		},
+		openai: {
+			envVar: 'OPENAI_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'gpt-4.1-mini',
+			models: [],
+		},
+		google: {
+			envVar: 'GEMINI_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'gemini-2.5-flash',
+			models: [],
+		},
+		mistral: {
+			envVar: 'MISTRAL_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'mistral-medium-latest',
+			models: [],
+		},
+		openrouter: {
+			envVar: 'OPENROUTER_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'anthropic/claude-haiku-4.5',
+			models: [],
+		},
+		ollama: { envVar: 'OLLAMA_API_KEY', auth: { apiKey: 'none' }, extractorModelId: 'llama3.2:3b', models: [] },
+		bedrock: {
+			envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+			auth: { apiKey: 'optional', alternativeEnvVars: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'] },
+			extractorModelId: 'anthropic.claude-sonnet-4-6',
+			models: [],
+		},
+		vertex: {
+			envVar: 'VERTEX_GOOGLE_SERVICE_ACCOUNT_JSON',
+			auth: { apiKey: 'none', extraFields: [{ envVar: 'GOOGLE_VERTEX_PROJECT' }] },
+			extractorModelId: 'gemini-2.5-flash',
+			models: [],
+		},
+		azure: { envVar: 'AZURE_API_KEY', auth: { apiKey: 'required' }, extractorModelId: '', models: [] },
+	},
+}));
+
+const { resolveFirstProjectModel } = await import('../src/utils/llm');
+
+const PROJECT_ID = 'test-project';
+
+function makeDbConfig(provider: LlmProvider) {
+	return { provider, projectId: PROJECT_ID, apiKey: 'test-key', enabledModels: [], baseUrl: null, credentials: null };
+}
+
+function makeModel() {
+	return { model: {} as never, providerOptions: {}, contextWindow: 200_000 };
+}
+
+describe('resolveFirstProjectModel', () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const envKeys = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'MISTRAL_API_KEY', 'OPENROUTER_API_KEY'];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		// snapshot and clear all provider env keys
+		for (const key of envKeys) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of envKeys) {
+			if (savedEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = savedEnv[key];
+			}
+		}
+	});
+
+	it('returns null when no DB configs and no env providers configured', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([]);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(result).toBeNull();
+		expect(mocks.createProviderModel).not.toHaveBeenCalled();
+	});
+
+	it('resolves first DB-configured provider and returns model', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('google'), makeDbConfig('mistral')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('google'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'gemini-2.5-flash');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('google', expect.anything(), 'gemini-2.5-flash');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('skips provider where selectModelId returns empty string (e.g. azure with no extractorModelId)', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('azure'), makeDbConfig('anthropic')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('anthropic'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, (provider) =>
+			provider === 'azure' ? '' : 'claude-haiku-4-5',
+		);
+
+		expect(mocks.createProviderModel).toHaveBeenCalledTimes(1);
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('anthropic', expect.anything(), 'claude-haiku-4-5');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('skips DB provider that cannot be resolved and tries next', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('ollama'), makeDbConfig('mistral')]);
+		mocks.getProjectLlmConfigByProvider
+			.mockResolvedValueOnce(null) // ollama has no DB config or env key
+			.mockResolvedValueOnce(makeDbConfig('mistral'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValueOnce(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledTimes(1);
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('mistral', expect.anything(), 'some-model');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('falls back to env-configured provider when DB has no configs', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([]);
+		process.env.GEMINI_API_KEY = 'env-google-key';
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'gemini-2.5-flash');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('google', expect.anything(), 'gemini-2.5-flash');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('does not retry env provider already in DB configs', async () => {
+		// google is in DB (but fails), anthropic is only in env
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('google')]);
+		process.env.GEMINI_API_KEY = 'env-key';
+		process.env.ANTHROPIC_API_KEY = 'env-key-2';
+		// google DB config lookup returns null, env key also present so createProviderModel called for google
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		const fakeModel = makeModel();
+		mocks.createProviderModel
+			.mockReturnValueOnce(null) // google fails
+			.mockReturnValueOnce(fakeModel); // anthropic (env-only) succeeds
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		const calledProviders = mocks.createProviderModel.mock.calls.map((c) => c[0] as string);
+		// google tried once total (not twice), anthropic tried once
+		expect(calledProviders.filter((p) => p === 'google')).toHaveLength(1);
+		expect(result).toBe(fakeModel);
+	});
+
+	it('returns null when all DB and env providers fail to resolve', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('bedrock')]);
+		process.env.OPENAI_API_KEY = 'env-key';
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		mocks.createProviderModel.mockReturnValue(null);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(result).toBeNull();
+	});
+
+	it('passes provider-specific modelId from selector to createProviderModel', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('anthropic')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('anthropic'));
+		mocks.createProviderModel.mockReturnValue(makeModel());
+
+		await resolveFirstProjectModel(PROJECT_ID, (provider) =>
+			provider === 'anthropic' ? 'claude-haiku-4-5' : 'gpt-4.1-mini',
+		);
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('anthropic', expect.anything(), 'claude-haiku-4-5');
+	});
+});

--- a/cli/nao_core/commands/sync/cleanup.py
+++ b/cli/nao_core/commands/sync/cleanup.py
@@ -172,6 +172,9 @@ def cleanup_stale_databases(active_databases: List, base_path: Path, verbose: bo
 def cleanup_stale_repos(config_repos: list, base_path: Path, verbose: bool = False) -> None:
     """Remove repositories that are not present in the config file."""
 
+    if not base_path.exists():
+        return
+
     repo_names = {repo.name for repo in config_repos}
     for repo_dir in base_path.iterdir():
         if repo_dir.is_dir() and repo_dir.name not in repo_names:

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -21,18 +21,25 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
 
+    # Guard against path traversal via malicious repo.name (e.g. "../other")
+    resolved_repo_path = repo_path.resolve()
+    if not resolved_repo_path.is_relative_to(base_path.resolve()):
+        console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
+        return False
+
+    tmp_path = base_path / f"{repo.name}.tmp"
+
     try:
-        if repo_path.exists():
-            console.print(f"  [dim]Re-cloning[/dim] {repo.name}")
-            shutil.rmtree(repo_path)
-        else:
-            console.print(f"  [dim]Cloning[/dim] {repo.name}")
+        console.print(f"  [dim]{'Re-cloning' if repo_path.exists() else 'Cloning'}[/dim] {repo.name}")
+
+        if tmp_path.exists():
+            shutil.rmtree(tmp_path)
 
         cmd = ["git", "clone"]
         if repo.branch:
             cmd.extend(["-b", repo.branch])
         if repo.url:
-            cmd.extend([repo.url, str(repo_path)])
+            cmd.extend([repo.url, str(tmp_path)])
 
         result = subprocess.run(
             cmd,
@@ -43,17 +50,24 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
 
         if result.returncode != 0:
             console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
+            shutil.rmtree(tmp_path, ignore_errors=True)
             return False
 
         # Strip .git/ so parent repo tracks files as regular content, not a gitlink
-        git_dir = repo_path / ".git"
+        git_dir = tmp_path / ".git"
         if git_dir.exists():
             shutil.rmtree(git_dir)
+
+        # Atomic swap: only replace existing repo after successful clone
+        if repo_path.exists():
+            shutil.rmtree(repo_path)
+        tmp_path.rename(repo_path)
 
         return True
 
     except Exception as e:
         console.print(f"  [yellow]⚠[/yellow] Error syncing {repo.name}: {e}")
+        shutil.rmtree(tmp_path, ignore_errors=True)
         return False
 
 

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -20,17 +20,16 @@ console = Console()
 def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
-
-    # Guard against path traversal via malicious repo.name (e.g. "../other")
-    resolved_repo_path = repo_path.resolve()
-    if not resolved_repo_path.is_relative_to(base_path.resolve()):
-        console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
-        return False
-
     tmp_path = base_path / f"{repo.name}.tmp"
 
     try:
-        console.print(f"  [dim]{'Re-cloning' if repo_path.exists() else 'Cloning'}[/dim] {repo.name}")
+        # Guard against path traversal via malicious repo.name (e.g. "../other")
+        if not repo_path.resolve().is_relative_to(base_path.resolve()):
+            console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
+            return False
+
+        action = "Re-cloning" if repo_path.exists() else "Cloning"
+        console.print(f"  [dim]{action}[/dim] {repo.name}")
 
         if tmp_path.exists():
             shutil.rmtree(tmp_path)

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -18,53 +18,37 @@ console = Console()
 
 
 def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
-    """Clone a repository if it doesn't exist, or pull latest changes if it does."""
+    """Clone a repository and strip .git/ so files are tracked as regular content."""
     repo_path = base_path / repo.name
 
     try:
         if repo_path.exists():
-            console.print(f"  [dim]Pulling latest changes for[/dim] {repo.name}")
-
-            result = subprocess.run(
-                ["git", "pull"],
-                cwd=repo_path,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-
-            if result.returncode != 0:
-                console.print(f"  [yellow]⚠[/yellow] Failed to pull {repo.name}: {result.stderr.strip()}")
-                return False
-
-            if repo.branch:
-                subprocess.run(
-                    ["git", "checkout", repo.branch],
-                    cwd=repo_path,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-
+            console.print(f"  [dim]Re-cloning[/dim] {repo.name}")
+            shutil.rmtree(repo_path)
         else:
             console.print(f"  [dim]Cloning[/dim] {repo.name}")
 
-            cmd = ["git", "clone"]
-            if repo.branch:
-                cmd.extend(["-b", repo.branch])
-            if repo.url:
-                cmd.extend([repo.url, str(repo_path)])
+        cmd = ["git", "clone"]
+        if repo.branch:
+            cmd.extend(["-b", repo.branch])
+        if repo.url:
+            cmd.extend([repo.url, str(repo_path)])
 
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-            if result.returncode != 0:
-                console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
-                return False
+        if result.returncode != 0:
+            console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
+            return False
+
+        # Strip .git/ so parent repo tracks files as regular content, not a gitlink
+        git_dir = repo_path / ".git"
+        if git_dir.exists():
+            shutil.rmtree(git_dir)
 
         return True
 

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -134,19 +134,28 @@ class TestRepositorySyncProvider:
         assert provider.should_sync(mock_config) is False
 
 
+def git_clone_stub(base_path: Path, repo_name: str):
+    """subprocess.run side_effect that simulates git clone by creating the .tmp target directory."""
+
+    def _run(*_args, **_kwargs):
+        (base_path / f"{repo_name}.tmp").mkdir(exist_ok=True)
+        return MagicMock(returncode=0)
+
+    return _run
+
+
 class TestCloneOrPullRepo:
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
     def test_clones_new_repo(self, mock_console, mock_run, tmp_path: Path):
         repo = RepoConfig(name="new-repo", url="https://github.com/test/new-repo")
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "new-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
         mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        assert "clone" in call_args[0][0]
+        assert "clone" in mock_run.call_args[0][0]
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
@@ -156,7 +165,7 @@ class TestCloneOrPullRepo:
             url="https://github.com/test/new-repo",
             branch="develop",
         )
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "new-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
@@ -167,36 +176,69 @@ class TestCloneOrPullRepo:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_pulls_existing_repo(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_reclones_existing_repo(self, mock_console, mock_run, tmp_path: Path):
+        """Re-sync always re-clones fresh rather than pulling in-place."""
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(name="existing-repo", url="https://github.com/test/existing-repo")
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "existing-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
-        call_args = mock_run.call_args[0][0]
-        assert "pull" in call_args
+        assert mock_run.call_count == 1
+        assert "clone" in mock_run.call_args[0][0]
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_pulls_and_checkouts_branch(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_reclones_existing_repo_with_branch(self, mock_console, mock_run, tmp_path: Path):
+        """Re-sync with branch uses a single clone -b, not pull + checkout."""
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(
             name="existing-repo",
             url="https://github.com/test/existing-repo",
             branch="feature",
         )
-        mock_run.return_value = MagicMock(returncode=0)
+        mock_run.side_effect = git_clone_stub(tmp_path, "existing-repo")
 
         result = clone_or_pull_repo(repo, tmp_path)
 
         assert result is True
-        assert mock_run.call_count == 2
+        assert mock_run.call_count == 1
+        call_args = mock_run.call_args[0][0]
+        assert "-b" in call_args
+        assert "feature" in call_args
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_strips_git_directory_after_clone(self, mock_console, mock_run, tmp_path: Path):
+        """Core fix: .git/ must be removed so parent repo tracks files, not a gitlink."""
+        repo = RepoConfig(name="my-repo", url="https://github.com/test/my-repo")
+
+        def fake_clone_with_git_dir(*args, **kwargs):
+            cloned = tmp_path / "my-repo.tmp"
+            cloned.mkdir(exist_ok=True)
+            (cloned / ".git").mkdir()
+            (cloned / "README.md").write_text("hello")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_clone_with_git_dir
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is True
+        assert not (tmp_path / "my-repo" / ".git").exists()
+        assert (tmp_path / "my-repo" / "README.md").exists()
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_rejects_path_traversal_repo_name(self, mock_console, mock_run, tmp_path: Path):
+        """Security: repo.name like '../evil' must be rejected before any git call."""
+        repo = RepoConfig(name="../evil", url="https://github.com/test/evil")
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is False
+        mock_run.assert_not_called()
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
@@ -210,12 +252,10 @@ class TestCloneOrPullRepo:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_returns_false_on_pull_failure(self, mock_console, mock_run, tmp_path: Path):
-        repo_path = tmp_path / "existing-repo"
-        repo_path.mkdir()
-
+    def test_returns_false_on_reclone_failure(self, mock_console, mock_run, tmp_path: Path):
+        (tmp_path / "existing-repo").mkdir()
         repo = RepoConfig(name="existing-repo", url="https://github.com/test/existing-repo")
-        mock_run.return_value = MagicMock(returncode=1, stderr="Error pulling")
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error cloning")
 
         result = clone_or_pull_repo(repo, tmp_path)
 


### PR DESCRIPTION
## Problem

`getDefaultEnvProvider` hardcoded only `ANTHROPIC_API_KEY` → `OPENAI_API_KEY`, silently returning `null` for 7 of 9 providers (google, mistral, openrouter, ollama, bedrock, vertex, azure).

This broke two features for non-Anthropic/OpenAI users:
- NLP cron parsing (`story.parseCronFromText`)
- Live story dynamic text refresh

No error shown, features just silently did nothing.

## Fix

Deleted `getProjectModelProvider` and replaced with `resolveFirstProjectModel`:

```ts
// Before — hardcoded
if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
if (process.env.OPENAI_API_KEY) return 'openai';
return undefined; // all other providers silently fail

// After, works for all 9 providers
export async function resolveFirstProjectModel(
  projectId: string,
  selectModelId: (provider: LlmProvider) => string,
): Promise<ProviderModelResult | null>
Tries DB-configured providers first, falls back to env, skips providers with no model ID (azure), validates credentials before returning.
```

Evidence
Tested with only GEMINI_API_KEY set (no Anthropic/OpenAI key):

<img width="1913" height="1026" alt="image" src="https://github.com/user-attachments/assets/684a41ea-58a1-43b5-9bb3-c94c415e77c0" />

Backend log confirming Gemini API was called (responseTime: 2719ms proves real API call, not null return):

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/461c637d-d9fe-4e91-a77c-677df8b20bd5" />


Tests
8 unit tests added - apps/backend/tests/resolve-first-project-model.test.ts

Tests  8 passed (8)
<img width="1477" height="766" alt="image" src="https://github.com/user-attachments/assets/8ac6d354-6686-4c8d-8cae-625ca4c9b5a3" />


Closes #643