### PR TITLE
feat(frontend): show centered spinner instead of black screen while session pending

### DIFF
--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { BrandingHead } from '../components/branding-head';
 import { ModifyPassword } from '../components/modify-password';
+import { Spinner } from '@/components/ui/spinner';
 import { useDisposeInactiveAgents } from '@/hooks/use-agent';
 import { useSessionOrNavigateToIndexPage } from '@/hooks/use-session-or-navigate-to-index-page';
 import { useNavigateToResetPasswordPageIfNeeded } from '@/hooks/useNavigateToResetPasswordPageIfNeeded';
@@ -20,13 +21,21 @@ function RootComponent() {
 	}
 
 	if (session.isPending) {
-		return null;
+		return <RootLoadingState />;
 	}
 
 	return (
 		<div className='flex h-screen'>
 			<BrandingHead />
 			<Outlet />
+		</div>
+	);
+}
+
+function RootLoadingState() {
+	return (
+		<div className='flex h-screen items-center justify-center bg-background'>
+			<Spinner className='size-6' />
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After logging in, the app would render a fully black screen for ~3s before the homepage appeared. Cause: `__root.tsx` returns `null` while `session.isPending` is `true`, so only the body's `bg-background` was painted (nearly black in dark mode). The wait itself is mostly the better-auth `/api/auth/get-session` round trip kicked off after `signIn.email` resolves, plus the home page's first-time `project.getCurrent` / `project.listForCurrentUser` queries.

## What

Replace the `return null` in `__root.tsx` with a small centered `Spinner` against `bg-background`. Same gating, but the user sees a clear loading affordance instead of a blank/black page.

## Demo

[login_loading_state_demo.mp4](https://cursor.com/agents/bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogin_loading_state_demo.mp4)

Spinner during signup → home transition (3G throttling so the wait is visible):
[Centered spinner during signup](https://cursor.com/agents/bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floading_spinner_signup.webp)

Spinner during login → home transition:
[Centered spinner during login](https://cursor.com/agents/bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Floading_spinner_login.webp)

Final home page:
[Home page loaded](https://cursor.com/agents/bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_page_loaded.webp)

## Testing

- `npm run lint` — passes (tsc + eslint across backend, frontend, shared).
- Manual: ran `npm run dev:backend` + `npm run dev:frontend` against a fresh SQLite db, signed up, logged out, and logged back in with Chrome DevTools throttled to 3G to make the wait visible. Spinner shows on every auth → home transition; no black flash.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48dff43d-7131-4dbb-9a87-7b1eb3c1b7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

