### PR TITLE
feat(chat): add live voice mode with OpenAI Realtime transcription

### DIFF
--- a/apps/backend/src/services/realtime-transcribe.service.ts
+++ b/apps/backend/src/services/realtime-transcribe.service.ts
@@ -1,0 +1,70 @@
+import { getDefaultTranscribeModelId, type TranscribeProvider } from '../agents/transcribe.providers';
+import * as projectQueries from '../queries/project.queries';
+import * as llmConfigQueries from '../queries/project-llm-config.queries';
+import { getEnvApiKey } from '../utils/llm';
+
+export type LiveTranscriptionSession = {
+	clientSecret: string;
+	expiresAt: number;
+};
+
+type OpenAITranscriptionSessionResponse = {
+	client_secret?: { value?: string; expires_at?: number };
+};
+
+export async function createLiveTranscriptionSession(projectId: string): Promise<LiveTranscriptionSession> {
+	const agentSettings = await projectQueries.getAgentSettings(projectId);
+	if (!agentSettings?.transcribe?.enabled) {
+		throw new Error('Voice input is not enabled. Enable transcription in Settings > Models.');
+	}
+
+	const modelId = agentSettings.transcribe.modelId ?? getDefaultTranscribeModelId('openai');
+	const { apiKey, baseURL } = await resolveProviderSettings(projectId, 'openai');
+	if (!apiKey) {
+		throw new Error('No OpenAI API key configured. Add one in Settings > Models.');
+	}
+
+	const apiBase = (baseURL ?? 'https://api.openai.com/v1').replace(/\/$/, '');
+	const response = await fetch(`${apiBase}/realtime/transcription_sessions`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			input_audio_format: 'pcm16',
+			input_audio_transcription: { model: modelId },
+			turn_detection: {
+				type: 'server_vad',
+				threshold: 0.5,
+				prefix_padding_ms: 300,
+				silence_duration_ms: 700,
+			},
+		}),
+	});
+
+	if (!response.ok) {
+		const detail = await response.text();
+		throw new Error(detail || `Failed to create live transcription session (${response.status})`);
+	}
+
+	const data = (await response.json()) as OpenAITranscriptionSessionResponse;
+	const clientSecret = data.client_secret?.value;
+	const expiresAt = data.client_secret?.expires_at;
+	if (!clientSecret || expiresAt == null) {
+		throw new Error('Invalid live transcription session response from OpenAI');
+	}
+
+	return { clientSecret, expiresAt };
+}
+
+async function resolveProviderSettings(
+	projectId: string,
+	provider: TranscribeProvider,
+): Promise<{ apiKey: string | undefined; baseURL: string | undefined }> {
+	const config = await llmConfigQueries.getProjectLlmConfigByProvider(projectId, provider);
+	if (config) {
+		return { apiKey: config.apiKey, baseURL: config.baseUrl ?? undefined };
+	}
+	return { apiKey: getEnvApiKey(provider), baseURL: undefined };
+}

--- a/apps/backend/src/trpc/transcribe.routes.ts
+++ b/apps/backend/src/trpc/transcribe.routes.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
+import * as realtimeTranscribeService from '../services/realtime-transcribe.service';
 import * as transcribeService from '../services/transcribe.service';
 import { projectProtectedProcedure } from './trpc';
 
@@ -32,5 +33,16 @@ export const transcribeRoutes = {
 
 	getModels: projectProtectedProcedure.query(async ({ ctx }) => {
 		return transcribeService.listAvailableTranscribeModels(ctx.project.id);
+	}),
+
+	createLiveSession: projectProtectedProcedure.mutation(async ({ ctx }) => {
+		try {
+			return await realtimeTranscribeService.createLiveTranscriptionSession(ctx.project.id);
+		} catch (error) {
+			throw new TRPCError({
+				code: 'BAD_REQUEST',
+				message: error instanceof Error ? error.message : 'Failed to start live voice session',
+			});
+		}
 	}),
 };

