### PR TITLE
feat: add "Import from GitHub" button on Settings > Project page

### DIFF
--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -93,6 +93,14 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 	{
 		page: '/settings/project',
 		pageLabel: 'Project',
+		title: 'Import from GitHub',
+		description: 'Import a GitHub repository into this project.',
+		keywords: ['github', 'repository', 'repo', 'import', 'git', 'clone'],
+		adminOnly: true,
+	},
+	{
+		page: '/settings/project',
+		pageLabel: 'Project',
 		title: 'Environment Variables',
 		description: 'Set environment variables referenced in nao_config.yaml.',
 		keywords: ['env', 'environment', 'variable', 'secret', 'credential', 'config', 'jinja'],

--- a/apps/frontend/src/components/settings/git-sync-section.tsx
+++ b/apps/frontend/src/components/settings/git-sync-section.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Github, GitBranch, Loader2, RefreshCw } from 'lucide-react';
 
+import { GitHubRepoPicker } from '@/components/settings/github-repo-picker';
 import { Button } from '@/components/ui/button';
 import { ErrorMessage } from '@/components/ui/error-message';
 import { SettingsCard } from '@/components/ui/settings-card';
@@ -32,10 +34,17 @@ function formatRelativeDate(isoDate: string): string {
 
 export function GitSyncSection() {
 	const queryClient = useQueryClient();
+	const [repoPickerOpen, setRepoPickerOpen] = useState(false);
 
 	const gitInfo = useQuery({
 		...trpc.github.getProjectGitInfo.queryOptions(),
 		staleTime: 30_000,
+	});
+
+	const githubAvailable = useQuery(trpc.github.isAvailable.queryOptions());
+	const githubStatus = useQuery({
+		...trpc.github.getStatus.queryOptions(),
+		enabled: githubAvailable.data === true,
 	});
 
 	const pullMutation = useMutation({
@@ -54,7 +63,39 @@ export function GitSyncSection() {
 	}
 
 	if (!gitInfo.data?.isGithub) {
-		return null;
+		if (githubAvailable.data !== true) {
+			return null;
+		}
+
+		const isGithubConnected = githubStatus.data?.connected === true;
+
+		return (
+			<>
+				<SettingsCard title='Import from GitHub' icon={<Github className='size-4' />}>
+					<div className='flex items-center justify-between'>
+						<p className='text-sm text-muted-foreground'>
+							{isGithubConnected
+								? 'Replace this project with a GitHub repository.'
+								: 'Connect GitHub to import a repository into this project.'}
+						</p>
+						{isGithubConnected ? (
+							<Button variant='secondary' size='sm' onClick={() => setRepoPickerOpen(true)}>
+								<Github className='size-3.5' />
+								Import from GitHub
+							</Button>
+						) : (
+							<Button variant='secondary' size='sm' asChild>
+								<a href='/api/github/connect'>
+									<Github className='size-3.5' />
+									Connect GitHub
+								</a>
+							</Button>
+						)}
+					</div>
+				</SettingsCard>
+				<GitHubRepoPicker open={repoPickerOpen} onOpenChange={setRepoPickerOpen} />
+			</>
+		);
 	}
 
 	const { repoFullName, branch, lastCommitMessage, lastCommitDate } = gitInfo.data;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an "Import from GitHub" card to the **Settings > Project** page when the current project is not already linked to a GitHub repository.

### Behavior

- **Project IS from GitHub** → shows the existing "Repository" card with "Pull latest" (unchanged)
- **Project is NOT from GitHub + GitHub integration available** → shows a new "Import from GitHub" card with a button to either connect GitHub or open the repo picker
- **GitHub integration not available** (no `CLOUD_GITHUB_CLIENT_ID` configured) → nothing shown (unchanged)

### Changes

- `apps/frontend/src/components/settings/git-sync-section.tsx` — Extended `GitSyncSection` to render an "Import from GitHub" card when `isGithub` is false but GitHub integration is available. Reuses the existing `GitHubRepoPicker` component.
- `apps/frontend/src/components/settings-search-index.ts` — Added search index entry for the new "Import from GitHub" option on the Project settings page.

### Demo

[Import from GitHub card on project settings page](https://cursor.com/agents/bc-0492f3aa-2f37-5170-9cf7-cbad3e7598da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_import_from_github_card.webp)

[import_from_github_project_settings.mp4](https://cursor.com/agents/bc-0492f3aa-2f37-5170-9cf7-cbad3e7598da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fimport_from_github_project_settings.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nao-nfc6582.slack.com/archives/D0AFSNPBD51/p1778776850852349?thread_ts=1778776850.852349&cid=D0AFSNPBD51)

<div><a href="https://cursor.com/agents/bc-0492f3aa-2f37-5170-9cf7-cbad3e7598da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0492f3aa-2f37-5170-9cf7-cbad3e7598da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

