### PR TITLE
feat(cli): column-level excludes via `exclude_columns`

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -258,6 +258,7 @@ def sync_database(
                 )
 
                 ctx = db_config.create_context(conn, schema, table)
+                ctx.set_exclude_columns(db_config.exclude_columns)
                 table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
 
                 for template_name in templates:

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -88,6 +88,14 @@ class DatabaseConfig(BaseModel, ABC):
         default_factory=list,
         description="Glob patterns for schemas/tables to exclude (e.g., 'temp_*.*', '*.backup_*')",
     )
+    exclude_columns: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Glob patterns for columns to exclude. Patterns are matched against the "
+            "fully-qualified 'schema.table.column' name (e.g., '*.version', '*._peerdb_*', "
+            "'analytics.events.*_id'). Empty means no columns are excluded."
+        ),
+    )
     templates: list[DatabaseTemplate] = Field(
         default_factory=lambda: [
             DatabaseTemplate.COLUMNS,
@@ -210,6 +218,18 @@ class DatabaseConfig(BaseModel, ABC):
 
         return True
 
+    def column_matches_pattern(self, schema: str, table: str, column: str) -> bool:
+        """Check if a column should be included given the exclude_columns patterns.
+
+        Patterns are matched against the fully-qualified ``schema.table.column``
+        name using shell-style globs (``fnmatch``). Returns ``True`` when the
+        column should be kept, ``False`` when it should be excluded.
+        """
+        if not self.exclude_columns:
+            return True
+        full_name = f"{schema}.{table}.{column}"
+        return not any(fnmatch.fnmatch(full_name, pattern) for pattern in self.exclude_columns)
+
     @abstractmethod
     def get_database_name(self) -> str:
         """Get the database name for this database type."""
@@ -239,7 +259,7 @@ class DatabaseConfig(BaseModel, ABC):
         """Create a DatabaseContext for this table. Override in subclasses for custom metadata."""
         from nao_core.config.databases.context import DatabaseContext
 
-        return DatabaseContext(conn, schema, table_name)
+        return DatabaseContext(conn, schema, table_name, exclude_columns=self.exclude_columns)
 
     def get_semantic_views(self, conn: "BaseBackend", schema: str) -> list[dict[str, str]]:
         """Fetch semantic views for a schema. Override in subclasses that support semantic views."""

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -69,16 +69,18 @@ class BigQueryDatabaseContext(DatabaseContext):
 
     def partition_columns(self) -> list[str]:
         if self._partition_metadata is not None and self._partition_metadata.partition_column is not None:
-            return [self._partition_metadata.partition_column]
+            return self._filter_excluded_names([self._partition_metadata.partition_column])
         try:
-            return _get_bq_partition_columns(self._conn, self._project_id, self._schema, self._table_name)
+            return self._filter_excluded_names(
+                _get_bq_partition_columns(self._conn, self._project_id, self._schema, self._table_name)
+            )
         except Exception:
             logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
             return []
 
     def clustering_columns(self) -> list[str]:
         if self._partition_metadata is not None:
-            return self._partition_metadata.clustering_columns
+            return self._filter_excluded_names(list(self._partition_metadata.clustering_columns))
         return []
 
     def description(self) -> str | None:
@@ -173,7 +175,9 @@ class BigQueryDatabaseContext(DatabaseContext):
         col_names = list(self.table.schema().keys())
         try:
             return [
-                {name: _coerce(row[i] if i < len(row) else None) for i, name in enumerate(col_names)}
+                self._filter_excluded_row(
+                    {name: _coerce(row[i] if i < len(row) else None) for i, name in enumerate(col_names)}
+                )
                 for row in self._conn.raw_sql(query)  # type: ignore[union-attr]
             ]
         except Exception:

--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -453,7 +453,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
     def columns(self) -> list[dict[str, Any]]:
         """Return column metadata; for stream-like engines use system.columns (no SELECT from table)."""
         if self._direct_select_disallowed:
-            return _columns_from_system(self._conn, self._schema, self._table_name)
+            return self._filter_excluded_columns(_columns_from_system(self._conn, self._schema, self._table_name))
         try:
             schema = self.table.schema()
             cols = [
@@ -492,9 +492,9 @@ class ClickHouseDatabaseContext(DatabaseContext):
                         col["type"] = native_type
                 if meta := defaults.get(name):
                     col.update(meta)
-            return cols
+            return self._filter_excluded_columns(cols)
         except Exception:
-            return _columns_from_system(self._conn, self._schema, self._table_name)
+            return self._filter_excluded_columns(_columns_from_system(self._conn, self._schema, self._table_name))
 
     def _fetchone(self, result) -> tuple | None:
         """Normalise clickhouse-connect QueryResult objects for profiling queries."""
@@ -554,7 +554,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
         try:
             cursor = self._conn.raw_sql(sql)  # type: ignore[union-attr]
             rows = _raw_sql_to_rows(cursor)
-            return [_normalize_row(r) for r in rows]
+            return [self._filter_excluded_row(_normalize_row(r)) for r in rows]
         except Exception as e:
             logger.debug(
                 "ClickHouse preview query failed for %s.%s: %s; returning empty list",

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -19,13 +20,53 @@ class DatabaseContext:
     to fetch warehouse-specific metadata (e.g. BigQuery partition info).
     """
 
-    def __init__(self, conn: BaseBackend, schema: str, table_name: str):
+    def __init__(
+        self,
+        conn: BaseBackend,
+        schema: str,
+        table_name: str,
+        exclude_columns: list[str] | None = None,
+    ):
         self._conn = conn
         self._schema = schema
         self._table_name = table_name
+        self._exclude_columns = list(exclude_columns) if exclude_columns else []
         self._table_ref = None
         self._columns_cache: list[dict[str, Any]] | None = None
         self._row_count_cache: int | None = None
+
+    def set_exclude_columns(self, patterns: list[str] | None) -> None:
+        """Set the list of glob patterns used to hide columns from the agent.
+
+        Patterns are matched against the fully-qualified ``schema.table.column``
+        name. Subclasses build their own column metadata; calling this lets the
+        sync provider thread the user-configured ``exclude_columns`` into any
+        context implementation without changing per-database constructors.
+        """
+        self._exclude_columns = list(patterns) if patterns else []
+
+    def _is_column_excluded(self, column_name: str) -> bool:
+        """Return True when the column should be hidden based on ``exclude_columns``.
+
+        Patterns are matched against the fully-qualified ``schema.table.column``
+        name using shell-style globs.
+        """
+        if not self._exclude_columns:
+            return False
+        full_name = f"{self._schema}.{self._table_name}.{column_name}"
+        return any(fnmatch.fnmatch(full_name, pattern) for pattern in self._exclude_columns)
+
+    def _filter_excluded_columns(self, cols: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Drop columns whose name matches an ``exclude_columns`` pattern."""
+        if not self._exclude_columns:
+            return cols
+        return [col for col in cols if not self._is_column_excluded(str(col.get("name", "")))]
+
+    def _filter_excluded_names(self, names: list[str]) -> list[str]:
+        """Drop column names that match an ``exclude_columns`` pattern."""
+        if not self._exclude_columns:
+            return names
+        return [name for name in names if not self._is_column_excluded(name)]
 
     @property
     def table(self):
@@ -45,7 +86,7 @@ class DatabaseContext:
                 }
                 for name, dtype in schema.items()
             ]
-        return self._columns_cache
+        return self._filter_excluded_columns(self._columns_cache)
 
     def row_count(self) -> int:
         if self._row_count_cache is None:
@@ -64,8 +105,14 @@ class DatabaseContext:
             for key, val in row_dict.items():
                 if val is not None and not isinstance(val, (str, int, float, bool, list, dict)):
                     row_dict[key] = str(val)
-            rows.append(row_dict)
+            rows.append(self._filter_excluded_row(row_dict))
         return rows
+
+    def _filter_excluded_row(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Drop keys from a preview row that match an ``exclude_columns`` pattern."""
+        if not self._exclude_columns:
+            return row
+        return {key: val for key, val in row.items() if not self._is_column_excluded(str(key))}
 
     def partition_columns(self) -> list[str]:
         """Return partition column names if available."""

--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -27,7 +27,9 @@ class DatabricksDatabaseContext(DatabaseContext):
 
     def partition_columns(self) -> list[str]:
         try:
-            return _get_databricks_partition_columns(self._conn, self._schema, self._table_name)
+            return self._filter_excluded_names(
+                _get_databricks_partition_columns(self._conn, self._schema, self._table_name)
+            )
         except Exception:
             logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
             return []

--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -47,7 +47,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                 }
                 for row in result
             ]
-        return self._columns_cache
+        return self._filter_excluded_columns(self._columns_cache)
 
     def row_count(self) -> int:
         if self._row_count_cache is None:
@@ -98,9 +98,11 @@ class RedshiftDatabaseContext(DatabaseContext):
         query = f"SELECT * FROM {schema_sql}.{table_sql} LIMIT {limit}"
         result = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
 
-        # Get column names from the columns metadata
-        columns = self.columns()
-        col_names = [col["name"] for col in columns]
+        # Use the unfiltered column metadata so row indices stay aligned with
+        # SELECT * output; the excluded columns are dropped after the dict is built.
+        if self._columns_cache is None:
+            self.columns()
+        col_names = [col["name"] for col in (self._columns_cache or [])]
 
         rows = []
         for row in result:
@@ -111,7 +113,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                     row_dict[col_name] = str(val)
                 else:
                     row_dict[col_name] = val
-            rows.append(row_dict)
+            rows.append(self._filter_excluded_row(row_dict))
         return rows
 
     def _fetch_column_descriptions(self) -> dict[str, str]:

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -24,7 +24,9 @@ class SnowflakeDatabaseContext(DatabaseContext):
 
     def partition_columns(self) -> list[str]:
         try:
-            return _get_snowflake_clustering_columns(self._conn, self._schema, self._table_name)
+            return self._filter_excluded_names(
+                _get_snowflake_clustering_columns(self._conn, self._schema, self._table_name)
+            )
         except Exception:
             logger.debug("Failed to fetch clustering keys for %s.%s", self._schema, self._table_name)
             return []

--- a/cli/nao_core/config/databases/starrocks.py
+++ b/cli/nao_core/config/databases/starrocks.py
@@ -176,11 +176,11 @@ class StarRocksDatabaseContext(DatabaseContext):
         try:
             columns = self._columns_from_information_schema()
             if columns:
-                return columns
+                return self._filter_excluded_columns(columns)
         except Exception:
             pass
         try:
-            return self._columns_from_show_full_columns()
+            return self._filter_excluded_columns(self._columns_from_show_full_columns())
         except Exception:
             return []
 
@@ -202,7 +202,7 @@ class StarRocksDatabaseContext(DatabaseContext):
             for key, value in record.items():
                 if value is not None and not isinstance(value, (str, int, float, bool, list, dict)):
                     record[key] = str(value)
-            out.append(record)
+            out.append(self._filter_excluded_row(record))
         return out
 
     def _build_profiling_query(self, col: dict) -> str:

--- a/cli/tests/nao_core/commands/sync/integration/base.py
+++ b/cli/tests/nao_core/commands/sync/integration/base.py
@@ -60,6 +60,10 @@ class SyncTestSpec:
     # When partition filter is required, the table name of the partition filter table (BigQuery only)
     events_table: str = "events"
 
+    # Column name expected to exist on the users table that exercises exclude_columns.
+    # Set to None to skip the exclude_columns integration test for this provider.
+    excluded_column_name: str | None = "email"
+
     @property
     def effective_filter_schema(self) -> str:
         return self.filter_schema or self.primary_schema
@@ -271,6 +275,28 @@ class BaseSyncIntegrationTests:
         assert (base / f"table={spec.users_table}").is_dir()
         assert not (base / f"table={spec.orders_table}").exists()
         assert state.tables_synced == spec.primary_table_count - 1
+
+    def test_exclude_columns_filter(self, tmp_path_factory, db_config, spec):
+        """Columns matching exclude_columns patterns should be hidden from output."""
+        if not spec.excluded_column_name:
+            pytest.skip("Provider spec does not declare a column to exclude")
+
+        config = db_config.model_copy(update={"exclude_columns": [f"*.*.{spec.excluded_column_name}"]})
+
+        output = tmp_path_factory.mktemp(f"{spec.db_type}_exclude_columns")
+        with Progress(transient=True) as progress:
+            sync_database(config, output, progress)
+
+        users_columns = self._read_table_file(output, config, spec, spec.users_table, "columns.md")
+        assert f"- {spec.excluded_column_name} (" not in users_columns
+
+        preview_content = self._read_table_file(output, config, spec, spec.users_table, "preview.md")
+        for row in self._parse_preview_rows(preview_content):
+            assert spec.excluded_column_name not in row
+
+        profiling_content = self._read_table_file(output, config, spec, spec.users_table, "profiling.md")
+        for row in self._parse_preview_rows(profiling_content):
+            assert row.get("column") != spec.excluded_column_name
 
     # ── check_connection ──────────────────────────────────────────────
 

--- a/cli/tests/nao_core/commands/sync/test_context.py
+++ b/cli/tests/nao_core/commands/sync/test_context.py
@@ -13,7 +13,7 @@ from nao_core.config.databases.base import ProfilingConfig, ProfilingRefreshPoli
 
 
 class TestDatabaseContext:
-    def _make_context(self):
+    def _make_context(self, exclude_columns: list[str] | None = None):
         mock_conn = MagicMock()
         mock_table = MagicMock()
         mock_schema = MagicMock()
@@ -25,7 +25,8 @@ class TestDatabaseContext:
         mock_schema.__len__ = lambda s: len(schema_items)
         mock_table.schema.return_value = mock_schema
         mock_conn.table.return_value = mock_table
-        return DatabaseContext(mock_conn, "my_schema", "my_table"), mock_table
+        ctx = DatabaseContext(mock_conn, "my_schema", "my_table", exclude_columns=exclude_columns)
+        return ctx, mock_table
 
     def test_columns_returns_metadata(self):
         ctx, _ = self._make_context()
@@ -124,3 +125,64 @@ class TestDatabaseContext:
                 refresh_policy=ProfilingRefreshPolicy.INTERVAL,
                 interval_days=0,  # interdit par ge=1
             )
+
+    def test_columns_filters_out_excluded_columns(self):
+        ctx, _ = self._make_context(exclude_columns=["*.name"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_columns_returns_all_when_pattern_does_not_match(self):
+        ctx, _ = self._make_context(exclude_columns=["*.something_else"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id", "name"]
+
+    def test_columns_supports_schema_table_column_pattern(self):
+        ctx, _ = self._make_context(exclude_columns=["my_schema.my_table.id"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["name"]
+
+    def test_columns_supports_wildcard_table_segment(self):
+        ctx, _ = self._make_context(exclude_columns=["*.*.id"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["name"]
+
+    def test_preview_filters_out_excluded_columns(self):
+        ctx, mock_table = self._make_context(exclude_columns=["*._peerdb_*", "*.name"])
+        df = pd.DataFrame(
+            {
+                "id": [1, 2],
+                "name": ["Alice", "Bob"],
+                "_peerdb_version": [1, 1],
+            }
+        )
+        mock_table.limit.return_value.execute.return_value = df
+
+        rows = ctx.preview(limit=2)
+
+        assert len(rows) == 2
+        assert rows[0] == {"id": 1}
+        assert rows[1] == {"id": 2}
+
+    def test_set_exclude_columns_overrides_constructor_value(self):
+        ctx, _ = self._make_context()
+        ctx.set_exclude_columns(["*.name"])
+
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_set_exclude_columns_with_none_clears_filter(self):
+        ctx, _ = self._make_context(exclude_columns=["*.name"])
+        ctx.set_exclude_columns(None)
+
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id", "name"]
+
+    def test_column_count_uses_filtered_columns(self):
+        ctx, _ = self._make_context(exclude_columns=["*.name"])
+        assert ctx.column_count() == 1

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -295,6 +295,45 @@ def test_query_history_sql_unsupported_database_returns_none_when_no_override():
     assert db.get_query_history_sql(30) is None
 
 
+def test_exclude_columns_default_is_empty():
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    assert db.exclude_columns == []
+
+
+def test_exclude_columns_matches_against_schema_table_column():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        exclude_columns=["*.version", "analytics.events.*_id"],
+    )
+    assert db.column_matches_pattern("analytics", "users", "name") is True
+    assert db.column_matches_pattern("analytics", "users", "version") is False
+    assert db.column_matches_pattern("analytics", "events", "user_id") is False
+    assert db.column_matches_pattern("staging", "events", "user_id") is True
+
+
+def test_exclude_columns_supports_glob_in_column_name():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        exclude_columns=["*._peerdb_*"],
+    )
+    assert db.column_matches_pattern("analytics", "users", "_peerdb_version") is False
+    assert db.column_matches_pattern("analytics", "users", "name") is True
+
+
+def test_exclude_columns_loaded_from_yaml_dict():
+    db = DuckDBConfig.model_validate(
+        {
+            "type": "duckdb",
+            "name": "test-db",
+            "path": ":memory:",
+            "exclude_columns": ["*._peerdb_*", "*.sign", "*.version"],
+        }
+    )
+    assert db.exclude_columns == ["*._peerdb_*", "*.sign", "*.version"]
+
+
 def test_query_history_fields_loaded_from_yaml_dict():
     db = DuckDBConfig.model_validate(
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #529.

## What

Adds a new `exclude_columns` field on `DatabaseConfig` (and therefore every per-database subclass: ClickHouse, Postgres, BigQuery, Snowflake, Databricks, MySQL, MSSQL, Redshift, Trino, Athena, StarRocks, DuckDB, Fabric).

```yaml
databases:
  - type: clickhouse
    name: nexus-clickhouse
    include:
      - "nexus_demand.*"
    exclude_columns:
      - "*._peerdb_*"        # internal replication metadata
      - "*.sign"             # ReplacingMergeTree internals
      - "*.version"          # ReplacingMergeTree internals
```

Patterns are matched against the fully-qualified `schema.table.column` name using `fnmatch` shell-style globs. Empty list means no columns are hidden (existing behaviour).

## Where the filter applies

Excluded columns are dropped from the data the agent ever sees:

- `DatabaseContext.columns()` (cascades to `column_count()` and `profiling()`, which iterate `self.columns()`)
- `DatabaseContext.preview()` row dicts
- `partition_columns()` / `clustering_columns()` results (BigQuery, Databricks, Snowflake)

For providers that build their own column metadata without going through `super().columns()` (ClickHouse, Redshift, StarRocks), the filter is applied at the return site of each custom override. Redshift's `preview()` keeps the unfiltered column list for `SELECT *` index alignment, then drops excluded keys from the resulting dict.

`db_config.exclude_columns` is threaded onto every context the sync provider creates via the new `DatabaseContext.set_exclude_columns()` method, so per-database `create_context` overrides don't need to know about the field.

## Tests

- Unit tests for `DatabaseConfig.column_matches_pattern` (`*.version`, `*._peerdb_*`, schema-prefixed patterns).
- Unit tests for `DatabaseContext` filtering across `columns()`, `preview()`, `column_count()`, and the new `set_exclude_columns()` setter.
- Shared integration test added to `BaseSyncIntegrationTests` that runs the real `sync_database` pipeline against DuckDB with `exclude_columns=["*.*.email"]` and asserts the excluded column is absent from `columns.md`, `preview.md`, and `profiling.md`.

## Walkthrough

End-to-end DuckDB demo with a `downloads` table containing user data plus replication metadata (`_peerdb_version`, `_peerdb_synced_at`) and ReplacingMergeTree-style internals (`sign`, `version`). With `exclude_columns: ["*._peerdb_*", "*.sign", "*.version"]`, the synced markdown only references the 3 business columns:

[exclude_columns_demo_output.log](https://cursor.com/agents/bc-dc11cc3a-3337-4103-b814-14568c570c29/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexclude_columns_demo_output.log)

Programmatic checks:

- `cd cli && make lint` — `ty check`, `ruff check`, `ruff format --check` all pass.
- `cd cli && uv run pytest --ignore=tests/nao_core/commands/sync/integration` — 601 passed.
- `cd cli && uv run pytest tests/nao_core/commands/sync/integration/test_duckdb.py` — 17 passed, 3 skipped (the new `test_exclude_columns_filter` runs against the real DuckDB).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc11cc3a-3337-4103-b814-14568c570c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc11cc3a-3337-4103-b814-14568c570c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

