### PR TITLE
feat(snowflake): add Programmatic Access Token (PAT) authentication

### DIFF
--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -132,9 +132,13 @@ class SnowflakeConfig(DatabaseConfig):
         default=None,
         description="Passphrase for the private key if it is encrypted",
     )
-    authenticator: Literal["externalbrowser", "username_password_mfa", "jwt_token", "oauth"] | None = Field(
+    token: str | None = Field(
         default=None,
-        description="Authentication method (e.g., 'externalbrowser' for SSO)",
+        description="Programmatic Access Token (PAT) value — use with authenticator='programmatic_access_token'",
+    )
+    authenticator: Literal["externalbrowser", "username_password_mfa", "jwt_token", "oauth", "programmatic_access_token"] | None = Field(
+        default=None,
+        description="Authentication method (e.g., 'externalbrowser' for SSO, 'programmatic_access_token' for PAT)",
     )
 
     @classmethod
@@ -148,15 +152,27 @@ class SnowflakeConfig(DatabaseConfig):
         schema = ask_text("Default schema (optional):")
 
         use_sso = ask_confirm("Use SSO (external browser) for authentication?", default=False)
-        key_pair_auth = False if use_sso else ask_confirm("Use key-pair authentication?", default=False)
-        authenticator = "externalbrowser" if use_sso else None
+        use_pat = False if use_sso else ask_confirm("Use Programmatic Access Token (PAT)?", default=False)
+        key_pair_auth = False if (use_sso or use_pat) else ask_confirm("Use key-pair authentication?", default=False)
+
+        if use_sso:
+            authenticator = "externalbrowser"
+        elif use_pat:
+            authenticator = "programmatic_access_token"
+        else:
+            authenticator = None
 
         private_key_path = None
         private_key = None
         passphrase = None
         password = None
+        token = None
 
-        if key_pair_auth:
+        if use_pat:
+            token = ask_text("Programmatic Access Token:", password=True, required_field=True)
+            if not token:
+                raise InitError("Token cannot be empty.")
+        elif key_pair_auth:
             use_inline = ask_confirm("Paste the private key directly (instead of a file path)?", default=False)
             if use_inline:
                 private_key = ask_text("PEM-encoded private key (paste full key):", password=True, required_field=True)
@@ -181,6 +197,7 @@ class SnowflakeConfig(DatabaseConfig):
             private_key_path=private_key_path,
             private_key=private_key,
             passphrase=passphrase,
+            token=token,
             authenticator=authenticator,
         )
 
@@ -205,6 +222,9 @@ class SnowflakeConfig(DatabaseConfig):
         if self.authenticator:
             kwargs["authenticator"] = self.authenticator
             UI.info(f"[yellow]Using authenticator: {self.authenticator}[/yellow]")
+
+        if self.token:
+            kwargs["token"] = self.token
 
         pem_data = _resolve_private_key(self.private_key_path, self.private_key)
         if pem_data is not None:

--- a/cli/tests/nao_core/commands/sync/integration/test_snowflake.py
+++ b/cli/tests/nao_core/commands/sync/integration/test_snowflake.py
@@ -5,7 +5,9 @@ Connection is configured via environment variables:
     For password auth:
         SNOWFLAKE_PASSWORD
     For key-pair auth:
-        SNOWFLAKE_PRIVATE_KEY_PATH, SNOWFLAKE_PASSPHRASE (optional),
+        SNOWFLAKE_PRIVATE_KEY_PATH, SNOWFLAKE_PASSPHRASE (optional)
+    For PAT auth:
+        SNOWFLAKE_TOKEN
     SNOWFLAKE_SCHEMA (default public), SNOWFLAKE_WAREHOUSE (optional).
 
 The test suite is skipped entirely when required env vars are not set.
@@ -29,15 +31,17 @@ SNOWFLAKE_USERNAME = os.environ.get("SNOWFLAKE_USERNAME")
 SNOWFLAKE_PASSWORD = os.environ.get("SNOWFLAKE_PASSWORD")
 SNOWFLAKE_PRIVATE_KEY_PATH = os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH")
 SNOWFLAKE_PASSPHRASE = os.environ.get("SNOWFLAKE_PASSPHRASE")
+SNOWFLAKE_TOKEN = os.environ.get("SNOWFLAKE_TOKEN")
 SNOWFLAKE_WAREHOUSE = os.environ.get("SNOWFLAKE_WAREHOUSE")
 
 # Default auth method:
 # - Prefer password if available (easier to set up locally)
-# - Otherwise fall back to key-pair
+# - Fall back to key-pair, then PAT
 SNOWFLAKE_AUTH_METHOD = (
-    os.environ.get("SNOWFLAKE_AUTH_METHOD") or ("password" if SNOWFLAKE_PASSWORD else "keypair")
+    os.environ.get("SNOWFLAKE_AUTH_METHOD")
+    or ("password" if SNOWFLAKE_PASSWORD else ("keypair" if SNOWFLAKE_PRIVATE_KEY_PATH else "pat"))
 ).lower()
-if SNOWFLAKE_AUTH_METHOD not in {"password", "keypair"}:
+if SNOWFLAKE_AUTH_METHOD not in {"password", "keypair", "pat"}:
     SNOWFLAKE_AUTH_METHOD = "password" if SNOWFLAKE_PASSWORD else "keypair"
 
 _missing_base_env = [
@@ -53,6 +57,9 @@ _missing_auth_env: list[str] = []
 if SNOWFLAKE_AUTH_METHOD == "password":
     if not SNOWFLAKE_PASSWORD:
         _missing_auth_env.append("SNOWFLAKE_PASSWORD")
+elif SNOWFLAKE_AUTH_METHOD == "pat":
+    if not SNOWFLAKE_TOKEN:
+        _missing_auth_env.append("SNOWFLAKE_TOKEN")
 else:
     if not SNOWFLAKE_PRIVATE_KEY_PATH:
         _missing_auth_env.append("SNOWFLAKE_PRIVATE_KEY_PATH")
@@ -160,6 +167,8 @@ def db_config(temp_database):
         password=os.environ.get("SNOWFLAKE_PASSWORD") if SNOWFLAKE_AUTH_METHOD == "password" else None,
         private_key_path=os.environ.get("SNOWFLAKE_PRIVATE_KEY_PATH") if SNOWFLAKE_AUTH_METHOD == "keypair" else None,
         passphrase=os.environ.get("SNOWFLAKE_PASSPHRASE") if SNOWFLAKE_AUTH_METHOD == "keypair" else None,
+        token=os.environ.get("SNOWFLAKE_TOKEN") if SNOWFLAKE_AUTH_METHOD == "pat" else None,
+        authenticator="programmatic_access_token" if SNOWFLAKE_AUTH_METHOD == "pat" else None,
         schema_name="public",
         warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"),
     )


### PR DESCRIPTION
Adds support for Snowflake PAT authentication via a new `token` field and `authenticator: programmatic_access_token` on SnowflakeConfig.