### PR TITLE
feat(cli): add --no-tty mode to `nao init` for agent-friendly use

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -112,6 +112,32 @@ The resulting project structure looks like:
 Options:
 
 - `--force` / `-f`: Force re-initialization even if the project already exists
+- `--yes` / `-y` / `--no-tty`: Run non-interactively. Skips all prompts and uses sensible defaults — useful for AI agents and automation scripts. When combined with a pre-written `nao_config.yaml` (e.g. written by an agent skill), only scaffolds the folder structure.
+- `--name` / `-n`: Project name. When set without an existing `nao_config.yaml`, this is used as the project name (and folder). In `--yes` mode without `--name`, the current directory name is used and the project is initialized in place.
+
+#### Non-interactive (agent-friendly) mode
+
+For LLM agents and automation, run `nao init` without any prompts:
+
+```bash
+# Initialize the current directory as a nao project (uses the directory name)
+nao init --yes
+
+# Or create a new sub-folder named "my-project"
+nao init --yes --name my-project
+
+# Pre-write nao_config.yaml then scaffold folders without prompting
+cat > nao_config.yaml <<'YAML'
+project_name: my-project
+databases:
+  - type: duckdb
+    name: local
+    path: ":memory:"
+YAML
+nao init --yes
+```
+
+In non-interactive mode, `nao init` never asks for input. Configure databases, LLM provider, and integrations by editing `nao_config.yaml` directly (or by pre-writing it before `nao init`).
 
 ### Start the nao chat UI
 

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -32,9 +32,19 @@ class CreatedFile:
     content: str | None
 
 
-def setup_project_name(force: bool = False) -> tuple[str, Path, NaoConfig | None]:
-    """Setup the project name. Returns existing config if found and user wants to extend."""
-    # Check if we're in a directory with an existing nao_config.yaml
+def setup_project_name(
+    force: bool = False,
+    name: str | None = None,
+    no_tty: bool = False,
+) -> tuple[str, Path, NaoConfig | None]:
+    """Setup the project name. Returns existing config if found and user wants to extend.
+
+    In non-interactive (no_tty) mode:
+    - If a `nao_config.yaml` exists in the current directory, the existing config is reused
+      (no confirmation prompt) and the project is initialized in place.
+    - Otherwise the project name is taken from `name` if provided, falling back to the
+      current directory name, and the project is initialized in the current directory.
+    """
     current_dir = Path.cwd()
     config_file = current_dir / "nao_config.yaml"
 
