### PR TITLE
fix: support all LLM providers in NLP cron and live story refresh

### DIFF
--- a/apps/backend/src/queries/project-llm-config.queries.ts
+++ b/apps/backend/src/queries/project-llm-config.queries.ts
@@ -3,7 +3,7 @@ import { and, eq } from 'drizzle-orm';
 
 import s, { DBProjectLlmConfig, NewProjectLlmConfig } from '../db/abstractSchema';
 import { db } from '../db/db';
-import { getDefaultEnvProvider, getDefaultModelId } from '../utils/llm';
+import { getDefaultModelId } from '../utils/llm';
 
 export const getProjectLlmConfigs = async (projectId: string): Promise<DBProjectLlmConfig[]> => {
 	return db.select().from(s.projectLlmConfig).where(eq(s.projectLlmConfig.projectId, projectId)).execute();
@@ -54,25 +54,6 @@ export const deleteProjectLlmConfig = async (projectId: string, provider: LlmPro
 		.delete(s.projectLlmConfig)
 		.where(and(eq(s.projectLlmConfig.projectId, projectId), eq(s.projectLlmConfig.provider, provider)))
 		.execute();
-};
-
-/** Get the provider for a project (for display purposes) */
-export const getProjectModelProvider = async (projectId: string): Promise<LlmProvider | undefined> => {
-	const configs = await getProjectLlmConfigs(projectId);
-
-	// Return first configured provider, preferring anthropic
-	const anthropicConfig = configs.find((c) => c.provider === 'anthropic');
-	if (anthropicConfig) {
-		return 'anthropic';
-	}
-
-	const openaiConfig = configs.find((c) => c.provider === 'openai');
-	if (openaiConfig) {
-		return 'openai';
-	}
-
-	// Fall back to env providers
-	return getDefaultEnvProvider();
 };
 
 /** Get the config to use for a specific model selection */

--- a/apps/backend/src/services/cron-nlp.ts
+++ b/apps/backend/src/services/cron-nlp.ts
@@ -2,9 +2,8 @@ import { generateText, Output } from 'ai';
 import { CronExpressionParser } from 'cron-parser';
 import { z } from 'zod';
 
-import { LLM_PROVIDERS, type ProviderModelResult } from '../agents/providers';
-import * as llmConfigQueries from '../queries/project-llm-config.queries';
-import { resolveProviderModel } from '../utils/llm';
+import { LLM_PROVIDERS } from '../agents/providers';
+import { resolveFirstProjectModel } from '../utils/llm';
 
 export async function naturalLanguageToCron(projectId: string, text: string): Promise<string | null> {
 	const modelConfig = await resolveModelForProject(projectId);
@@ -48,12 +47,6 @@ export async function naturalLanguageToCron(projectId: string, text: string): Pr
 	}
 }
 
