### PR TITLE
fix: disable clarification tool during test runs

### DIFF
--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -31,13 +31,18 @@ export const tools = {
 	suggest_follow_ups: suggestFollowUps,
 };
 
-export const getTools = (agentSettings: AgentSettings | null, extraTools?: Record<string, unknown>) => {
+export const getTools = (
+	agentSettings: AgentSettings | null,
+	extraTools?: Record<string, unknown>,
+	opts?: { testMode?: boolean },
+) => {
 	const mcpTools = mcpService.getMcpTools();
 
-	const { execute_python, execute_sandboxed_code, ...baseTools } = tools;
+	const { execute_python, execute_sandboxed_code, clarification: clarificationTool, ...baseTools } = tools;
 
 	return {
 		...baseTools,
+		...(!opts?.testMode && { clarification: clarificationTool }),
 		...mcpTools,
 		...(agentSettings?.experimental?.pythonSandboxing && execute_python && { execute_python }),
 		...(agentSettings?.experimental?.sandboxes && execute_sandboxed_code && { execute_sandboxed_code }),

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -17,11 +17,19 @@ type SystemPromptProps = {
 	connections?: Connection[];
 	skills?: Skill[];
 	timezone?: string;
+	testMode?: boolean;
 };
 
 export const MEMORY_TOKEN_LIMIT = 1000;
 
-export function SystemPrompt({ memories = [], userRules, connections = [], skills = [], timezone }: SystemPromptProps) {
+export function SystemPrompt({
+	memories = [],
+	userRules,
+	connections = [],
+	skills = [],
+	timezone,
+	testMode,
+}: SystemPromptProps) {
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
 	const hasClickHouse = connections.some((connection) => connection.type.toLowerCase() === 'clickhouse');
 	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
@@ -89,13 +97,15 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 					researching.
 				</ListItem>
 				<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>
-				<ListItem>
-					Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
-					proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
-					range, undefined metric). If you need to ask another clarifying question after the user answers,
-					call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
-					examples.
-				</ListItem>
+				{!testMode && (
+					<ListItem>
+						Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
+						proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
+						range, undefined metric). If you need to ask another clarifying question after the user answers,
+						call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
+						examples.
+					</ListItem>
+				)}
 				<ListItem>
 					For display_chart x_axis_type: use "date" only when x-axis values are parseable by JavaScript Date
 					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -17,19 +17,11 @@ type SystemPromptProps = {
 	connections?: Connection[];
 	skills?: Skill[];
 	timezone?: string;
-	testMode?: boolean;
 };
 
 export const MEMORY_TOKEN_LIMIT = 1000;
 
-export function SystemPrompt({
-	memories = [],
-	userRules,
-	connections = [],
-	skills = [],
-	timezone,
-	testMode,
-}: SystemPromptProps) {
+export function SystemPrompt({ memories = [], userRules, connections = [], skills = [], timezone }: SystemPromptProps) {
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
 	const hasClickHouse = connections.some((connection) => connection.type.toLowerCase() === 'clickhouse');
 	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
@@ -90,16 +82,6 @@ export function SystemPrompt({
 					conversation fillers. Jump straight to providing value.
 				</ListItem>
 			</List>
-			{testMode && (
-				<>
-					<Title level={2}>Test Mode</Title>
-					<Span>
-						You are running in <Bold>test mode</Bold> where the user cannot provide follow-up input. Never
-						ask for clarification — make reasonable assumptions and give your best answer, or state that you
-						cannot answer with the available information.
-					</Span>
-				</>
-			)}
 			<Title level={2}>Tool Calls</Title>
 			<List>
 				<ListItem>
@@ -107,15 +89,13 @@ export function SystemPrompt({
 					researching.
 				</ListItem>
 				<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>
-				{!testMode && (
-					<ListItem>
-						Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
-						proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
-						range, undefined metric). If you need to ask another clarifying question after the user answers,
-						call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
-						examples.
-					</ListItem>
-				)}
+				<ListItem>
+					Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
+					proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
+					range, undefined metric). If you need to ask another clarifying question after the user answers,
+					call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
+					examples.
+				</ListItem>
 				<ListItem>
 					For display_chart x_axis_type: use "date" only when x-axis values are parseable by JavaScript Date
 					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -17,11 +17,19 @@ type SystemPromptProps = {
 	connections?: Connection[];
 	skills?: Skill[];
 	timezone?: string;
+	testMode?: boolean;
 };
 
 export const MEMORY_TOKEN_LIMIT = 1000;
 
-export function SystemPrompt({ memories = [], userRules, connections = [], skills = [], timezone }: SystemPromptProps) {
+export function SystemPrompt({
+	memories = [],
+	userRules,
+	connections = [],
+	skills = [],
+	timezone,
+	testMode,
+}: SystemPromptProps) {
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
 	const hasClickHouse = connections.some((connection) => connection.type.toLowerCase() === 'clickhouse');
 	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
@@ -82,6 +90,16 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 					conversation fillers. Jump straight to providing value.
 				</ListItem>
 			</List>
+			{testMode && (
+				<>
+					<Title level={2}>Test Mode</Title>
+					<Span>
+						You are running in <Bold>test mode</Bold> where the user cannot provide follow-up input. Never
+						ask for clarification — make reasonable assumptions and give your best answer, or state that you
+						cannot answer with the available information.
+					</Span>
+				</>
+			)}
 			<Title level={2}>Tool Calls</Title>
 			<List>
 				<ListItem>
@@ -89,13 +107,15 @@ export function SystemPrompt({ memories = [], userRules, connections = [], skill
 					researching.
 				</ListItem>
 				<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>
-				<ListItem>
-					Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
-					proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
-					range, undefined metric). If you need to ask another clarifying question after the user answers,
-					call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
-					examples.
-				</ListItem>
+				{!testMode && (
+					<ListItem>
+						Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
+						proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
+						range, undefined metric). If you need to ask another clarifying question after the user answers,
+						call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
+						examples.
+					</ListItem>
+				)}
 				<ListItem>
 					For display_chart x_axis_type: use "date" only when x-axis values are parseable by JavaScript Date
 					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -80,6 +80,7 @@ export interface AgentRunResult {
 
 export type AgentChat = Pick<DBChat, 'id' | 'projectId' | 'userId'> & {
 	forkMetadata?: ForkMetadata | null;
+	testMode?: boolean;
 };
 
 export class AgentService {
@@ -98,7 +99,7 @@ export class AgentService {
 		const agentSettings = await projectQueries.getAgentSettings(chat.projectId);
 		const toolContext = await this._getToolContext(chat.projectId, chat.id, chat.userId, agentSettings);
 		const webTools = await this._resolveWebTools(chat.projectId, resolvedLlmSelectedModel.provider, agentSettings);
-		const agentTools = getTools(agentSettings, webTools ?? undefined);
+		const agentTools = getTools(agentSettings, webTools ?? undefined, { testMode: chat.testMode });
 		const agent = new AgentManager(
 			chat,
 			modelConfig,
@@ -215,13 +216,17 @@ class AgentManager {
 		private readonly _agentTools: AgentTools,
 		private readonly _toolContext: ToolContext,
 	) {
+		const stopConditions = chat.testMode
+			? [hasToolCall('suggest_follow_ups')]
+			: [hasToolCall('suggest_follow_ups'), hasToolCall('clarification')];
+
 		this._agent = new ToolLoopAgent({
 			model: this._modelConfig.model,
 			providerOptions: this._modelConfig.providerOptions,
 			tools: this._agentTools,
 			maxOutputTokens: MAX_OUTPUT_TOKENS,
 			prepareStep: async ({ messages }) => this._prepareStep(messages),
-			stopWhen: [hasToolCall('suggest_follow_ups'), hasToolCall('clarification')],
+			stopWhen: stopConditions,
 			experimental_context: this._toolContext,
 		});
 	}
@@ -361,7 +366,9 @@ class AgentManager {
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
 		const skills = skillService.getSkills();
-		const basePrompt = renderToMarkdown(SystemPrompt({ memories, userRules, connections, skills, timezone }));
+		const basePrompt = renderToMarkdown(
+			SystemPrompt({ memories, userRules, connections, skills, timezone, testMode: this.chat.testMode }),
+		);
 		const renderedPrompt = provider
 			? renderToMarkdown(MessagingProviderSystemPrompt({ basePrompt, provider, chatUrl }))
 			: basePrompt;

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -366,9 +366,7 @@ class AgentManager {
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
 		const skills = skillService.getSkills();
-		const basePrompt = renderToMarkdown(
-			SystemPrompt({ memories, userRules, connections, skills, timezone, testMode: this.chat.testMode }),
-		);
+		const basePrompt = renderToMarkdown(SystemPrompt({ memories, userRules, connections, skills, timezone }));
 		const renderedPrompt = provider
 			? renderToMarkdown(MessagingProviderSystemPrompt({ basePrompt, provider, chatUrl }))
 			: basePrompt;

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -366,7 +366,9 @@ class AgentManager {
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
 		const skills = skillService.getSkills();
-		const basePrompt = renderToMarkdown(SystemPrompt({ memories, userRules, connections, skills, timezone }));
+		const basePrompt = renderToMarkdown(
+			SystemPrompt({ memories, userRules, connections, skills, timezone, testMode: this.chat.testMode }),
+		);
 		const renderedPrompt = provider
 			? renderToMarkdown(MessagingProviderSystemPrompt({ basePrompt, provider, chatUrl }))
 			: basePrompt;

--- a/apps/backend/src/services/test-agent.service.ts
+++ b/apps/backend/src/services/test-agent.service.ts
@@ -30,6 +30,7 @@ export class TestAgentService extends AgentService {
 			messages: [userMessage],
 			userId: 'test',
 			projectId,
+			testMode: true,
 		};
 
 		const agent = await this.create(tempChat, modelSelection);


### PR DESCRIPTION
## Summary
- Adds a `testMode` flag to `AgentChat`, set automatically in `TestAgentService.runTest()`
- Removes the `clarification` tool from the agent's toolset during test runs so the agent cannot call it
- Removes `clarification` from the `stopWhen` conditions in test mode
- Adds a "Test Mode" section to the system prompt instructing the agent to make assumptions or state it cannot answer instead of asking for clarification

## Test plan
- [ ] Run `nao test` with prompts that previously triggered clarification — agent should now attempt an answer
- [ ] Run `nao test` with unambiguous prompts — no behavior change expected
- [ ] Verify interactive chat still has the clarification tool available and working

Closes #792

🤖 Generated with [Claude Code](https://claude.ai/code)