### PR TITLE
Add tests folder with `nao init`

### DIFF
--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -94,6 +94,10 @@ def create_empty_structure(project_path: Path) -> tuple[list[str], list[CreatedF
     FILES = [
         CreatedFile(path=Path("RULES.md"), content=None),
         CreatedFile(path=Path(".naoignore"), content="templates/\n*.j2\ntests/\n"),
+        CreatedFile(
+            path=Path("tests/test_example.yml"),
+            content=("name: test_example\nprompt: What is the result of 1+1?\nsql: |\n  SELECT 2 AS answer_integer\n"),
+        ),
     ]
 
     created_folders = []

--- a/cli/tests/nao_core/commands/test_init.py
+++ b/cli/tests/nao_core/commands/test_init.py
@@ -87,22 +87,35 @@ class TestCreateEmptyStructure:
         assert rules_file.is_file()
 
     def test_creates_naoignore_file(self, tmp_path: Path):
-        """Creates .naoignore file with templates/ entry."""
+        """Creates .naoignore file with ignored generated paths."""
         folders, files = create_empty_structure(tmp_path)
 
         naoignore_file = tmp_path / ".naoignore"
         assert naoignore_file.exists()
         content = naoignore_file.read_text()
         assert "templates/" in content
+        assert "tests/" in content
+
+    def test_creates_sample_test_file(self, tmp_path: Path):
+        """Creates a sample test users can run as a starting point."""
+        folders, files = create_empty_structure(tmp_path)
+
+        sample_test = tmp_path / "tests" / "test_example.yml"
+        assert sample_test.exists()
+        content = sample_test.read_text()
+        assert "name: test_example" in content
+        assert "prompt: What is the result of 1+1?" in content
+        assert "SELECT 2 AS answer_integer" in content
 
     def test_returns_created_files_list(self, tmp_path: Path):
         """Returns list of created files."""
         folders, files = create_empty_structure(tmp_path)
 
-        assert len(files) >= 2
+        assert len(files) >= 3
         file_paths = [f.path for f in files]
         assert Path("RULES.md") in file_paths
         assert Path(".naoignore") in file_paths
+        assert Path("tests/test_example.yml") in file_paths
 
     def test_creates_nested_folders(self, tmp_path: Path):
         """Creates nested folder structures like agent/tools."""


### PR DESCRIPTION
## Summary

- Scaffold a starter `tests/basic_arithmetic.yml` file during `nao init`.
- Keep `tests/` in `.naoignore` so local test outputs/data stay out of synced context.
- Extend init command tests to cover the `.naoignore` entry and sample test file.

## Why

New projects already created a `tests/` directory, but it was empty. That left users without a working example for the expected test YAML format.

## Validation

- `uv run pytest tests/nao_core/commands/test_init.py`
- `uv run ruff check nao_core/commands/init.py tests/nao_core/commands/test_init.py`

Fixes #756.