@@ -52,16 +62,24 @@ def setup_project_name(force: bool = False) -> tuple[str, Path, NaoConfig | None
         UI.title("Found existing nao_config.yaml")
         UI.print(f"[dim]Project: {existing_config.project_name}[/dim]\n")
 
-        if force or ask_confirm("Update this project configuration?", default=True):
+        if force or no_tty or ask_confirm("Update this project configuration?", default=True):
             return existing_config.project_name, current_dir, existing_config
 
         raise InitError("Initialization cancelled.")
 
-    # Normal flow: prompt for project name
-    project_name = ask_text("Enter your project name:", required_field=True)
+    if no_tty:
+        project_name = name or current_dir.name
+    elif name:
+        project_name = name
+    else:
+        project_name = ask_text("Enter your project name:", required_field=True)
 
     if not project_name:
         raise EmptyProjectNameError()
+
+    if no_tty and not name:
+        # Initialize in the current directory when no explicit name is given
+        return project_name, current_dir, None
 
     project_path = Path(project_name)
 
@@ -140,10 +158,24 @@ def _install_with_progress(extras: list[str]) -> bool:
     return False
 
 
+def _build_no_tty_config(project_name: str, existing_config: NaoConfig | None) -> NaoConfig:
+    """Return a config to save in non-interactive mode.
+
+    Keeps any existing config as-is so an agent can pre-write `nao_config.yaml`
+    and have `nao init` only scaffold folders. Otherwise creates a minimal
+    config with just the project name.
+    """
+    if existing_config:
+        return existing_config
+    return NaoConfig(project_name=project_name)
+
+
 @track_command("init")
 def init(
     *,
     force: Annotated[bool, Parameter(name=["-f", "--force"])] = False,
+    yes: Annotated[bool, Parameter(name=["-y", "--yes", "--no-tty"])] = False,
+    name: Annotated[str | None, Parameter(name=["-n", "--name"])] = None,
 ):
     """Initialize a new nao project.
 
@@ -153,12 +185,26 @@ def init(
     ----------
     force : bool
         Force re-initialization even if the folder already exists.
+    yes : bool
+        Run non-interactively (no TTY). Skips all prompts and uses sensible defaults.
+        Useful for AI agents and automation scripts. When combined with a pre-written
+        `nao_config.yaml`, only scaffolds the folder structure.
+    name : str
+        Project name. When set without an existing `nao_config.yaml`, this is used
+        as the project name (and folder). In non-interactive mode without an existing
+        config and without `--name`, the current directory name is used and the
+        project is initialized in place.
     """
     UI.info("\n🚀 nao project initialization\n")
 
     try:
-        project_name, project_path, existing_config = setup_project_name(force=force)
-        config = NaoConfig.promptConfig(project_name, existing=existing_config)
+        project_name, project_path, existing_config = setup_project_name(force=force, name=name, no_tty=yes)
+
+        if yes:
+            config = _build_no_tty_config(project_name, existing_config)
+        else:
+            config = NaoConfig.promptConfig(project_name, existing=existing_config)
+
         config.save(project_path)
 
         # Create project folder structure
@@ -182,7 +228,8 @@ def init(
             UI.title("Installing provider dependencies")
             UI.print(f"[dim]Extras: {extras_label}[/dim]\n")
 
-            if ask_confirm("Install the required provider dependencies now?", default=True):
+            should_install = yes or ask_confirm("Install the required provider dependencies now?", default=True)
+            if should_install:
                 UI.print()
                 deps_ready = _install_with_progress(missing)
             else:

--- a/cli/tests/nao_core/commands/test_init.py
+++ b/cli/tests/nao_core/commands/test_init.py
@@ -9,6 +9,7 @@ from nao_core.commands.init import (
     CreatedFile,
     EmptyProjectNameError,
     ProjectExistsError,
+    _build_no_tty_config,
     create_empty_structure,
     setup_project_name,
 )
@@ -630,3 +631,173 @@ class TestInitCommand:
         mock_ui.error.assert_called()
         calls = [str(c) for c in mock_ui.error.call_args_list]
         assert any("cannot be empty" in c for c in calls)
+
+
+class TestSetupProjectNameNoTty:
+    """Tests for setup_project_name in non-interactive (no_tty) mode."""
+
+    @patch("nao_core.commands.init.ask_text")
+    def test_no_tty_uses_current_dir_name_when_no_name_given(self, mock_ask_text, tmp_path: Path, monkeypatch):
+        """In no-tty mode without --name, uses current directory name and inits in place."""
+        project_dir = tmp_path / "my-agent-project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        name, path, existing = setup_project_name(no_tty=True)
+
+        assert name == "my-agent-project"
+        assert path == project_dir
+        assert existing is None
+        mock_ask_text.assert_not_called()
+
+    @patch("nao_core.commands.init.ask_text")
+    def test_no_tty_uses_explicit_name_and_creates_subfolder(self, mock_ask_text, tmp_path: Path, monkeypatch):
+        """In no-tty mode with --name, creates a subfolder for the project."""
+        monkeypatch.chdir(tmp_path)
+
+        name, path, existing = setup_project_name(no_tty=True, name="explicit-name")
+
+        assert name == "explicit-name"
+        assert path == Path("explicit-name")
+        assert path.exists()
+        assert existing is None
+        mock_ask_text.assert_not_called()
+
+    @patch("nao_core.commands.init.ask_confirm")
+    @patch("nao_core.commands.init.NaoConfig.try_load")
+    def test_no_tty_skips_update_confirmation_for_existing_config(
+        self, mock_try_load, mock_confirm, tmp_path: Path, monkeypatch
+    ):
+        """In no-tty mode with existing config, skips the update confirmation prompt."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "nao_config.yaml").write_text("project_name: existing\n")
+
+        mock_config = MagicMock()
+        mock_config.project_name = "existing"
+        mock_try_load.return_value = mock_config
+
+        name, path, existing = setup_project_name(no_tty=True)
+
+        assert name == "existing"
+        assert path == tmp_path
+        assert existing == mock_config
+        mock_confirm.assert_not_called()
+
+    @patch("nao_core.commands.init.ask_text")
+    def test_explicit_name_skips_text_prompt(self, mock_ask_text, tmp_path: Path, monkeypatch):
+        """Passing --name without --yes still skips the project name prompt."""
+        monkeypatch.chdir(tmp_path)
+
+        name, path, existing = setup_project_name(name="cli-named-project")
+
+        assert name == "cli-named-project"
+        assert path == Path("cli-named-project")
+        assert path.exists()
+        assert existing is None
+        mock_ask_text.assert_not_called()
+
+
+class TestBuildNoTtyConfig:
+    """Tests for _build_no_tty_config helper."""
+
+    def test_returns_existing_config_when_present(self):
+        """Reuses existing config without modification."""
+        from nao_core.config import NaoConfig
+
+        existing = NaoConfig(project_name="kept-as-is")
+        result = _build_no_tty_config("ignored-name", existing)
+
+        assert result is existing
+        assert result.project_name == "kept-as-is"
+
+    def test_creates_minimal_config_when_no_existing(self):
+        """Builds a minimal config with just the project name."""
+        result = _build_no_tty_config("brand-new", None)
+
+        assert result.project_name == "brand-new"
+        assert result.databases == []
+        assert result.repos == []
+        assert result.llm is None
+        assert result.slack is None
+        assert result.notion is None
+        assert result.mcp is None
+        assert result.skills is None
+
+
+class TestInitCommandNoTty:
+    """Tests for the init command in non-interactive (--yes / --no-tty) mode."""
+
+    @patch("nao_core.commands.init.NaoConfig.promptConfig")
+    @patch("nao_core.commands.init.UI")
+    def test_yes_does_not_prompt_for_config(
+        self,
+        mock_ui,
+        mock_prompt_config,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """`--yes` skips the interactive promptConfig flow entirely."""
+        from nao_core.commands.init import init
+
+        project_dir = tmp_path / "no-tty-project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        init(yes=True)
+
+        mock_prompt_config.assert_not_called()
+        config_file = project_dir / "nao_config.yaml"
+        assert config_file.exists()
+        content = config_file.read_text()
+        assert "project_name: no-tty-project" in content
+
+    @patch("nao_core.commands.init.NaoConfig.promptConfig")
+    @patch("nao_core.commands.init.UI")
+    def test_yes_with_explicit_name_creates_subfolder(
+        self,
+        mock_ui,
+        mock_prompt_config,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """`--yes --name foo` creates a subfolder named foo with a minimal config."""
+        from nao_core.commands.init import init
+
+        monkeypatch.chdir(tmp_path)
+
+        init(yes=True, name="my-agent")
+
+        project_path = tmp_path / "my-agent"
+        assert project_path.exists()
+        assert (project_path / "nao_config.yaml").exists()
+        assert (project_path / "RULES.md").exists()
+        assert (project_path / "databases").is_dir()
+        mock_prompt_config.assert_not_called()
+
+    @patch("nao_core.commands.init.NaoConfig.promptConfig")
+    @patch("nao_core.commands.init.UI")
+    def test_yes_preserves_pre_written_config(
+        self,
+        mock_ui,
+        mock_prompt_config,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        """`--yes` reuses an existing nao_config.yaml without prompting to update."""
+        from nao_core.commands.init import init
+
+        project_dir = tmp_path / "pre-written"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        config_yaml = project_dir / "nao_config.yaml"
+        config_yaml.write_text("project_name: pre-written\n")
+
+        init(yes=True)
+
+        mock_prompt_config.assert_not_called()
+        # Folder structure is still scaffolded
+        assert (project_dir / "RULES.md").exists()
+        assert (project_dir / "databases").is_dir()
+        # The config still names the existing project
+        assert "project_name: pre-written" in config_yaml.read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #713.

## Why

When an agent (e.g. Claude Code, Cursor, Codex running a nao skill) invokes `nao init`, it currently blocks on interactive prompts (project name, "Set up databases?", "Set up LLM?", etc.) and times out. The `setup-context` skill works around this by pre-writing `nao_config.yaml`, but `nao init` still prompts to confirm "Update this project configuration?" and tries to extend the config interactively.

This PR makes `nao init` runnable end-to-end with no input.

## What

Adds three new flags to `nao init`:

- `--yes` / `-y` / `--no-tty` — run non-interactively. Skips every prompt and uses sensible defaults.
- `--name` / `-n` — set the project name from the CLI (works in interactive mode too).

Behavior in `--yes` mode:

| Situation | Behavior |
| -------- | -------- |
| `nao_config.yaml` already exists in cwd | Reuses it as-is (no "update?" prompt), only scaffolds folders. This is the agent-skill workflow. |
| No config + `--name foo` | Creates `./foo/` with a minimal `nao_config.yaml` (just `project_name: foo`). |
| No config + no `--name` | Uses the current directory name and initializes in place. |

In all cases the CLI never calls `questionary` and never tries to add databases/LLM/integrations — agents are expected to write `nao_config.yaml` themselves (or edit it post-init).

Other prompts removed in `--yes` mode:
- "Update this project configuration?" — auto-confirm
- "Install the required provider dependencies now?" — auto-install (default was already True)
- All `_prompt_*` integration prompts — never reached because `promptConfig` is skipped entirely

## Files

- `cli/nao_core/commands/init.py` — flags + non-interactive code path (`_build_no_tty_config`, updated `setup_project_name`, `init`)
- `cli/tests/nao_core/commands/test_init.py` — 9 new tests covering the new flag behavior
- `cli/README.md` — documents the flags + agent workflow

## Demo

End-to-end log of all three scenarios (subfolder with `--name`, in-place with cwd name, pre-written config + `nao init --yes`):

[nao_init_no_tty_demo.log](https://cursor.com/agents/bc-e857c789-4e73-4de2-a0ef-513b6223a386/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnao_init_no_tty_demo.log)

## Testing

- ✅ `make lint` — `ty`, `ruff check`, `ruff format --check` all clean
- ✅ `uv run pytest tests/ --ignore=tests/nao_core/commands/sync/integration` — 584 passed (48 in `test_init.py`, including 9 new no-tty tests)
- ✅ Manual smoke test running `nao init --yes`, `nao init --no-tty`, and `nao init --yes` with a pre-written config, all with `</dev/null` to confirm zero prompts (see demo log above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e857c789-4e73-4de2-a0ef-513b6223a386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e857c789-4e73-4de2-a0ef-513b6223a386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