-async function resolveModelForProject(projectId: string): Promise<ProviderModelResult | null> {
-	const provider = await llmConfigQueries.getProjectModelProvider(projectId);
-	if (!provider) {
-		return null;
-	}
-
-	const extractorModelId = LLM_PROVIDERS[provider].extractorModelId;
-	return resolveProviderModel(projectId, provider, extractorModelId);
+async function resolveModelForProject(projectId: string) {
+	return resolveFirstProjectModel(projectId, (provider) => LLM_PROVIDERS[provider].extractorModelId);
 }

--- a/apps/backend/src/services/live-story.ts
+++ b/apps/backend/src/services/live-story.ts
@@ -7,10 +7,9 @@ import { env } from '../env';
 import { renderToMarkdown } from '../lib/markdown';
 import * as chatQueries from '../queries/chat.queries';
 import * as projectQueries from '../queries/project.queries';
-import * as llmConfigQueries from '../queries/project-llm-config.queries';
 import { getQueryDataFromCode } from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
-import { getDefaultModelId, resolveProviderModel } from '../utils/llm';
+import { getDefaultModelId, resolveFirstProjectModel } from '../utils/llm';
 import { MAX_OUTPUT_TOKENS } from './agent';
 const MAX_RENDERED_ROWS = 60;
 
@@ -166,12 +165,7 @@ async function generateDynamicStoryCode(
 	originalCode: string,
 	queryData: Record<string, { data: unknown[]; columns: string[] }>,
 ): Promise<string | null> {
-	const provider = await llmConfigQueries.getProjectModelProvider(projectId);
-	if (!provider) {
-		return null;
-	}
-
-	const model = await resolveProviderModel(projectId, provider, getDefaultModelId(provider));
+	const model = await resolveFirstProjectModel(projectId, (provider) => getDefaultModelId(provider));
 	if (!model) {
 		return null;
 	}

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -47,15 +47,9 @@ export function getEnvBaseUrls(): Record<string, string> {
 	);
 }
 
-/** Get the first available provider from env (preferring anthropic) */
+/** Get the first available provider from env */
 export function getDefaultEnvProvider(): LlmProvider | undefined {
-	if (hasEnvApiKey('anthropic')) {
-		return 'anthropic';
-	}
-	if (hasEnvApiKey('openai')) {
-		return 'openai';
-	}
-	return undefined;
+	return getEnvProviders()[0];
 }
 
 /** Check if a model ID is known for a provider */
@@ -137,6 +131,48 @@ export async function resolveProviderModel(
 
 	if (hasEnvApiKey(provider)) {
 		return createProviderModel(provider, { apiKey: '' }, modelId);
+	}
+
+	return null;
+}
+
+/**
+ * Resolves the first available working model for a project.
+ * Tries DB-configured providers first, then env-configured fallback.
+ * Skips providers where selectModelId returns an empty string.
+ */
+export async function resolveFirstProjectModel(
+	projectId: string,
+	selectModelId: (provider: LlmProvider) => string,
+): Promise<ProviderModelResult | null> {
+	const configs = await projectLlmConfigQueries.getProjectLlmConfigs(projectId);
+
+	for (const config of configs) {
+		const provider = config.provider as LlmProvider;
+		const modelId = selectModelId(provider);
+		if (!modelId) {
+			continue;
+		}
+		const result = await resolveProviderModel(projectId, provider, modelId);
+		if (result) {
+			return result;
+		}
+	}
+
+	const configuredProviders = new Set(configs.map((c) => c.provider));
+
+	for (const provider of getEnvProviders()) {
+		if (configuredProviders.has(provider)) {
+			continue;
+		}
+		const modelId = selectModelId(provider);
+		if (!modelId) {
+			continue;
+		}
+		const result = await resolveProviderModel(projectId, provider, modelId);
+		if (result) {
+			return result;
+		}
 	}
 
 	return null;

--- a/apps/backend/tests/resolve-first-project-model.test.ts
+++ b/apps/backend/tests/resolve-first-project-model.test.ts
@@ -1,0 +1,213 @@
+import type { LlmProvider } from '@nao/shared/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Full factory mocks — avoid loading bun:sqlite or SDK packages
+const mocks = vi.hoisted(() => ({
+	getProjectLlmConfigs: vi.fn(),
+	getProjectLlmConfigByProvider: vi.fn(),
+	createProviderModel: vi.fn(),
+	getDefaultModelId: vi.fn((provider: string) => `default-model-${provider}`),
+	PROVIDER_META: {} as Record<string, unknown>,
+	KNOWN_MODELS: {} as Record<string, unknown>,
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigs: mocks.getProjectLlmConfigs,
+	getProjectLlmConfigByProvider: mocks.getProjectLlmConfigByProvider,
+}));
+
+vi.mock('../src/agents/providers', () => ({
+	createProviderModel: mocks.createProviderModel,
+	getDefaultModelId: mocks.getDefaultModelId,
+	PROVIDER_META: mocks.PROVIDER_META,
+	KNOWN_MODELS: mocks.KNOWN_MODELS,
+	LLM_PROVIDERS: {
+		anthropic: {
+			envVar: 'ANTHROPIC_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'claude-haiku-4-5',
+			models: [],
+		},
+		openai: {
+			envVar: 'OPENAI_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'gpt-4.1-mini',
+			models: [],
+		},
+		google: {
+			envVar: 'GEMINI_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'gemini-2.5-flash',
+			models: [],
+		},
+		mistral: {
+			envVar: 'MISTRAL_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'mistral-medium-latest',
+			models: [],
+		},
+		openrouter: {
+			envVar: 'OPENROUTER_API_KEY',
+			auth: { apiKey: 'required' },
+			extractorModelId: 'anthropic/claude-haiku-4.5',
+			models: [],
+		},
+		ollama: { envVar: 'OLLAMA_API_KEY', auth: { apiKey: 'none' }, extractorModelId: 'llama3.2:3b', models: [] },
+		bedrock: {
+			envVar: 'AWS_BEARER_TOKEN_BEDROCK',
+			auth: { apiKey: 'optional', alternativeEnvVars: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'] },
+			extractorModelId: 'anthropic.claude-sonnet-4-6',
+			models: [],
+		},
+		vertex: {
+			envVar: 'VERTEX_GOOGLE_SERVICE_ACCOUNT_JSON',
+			auth: { apiKey: 'none', extraFields: [{ envVar: 'GOOGLE_VERTEX_PROJECT' }] },
+			extractorModelId: 'gemini-2.5-flash',
+			models: [],
+		},
+		azure: { envVar: 'AZURE_API_KEY', auth: { apiKey: 'required' }, extractorModelId: '', models: [] },
+	},
+}));
+
+const { resolveFirstProjectModel } = await import('../src/utils/llm');
+
+const PROJECT_ID = 'test-project';
+
+function makeDbConfig(provider: LlmProvider) {
+	return { provider, projectId: PROJECT_ID, apiKey: 'test-key', enabledModels: [], baseUrl: null, credentials: null };
+}
+
+function makeModel() {
+	return { model: {} as never, providerOptions: {}, contextWindow: 200_000 };
+}
+
+describe('resolveFirstProjectModel', () => {
+	const savedEnv: Record<string, string | undefined> = {};
+	const envKeys = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'MISTRAL_API_KEY', 'OPENROUTER_API_KEY'];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		// snapshot and clear all provider env keys
+		for (const key of envKeys) {
+			savedEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of envKeys) {
+			if (savedEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = savedEnv[key];
+			}
+		}
+	});
+
+	it('returns null when no DB configs and no env providers configured', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([]);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(result).toBeNull();
+		expect(mocks.createProviderModel).not.toHaveBeenCalled();
+	});
+
+	it('resolves first DB-configured provider and returns model', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('google'), makeDbConfig('mistral')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('google'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'gemini-2.5-flash');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('google', expect.anything(), 'gemini-2.5-flash');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('skips provider where selectModelId returns empty string (e.g. azure with no extractorModelId)', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('azure'), makeDbConfig('anthropic')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('anthropic'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, (provider) =>
+			provider === 'azure' ? '' : 'claude-haiku-4-5',
+		);
+
+		expect(mocks.createProviderModel).toHaveBeenCalledTimes(1);
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('anthropic', expect.anything(), 'claude-haiku-4-5');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('skips DB provider that cannot be resolved and tries next', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('ollama'), makeDbConfig('mistral')]);
+		mocks.getProjectLlmConfigByProvider
+			.mockResolvedValueOnce(null) // ollama has no DB config or env key
+			.mockResolvedValueOnce(makeDbConfig('mistral'));
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValueOnce(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledTimes(1);
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('mistral', expect.anything(), 'some-model');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('falls back to env-configured provider when DB has no configs', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([]);
+		process.env.GEMINI_API_KEY = 'env-google-key';
+		const fakeModel = makeModel();
+		mocks.createProviderModel.mockReturnValue(fakeModel);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'gemini-2.5-flash');
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('google', expect.anything(), 'gemini-2.5-flash');
+		expect(result).toBe(fakeModel);
+	});
+
+	it('does not retry env provider already in DB configs', async () => {
+		// google is in DB (but fails), anthropic is only in env
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('google')]);
+		process.env.GEMINI_API_KEY = 'env-key';
+		process.env.ANTHROPIC_API_KEY = 'env-key-2';
+		// google DB config lookup returns null, env key also present so createProviderModel called for google
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		const fakeModel = makeModel();
+		mocks.createProviderModel
+			.mockReturnValueOnce(null) // google fails
+			.mockReturnValueOnce(fakeModel); // anthropic (env-only) succeeds
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		const calledProviders = mocks.createProviderModel.mock.calls.map((c) => c[0] as string);
+		// google tried once total (not twice), anthropic tried once
+		expect(calledProviders.filter((p) => p === 'google')).toHaveLength(1);
+		expect(result).toBe(fakeModel);
+	});
+
+	it('returns null when all DB and env providers fail to resolve', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('bedrock')]);
+		process.env.OPENAI_API_KEY = 'env-key';
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(null);
+		mocks.createProviderModel.mockReturnValue(null);
+
+		const result = await resolveFirstProjectModel(PROJECT_ID, () => 'some-model');
+
+		expect(result).toBeNull();
+	});
+
+	it('passes provider-specific modelId from selector to createProviderModel', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([makeDbConfig('anthropic')]);
+		mocks.getProjectLlmConfigByProvider.mockResolvedValue(makeDbConfig('anthropic'));
+		mocks.createProviderModel.mockReturnValue(makeModel());
+
+		await resolveFirstProjectModel(PROJECT_ID, (provider) =>
+			provider === 'anthropic' ? 'claude-haiku-4-5' : 'gpt-4.1-mini',
+		);
+
+		expect(mocks.createProviderModel).toHaveBeenCalledWith('anthropic', expect.anything(), 'claude-haiku-4-5');
+	});
+});