--- a/apps/backend/tests/realtime-transcribe.service.test.ts
+++ b/apps/backend/tests/realtime-transcribe.service.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as projectQueries from '../src/queries/project.queries';
+import * as llmConfigQueries from '../src/queries/project-llm-config.queries';
+import { createLiveTranscriptionSession } from '../src/services/realtime-transcribe.service';
+
+vi.mock('../src/queries/project.queries');
+vi.mock('../src/queries/project-llm-config.queries');
+
+describe('createLiveTranscriptionSession', () => {
+	const fetchMock = vi.fn();
+
+	beforeEach(() => {
+		vi.stubGlobal('fetch', fetchMock);
+		vi.mocked(projectQueries.getAgentSettings).mockResolvedValue({
+			transcribe: { enabled: true, provider: 'openai', modelId: 'gpt-4o-mini-transcribe' },
+		});
+		vi.mocked(llmConfigQueries.getProjectLlmConfigByProvider).mockResolvedValue({
+			apiKey: 'test-key',
+			baseUrl: null,
+		} as never);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it('returns client secret from OpenAI transcription session', async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				client_secret: { value: 'ek_test', expires_at: 1_700_000_000 },
+			}),
+		});
+
+		const session = await createLiveTranscriptionSession('project-1');
+
+		expect(session).toEqual({ clientSecret: 'ek_test', expiresAt: 1_700_000_000 });
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.openai.com/v1/realtime/transcription_sessions',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+
+	it('throws when transcription is disabled', async () => {
+		vi.mocked(projectQueries.getAgentSettings).mockResolvedValue({
+			transcribe: { enabled: false },
+		});
+
+		await expect(createLiveTranscriptionSession('project-1')).rejects.toThrow('Voice input is not enabled');
+	});
+});

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -19,7 +19,9 @@ import { InputGroup, InputGroupAddon } from '@/components/ui/input-group';
 import { trpc } from '@/main';
 import { useAgentContext } from '@/contexts/agent.provider';
 import { useRegisterSetChatInputCallback } from '@/contexts/set-chat-input-callback';
+import { useLiveVoice } from '@/hooks/use-live-voice';
 import { useTranscribe } from '@/hooks/use-transcribe';
+import { LiveVoiceButton } from '@/components/live-voice-button';
 import { useImageUpload } from '@/hooks/use-image-upload';
 import { parseBudgetError } from '@/lib/ai';
 import { cn } from '@/lib/utils';
