### PR TITLE
added rerun feature for execute_sql tool call

### DIFF
--- a/apps/backend/src/queries/chat.queries.ts
+++ b/apps/backend/src/queries/chat.queries.ts
@@ -17,7 +17,7 @@ import s, {
 } from '../db/abstractSchema';
 import { db } from '../db/db';
 import dbConfig, { Dialect } from '../db/dbConfig';
-import { ForkMetadata, StopReason, TokenUsage, UIChat, UIMessage, UIMessagePart } from '../types/chat';
+import { ForkMetadata, StopReason, TokenUsage, ToolState, UIChat, UIMessage, UIMessagePart } from '../types/chat';
 import { applyChatFilters, buildChatGroups, type EnrichedChat, type SourcePlatform } from '../utils/chat-list';
 import { convertDBPartToUIPart, mapUIPartsToDBParts } from '../utils/chat-message-part-mappings';
 import { getErrorMessage } from '../utils/utils';
@@ -442,6 +442,37 @@ export const getLastAssistantMessageId = async (chatId: string): Promise<string 
 		.limit(1)
 		.execute();
 	return result?.id ?? null;
+};
+
+export const getToolCallForRerun = async (
+	toolCallId: string,
+): Promise<{
+	chatId: string;
+	projectId: string;
+	userId: string;
+	toolName: string | null;
+	toolState: ToolState | null;
+	toolInput: unknown;
+} | null> => {
+	const [result] = await db
+		.select({
+			chatId: s.chat.id,
+			projectId: s.chat.projectId,
+			userId: s.chat.userId,
+			toolName: s.messagePart.toolName,
+			toolState: s.messagePart.toolState,
+			toolInput: s.messagePart.toolInput,
+		})
+		.from(s.messagePart)
+		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
+		.innerJoin(s.chat, eq(s.chatMessage.chatId, s.chat.id))
+		.where(
+			and(eq(s.messagePart.toolCallId, toolCallId), isNull(s.chatMessage.supersededAt), isNull(s.chat.deletedAt)),
+		)
+		.limit(1)
+		.execute();
+
+	return result ?? null;
 };
 
 export const getChatBySlackThread = async (threadId: string): Promise<{ id: string; title: string } | null> => {

--- a/apps/backend/src/trpc/chat.routes.ts
+++ b/apps/backend/src/trpc/chat.routes.ts
@@ -1,12 +1,17 @@
+import { executeSql } from '@nao/shared/tools';
 import { CHAT_FILTER_OPTIONS, CHAT_GROUP_BY_OPTIONS, type GroupedChatListResponse } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
+import { executeQuery } from '../agents/tools/execute-sql';
 import type { SearchChatResult } from '../queries/chat.queries';
 import * as chatQueries from '../queries/chat.queries';
+import * as projectQueries from '../queries/project.queries';
 import { agentService } from '../services/agent';
+import { hasFeature, LICENSE_FEATURES } from '../services/license.service';
+import { getAzureAccessTokenForUser } from '../services/microsoft-auth.service';
 import { posthog, PostHogEvent } from '../services/posthog';
-import type { ContextUsage, ForkMetadata, UIChat } from '../types/chat';
+import type { ContextUsage, ForkMetadata, UIChat, UIMessagePart } from '../types/chat';
 import { llmProviderSchema } from '../types/llm';
 import { getChatContextUsage } from '../utils/chat-context-usage';
 import { ownedResourceProcedure, projectProtectedProcedure, protectedProcedure } from './trpc';
@@ -63,6 +68,67 @@ export const chatRoutes = {
 		const projectId = await chatQueries.getChatProjectId(input.chatId);
 		posthog.capture(ctx.user.id, PostHogEvent.AgentStopped, { project_id: projectId, chat_id: input.chatId });
 	}),
+
+	rerunExecuteSqlToolCall: protectedProcedure
+		.input(z.object({ toolCallId: z.string() }))
+		.mutation(async ({ input, ctx }): Promise<{ chatId: string; messageId: string }> => {
+			const toolCall = await chatQueries.getToolCallForRerun(input.toolCallId);
+			if (!toolCall) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Tool call not found.' });
+			}
+			if (toolCall.userId !== ctx.user.id) {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not authorized to modify this chat.' });
+			}
+			if (toolCall.toolName !== 'execute_sql') {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only execute_sql tool calls can be rerun.' });
+			}
+			if (toolCall.toolState !== 'output-available') {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Only successful tool calls can be rerun.' });
+			}
+
+			const userRole = await projectQueries.getUserRoleInProject(toolCall.projectId, ctx.user.id);
+			if (userRole !== 'admin' && userRole !== 'user') {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'Viewers cannot rerun tool calls.' });
+			}
+
+			const parsedInput = executeSql.InputSchema.safeParse(toolCall.toolInput);
+			if (!parsedInput.success) {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Stored SQL tool input is invalid.' });
+			}
+
+			const [project, agentSettings, envVars, azureAccessToken] = await Promise.all([
+				projectQueries.retrieveProjectById(toolCall.projectId),
+				projectQueries.getAgentSettings(toolCall.projectId),
+				projectQueries.getEnvVars(toolCall.projectId),
+				hasFeature(LICENSE_FEATURES.sso).then((enabled) =>
+					enabled ? getAzureAccessTokenForUser(ctx.user.id) : null,
+				),
+			]);
+
+			const output = await executeQuery(parsedInput.data, {
+				projectFolder: project.path ?? '',
+				chatId: toolCall.chatId,
+				agentSettings,
+				envVars,
+				azureAccessToken,
+				queryResults: new Map(),
+			});
+
+			const toolPart: UIMessagePart = {
+				type: 'tool-execute_sql',
+				toolCallId: crypto.randomUUID(),
+				state: 'output-available',
+				input: parsedInput.data,
+				output,
+			};
+			const { messageId } = await chatQueries.upsertMessage({
+				chatId: toolCall.chatId,
+				role: 'assistant',
+				parts: [toolPart],
+			});
+
+			return { chatId: toolCall.chatId, messageId };
+		}),
 
 	rename: chatOwnerProcedure
 		.input(z.object({ chatId: z.string(), title: z.string().min(1).max(255) }))

