### PR TITLE
Redefine MCP endpoint modes with separate tool sets

### DIFF
--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -2,35 +2,17 @@ import { displayChart } from '@nao/shared/tools';
 import { tool } from 'ai';
 
 import { DisplayChartOutput, renderToModelOutput } from '../../components/tool-outputs';
+import { validateChartConfig } from '../../utils/validate-chart-config';
 
 export default tool<displayChart.Input, displayChart.Output>({
 	description: 'Display a chart visualization of the data from a previous `execute_sql` tool call.',
 	inputSchema: displayChart.InputSchema,
 	outputSchema: displayChart.OutputSchema,
 
-	execute: async ({ chart_type: chartType, x_axis_key: xAxisKey, series }) => {
-		// Validate xAxisKey is provided for cartesian and polar charts
-		if (['bar', 'line', 'area', 'stacked_area', 'scatter', 'radar'].includes(chartType) && !xAxisKey) {
-			return { _version: '1', success: false, error: `xAxisKey is required for ${chartType} charts.` };
-		}
-
-		// Validate pie charts have exactly one series
-		if (chartType === 'pie' && series.length !== 1) {
-			return { _version: '1', success: false, error: 'Pie charts require exactly one series.' };
-		}
-
-		// Validate series is not empty
-		if (series.length === 0) {
-			return { _version: '1', success: false, error: 'At least one series is required.' };
-		}
-
-		// Stacked charts require at least two series
-		if ((chartType === 'stacked_bar' || chartType === 'stacked_area') && series.length < 2) {
-			return {
-				_version: '1',
-				success: false,
-				error: `Stacked ${chartType === 'stacked_bar' ? 'bar' : 'area'} chart requires at least two series. You may need to pivot the data to create a series for each stack.`,
-			};
+	execute: async (input) => {
+		const validation = validateChartConfig(input);
+		if (!validation.success) {
+			return { _version: '1', success: false, error: validation.error };
 		}
 
 		// TODO: check that the chart is displayable and that the data is valid

--- a/apps/backend/src/mcp/context-layer-guidance.ts
+++ b/apps/backend/src/mcp/context-layer-guidance.ts
@@ -1,0 +1,4 @@
+export const CONTEXT_LAYER_GUIDANCE =
+	'Before running SQL, use `ls` and `grep` to explore the nao project context on disk. ' +
+	'Read `RULES.md` at the project root for business rules, metrics, and analysis process; use `databases/` and related paths for table/column detail. ' +
+	'Do not run `execute_sql` until you understand the schema and conventions from that context.';

--- a/apps/backend/src/mcp/logging.ts
+++ b/apps/backend/src/mcp/logging.ts
@@ -26,12 +26,12 @@ export const TOOL_MODE_MAP: Record<string, keyof McpEndpointSettings> = {
 	execute_sql: 'toolsModeEnabled',
 	grep: 'toolsModeEnabled',
 	ls: 'toolsModeEnabled',
+	build_chart: 'toolsModeEnabled',
+	create_story: 'toolsModeEnabled',
+	update_story: 'toolsModeEnabled',
 	list_stories: 'objectsModeEnabled',
-	get_story: 'objectsModeEnabled',
-	create_story: 'objectsModeEnabled',
-	update_story: 'objectsModeEnabled',
+	search_stories: 'objectsModeEnabled',
 	archive_story: 'objectsModeEnabled',
-	delete_story: 'objectsModeEnabled',
 };
 
 export function withLogging<T>(toolName: string, ctx: McpContext, handler: ToolHandler<T>): ToolHandler<T> {

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -4,9 +4,10 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { listUserProjects } from '../queries/project.queries';
 import type { McpEndpointSettings } from '../types/mcp-endpoint';
 import { registerAgentTools } from './tools/agent';
+import { registerChartTools } from './tools/chart';
 import { registerDataTools } from './tools/data';
 import { registerFileTools } from './tools/files';
-import { registerStoryTools } from './tools/stories';
+import { registerContextStoryTools, registerStoryManagementTools } from './tools/stories';
 
 export interface McpSession {
 	transport: StreamableHTTPServerTransport;
@@ -54,11 +55,13 @@ export function createMcpServer(userId: string, projectId: string, settings: Mcp
 		registerAgentTools(server, ctx);
 	}
 	if (settings.toolsModeEnabled) {
-		registerDataTools(server, ctx);
 		registerFileTools(server, ctx);
+		registerDataTools(server, ctx);
+		registerChartTools(server, ctx);
+		registerContextStoryTools(server, ctx);
 	}
 	if (settings.objectsModeEnabled) {
-		registerStoryTools(server, ctx);
+		registerStoryManagementTools(server, ctx);
 	}
 
 	return server;

--- a/apps/backend/src/mcp/tools/agent.ts
+++ b/apps/backend/src/mcp/tools/agent.ts
@@ -13,12 +13,11 @@ import { withLogging } from '../logging';
 import { chatUrl } from '../urls';
 
 const ASK_NAO_DESCRIPTION =
-	'Ask nao an analytics question in natural language. Creates a chat that is visible in the UI.\n\n' +
-	'Use this for ad-hoc data exploration and Q&A. ' +
-	'To create a persistent Nao Story (markdown dashboard with embedded charts/tables), do NOT ask nao in natural language — call `create_story` directly with the SQL results from `execute_sql`. ' +
-	'To browse or update existing stories, use `list_stories` / `get_story` / `update_story`.\n\n' +
-	'Returns `chatId` and a `url` that opens the chat in the Nao UI — surface the URL to the user as a clickable link so they can jump to the conversation (and any rendered charts/tables). ' +
-	'The returned `chatId` can also be passed to `create_story` as `chat_id` to attach a follow-up story to this conversation.';
+	'Ask nao an analytics question in natural language. Creates a chat that is visible in the Nao UI.\n\n' +
+	'Use this for ad-hoc data exploration and Q&A. Nao runs SQL, charts, and other tools internally to answer. ' +
+	'You can also ask Nao to create or update stories (markdown dashboards with embedded charts/tables) in that chat, ' +
+	'E.g. "turn this analysis into a dashboard" or "update the revenue chart in my story".\n\n' +
+	'Returns `chatId` and a `url` that opens the chat in the Nao UI, surface the URL to the user as a clickable link.';
 
 export function registerAgentTools(server: McpServer, ctx: McpContext): void {
 	server.registerTool(

--- a/apps/backend/src/mcp/tools/chart.ts
+++ b/apps/backend/src/mcp/tools/chart.ts
@@ -1,0 +1,51 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { displayChart } from '@nao/shared/tools';
+import { z } from 'zod';
+
+import { formatChartBlock } from '../../utils/chart-block';
+import { logger } from '../../utils/logger';
+import { validateChartConfig } from '../../utils/validate-chart-config';
+import type { McpContext } from '../logging';
+import { withLogging } from '../logging';
+
+const BUILD_CHART_DESCRIPTION =
+	'Build a validated `<chart />` block for embedding in story content. ' +
+	'Pass the `query_id` returned by `execute_sql` and chart configuration; returns a ready-to-paste block for `create_story` or `update_story` `content`.';
+
+export function registerChartTools(server: McpServer, ctx: McpContext): void {
+	server.registerTool(
+		'build_chart',
+		{
+			title: 'Build Chart',
+			description: BUILD_CHART_DESCRIPTION,
+			inputSchema: displayChart.InputSchema,
+			outputSchema: {
+				success: z.boolean(),
+				error: z.string().optional(),
+				chart_block: z
+					.string()
+					.optional()
+					.describe('The `<chart />` block to embed in story content. Present when success is true.'),
+			},
+		},
+		withLogging('build_chart', ctx, async (input) => {
+			try {
+				const validation = validateChartConfig(input);
+				if (!validation.success) {
+					return {
+						content: [{ type: 'text' as const, text: JSON.stringify(validation) }],
+						isError: true,
+					};
+				}
+
+				const chartBlock = formatChartBlock(input);
+				const output = { success: true as const, chart_block: chartBlock };
+				return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.error(`MCP build_chart error: ${message}`, { source: 'tool', context: { userId: ctx.userId } });
+				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+			}
+		}),
+	);
+}

--- a/apps/backend/src/mcp/tools/data.ts
+++ b/apps/backend/src/mcp/tools/data.ts
@@ -1,15 +1,16 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import executeSqlTool from '../../agents/tools/execute-sql';
+import { CONTEXT_LAYER_GUIDANCE } from '../context-layer-guidance';
 import type { McpContext } from '../logging';
 import { registerAgentToolAsMcp } from './wrap-agent-tool';
 
 const EXECUTE_SQL_DESCRIPTION =
+	`${CONTEXT_LAYER_GUIDANCE}\n\n` +
 	'Run a SQL query against the connected data warehouse. Returns rows as JSON, including an `id` ' +
-	'(e.g. "query_a1b2c3d4"). To embed the result in a story, pass that `id` as the `query_id` attribute ' +
-	'of a `<chart query_id="..." />` or `<table query_id="..." />` block inside `create_story` / `update_story`. ' +
-	'Add a `LIMIT` clause to your SQL if you want to cap the number of rows returned. ' +
-	'Use `ask_nao` instead if you want Nao to write the SQL for you.';
+	'(e.g. "query_a1b2c3d4"). Use that `id` with `build_chart`, or as the `query_id` in `<chart>` / `<table>` blocks ' +
+	'inside `create_story` / `update_story`, with matching rows in `query_data`. ' +
+	'Add a `LIMIT` clause to your SQL if you want to cap the number of rows returned.';
 
 export function registerDataTools(server: McpServer, ctx: McpContext): void {
 	registerAgentToolAsMcp(server, ctx, {

--- a/apps/backend/src/mcp/tools/files.ts
+++ b/apps/backend/src/mcp/tools/files.ts
@@ -2,19 +2,30 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import grepTool from '../../agents/tools/grep';
 import listTool from '../../agents/tools/list';
+import { CONTEXT_LAYER_GUIDANCE } from '../context-layer-guidance';
 import type { McpContext } from '../logging';
 import { registerAgentToolAsMcp } from './wrap-agent-tool';
+
+const LS_DESCRIPTION =
+	'List files and directories in the nao project context (E.g. `RULES.md`, `databases/`, `docs/`, `semantics/`). ' +
+	'Use this to discover schema and business context before writing SQL.';
+
+const GREP_DESCRIPTION =
+	`${CONTEXT_LAYER_GUIDANCE}\n\n` +
+	'Search file contents with a regex pattern. Start with `RULES.md` and `databases/` to learn table names, columns, and business rules.';
 
 export function registerFileTools(server: McpServer, ctx: McpContext): void {
 	registerAgentToolAsMcp(server, ctx, {
 		name: 'grep',
 		agentTool: grepTool,
 		title: 'Search Files',
+		description: GREP_DESCRIPTION,
 	});
 
 	registerAgentToolAsMcp(server, ctx, {
 		name: 'ls',
 		agentTool: listTool,
 		title: 'List Files',
+		description: LS_DESCRIPTION,
 	});
 }

--- a/apps/backend/src/mcp/tools/stories.ts
+++ b/apps/backend/src/mcp/tools/stories.ts
@@ -10,90 +10,49 @@ import type { McpContext } from '../logging';
 import { withLogging } from '../logging';
 import { storyChatUrl, storyUrl } from '../urls';
 
-export function registerStoryTools(server: McpServer, ctx: McpContext): void {
-	server.registerTool(
-		'list_stories',
-		{
-			title: 'List Stories',
-			description:
-				'List analytics stories (dashboards/reports) in the current project. Each story includes a `url` that opens the rendered story in the Nao UI, and a `chatUrl` that opens the underlying chat conversation (null for standalone stories).',
-			inputSchema: {
-				limit: z.number().optional().default(20).describe('Max stories to return (default 20, max 100)'),
-				archived: z.boolean().optional().default(false).describe('Include archived stories'),
-			},
-		},
-		withLogging('list_stories', ctx, async ({ limit, archived }) => {
-			try {
-				const stories = await storyQueries.listAllUserStoriesInProject(ctx.userId, ctx.projectId, {
-					archived,
-					limit,
-				});
-				const result = stories.map((story) => ({
-					id: story.id,
-					title: story.title,
-					createdAt: story.createdAt,
-					updatedAt: story.updatedAt,
-					archived: story.archivedAt !== null,
-					url: storyUrl(story),
-					chatUrl: storyChatUrl(story),
-				}));
-				return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				logger.error(`MCP list_stories error: ${message}`, { source: 'tool', context: { userId: ctx.userId } });
-				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
-			}
-		}),
-	);
+const CHART_BLOCK_SYNTAX =
+	'Supported blocks (write them inline in `content`):\n' +
+	'- Charts: `<chart query_id="..." chart_type="bar|stacked_bar|line|area|stacked_area|pie|kpi_card|scatter|radar" x_axis_key="..." x_axis_type="date|number|category" series=\'[{"data_key":"...","color":"...","label":"..."}]\' title="..." />` — `series` is JSON inside single quotes; `x_axis_type` is optional; `kpi_card` and `pie` accept omitted/null `x_axis_type`.\n' +
+	'- Tables: `<table query_id="..." title="..." />`\n' +
+	'- Grids: `<grid cols="2">...blocks...</grid>` (1-4 columns)';
 
-	server.registerTool(
-		'get_story',
-		{
-			title: 'Get Story',
-			description:
-				'Retrieve a full story including its latest content/code. Returns a `url` that opens the rendered story in the Nao UI, and a `chatUrl` that opens the underlying chat conversation (null for standalone stories).',
-			inputSchema: {
-				story_id: z.string().describe('The story ID to retrieve'),
-			},
-		},
-		withLogging('get_story', ctx, async ({ story_id }) => {
-			try {
-				const story = await resolveStory(story_id, ctx);
-				const version = await fetchLatestVersion(story);
+const CREATE_STORY_DESCRIPTION =
+	'Create a new analytics story. Stories are markdown documents with embedded chart/table components rendered by the Nao UI.\n\n' +
+	'Typical workflow:\n' +
+	'1. `ls` / `grep` - read `RULES.md` and explore `databases/` for schema context\n' +
+	'2. `execute_sql` - get rows + `query_id`\n' +
+	'3. Optional: `build_chart` - validated `<chart />` block\n' +
+	'4. `create_story` - set `content` with chart/table blocks; pass SQL rows keyed by `query_id` in `query_data`\n\n' +
+	`${CHART_BLOCK_SYNTAX}\n\n` +
+	'Omit `content` to create an empty story.\n\n' +
+	'Pass `chat_id` to attach the story to an existing chat. Omit it for a standalone project-level story.\n\n' +
+	'Returns a `url` that opens the rendered story in the Nao UI and a `chatUrl` for the underlying chat (null for standalone stories).';
 
-				const output = {
-					id: story.id,
-					title: story.title,
-					slug: story.slug,
-					chatId: story.chatId,
-					projectId: story.projectId,
-					code: version?.code ?? null,
-					version: version?.version ?? null,
-					isLive: story.isLive,
-					archived: story.archivedAt !== null,
-					createdAt: story.createdAt,
-					updatedAt: story.updatedAt,
-					url: storyUrl(story),
-					chatUrl: storyChatUrl(story),
-				};
-				return { content: [{ type: 'text' as const, text: JSON.stringify(output) }] };
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				logger.error(`MCP get_story error: ${message}`, {
-					source: 'tool',
-					context: { story_id, userId: ctx.userId },
-				});
-				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
-			}
-		}),
-	);
+const UPDATE_STORY_DESCRIPTION =
+	'Update a story title and/or content. Omit fields to keep their current values.\n\n' +
+	'When adding charts, run `execute_sql` first, optionally use `build_chart`, then include blocks in `content` and pass new `query_id` rows in `query_data`.\n\n' +
+	`${CHART_BLOCK_SYNTAX}\n\n` +
+	'Returns a `url` that opens the rendered story in the Nao UI and a `chatUrl` for the underlying chat (null for standalone stories).';
 
+function mapStorySummary(story: UserStoryRow) {
+	return {
+		id: story.id,
+		title: story.title,
+		slug: story.slug,
+		createdAt: story.createdAt,
+		updatedAt: story.updatedAt,
+		archived: story.archivedAt !== null,
+		url: storyUrl(story),
+		chatUrl: storyChatUrl(story),
+	};
+}
+
+export function registerContextStoryTools(server: McpServer, ctx: McpContext): void {
 	server.registerTool(
 		'create_story',
 		{
 			title: 'Create Story',
-			description:
-				'Create a new analytics story. Stories are markdown documents with embedded chart/table components rendered by the Nao UI.\n\nWorkflow for stories with charts:\n1. `execute_sql` → get rows + `query_id`\n2. `create_story` → embed `<chart>` / `<table>` blocks in `content`; pass the SQL rows keyed by `query_id` in `query_data`\n\nSupported blocks (write them inline in `content`):\n- Charts: `<chart query_id="..." chart_type="bar|stacked_bar|line|area|stacked_area|pie|kpi_card|scatter|radar" x_axis_key="..." x_axis_type="date|number|category" series=\'[{"data_key":"...","color":"...","label":"..."}]\' title="..." />` — `series` is JSON inside single quotes; `x_axis_type` is optional; `kpi_card` and `pie` accept omitted/null `x_axis_type`.\n- Tables: `<table query_id="..." title="..." />`\n- Grids: `<grid cols="2">...blocks...</grid>` (1–4 columns)\n\nOmit `content` to create an empty story.\n\nPass `chat_id` to attach the story to an existing chat (e.g. one returned by `ask_nao`). Omit it to create a standalone story listed at the project level.\n\nReturns a `url` that opens the rendered story in the Nao UI and a `chatUrl` that opens the underlying chat (null for standalone stories) — surface the relevant link to the user as a clickable link in your reply.',
+			description: CREATE_STORY_DESCRIPTION,
 			inputSchema: {
 				title: z.string().describe('Story title'),
 				content: z
@@ -115,9 +74,7 @@ export function registerStoryTools(server: McpServer, ctx: McpContext): void {
 					.string()
 					.optional()
 					.describe(
-						'Attach the story to an existing chat (e.g. the chat ID returned by `ask_nao`). ' +
-							'Omit to create a standalone story listed at the project level. ' +
-							'When provided, the chat must belong to the current user.',
+						'UUID of an existing chat to attach this story to. Omit for a standalone project-level story. The chat must belong to the current user.',
 					),
 			},
 		},
@@ -164,8 +121,7 @@ export function registerStoryTools(server: McpServer, ctx: McpContext): void {
 		'update_story',
 		{
 			title: 'Update Story',
-			description:
-				'Update a story title and/or content. Omit fields to keep their current values.\n\nWhen adding or replacing charts, write the `<chart>` block directly in `content` (see `create_story` for the full chart syntax) and include the SQL rows for any new `query_id`s in `query_data`.\n\nReturns a `url` that opens the rendered story in the Nao UI and a `chatUrl` that opens the underlying chat (null for standalone stories) — surface the relevant link to the user as a clickable link in your reply.',
+			description: UPDATE_STORY_DESCRIPTION,
 			inputSchema: {
 				story_id: z.string().describe('The story ID to update'),
 				title: z.string().optional().describe('New title (omit to keep current)'),
@@ -222,12 +178,82 @@ export function registerStoryTools(server: McpServer, ctx: McpContext): void {
 			}
 		}),
 	);
+}
+
+export function registerStoryManagementTools(server: McpServer, ctx: McpContext): void {
+	server.registerTool(
+		'list_stories',
+		{
+			title: 'List Stories',
+			description:
+				'List analytics stories (dashboards/reports) in the current project. Returns metadata including `url` (rendered story) and `chatUrl` (underlying chat, null for standalone stories). Use `search_stories` to filter by title.',
+			inputSchema: {
+				limit: z.number().optional().default(20).describe('Max stories to return (default 20, max 100)'),
+				archived: z.boolean().optional().default(false).describe('Include archived stories'),
+			},
+		},
+		withLogging('list_stories', ctx, async ({ limit, archived }) => {
+			try {
+				const stories = await storyQueries.listAllUserStoriesInProject(ctx.userId, ctx.projectId, {
+					archived,
+					limit,
+				});
+				const result = stories.map(mapStorySummary);
+				return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.error(`MCP list_stories error: ${message}`, { source: 'tool', context: { userId: ctx.userId } });
+				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+			}
+		}),
+	);
+
+	server.registerTool(
+		'search_stories',
+		{
+			title: 'Search Stories',
+			description:
+				'Search stories by title or slug (case-insensitive). Returns the same fields as `list_stories`. Use `archive_story` to soft-delete a story.',
+			inputSchema: {
+				query: z.string().describe('Search text matched against story title and slug'),
+				limit: z.number().optional().default(20).describe('Max stories to return (default 20, max 100)'),
+				archived: z.boolean().optional().default(false).describe('Include archived stories'),
+			},
+		},
+		withLogging('search_stories', ctx, async ({ query, limit, archived }) => {
+			try {
+				const stories = await storyQueries.listAllUserStoriesInProject(ctx.userId, ctx.projectId, {
+					archived,
+					limit: 100,
+				});
+				const lowerQuery = query.toLowerCase().trim();
+				const filtered = lowerQuery
+					? stories.filter(
+							(story) =>
+								story.title.toLowerCase().includes(lowerQuery) ||
+								story.slug.toLowerCase().includes(lowerQuery),
+						)
+					: stories;
+				const capped = filtered.slice(0, Math.min(limit, 100));
+				const result = capped.map(mapStorySummary);
+				return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.error(`MCP search_stories error: ${message}`, {
+					source: 'tool',
+					context: { query, userId: ctx.userId },
+				});
+				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+			}
+		}),
+	);
 
 	server.registerTool(
 		'archive_story',
 		{
 			title: 'Archive Story',
-			description: 'Soft-delete a story by archiving it. The story can be restored later.',
+			description:
+				'Soft-delete a story by archiving it. Archived stories can be listed with `archived: true` on `list_stories` or `search_stories`.',
 			inputSchema: {
 				story_id: z.string().describe('The story ID to archive'),
 			},
@@ -242,34 +268,6 @@ export function registerStoryTools(server: McpServer, ctx: McpContext): void {
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				logger.error(`MCP archive_story error: ${message}`, {
-					source: 'tool',
-					context: { story_id, userId: ctx.userId },
-				});
-				return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
-			}
-		}),
-	);
-
-	server.registerTool(
-		'delete_story',
-		{
-			title: 'Delete Story',
-			description:
-				'Permanently delete a story and all its versions. This cannot be undone. Use archive_story if you want a recoverable soft-delete.',
-			inputSchema: {
-				story_id: z.string().describe('The story ID to permanently delete'),
-			},
-		},
-		withLogging('delete_story', ctx, async ({ story_id }) => {
-			try {
-				const story = await resolveStory(story_id, ctx);
-				await storyQueries.deleteStory(story.id);
-				return {
-					content: [{ type: 'text' as const, text: JSON.stringify({ id: story.id, deleted: true }) }],
-				};
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				logger.error(`MCP delete_story error: ${message}`, {
 					source: 'tool',
 					context: { story_id, userId: ctx.userId },
 				});

--- a/apps/backend/src/utils/chart-block.ts
+++ b/apps/backend/src/utils/chart-block.ts
@@ -1,0 +1,21 @@
+import type { displayChart } from '@nao/shared/tools';
+
+function escapeDoubleQuotedAttr(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function escapeSingleQuotedAttr(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+export function formatChartBlock(config: displayChart.Input): string {
+	const seriesJson = JSON.stringify(config.series);
+	return (
+		`<chart query_id="${escapeDoubleQuotedAttr(config.query_id)}" ` +
+		`chart_type="${escapeDoubleQuotedAttr(config.chart_type)}" ` +
+		`x_axis_key="${escapeDoubleQuotedAttr(config.x_axis_key)}" ` +
+		`x_axis_type="${escapeDoubleQuotedAttr(config.x_axis_type ?? '')}" ` +
+		`series='${escapeSingleQuotedAttr(seriesJson)}' ` +
+		`title="${escapeDoubleQuotedAttr(config.title ?? '')}" />`
+	);
+}

--- a/apps/backend/src/utils/validate-chart-config.ts
+++ b/apps/backend/src/utils/validate-chart-config.ts
@@ -1,0 +1,28 @@
+import type { displayChart } from '@nao/shared/tools';
+
+export function validateChartConfig({
+	chart_type: chartType,
+	x_axis_key: xAxisKey,
+	series,
+}: displayChart.Input): { success: true } | { success: false; error: string } {
+	if (['bar', 'line', 'area', 'stacked_area', 'scatter', 'radar'].includes(chartType) && !xAxisKey) {
+		return { success: false, error: `xAxisKey is required for ${chartType} charts.` };
+	}
+
+	if (chartType === 'pie' && series.length !== 1) {
+		return { success: false, error: 'Pie charts require exactly one series.' };
+	}
+
+	if (series.length === 0) {
+		return { success: false, error: 'At least one series is required.' };
+	}
+
+	if ((chartType === 'stacked_bar' || chartType === 'stacked_area') && series.length < 2) {
+		return {
+			success: false,
+			error: `Stacked ${chartType === 'stacked_bar' ? 'bar' : 'area'} chart requires at least two series. You may need to pivot the data to create a series for each stack.`,
+		};
+	}
+
+	return { success: true };
+}

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -203,24 +203,24 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		section: 'MCP Modes',
 		title: 'Sub-agent mode',
 		description:
-			'External agents use nao as a subagent to answer analytics questions like "How many users do we have?".',
-		keywords: ['ask_nao', 'agent', 'analytics'],
+			'External agents ask analytics questions via ask_nao. Nao can create and update stories inside that chat.',
+		keywords: ['ask_nao', 'agent', 'analytics', 'subagent'],
 	},
 	{
 		page: '/settings/mcp-endpoint',
 		pageLabel: 'MCP Endpoint',
 		section: 'MCP Modes',
 		title: 'Context-layer mode',
-		description: 'Let agents use nao as a context-layer to browse nao filesystem, execute SQL, create charts, etc.',
-		keywords: ['execute_sql', 'sql', 'query'],
+		description: 'Direct tools to browse project context (ls, grep), run SQL, build charts, and author stories.',
+		keywords: ['execute_sql', 'sql', 'grep', 'ls', 'build_chart', 'create_story', 'update_story', 'RULES.md'],
 	},
 	{
 		page: '/settings/mcp-endpoint',
 		pageLabel: 'MCP Endpoint',
 		section: 'MCP Modes',
-		title: 'Story mode',
-		description: 'Let external agents create and manage nao stories (create, read, update, archive, etc.).',
-		keywords: ['stories', 'dashboard', 'report', 'crud'],
+		title: 'Story management',
+		description: 'List, search, and archive existing nao stories.',
+		keywords: ['stories', 'list_stories', 'search_stories', 'archive_story', 'dashboard', 'report'],
 	},
 
 	// ── Project > Slack ──────────────────────────────────────

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -78,7 +78,7 @@ export function McpEndpointSettings({ isAdmin }: Props) {
 				<SettingsToggleRow
 					id='mcp-agent-mode'
 					label='Sub-agent mode'
-					description='External agents use nao as a subagent to answer analytics questions like "How many users do we have?".'
+					description='External agents ask analytics questions via ask_nao. Nao can create and update stories inside that chat.'
 					checked={settings?.agentModeEnabled ?? true}
 					onCheckedChange={(v) => toggle('agentModeEnabled', v)}
 					disabled={!isAdmin || !enabled || pending}
@@ -86,15 +86,15 @@ export function McpEndpointSettings({ isAdmin }: Props) {
 				<SettingsToggleRow
 					id='mcp-tools-mode'
 					label='Context-layer mode'
-					description='External agents use nao as a context-layer to browse nao filesystem, execute SQL, create charts, etc.'
+					description='Direct tools to browse project context (ls, grep), run SQL, build charts, and author stories — no sub-agent required.'
 					checked={settings?.toolsModeEnabled ?? true}
 					onCheckedChange={(v) => toggle('toolsModeEnabled', v)}
 					disabled={!isAdmin || !enabled || pending}
 				/>
 				<SettingsToggleRow
 					id='mcp-objects-mode'
-					label='Story mode'
-					description='Manage nao stories (create, read, update, archive, etc.). Useful to migrate from other BI tools to nao.'
+					label='Story management'
+					description='List, search, and archive existing nao stories.'
 					checked={settings?.objectsModeEnabled ?? true}
 					onCheckedChange={(v) => toggle('objectsModeEnabled', v)}
 					disabled={!isAdmin || !enabled || pending}


### PR DESCRIPTION
**Description**
This PR splits the outbound MCP server into three independent modes so external clients only see tools for what they enabled.
1> Sub-agent mode exposes `ask_nao` only. The tool description now explains that Nao can create and update stories inside that chat, without pointing at other MCP tools.
2> Context-layer mode exposes `ls, grep, execute_sql, build_chart, create_story, and update_story.` Tool descriptions tell agents to read RULES.md and browse the project filesystem before running SQL. build_chart returns a validated <chart /> block for story content.
3> Story management exposes `list_stories, search_stories, and archive_story`. **get_story and delete_story are removed from the MCP endpoint.**

Settings labels and copy are updated to match (Story mode is now Story management).

Issue: Closes https://github.com/getnao/nao/issues/785