### PR DESCRIPTION
## Problem

`getDefaultEnvProvider` hardcoded only `ANTHROPIC_API_KEY` → `OPENAI_API_KEY`, silently returning `null` for 7 of 9 providers (google, mistral, openrouter, ollama, bedrock, vertex, azure).

This broke two features for non-Anthropic/OpenAI users:
- NLP cron parsing (`story.parseCronFromText`)
- Live story dynamic text refresh

No error shown, features just silently did nothing.

## Fix

Deleted `getProjectModelProvider` and replaced with `resolveFirstProjectModel`:

```ts
// Before: hardcoded
if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
if (process.env.OPENAI_API_KEY) return 'openai';
return undefined; // all other providers silently fail

// After: works for all 9 providers
export async function resolveFirstProjectModel(
  projectId: string,
  selectModelId: (provider: LlmProvider) => string,
): Promise<ProviderModelResult | null>
Tries DB-configured providers first, falls back to env, skips providers with no model ID (azure), validates credentials before returning.
```

Evidence
Tested with only GEMINI_API_KEY set (no Anthropic/OpenAI key):
<img width="1912" height="972" alt="image" src="https://github.com/user-attachments/assets/85828243-1b7c-4736-9111-40371a0af466" />

Backend log confirming Gemini API was called (responseTime: 2719ms proves real API call, not null return):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c7b97e8d-a64c-435c-9fa7-45f9b531d63a" />


Tests
8 unit tests added - apps/backend/tests/resolve-first-project-model.test.ts

<img width="1477" height="766" alt="Screenshot 2026-05-08 013651" src="https://github.com/user-attachments/assets/1b553fb0-58a0-42d0-8352-73aa4e3d071a" />
Tests  8 passed (8)

Closes #643