--- a/apps/backend/tests/chat-rerun-execute-sql.test.ts
+++ b/apps/backend/tests/chat-rerun-execute-sql.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	executeQuery: vi.fn(),
+	getToolCallForRerun: vi.fn(),
+	upsertMessage: vi.fn(),
+	getUserRoleInProject: vi.fn(),
+	retrieveProjectById: vi.fn(),
+	getAgentSettings: vi.fn(),
+	getEnvVars: vi.fn(),
+	hasFeature: vi.fn(),
+	getAzureAccessTokenForUser: vi.fn(),
+}));
+
+vi.mock('../src/agents/tools/execute-sql', () => ({
+	executeQuery: mocks.executeQuery,
+}));
+
+vi.mock('../src/queries/chat.queries', () => ({
+	getChatOwnerId: vi.fn(),
+	getToolCallForRerun: mocks.getToolCallForRerun,
+	upsertMessage: mocks.upsertMessage,
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getUserRoleInProject: mocks.getUserRoleInProject,
+	retrieveProjectById: mocks.retrieveProjectById,
+	getAgentSettings: mocks.getAgentSettings,
+	getEnvVars: mocks.getEnvVars,
+	getProjectByUserId: vi.fn(),
+}));
+
+vi.mock('../src/services/license.service', () => ({
+	LICENSE_FEATURES: { sso: 'sso' },
+	hasFeature: mocks.hasFeature,
+}));
+
+vi.mock('../src/services/microsoft-auth.service', () => ({
+	getAzureAccessTokenForUser: mocks.getAzureAccessTokenForUser,
+}));
+
+vi.mock('../src/services/agent', () => ({
+	agentService: { get: vi.fn() },
+}));
+
+vi.mock('../src/services/posthog', () => ({
+	PostHogEvent: {},
+	posthog: { capture: vi.fn() },
+}));
+
+vi.mock('../src/auth', () => ({
+	getAuth: vi.fn(),
+}));
+
+vi.mock('../src/utils/chat-context-usage', () => ({
+	getChatContextUsage: vi.fn(),
+}));
+
+import { chatRoutes } from '../src/trpc/chat.routes';
+import { router } from '../src/trpc/trpc';
+
+const caller = () =>
+	router({ chat: chatRoutes }).createCaller({
+		session: {
+			user: { id: 'user-1', email: 'user@example.com', name: 'User' },
+		},
+		selectedProjectId: 'project-1',
+	});
+
+describe('chat.rerunExecuteSqlToolCall', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getToolCallForRerun.mockResolvedValue({
+			chatId: 'chat-1',
+			projectId: 'project-1',
+			userId: 'user-1',
+			toolName: 'execute_sql',
+			toolState: 'output-available',
+			toolInput: { sql_query: 'select 1 as value', database_id: 'warehouse' },
+		});
+		mocks.getUserRoleInProject.mockResolvedValue('user');
+		mocks.retrieveProjectById.mockResolvedValue({ id: 'project-1', path: '/workspace/project' });
+		mocks.getAgentSettings.mockResolvedValue({ sql: { dangerouslyWritePermEnabled: false } });
+		mocks.getEnvVars.mockResolvedValue({ FOO: 'bar' });
+		mocks.hasFeature.mockResolvedValue(false);
+		mocks.executeQuery.mockResolvedValue({
+			_version: '1',
+			id: 'query_12345678',
+			columns: ['value'],
+			data: [{ value: 1 }],
+			row_count: 1,
+		});
+		mocks.upsertMessage.mockResolvedValue({ messageId: 'message-1' });
+	});
+
+	it('reruns a stored successful SQL tool call and appends the fresh result', async () => {
+		await expect(caller().chat.rerunExecuteSqlToolCall({ toolCallId: 'tool-call-1' })).resolves.toEqual({
+			chatId: 'chat-1',
+			messageId: 'message-1',
+		});
+
+		expect(mocks.executeQuery).toHaveBeenCalledWith(
+			{ sql_query: 'select 1 as value', database_id: 'warehouse' },
+			expect.objectContaining({
+				projectFolder: '/workspace/project',
+				chatId: 'chat-1',
+				agentSettings: { sql: { dangerouslyWritePermEnabled: false } },
+				envVars: { FOO: 'bar' },
+				azureAccessToken: null,
+				queryResults: expect.any(Map),
+			}),
+		);
+		expect(mocks.upsertMessage).toHaveBeenCalledWith({
+			chatId: 'chat-1',
+			role: 'assistant',
+			parts: [
+				expect.objectContaining({
+					type: 'tool-execute_sql',
+					state: 'output-available',
+					input: { sql_query: 'select 1 as value', database_id: 'warehouse' },
+					output: expect.objectContaining({ id: 'query_12345678', row_count: 1 }),
+					toolCallId: expect.any(String),
+				}),
+			],
+		});
+	});
+
+	it('rejects viewers before executing SQL', async () => {
+		mocks.getUserRoleInProject.mockResolvedValue('viewer');
+
+		await expect(caller().chat.rerunExecuteSqlToolCall({ toolCallId: 'tool-call-1' })).rejects.toMatchObject({
+			code: 'FORBIDDEN',
+			message: 'Viewers cannot rerun tool calls.',
+		});
+
+		expect(mocks.executeQuery).not.toHaveBeenCalled();
+		expect(mocks.upsertMessage).not.toHaveBeenCalled();
+	});
+});

