### PR TITLE
Persist sidebar section open/closed state in localStorage

### DIFF
--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -28,6 +28,7 @@ import { useCommandMenuCallback } from '@/contexts/command-menu-callback';
 import { useSidebar } from '@/contexts/sidebar';
 import { brandingAssetUrl, useBranding } from '@/hooks/use-branding';
 import { useChatViewPreferences } from '@/hooks/use-chat-view-preferences';
+import { useSidebarSectionOpen } from '@/hooks/use-sidebar-section-open';
 import { useTimeAgo } from '@/hooks/use-time-ago';
 import { getActiveProjectId, setActiveProjectId } from '@/lib/active-project';
 import { cn, hideIf } from '@/lib/utils';
@@ -410,7 +411,7 @@ function AutomationsSection({
 		updatedAt: Date;
 	}>;
 }) {
-	const [isOpen, setIsOpen] = useState(true);
+	const { isOpen, toggle } = useSidebarSectionOpen('section:automations');
 
 	if (items.length === 0) {
 		return null;
@@ -419,7 +420,7 @@ function AutomationsSection({
 	return (
 		<>
 			<div className='px-2 space-y-0.5'>
-				<SidebarSectionHeader label='Automations' isOpen={isOpen} onToggle={() => setIsOpen((p) => !p)} />
+				<SidebarSectionHeader label='Automations' isOpen={isOpen} onToggle={toggle} />
 			</div>
 			{isOpen && (
 				<div className='px-2 space-y-1'>
@@ -468,7 +469,7 @@ function AutomationListItem({
 const GROUP_INITIAL_COUNT = 10;
 
 function GroupSection({ group, groupBy }: { group: ChatGroup; groupBy: ChatGroupBy }) {
-	const [isOpen, setIsOpen] = useState(true);
+	const { isOpen, toggle } = useSidebarSectionOpen(`section:chat-group:${group.label}`);
 	const [expanded, setExpanded] = useState(false);
 	const hasMore = group.chats.length > GROUP_INITIAL_COUNT;
 	const visibleChats = expanded ? group.chats : group.chats.slice(0, GROUP_INITIAL_COUNT);
@@ -480,7 +481,7 @@ function GroupSection({ group, groupBy }: { group: ChatGroup; groupBy: ChatGroup
 	return (
 		<>
 			<div className='px-2 space-y-0.5'>
-				<SidebarSectionHeader label={group.label} isOpen={isOpen} onToggle={() => setIsOpen((p) => !p)} />
+				<SidebarSectionHeader label={group.label} isOpen={isOpen} onToggle={toggle} />
 			</div>
 
 			{isOpen && (

--- a/apps/frontend/src/hooks/use-sidebar-section-open.ts
+++ b/apps/frontend/src/hooks/use-sidebar-section-open.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+
+const STORAGE_KEY = 'sidebar-collapsed-sections';
+
+function readCollapsed(): Set<string> {
+	try {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (!stored) {
+			return new Set();
+		}
+		const parsed = JSON.parse(stored);
+		return new Set(Array.isArray(parsed) ? parsed.filter((item) => typeof item === 'string') : []);
+	} catch {
+		return new Set();
+	}
+}
+
+function writeCollapsed(set: Set<string>) {
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(set)));
+	} catch {
+		// Ignore quota / availability errors
+	}
+}
+
+/**
+ * Persists the open/closed state of a sidebar section in localStorage.
+ * Sections default to open; only collapsed sections are stored, keyed by `key`.
+ */
+export function useSidebarSectionOpen(key: string, defaultOpen = true) {
+	const [isOpen, setIsOpenState] = useState<boolean>(() => {
+		const collapsed = readCollapsed();
+		return collapsed.has(key) ? false : defaultOpen;
+	});
+
+	const setIsOpen = useCallback(
+		(value: boolean | ((prev: boolean) => boolean)) => {
+			setIsOpenState((prev) => {
+				const next = typeof value === 'function' ? value(prev) : value;
+				const collapsed = readCollapsed();
+				if (next) {
+					collapsed.delete(key);
+				} else {
+					collapsed.add(key);
+				}
+				writeCollapsed(collapsed);
+				return next;
+			});
+		},
+		[key],
+	);
+
+	const toggle = useCallback(() => setIsOpen((prev) => !prev), [setIsOpen]);
+
+	return { isOpen, setIsOpen, toggle };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the user collapses a subcategory in the sidebar (e.g. a chat date group like "Today", or the "Automations" section), the closed state is now preserved across page refreshes via `localStorage`.

Previously these sections always reset to the open state on mount because they relied on `useState(true)` only.

## Implementation

- New hook `useSidebarSectionOpen(key)` in `apps/frontend/src/hooks/use-sidebar-section-open.ts`. Reads/writes the set of collapsed section keys to `localStorage` under `sidebar-collapsed-sections`. Sections default to open; only collapsed keys are stored, keeping storage minimal.
- `sidebar.tsx`:
  - `AutomationsSection` now uses key `section:automations`.
  - `GroupSection` now uses key `section:chat-group:<groupLabel>` (e.g. `section:chat-group:Today`).

## Walkthrough

[sidebar_section_persist_demo.mp4](https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_section_persist_demo.mp4)
Demo: collapsing the "Chats" group, refreshing, observing it stays collapsed; expanding, refreshing, observing it stays expanded.

[Chats section collapsed before refresh](https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_collapsed_before_refresh.png)
[Chats section still collapsed after page refresh](https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_collapsed_after_refresh.png)
[Chats section expanded persists after refresh](https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_expanded_after_refresh.png)
[sidebar-collapsed-sections key visible in DevTools localStorage](https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsidebar_localstorage.png)

## Testing

- `npm run -w @nao/frontend lint` — passes.
- Manual end-to-end via Chrome at `http://localhost:3000`: collapsed/expanded states persist across reloads, and the `sidebar-collapsed-sections` key is visible in DevTools.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1085c3d2-8a94-47f0-8186-65609cfec1e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1085c3d2-8a94-47f0-8186-65609cfec1e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

