### PR TITLE
Enable prompt caching for Claude models served through Vertex

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -650,14 +650,18 @@ class AgentManager {
 
 	/**
 	 * Add Anthropic cache breakpoints to messages.
-	 * No-op for non-Anthropic providers.
+	 * Applies to the `anthropic` provider and to Claude models accessed via `vertex`
+	 * (which uses @ai-sdk/google-vertex/anthropic and reads the same `anthropic` provider options).
 	 *
 	 * Cache strategy:
 	 * - System message: 1h TTL (instructions rarely change)
 	 * - Last message: 5m TTL (current step's leaf for agentic caching)
 	 */
 	private _addCache(messages: ModelMessage[]): ModelMessage[] {
-		if (messages.length === 0 || this._modelSelection.provider !== 'anthropic') {
+		const { provider, modelId } = this._modelSelection;
+		const isAnthropicCompatible =
+			provider === 'anthropic' || (provider === 'vertex' && modelId.startsWith('claude-'));
+		if (messages.length === 0 || !isAnthropicCompatible) {
 			return messages;
 		}
 


### PR DESCRIPTION
**Summary** 
Extended prompt caching capabilities for Claude models access through the Vertex AI provider. Previously casching was only enabled for the direct Anthropic provider.

Users leveraging Vertex AI's marketplace to access Claude models were unable to benefit from prompt caching, despite using Claude models under the hood. 

**What changed**
Updated the `_addCache` guard in `AgentManager` to recognize both:

- Direct anthropic provider
- Claude models (`claude-*` model Id) from the `vertex` provider, which internally uses `@ai-sdk/google-vertex/anthropic` and reads the same `anthropic` provider options for cache control. 

Thus the change leverages the existing `withCache` helper so no changes to cache application logic were required.  

**Linked Issue**: Closes #778 

**Model**
This PR was written using Claude Sonnet 4.6 (claude-sonnet-4-6).