### PR TITLE
feat: per-surface system prompt overrides from context repo

### DIFF
--- a/apps/backend/src/agents/user-rules.ts
+++ b/apps/backend/src/agents/user-rules.ts
@@ -19,6 +19,21 @@ export function getUserRules(projectFolder: string): string | undefined {
 	}
 }
 
+export function getPromptOverride(projectFolder: string, surface: string): string | undefined {
+	const promptPath = join(projectFolder, 'prompts', `${surface}.md`);
+
+	if (!existsSync(promptPath)) {
+		return undefined;
+	}
+
+	try {
+		return readFileSync(promptPath, 'utf-8');
+	} catch (error) {
+		console.error(`Error reading prompts/${surface}.md:`, error);
+		return undefined;
+	}
+}
+
 type Connection = {
 	type: string;
 	database: string;

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -14,6 +14,7 @@ type Connection = {
 type SystemPromptProps = {
 	memories?: UserMemory[];
 	userRules?: string;
+	surfaceOverride?: string;
 	connections?: Connection[];
 	skills?: Skill[];
 	timezone?: string;
@@ -21,7 +22,14 @@ type SystemPromptProps = {
 
 export const MEMORY_TOKEN_LIMIT = 1000;
 
-export function SystemPrompt({ memories = [], userRules, connections = [], skills = [], timezone }: SystemPromptProps) {
+export function SystemPrompt({
+	memories = [],
+	userRules,
+	surfaceOverride,
+	connections = [],
+	skills = [],
+	timezone,
+}: SystemPromptProps) {
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
 	const hasClickHouse = connections.some((connection) => connection.type.toLowerCase() === 'clickhouse');
 	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
@@ -180,6 +188,12 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 				<ListItem>The Query ID is shown in the execute_sql tool output (e.g., Query ID: query_a1b2).</ListItem>
 			</List>
 			<Block separator={'\n\n---\n\n'}>
+				{surfaceOverride && (
+					<Block>
+						<Title level={2}>Bot Configuration</Title>
+						{surfaceOverride}
+					</Block>
+				)}
 				{userRules && (
 					<Block>
 						<Title level={2}>User Rules</Title>

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 import { CACHE_1H, CACHE_5M, LLM_PROVIDERS, ProviderModelResult } from '../agents/providers';
 import { getTools } from '../agents/tools';
 import { createWebSearchTools } from '../agents/tools/web-search';
-import { getConnections, getTableColumnsContent, getUserRules } from '../agents/user-rules';
+import { getConnections, getPromptOverride, getTableColumnsContent, getUserRules } from '../agents/user-rules';
 import { ChatForkContextPrompt, MessagingProviderSystemPrompt, SystemPrompt } from '../components/ai';
 import { DBChat } from '../db/abstractSchema';
 import { renderToMarkdown } from '../lib/markdown';
@@ -359,9 +359,13 @@ class AgentManager {
 
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
+		const surface = provider ? `${provider}_bot` : 'nao_bot';
+		const surfaceOverride = getPromptOverride(this._toolContext.projectFolder, surface);
 		const connections = getConnections(this._toolContext.projectFolder);
 		const skills = skillService.getSkills();
-		const basePrompt = renderToMarkdown(SystemPrompt({ memories, userRules, connections, skills, timezone }));
+		const basePrompt = renderToMarkdown(
+			SystemPrompt({ memories, userRules, surfaceOverride, connections, skills, timezone }),
+		);
 		const renderedPrompt = provider
 			? renderToMarkdown(MessagingProviderSystemPrompt({ basePrompt, provider, chatUrl }))
 			: basePrompt;


### PR DESCRIPTION
Closes #681

Admins can now customize bot behavior per surface by adding a markdown file to a `prompts/` folder in their context repo, no code changes needed.

**Supported files:**
- `prompts/nao_bot.md` - web chat
- `prompts/slack_bot.md` -  Slack bot
- `prompts/teams_bot.md` - Teams bot
- `prompts/telegram_bot.md` - Telegram bot
- `prompts/whatsapp_bot.md` - WhatsApp bot

Content is injected into the system prompt as a **Bot Configuration** section. Falls back to the product default if the file is absent, fully backward compatible.

**Files changed:**
- `agents/user-rules.ts` - `getPromptOverride()` reads `prompts/{surface}.md`
- `components/ai/system-prompt.tsx` - accepts and renders `surfaceOverride` prop
- `services/agent.ts` - derives surface from provider, loads override