--- a/apps/frontend/src/components/tool-calls/execute-sql.tsx
+++ b/apps/frontend/src/components/tool-calls/execute-sql.tsx
@@ -1,21 +1,49 @@
 import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Streamdown } from 'streamdown';
-import { ArrowUpRight, Code, Copy, Table as TableIcon } from 'lucide-react';
+import { ArrowUpRight, Code, Copy, RefreshCw, Table as TableIcon } from 'lucide-react';
 import { ToolCallWrapper } from './tool-call-wrapper';
 import { TableDisplay } from './display-table';
 import type { ToolCallComponentProps } from '.';
 import { useSidePanel } from '@/contexts/side-panel';
 import { useToolCallContext } from '@/contexts/tool-call';
 import { SidePanelContent } from '@/components/side-panel/sql-editor';
+import { trpc } from '@/main';
 
 type ViewMode = 'results' | 'query';
 
-export const ExecuteSqlToolCall = ({ toolPart: { output, input, state } }: ToolCallComponentProps<'execute_sql'>) => {
+export const ExecuteSqlToolCall = ({
+	toolPart: { output, input, state, toolCallId },
+}: ToolCallComponentProps<'execute_sql'>) => {
 	const [viewMode, setViewMode] = useState<ViewMode>('results');
 	const { isSettled } = useToolCallContext();
 	const { open: openSidePanel } = useSidePanel();
+	const queryClient = useQueryClient();
+	const rerunMutation = useMutation(
+		trpc.chat.rerunExecuteSqlToolCall.mutationOptions({
+			onSuccess: async (result) => {
+				await Promise.all([
+					queryClient.invalidateQueries({ queryKey: trpc.chat.get.queryKey({ chatId: result.chatId }) }),
+					queryClient.invalidateQueries({ queryKey: [['chat', 'listGrouped']] }),
+				]);
+			},
+		}),
+	);
+	const canRerun = isSettled && state === 'output-available' && !!toolCallId;
 
 	const actions = [
+		...(canRerun
+			? [
+					{
+						id: 'rerun',
+						label: <RefreshCw className='size-3' />,
+						disabled: rerunMutation.isPending,
+						onClick: () => {
+							rerunMutation.mutate({ toolCallId });
+						},
+					},
+				]
+			: []),
 		{
 			id: 'results',
 			label: <TableIcon className='size-3' />,

--- a/apps/frontend/src/components/tool-calls/tool-call-wrapper.tsx
+++ b/apps/frontend/src/components/tool-calls/tool-call-wrapper.tsx
@@ -10,6 +10,7 @@ interface ActionButton {
 	id: string;
 	label: ReactNode;
 	isActive?: boolean;
+	disabled?: boolean;
 	onClick: () => void;
 	expandOnClick?: boolean;
 }
@@ -63,8 +64,12 @@ export const ToolCallWrapper = ({
 						variant='ghost-muted'
 						size='icon-xs'
 						key={action.id}
+						disabled={action.disabled}
 						onClick={(e) => {
 							e.stopPropagation();
+							if (action.disabled) {
+								return;
+							}
 							if (action.expandOnClick && !isExpanded) {
 								setIsExpanded(true);
 							}


### PR DESCRIPTION
fixes #764 

## Summary

Adds support for rerunning successful `execute_sql` tool calls from the chat UI.

- Adds a rerun action to SQL tool call cards, with pending/disabled state handling.
- Adds a backend `chat.rerunExecuteSqlToolCall` mutation that validates ownership, role, tool type, and successful tool state before re-executing the stored SQL input.
- Appends the fresh SQL result as a new assistant tool message and refreshes the chat/list queries in the frontend.
- Adds backend tests for successful reruns and viewer permission rejection.

## Testing

- Added `apps/backend/tests/chat-rerun-execute-sql.test.ts`