@@ -105,6 +107,7 @@ function ChatInputBase({
 	const isBudgetExceeded = !!parseBudgetError(error) || budgetStatus.data?.level === 'exceeded';
 
 	const [micWarning, setMicWarning] = useState(false);
+	const [liveVoiceActive, setLiveVoiceActive] = useState(false);
 	const micWarningTimer = useRef(0);
 	const dropZoneRef = useRef<HTMLDivElement>(null);
 	const [isDragging, setIsDragging] = useState(false);
@@ -242,6 +245,27 @@ function ChatInputBase({
 		analyserRef,
 	} = useTranscribe({ onTranscribed: submitMessage });
 
+	const liveVoice = useLiveVoice({
+		active: liveVoiceActive && isTranscribeReady,
+		paused: isRunning,
+		onUtterance: submitMessage,
+	});
+
+	const toggleLiveVoice = useCallback(() => {
+		if (!isTranscribeReady) {
+			showMicWarning();
+			return;
+		}
+		if (isRecording) {
+			toggleRecording();
+		}
+		setLiveVoiceActive((on) => !on);
+	}, [isTranscribeReady, isRecording, toggleRecording, showMicWarning]);
+
+	useEffect(() => {
+		setLiveVoiceActive(false);
+	}, [chatId]);
+
 	useEffect(() => {
 		if (typeof initialText !== 'string') {
 			return;
@@ -287,6 +311,14 @@ function ChatInputBase({
 			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
+			{liveVoiceActive && liveVoice.errorMessage && (
+				<div className='mb-2 rounded-2xl border border-input/50 bg-muted/50 px-3 py-2 text-sm text-muted-foreground'>
+					{liveVoice.errorMessage}
+				</div>
+			)}
+			{liveVoice.isListening && (
+				<div className='mb-2 text-xs text-muted-foreground'>Live voice — speak, then wait for a written reply</div>
+			)}
 
 			<form onSubmit={handleSubmitMessage} className='mx-auto relative'>
 				<InputGroup
@@ -311,9 +343,12 @@ function ChatInputBase({
 					/>
 
 					<InputGroupAddon align='block-end'>
-						{(!isTranscribeReady || (!isRecording && !isTranscribing)) && <ChatInputModelSelect />}
+						{(!isTranscribeReady || (!isRecording && !isTranscribing && !liveVoice.isListening)) && (
+							<ChatInputModelSelect />
+						)}
 
 						{isTranscribeReady && isRecording && <SlidingWaveform analyserRef={analyserRef} />}
+						{liveVoice.isListening && <SlidingWaveform analyserRef={liveVoice.analyserRef} />}
 
 						<div className='flex items-center gap-1.5 md:gap-2 ml-auto relative'>
 							<ChatInputPlusMenu
@@ -340,10 +375,16 @@ function ChatInputBase({
 							<ContextWindowRing />
 
 							{isTranscribeReady && isRecording && <RecordingTimer />}
+							<LiveVoiceButton
+								active={liveVoiceActive}
+								status={liveVoice.status}
+								disabled={(isRunning && !allowQueueing) || isTranscribing}
+								onClick={toggleLiveVoice}
+							/>
 							<MicButton
 								state={isTranscribeReady ? transcribeState : 'idle'}
 								onClick={isTranscribeReady ? toggleRecording : showMicWarning}
-								disabled={isRunning && !allowQueueing}
+								disabled={liveVoiceActive || (isRunning && !allowQueueing)}
 							/>
 							{micWarning && <MicWarningBanner onDismiss={() => setMicWarning(false)} />}
 

--- a/apps/frontend/src/components/live-voice-button.tsx
+++ b/apps/frontend/src/components/live-voice-button.tsx
@@ -1,0 +1,35 @@
+import { AudioLines, Loader2 } from 'lucide-react';
+
+import type { LiveVoiceStatus } from '@/hooks/use-live-voice';
+import { cn } from '@/lib/utils';
+
+export function LiveVoiceButton({
+	active,
+	status,
+	disabled,
+	onClick,
+}: {
+	active: boolean;
+	status: LiveVoiceStatus;
+	disabled?: boolean;
+	onClick: () => void;
+}) {
+	const isConnecting = status === 'connecting';
+
+	return (
+		<button
+			type='button'
+			onClick={onClick}
+			disabled={disabled || isConnecting}
+			aria-label={active ? 'Stop live voice' : 'Start live voice'}
+			aria-pressed={active}
+			className={cn(
+				'inline-flex items-center justify-center rounded-full size-7 transition-all cursor-pointer',
+				'disabled:pointer-events-none disabled:opacity-50',
+				active ? 'bg-violet/30 animate-pulse' : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+			)}
+		>
+			{isConnecting ? <Loader2 className='size-3.5 animate-spin' /> : <AudioLines className='size-3.5' />}
+		</button>
+	);
+}

--- a/apps/frontend/src/hooks/use-live-voice.ts
+++ b/apps/frontend/src/hooks/use-live-voice.ts
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { createMicPcm16Stream } from '@/lib/pcm16-audio';
+import { trpcClient } from '@/main';
+
+const REALTIME_URL = 'wss://api.openai.com/v1/realtime?intent=transcription';
+
+export type LiveVoiceStatus = 'idle' | 'connecting' | 'listening' | 'error';
+
+type RealtimeServerEvent = {
+	type?: string;
+	transcript?: string;
+	error?: { message?: string };
+};
+
+export function useLiveVoice({
+	active,
+	paused,
+	onUtterance,
+}: {
+	active: boolean;
+	paused: boolean;
+	onUtterance: (text: string) => void | Promise<void>;
+}) {
+	const [status, setStatus] = useState<LiveVoiceStatus>('idle');
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const analyserRef = useRef<AnalyserNode | null>(null);
+	const wsRef = useRef<WebSocket | null>(null);
+	const micRef = useRef<{ stop: () => void } | null>(null);
+	const onUtteranceRef = useRef(onUtterance);
+	const pausedRef = useRef(paused);
+	const lastTranscriptRef = useRef('');
+	const handlingUtteranceRef = useRef(false);
+
+	useEffect(() => {
+		onUtteranceRef.current = onUtterance;
+	});
+
+	useEffect(() => {
+		pausedRef.current = paused;
+	});
+
+	const teardown = useCallback(() => {
+		wsRef.current?.close();
+		wsRef.current = null;
+		micRef.current?.stop();
+		micRef.current = null;
+		analyserRef.current = null;
+		lastTranscriptRef.current = '';
+		handlingUtteranceRef.current = false;
+	}, []);
+
+	useEffect(() => {
+		if (!active) {
+			teardown();
+			setStatus('idle');
+			setErrorMessage(null);
+			return;
+		}
+
+		let cancelled = false;
+
+		const connect = async () => {
+			setStatus('connecting');
+			setErrorMessage(null);
+
+			try {
+				const session = await trpcClient.transcribe.createLiveSession.mutate();
+				if (cancelled) {
+					return;
+				}
+
+				const ws = new WebSocket(REALTIME_URL, ['realtime', `openai-insecure-api-key.${session.clientSecret}`]);
+				wsRef.current = ws;
+
+				ws.onopen = () => {
+					if (cancelled) {
+						ws.close();
+						return;
+					}
+					setStatus('listening');
+				};
+
+				ws.onmessage = (event) => {
+					let payload: RealtimeServerEvent;
+					try {
+						payload = JSON.parse(event.data as string) as RealtimeServerEvent;
+					} catch {
+						return;
+					}
+
+					if (payload.type === 'error') {
+						setErrorMessage(payload.error?.message ?? 'Live voice connection error');
+						setStatus('error');
+						return;
+					}
+
+					if (payload.type === 'input_audio_buffer.speech_started') {
+						lastTranscriptRef.current = '';
+						return;
+					}
+
+					if (payload.type !== 'conversation.item.input_audio_transcription.completed') {
+						return;
+					}
+
+					const transcript = payload.transcript?.trim() ?? '';
+					if (!transcript || transcript === lastTranscriptRef.current || handlingUtteranceRef.current) {
+						return;
+					}
+
+					lastTranscriptRef.current = transcript;
+					handlingUtteranceRef.current = true;
+					void Promise.resolve(onUtteranceRef.current(transcript)).finally(() => {
+						handlingUtteranceRef.current = false;
+					});
+				};
+
+				ws.onerror = () => {
+					if (!cancelled) {
+						setErrorMessage('Live voice connection failed');
+						setStatus('error');
+					}
+				};
+
+				ws.onclose = () => {
+					if (!cancelled && wsRef.current === ws) {
+						setStatus('error');
+						setErrorMessage((prev) => prev ?? 'Live voice connection closed');
+					}
+				};
+
+				const mic = createMicPcm16Stream((audio) => {
+					if (cancelled || pausedRef.current || ws.readyState !== WebSocket.OPEN) {
+						return;
+					}
+					ws.send(JSON.stringify({ type: 'input_audio_buffer.append', audio }));
+				});
+				micRef.current = mic;
+				analyserRef.current = mic.analyser;
+			} catch (err) {
+				if (!cancelled) {
+					setErrorMessage(err instanceof Error ? err.message : 'Failed to start live voice');
+					setStatus('error');
+				}
+			}
+		};
+
+		void connect();
+
+		return () => {
+			cancelled = true;
+			teardown();
+		};
+	}, [active, teardown]);
+
+	return {
+		status,
+		errorMessage,
+		analyserRef,
+		isListening: status === 'listening' && !paused,
+	};
+}

--- a/apps/frontend/src/lib/pcm16-audio.ts
+++ b/apps/frontend/src/lib/pcm16-audio.ts
@@ -1,0 +1,81 @@
+const TARGET_SAMPLE_RATE = 24_000;
+
+export function float32ToPcm16Base64(samples: Float32Array): string {
+	const bytes = new Uint8Array(samples.length * 2);
+	const view = new DataView(bytes.buffer);
+	for (let i = 0; i < samples.length; i++) {
+		const clamped = Math.max(-1, Math.min(1, samples[i]));
+		view.setInt16(i * 2, clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff, true);
+	}
+	let binary = '';
+	for (let i = 0; i < bytes.length; i++) {
+		binary += String.fromCharCode(bytes[i]);
+	}
+	return btoa(binary);
+}
+
+export function downsampleToPcm16Base64(input: Float32Array, inputSampleRate: number): string {
+	if (inputSampleRate === TARGET_SAMPLE_RATE) {
+		return float32ToPcm16Base64(input);
+	}
+
+	const ratio = inputSampleRate / TARGET_SAMPLE_RATE;
+	const outputLength = Math.floor(input.length / ratio);
+	const output = new Float32Array(outputLength);
+	for (let i = 0; i < outputLength; i++) {
+		const start = Math.floor(i * ratio);
+		const end = Math.floor((i + 1) * ratio);
+		let sum = 0;
+		let count = 0;
+		for (let j = start; j < end && j < input.length; j++) {
+			sum += input[j];
+			count++;
+		}
+		output[i] = count > 0 ? sum / count : 0;
+	}
+	return float32ToPcm16Base64(output);
+}
+
+export function createMicPcm16Stream(onChunk: (base64Pcm16: string) => void): {
+	analyser: AnalyserNode;
+	stop: () => void;
+} {
+	const audioContext = new AudioContext();
+	const analyser = audioContext.createAnalyser();
+	analyser.fftSize = 512;
+	analyser.smoothingTimeConstant = 0.4;
+
+	let mediaStream: MediaStream | null = null;
+	let processor: ScriptProcessorNode | null = null;
+	let source: MediaStreamAudioSourceNode | null = null;
+	let stopped = false;
+
+	const start = async () => {
+		mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		source = audioContext.createMediaStreamSource(mediaStream);
+		source.connect(analyser);
+		processor = audioContext.createScriptProcessor(4096, 1, 1);
+		processor.onaudioprocess = (event) => {
+			if (stopped) {
+				return;
+			}
+			const channel = event.inputBuffer.getChannelData(0);
+			onChunk(downsampleToPcm16Base64(channel, audioContext.sampleRate));
+		};
+		source.connect(processor);
+		processor.connect(audioContext.destination);
+	};
+
+	void start();
+
+	return {
+		analyser,
+		stop: () => {
+			stopped = true;
+			processor?.disconnect();
+			source?.disconnect();
+			mediaStream?.getTracks().forEach((track) => track.stop());
+			void audioContext.close();
+		},
+	};
+}


### PR DESCRIPTION
#### summary

- Add live voice mode in chat: stream mic audio via OpenAI Realtime transcription (server VAD).
- On each completed utterance, send transcript to the existing agent; replies stay text-only.
- Backend issues ephemeral transcription sessions; frontend connects over WebSocket and auto-submits turns.
- Pause listening while the agent runs; resume when the reply finishes.

#### Test plan
[ ] Enable transcription + OpenAI key in Settings → Models
[ ] Start live voice, speak, confirm message is sent and agent replies in text
[ ] Confirm batch mic still works when live mode is off
[ ] Switch chats and confirm live mode stops
[ ] Test with agent still running (follow-up / queue behavior)


fix #759