### PR TITLE
feat: make optional 'Max output tokens per model'

### DIFF
--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -195,6 +195,14 @@ export const updateAgentSettings = async (projectId: string, settings: AgentSett
 	const next: AgentSettings = {
 		...current,
 		...settings,
+		llm: {
+			...current.llm,
+			...settings.llm,
+			maxOutputTokensByProviderModel: {
+				...current.llm?.maxOutputTokensByProviderModel,
+				...settings.llm?.maxOutputTokensByProviderModel,
+			},
+		},
 		experimental: {
 			...current.experimental,
 			...settings.experimental,

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -46,8 +46,10 @@ import { convertToCost, convertToTokenUsage, findLastUserMessage, getLastUserMes
 import { assertBudgetNotExceeded } from '../utils/budget';
 import { HandlerError } from '../utils/error';
 import {
+	DEFAULT_MAX_OUTPUT_TOKENS,
 	getDefaultModelId,
 	getEnvModelSelections,
+	resolveMaxOutputTokens,
 	resolveAnnotationModelId,
 	resolveProviderModel,
 	resolveProviderSettings,
@@ -95,6 +97,12 @@ export class AgentService {
 		const resolvedLlmSelectedModel = await this._getResolvedLlmSelectedModel(chat.projectId, modelSelection);
 		await assertBudgetNotExceeded(chat.projectId, resolvedLlmSelectedModel.provider);
 		const modelConfig = await this._getModelConfig(chat.projectId, resolvedLlmSelectedModel);
+		const maxOutputTokens = await resolveMaxOutputTokens(
+			chat.projectId,
+			resolvedLlmSelectedModel.provider,
+			resolvedLlmSelectedModel.modelId,
+			MAX_OUTPUT_TOKENS,
+		);
 		const agentSettings = await projectQueries.getAgentSettings(chat.projectId);
 		const toolContext = await this._getToolContext(chat.projectId, chat.id, chat.userId, agentSettings);
 		const webTools = await this._resolveWebTools(chat.projectId, resolvedLlmSelectedModel.provider, agentSettings);
@@ -102,6 +110,7 @@ export class AgentService {
 		const agent = new AgentManager(
 			chat,
 			modelConfig,
+			maxOutputTokens,
 			resolvedLlmSelectedModel,
 			() => this._agents.delete(chat.id),
 			new AbortController(),
@@ -200,7 +209,7 @@ export class AgentService {
 	}
 }
 
-export const MAX_OUTPUT_TOKENS = 16_000;
+export const MAX_OUTPUT_TOKENS = DEFAULT_MAX_OUTPUT_TOKENS;
 
 class AgentManager {
 	private readonly _agent: ToolLoopAgent<never, AgentTools, never>;
@@ -209,6 +218,7 @@ class AgentManager {
 	constructor(
 		readonly chat: AgentChat,
 		private readonly _modelConfig: ProviderModelResult,
+		private readonly _maxOutputTokens: number,
 		private readonly _modelSelection: LlmSelectedModel,
 		private readonly _onDispose: () => void,
 		private readonly _abortController: AbortController,
@@ -219,7 +229,7 @@ class AgentManager {
 			model: this._modelConfig.model,
 			providerOptions: this._modelConfig.providerOptions,
 			tools: this._agentTools,
-			maxOutputTokens: MAX_OUTPUT_TOKENS,
+			maxOutputTokens: this._maxOutputTokens,
 			prepareStep: async ({ messages }) => this._prepareStep(messages),
 			stopWhen: [hasToolCall('suggest_follow_ups'), hasToolCall('clarification')],
 			experimental_context: this._toolContext,
@@ -232,7 +242,7 @@ class AgentManager {
 		// 	provider: this._modelSelection.provider,
 		// 	messages,
 		// 	tools: this._agentTools,
-		// 	maxOutputTokens: MAX_OUTPUT_TOKENS,
+		// 	maxOutputTokens: this._maxOutputTokens,
 		// 	contextWindow: this._modelConfig.contextWindow,
 		// 	onCompactionStarted: () => {
 		// 		this._streamWriter?.write({

--- a/apps/backend/src/services/live-story.ts
+++ b/apps/backend/src/services/live-story.ts
@@ -10,7 +10,7 @@ import * as projectQueries from '../queries/project.queries';
 import * as llmConfigQueries from '../queries/project-llm-config.queries';
 import { getQueryDataFromCode } from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
-import { getDefaultModelId, resolveProviderModel } from '../utils/llm';
+import { getDefaultModelId, resolveMaxOutputTokens, resolveProviderModel } from '../utils/llm';
 import { MAX_OUTPUT_TOKENS } from './agent';
 const MAX_RENDERED_ROWS = 60;
 
@@ -171,10 +171,12 @@ async function generateDynamicStoryCode(
 		return null;
 	}
 
-	const model = await resolveProviderModel(projectId, provider, getDefaultModelId(provider));
+	const modelId = getDefaultModelId(provider);
+	const model = await resolveProviderModel(projectId, provider, modelId);
 	if (!model) {
 		return null;
 	}
+	const maxOutputTokens = await resolveMaxOutputTokens(projectId, provider, modelId, MAX_OUTPUT_TOKENS);
 
 	try {
 		const querySummaries = buildQueryDataSummary(queryData);
@@ -189,7 +191,7 @@ async function generateDynamicStoryCode(
 					code: z.string().min(1),
 				}),
 			}),
-			maxOutputTokens: MAX_OUTPUT_TOKENS,
+			maxOutputTokens,
 		});
 
 		const candidate = stripCodeFence(output.code.trim());

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -21,7 +21,13 @@ import { listAvailableTranscribeModels as getAvailableTranscribeModels } from '.
 import { AgentSettings } from '../types/agent-settings';
 import { llmConfigSchema, llmProviderSchema } from '../types/llm';
 import { isValidIsoDateString } from '../utils/date';
-import { getEnvApiKey, getEnvBaseUrls, getEnvProviders, getProjectAvailableModels } from '../utils/llm';
+import {
+	getEnvApiKey,
+	getEnvBaseUrls,
+	getEnvProviders,
+	getProjectAvailableModels,
+	getProviderModelKey,
+} from '../utils/llm';
 import { extractRequiredEnvVars } from '../utils/nao-config';
 import { buildCredentialPreviews } from '../utils/utils';
 import { adminProtectedProcedure, projectProtectedProcedure, protectedProcedure, publicProcedure } from './trpc';
@@ -87,6 +93,8 @@ export const projectRoutes = {
 			}
 
 			const configs = await llmConfigQueries.getProjectLlmConfigs(ctx.project.id);
+			const settings = await projectQueries.getAgentSettings(ctx.project.id);
+			const maxOutputTokensByProviderModel = settings?.llm?.maxOutputTokensByProviderModel ?? {};
 
 			const projectConfigs = configs.map((c) => ({
 				id: c.id,
@@ -94,6 +102,11 @@ export const projectRoutes = {
 				apiKeyPreview: c.apiKey ? c.apiKey.slice(0, 8) + '...' + c.apiKey.slice(-4) : null,
 				credentialPreviews: buildCredentialPreviews(c.credentials),
 				enabledModels: c.enabledModels ?? [],
+				maxOutputTokensByModel: Object.fromEntries(
+					Object.entries(maxOutputTokensByProviderModel)
+						.filter(([key]) => key.startsWith(`${c.provider}:`))
+						.map(([key, value]) => [key.slice(c.provider.length + 1), value]),
+				),
 				baseUrl: c.baseUrl ?? null,
 				createdAt: c.createdAt,
 				updatedAt: c.updatedAt,
@@ -130,6 +143,7 @@ export const projectRoutes = {
 				apiKey: z.string().min(1).optional(),
 				credentials: z.record(z.string(), z.string()).optional(),
 				enabledModels: z.array(z.string()).optional(),
+				maxOutputTokensByModel: z.record(z.string(), z.number().int().positive()).optional(),
 				baseUrl: z.string().url().optional().or(z.literal('')),
 			}),
 		)
@@ -168,12 +182,36 @@ export const projectRoutes = {
 				baseUrl: input.baseUrl || null,
 			} as Parameters<typeof llmConfigQueries.upsertProjectLlmConfig>[0]);
 
+			if (input.maxOutputTokensByModel) {
+				const currentSettings = (await projectQueries.getAgentSettings(ctx.project.id)) ?? {};
+				const existingMap = currentSettings.llm?.maxOutputTokensByProviderModel ?? {};
+				const withoutCurrentProvider = Object.fromEntries(
+					Object.entries(existingMap).filter(([key]) => !key.startsWith(`${input.provider}:`)),
+				);
+				const nextProviderEntries = Object.entries(input.maxOutputTokensByModel)
+					.filter(([, value]) => Number.isFinite(value) && value > 0)
+					.map(
+						([modelId, value]) =>
+							[getProviderModelKey(input.provider, modelId), Math.floor(value)] as const,
+					);
+
+				await projectQueries.updateAgentSettings(ctx.project.id, {
+					llm: {
+						maxOutputTokensByProviderModel: {
+							...withoutCurrentProvider,
+							...Object.fromEntries(nextProviderEntries),
+						},
+					},
+				});
+			}
+
 			return {
 				id: config.id,
 				provider: config.provider as LlmProvider,
 				apiKeyPreview: config.apiKey ? config.apiKey.slice(0, 8) + '...' + config.apiKey.slice(-4) : null,
 				credentialPreviews: buildCredentialPreviews(config.credentials),
 				enabledModels: config.enabledModels ?? [],
+				maxOutputTokensByModel: input.maxOutputTokensByModel ?? null,
 				baseUrl: config.baseUrl ?? null,
 			};
 		}),

--- a/apps/backend/src/types/agent-settings.ts
+++ b/apps/backend/src/types/agent-settings.ts
@@ -2,6 +2,10 @@ export type WebSearchMode = 'provider';
 
 export interface AgentSettings {
 	memoryEnabled?: boolean;
+	llm?: {
+		/** Per-model max output tokens keyed by "provider:modelId". */
+		maxOutputTokensByProviderModel?: Record<string, number>;
+	};
 	experimental?: {
 		pythonSandboxing?: boolean;
 		sandboxes?: boolean;

--- a/apps/backend/src/types/llm.ts
+++ b/apps/backend/src/types/llm.ts
@@ -26,6 +26,7 @@ export const llmConfigSchema = z.object({
 	apiKeyPreview: z.string().nullable(),
 	credentialPreviews: z.record(z.string(), z.string()).nullable(),
 	enabledModels: z.array(z.string()).nullable(),
+	maxOutputTokensByModel: z.record(z.string(), z.number().int().positive()).nullable(),
 	baseUrl: z.string().url().nullable(),
 	createdAt: z.date(),
 	updatedAt: z.date(),

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -2,9 +2,15 @@ import type { LlmProvider, LlmSelectedModel } from '@nao/shared/types';
 
 import { createProviderModel, getDefaultModelId, LLM_PROVIDERS, type ProviderModelResult } from '../agents/providers';
 import * as projectLlmConfigQueries from '../queries/project-llm-config.queries';
+import * as projectQueries from '../queries/project.queries';
 import type { ProviderSettings } from '../types/llm';
 
 export { getDefaultModelId };
+export const DEFAULT_MAX_OUTPUT_TOKENS = 16_000;
+
+export function getProviderModelKey(provider: LlmProvider, modelId: string): string {
+	return `${provider}:${modelId}`;
+}
 
 /** Get the API key from environment for a provider */
 export function getEnvApiKey(provider: LlmProvider): string | undefined {
@@ -197,3 +203,18 @@ export const getProjectAvailableModels = async (
 
 const getModelName = (provider: LlmProvider, modelId: string): string =>
 	LLM_PROVIDERS[provider].models.find((m) => m.id === modelId)?.name ?? modelId;
+
+export async function resolveMaxOutputTokens(
+	projectId: string,
+	provider: LlmProvider,
+	modelId: string,
+	defaultValue: number = DEFAULT_MAX_OUTPUT_TOKENS,
+): Promise<number> {
+	const settings = await projectQueries.getAgentSettings(projectId);
+	const byModel = settings?.llm?.maxOutputTokensByProviderModel ?? {};
+	const value = byModel[getProviderModelKey(provider, modelId)];
+	if (!Number.isFinite(value) || value <= 0) {
+		return defaultValue;
+	}
+	return Math.floor(value);
+}

--- a/apps/frontend/src/components/settings/llm-provider-card.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-card.tsx
@@ -11,6 +11,7 @@ interface ProviderCardProps {
 	baseUrl?: string | null;
 	envBaseUrl?: string;
 	enabledModels?: string[] | null;
+	maxOutputTokensByModel?: Record<string, number> | null;
 	isEnvProvider: boolean;
 	isAdmin: boolean;
 	isFormActive: boolean;
@@ -27,6 +28,7 @@ export function ProviderCard({
 	baseUrl,
 	envBaseUrl,
 	enabledModels,
+	maxOutputTokensByModel,
 	isEnvProvider,
 	isAdmin,
 	isFormActive,
@@ -118,6 +120,21 @@ export function ProviderCard({
 					</>
 				) : (
 					<span className='text-xs text-muted-foreground'>Default model: {getDefaultModelId(provider)}</span>
+				)}
+				{maxOutputTokensByModel && Object.keys(maxOutputTokensByModel).length > 0 && (
+					<div className='mt-2'>
+						<span className='text-xs text-muted-foreground'>Max output tokens:</span>
+						<div className='flex flex-wrap gap-1.5 mt-1.5'>
+							{Object.entries(maxOutputTokensByModel).map(([modelId, value]) => (
+								<span
+									key={modelId}
+									className='px-2 py-0.5 text-xs rounded bg-secondary text-muted-foreground'
+								>
+									{getModelDisplayName(provider, modelId)}: {value}
+								</span>
+							))}
+						</div>
+					</div>
 				)}
 			</div>
 		</div>

--- a/apps/frontend/src/components/settings/llm-provider-form.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-form.tsx
@@ -15,6 +15,7 @@ export interface LlmProviderFormProps {
 	initialValues?: {
 		enabledModels: string[];
 		baseUrl: string;
+		maxOutputTokensByModel: Record<string, number>;
 	};
 	currentModels: readonly { id: string; name: string; default?: boolean }[];
 	onSubmit: (values: {
@@ -22,6 +23,7 @@ export interface LlmProviderFormProps {
 		credentials?: Record<string, string>;
 		enabledModels: string[];
 		baseUrl?: string;
+		maxOutputTokensByModel?: Record<string, number>;
 	}) => Promise<void>;
 	onCancel: () => void;
 	isPending: boolean;
@@ -59,6 +61,7 @@ export function LlmProviderForm({
 			credentials: defaultCredentials,
 			enabledModels: initialValues?.enabledModels ?? [],
 			baseUrl: initialValues?.baseUrl ?? '',
+			maxOutputTokensByModel: initialValues?.maxOutputTokensByModel ?? {},
 		},
 		onSubmit: async ({ value }) => {
 			const filledCredentials = Object.fromEntries(Object.entries(value.credentials).filter(([, v]) => v));
@@ -68,6 +71,7 @@ export function LlmProviderForm({
 				credentials: Object.keys(filledCredentials).length > 0 ? filledCredentials : undefined,
 				enabledModels: value.enabledModels,
 				baseUrl: value.baseUrl || undefined,
+				maxOutputTokensByModel: value.maxOutputTokensByModel,
 			});
 		},
 	});
@@ -241,6 +245,72 @@ export function LlmProviderForm({
 									<Plus className='size-4' />
 								</Button>
 							</div>
+							<form.Field name='maxOutputTokensByModel'>
+								{(tokenField) => {
+									const configuredModelIds = new Set<string>([
+										...currentModels.map((m) => m.id),
+										...enabledModels,
+									]);
+									if (configuredModelIds.size === 0) {
+										configuredModelIds.add(getDefaultModelId(provider));
+									}
+
+									const sortedModelIds = [...configuredModelIds].sort((a, b) => a.localeCompare(b));
+
+									return (
+										<div className='grid gap-2 mt-2'>
+											<label className='text-sm font-medium text-foreground'>
+												Max output tokens per model
+												<span className='text-muted-foreground font-normal ml-1'>
+													(default 16000)
+												</span>
+											</label>
+											<div className='grid gap-2'>
+												{sortedModelIds.map((modelId) => {
+													const currentValue = tokenField.state.value[modelId];
+													return (
+														<div
+															key={modelId}
+															className='grid grid-cols-[1fr_140px] gap-2 items-center'
+														>
+															<span
+																className='text-xs text-muted-foreground truncate'
+																title={modelId}
+															>
+																{modelId}
+															</span>
+															<Input
+																type='number'
+																min={1}
+																step={1}
+																value={currentValue ?? ''}
+																onChange={(e) => {
+																	const raw = e.target.value.trim();
+																	if (!raw) {
+																		const next = { ...tokenField.state.value };
+																		delete next[modelId];
+																		tokenField.handleChange(next);
+																		return;
+																	}
+																	const parsed = Number(raw);
+																	if (!Number.isFinite(parsed) || parsed <= 0) {
+																		return;
+																	}
+																	tokenField.handleChange({
+																		...tokenField.state.value,
+																		[modelId]: Math.floor(parsed),
+																	});
+																}}
+																placeholder='16000'
+															/>
+														</div>
+													);
+												})}
+											</div>
+										</div>
+									);
+								}}
+							</form.Field>
 						</div>
 					);
 				}}

--- a/apps/frontend/src/components/settings/llm-providers-section.tsx
+++ b/apps/frontend/src/components/settings/llm-providers-section.tsx
@@ -89,6 +89,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 						baseUrl={config.baseUrl}
 						envBaseUrl={envBaseUrls[config.provider]}
 						enabledModels={config.enabledModels}
+						maxOutputTokensByModel={config.maxOutputTokensByModel}
 						isEnvProvider={envProviders.includes(config.provider)}
 						isAdmin={isAdmin}
 						isFormActive={!!editingState}

--- a/apps/frontend/src/hooks/use-llm-providers.ts
+++ b/apps/frontend/src/hooks/use-llm-providers.ts
@@ -11,6 +11,7 @@ export interface EditingState {
 	initialValues?: {
 		enabledModels: string[];
 		baseUrl: string;
+		maxOutputTokensByModel: Record<string, number>;
 	};
 }
 
@@ -58,6 +59,7 @@ export function useLlmProviders() {
 		credentials?: Record<string, string>;
 		enabledModels: string[];
 		baseUrl?: string;
+		maxOutputTokensByModel?: Record<string, number>;
 	}) => {
 		if (!editingState?.provider) {
 			return;
@@ -69,6 +71,7 @@ export function useLlmProviders() {
 			credentials: values.credentials,
 			enabledModels: values.enabledModels,
 			baseUrl: values.baseUrl,
+			maxOutputTokensByModel: values.maxOutputTokensByModel,
 		});
 		await invalidateQueries();
 		setEditingState(null);
@@ -88,6 +91,7 @@ export function useLlmProviders() {
 			initialValues: {
 				enabledModels: config.enabledModels ?? [],
 				baseUrl: config.baseUrl ?? '',
+				maxOutputTokensByModel: config.maxOutputTokensByModel ?? {},
 			},
 		});
 	};


### PR DESCRIPTION
Added configurable max_output_tokens per provider/model in Project Settings, while keeping 16,000 as the default fallback.

This change fixes provider-side failures where a global hardcoded value exceeded model limits (for example, models capped at 4096 total tokens), causing requests to be rejected before generation. Making the limit model-specific keeps current behavior by default, but allows safe overrides for constrained models/endpoints and prevents runtime token-limit errors.

```
[ERROR] [agent] Agent stream error: 
Error: max_output_tokens=16000 cannot be greater than 
max_model_len=max_total_tokens=4096. Please request fewer output tokens. (parameter=max_output_tokens, 
value=16000)
```

<img width="908" height="809" alt="Screenshot 2026-05-18 at 2 13 10 PM" src="https://github.com/user-attachments/assets/58b69c80-16c1-4f48-b464-83c1055228ab" />
