### PR TITLE
Fix timestamp type for period calculation of providers budget  in Postgres

### DIFF
--- a/apps/backend/src/queries/budget.queries.ts
+++ b/apps/backend/src/queries/budget.queries.ts
@@ -152,7 +152,7 @@ export const getProviderPeriodCosts = async (
 	const weekStart = getCurrentPeriodStart('week');
 	const monthStart = getCurrentPeriodStart('month');
 
-	const toParam = (d: Date) => (isPostgres ? d.toISOString() : d.getTime());
+	const toParam = (d: Date) => (isPostgres ? sql`${d.toISOString()}::timestamp` : sql`${d.getTime()}`);
 	const periodStartExpr = sql`CASE ${s.projectProviderBudget.period}
 		WHEN 'day' THEN ${toParam(dayStart)}
 		WHEN 'week' THEN ${toParam(weekStart)}


### PR DESCRIPTION
## Summary

- Issue : Postgres returned an error when calculating the budget overrun for budgets allocated to model providers because it did not receive the value with the correct data type
- Solution : Make the CASE expression return a real timestamp on Postgres by emitting the cast inline