### PR TITLE
add role and project permissions for new manually added users

### DIFF
--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -33,6 +33,7 @@ export const getOrgMember = async (orgId: string, userId: string): Promise<DBOrg
 
 export const addOrgMember = async (member: NewOrgMember): Promise<DBOrgMember> => {
 	const [created] = await db.insert(s.orgMember).values(member).returning().execute();
+	await syncUserProjectMembershipInOrg(member.orgId, member.userId, member.role);
 	return created;
 };
 
@@ -249,6 +250,11 @@ export const ensureOrganizationSetup = async (): Promise<void> => {
 
 	// Ensure a project exists for the current NAO_DEFAULT_PROJECT_PATH
 	await ensureDefaultProject(org);
+
+	const orgMembers = await db.select().from(s.orgMember).where(eq(s.orgMember.orgId, org.id)).execute();
+	for (const member of orgMembers) {
+		await syncUserProjectMembershipInOrg(org.id, member.userId, member.role);
+	}
 };
 
 export interface OrgMemberWithUser {
@@ -305,6 +311,20 @@ export const updateOrgMemberRole = async (orgId: string, userId: string, role: O
 		.set({ role })
 		.where(and(eq(s.orgMember.orgId, orgId), eq(s.orgMember.userId, userId)))
 		.execute();
+	await syncUserProjectMembershipInOrg(orgId, userId, role);
+};
+
+export const syncUserProjectMembershipInOrg = async (orgId: string, userId: string, role: OrgRole): Promise<void> => {
+	const projects = await db.select({ id: s.project.id }).from(s.project).where(eq(s.project.orgId, orgId)).execute();
+
+	for (const project of projects) {
+		const existing = await projectQueries.getProjectMember(project.id, userId);
+		if (existing) {
+			await projectQueries.updateProjectMemberRole(project.id, userId, role);
+		} else {
+			await projectQueries.addProjectMember({ projectId: project.id, userId, role });
+		}
+	}
 };
 
 export const removeOrgMember = async (orgId: string, userId: string): Promise<void> => {

--- a/apps/backend/src/trpc/organization.routes.ts
+++ b/apps/backend/src/trpc/organization.routes.ts
@@ -59,7 +59,13 @@ export const organizationRoutes = {
 		}),
 
 	addMember: orgAdminOnlyProcedure
-		.input(z.object({ email: z.string().min(1), name: z.string().min(1).optional() }))
+		.input(
+			z.object({
+				email: z.string().min(1),
+				name: z.string().min(1).optional(),
+				role: z.enum(ORG_ROLES).default('user'),
+			}),
+		)
 		.mutation(async ({ input, ctx }) => {
 			const orgId = ctx.org.id;
 
@@ -68,7 +74,7 @@ export const organizationRoutes = {
 				name: input.name,
 				checkExisting: async (userId) => !!(await orgQueries.getOrgMember(orgId, userId)),
 				addMember: async (userId) => {
-					await orgQueries.addOrgMember({ orgId, userId, role: 'user' });
+					await orgQueries.addOrgMember({ orgId, userId, role: input.role });
 				},
 				buildEmail: (user, password) => buildUserAddedEmail(user, ctx.org.name, 'organization', password),
 			});

--- a/apps/frontend/src/components/settings/team/add-member-dialog.tsx
+++ b/apps/frontend/src/components/settings/team/add-member-dialog.tsx
@@ -1,23 +1,42 @@
 import { useState } from 'react';
 import { useForm } from '@tanstack/react-form';
+import { ChevronDown } from 'lucide-react';
+import { USER_ROLES } from '@nao/shared/types';
+import type { UserRole } from '@nao/shared/types';
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuItem,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface AddMemberDialogProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	title?: string;
-	onSubmit: (data: { email: string; name?: string }) => Promise<{ needsName?: boolean }>;
+	availableRoles?: readonly UserRole[];
+	defaultRole?: UserRole;
+	onSubmit: (data: { email: string; name?: string; role: UserRole }) => Promise<{ needsName?: boolean }>;
 }
 
-export function AddMemberDialog({ open, onOpenChange, title = 'Add Member', onSubmit }: AddMemberDialogProps) {
+export function AddMemberDialog({
+	open,
+	onOpenChange,
+	title = 'Add Member',
+	availableRoles,
+	defaultRole = 'user',
+	onSubmit,
+}: AddMemberDialogProps) {
 	const [error, setError] = useState('');
 	const [needsName, setNeedsName] = useState(false);
+	const showRolePicker = availableRoles !== undefined && availableRoles.length > 0;
 
 	const form = useForm({
-		defaultValues: { email: '', name: '' },
+		defaultValues: { email: '', name: '', role: defaultRole },
 		onSubmit: async ({ value }) => {
 			setError('');
 			if (needsName && !value.name.trim()) {
@@ -28,6 +47,7 @@ export function AddMemberDialog({ open, onOpenChange, title = 'Add Member', onSu
 				const result = await onSubmit({
 					email: value.email,
 					name: needsName ? value.name : undefined,
+					role: value.role,
 				});
 				if (result.needsName) {
 					setNeedsName(true);
@@ -46,6 +66,8 @@ export function AddMemberDialog({ open, onOpenChange, title = 'Add Member', onSu
 		setNeedsName(false);
 		form.reset();
 	};
+
+	const roles = availableRoles ?? USER_ROLES;
 
 	return (
 		<Dialog open={open} onOpenChange={handleClose}>
@@ -77,6 +99,41 @@ export function AddMemberDialog({ open, onOpenChange, title = 'Add Member', onSu
 							</div>
 						)}
 					</form.Field>
+
+					{showRolePicker && (
+						<form.Field name='role'>
+							{(field) => (
+								<div className='flex flex-col gap-2'>
+									<label htmlFor='member-role' className='text-sm font-medium'>
+										Role
+									</label>
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												id='member-role'
+												variant='outline'
+												className='w-full justify-between'
+											>
+												<span className='capitalize'>{field.state.value}</span>
+												<ChevronDown className='h-4 w-4 opacity-50' />
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align='start' className='w-full'>
+											{roles.map((role) => (
+												<DropdownMenuItem
+													key={role}
+													onClick={() => field.handleChange(role)}
+													className={field.state.value === role ? 'bg-accent' : ''}
+												>
+													<span className='capitalize'>{role}</span>
+												</DropdownMenuItem>
+											))}
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</div>
+							)}
+						</form.Field>
+					)}
 
 					{needsName && (
 						<>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
@@ -69,11 +69,12 @@ function OrganizationPage() {
 			role: m.role as UserRole,
 		})) ?? [];
 
-	const handleAdd = async (data: { email: string; name?: string }) => {
+	const handleAdd = async (data: { email: string; name?: string; role: UserRole }) => {
 		try {
 			const result = await addMember.mutateAsync({
 				email: data.email,
 				name: data.name,
+				role: data.role,
 			});
 			invalidateMembers();
 			if (result.password) {
@@ -201,6 +202,7 @@ function OrganizationPage() {
 				open={isAddOpen}
 				onOpenChange={setIsAddOpen}
 				title='Add Member to Organization'
+				availableRoles={USER_ROLES}
 				onSubmit={handleAdd}
 			/>
 

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
@@ -54,15 +54,15 @@ function ProjectTeamTabPage() {
 		queryClient.invalidateQueries({ queryKey: trpc.project.listAllUsersWithRoles.queryKey() });
 	}, [queryClient]);
 
-	const handleAdd = async (data: { email: string; name?: string }) => {
+	const handleAdd = async ({ email, name }: { email: string; name?: string; role: UserRole }) => {
 		try {
 			const result = await addUser.mutateAsync({
-				email: data.email,
-				name: data.name,
+				email,
+				name,
 			});
 			invalidateMembers();
 			if (result.password) {
-				setCredentials({ email: data.email, password: result.password });
+				setCredentials({ email, password: result.password });
 			}
 			return {};
 		} catch (err: any) {


### PR DESCRIPTION
Fixes project access for users added via `Organization → Add Member`. They were only added to org_member, not project_member, so self-hosted users saw “No project configured” even with org admin role. Org membership now syncs to all org projects with the same role; Add Member supports role selection.

<img width="599" height="446" alt="Screenshot 2026-05-20 at 12 14 21 PM" src="https://github.com/user-attachments/assets/baec32e3-857f-488f-bc7f-8d8b201a2695" />
<img width="647" height="415" alt="Screenshot 2026-05-20 at 12 13 52 PM" src="https://github.com/user-attachments/assets/8dd6a15b-f396-46c2-8566-d017b6c12ec6" />
