### PR TITLE
ci(publish): smoke-test built wheel before publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,8 +117,157 @@ jobs:
                   path: cli/dist/*.whl
                   retention-days: 7
 
-    publish:
+    smoke-test:
+        name: Smoke test built wheel (linux-x64, duckdb + openai)
         needs: build
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.12'
+
+            - name: Download Linux x64 wheel
+              uses: actions/download-artifact@v4
+              with:
+                  name: wheel-manylinux2014_x86_64
+                  path: dist
+
+            - name: List downloaded wheels
+              run: ls -la dist/
+
+            - name: Install nao-core from wheel (with duckdb + openai extras)
+              run: |
+                  WHEEL=$(ls dist/*.whl | head -n1)
+                  if [ -z "$WHEEL" ]; then
+                    echo "::error::No wheel found in dist/"
+                    exit 1
+                  fi
+                  echo "Installing $WHEEL[duckdb,openai]"
+                  python -m pip install --upgrade pip
+                  python -m pip install "${WHEEL}[duckdb,openai]"
+
+            - name: Verify nao --version
+              run: nao --version
+
+            - name: Prepare smoke-test project
+              run: |
+                  mkdir -p smoke-project
+                  cp example/jaffle_shop.duckdb smoke-project/
+                  mkdir -p smoke-project/tests
+                  cp example/tests/total_revenue.yml smoke-project/tests/
+
+                  cat > smoke-project/nao_config.yaml <<'YAML'
+                  project_name: smoke-project
+                  databases:
+                    - name: duckdb-jaffle-shop
+                      type: duckdb
+                      path: ./jaffle_shop.duckdb
+                      templates:
+                        - columns
+                        - preview
+                      profiling:
+                        refresh_policy: interval
+                        interval_days: 1
+                      include: []
+                      exclude: []
+                  llm:
+                    provider: openai
+                    api_key: "{{ env('OPENAI_API_KEY') }}"
+                  repos: []
+                  notion: null
+                  slack: null
+                  YAML
+
+                  echo "---- nao_config.yaml ----"
+                  cat smoke-project/nao_config.yaml
+
+            - name: nao init (non-interactive)
+              working-directory: smoke-project
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+              run: nao init --yes
+
+            - name: nao sync
+              working-directory: smoke-project
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+              run: nao sync
+
+            - name: Start nao chat in background
+              working-directory: smoke-project
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  ENABLE_USER_LOGIN: 'true'
+                  ENABLE_USER_SIGNUP: 'true'
+                  BETTER_AUTH_URL: 'http://localhost:5005'
+                  BROWSER: 'none'
+              run: |
+                  set -euo pipefail
+                  nohup nao chat > chat.log 2>&1 &
+                  echo $! > chat.pid
+                  echo "Started nao chat (pid $(cat chat.pid))"
+
+                  echo "Waiting for chat server on http://localhost:5005/api ..."
+                  for i in $(seq 1 90); do
+                    if curl -fsS http://localhost:5005/api > /dev/null 2>&1; then
+                      echo "Chat server is up after ${i}s"
+                      exit 0
+                    fi
+                    sleep 1
+                  done
+
+                  echo "::error::Chat server failed to come up within 90s"
+                  echo "---- chat.log ----"
+                  cat chat.log || true
+                  exit 1
+
+            - name: Sign up admin user
+              run: |
+                  set -euo pipefail
+                  curl -fsS -X POST http://localhost:5005/api/auth/sign-up/email \
+                    -H 'Content-Type: application/json' \
+                    -d '{"name":"Smoke Test","email":"smoke@nao.test","password":"smoke-password-1234"}' \
+                    -o signup.json
+                  echo "---- signup response ----"
+                  cat signup.json
+
+            - name: nao test (openai:gpt-4.1-mini against DuckDB jaffle_shop)
+              working-directory: smoke-project
+              env:
+                  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  NAO_USERNAME: smoke@nao.test
+                  NAO_PASSWORD: smoke-password-1234
+                  BACKEND_URL: 'http://localhost:5005'
+              run: nao test -m openai:gpt-4.1-mini -s total_revenue
+
+            - name: Dump chat.log on failure
+              if: failure()
+              working-directory: smoke-project
+              run: |
+                  echo "---- chat.log ----"
+                  cat chat.log || true
+
+            - name: Stop nao chat
+              if: always()
+              working-directory: smoke-project
+              run: |
+                  if [ -f chat.pid ]; then
+                    PID=$(cat chat.pid)
+                    if kill -0 "$PID" 2>/dev/null; then
+                      kill "$PID" || true
+                      sleep 2
+                      kill -9 "$PID" 2>/dev/null || true
+                    fi
+                  fi
+
+    publish:
+        needs: [build, smoke-test]
         runs-on: ubuntu-latest
         environment: pypi
         permissions:

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict, dataclass
 from datetime import datetime
@@ -434,3 +435,4 @@ def test(
         UI.success(f"All {total} test(s) passed")
     else:
         UI.print(f"[green]{passed} passed[/green], [red]{failed} failed[/red], {total} total")
+        sys.exit(1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a CI gate that runs the full end-user flow against the freshly built Linux x64 wheel before it is published to PyPI. If the smoke test fails the release is blocked.

The new `smoke-test` job runs between `build` and `publish` in `.github/workflows/publish.yml` and exercises the four commands called out in the request, backed by DuckDB and OpenAI:

- install the wheel produced by `build` with `pip install <wheel>[duckdb,openai]`
- `nao init --yes` against a pre-written `nao_config.yaml`
- `nao sync` to materialize the DuckDB schema docs
- `nao chat` launched in the background, gated on `GET /api` readiness
- sign up an admin via better-auth so we can authenticate against the running server
- `nao test -m openai:gpt-4.1-mini -s total_revenue` against the running chat server, using the example `jaffle_shop.duckdb`

`publish` now depends on both `build` and `smoke-test`, so a tag push will only ship to PyPI if the produced wheel actually runs all four core commands end-to-end.

## Required configuration

- Add a repository (or `pypi` environment) secret named `OPENAI_API_KEY`. The smoke job reads it via `${{ secrets.OPENAI_API_KEY }}` and forwards it to `nao chat` / `nao test` through the project config (`{{ env('OPENAI_API_KEY') }}`).

## Side change: `nao test` exit code

`nao test` previously always returned exit code 0, even when one or more cases failed. That made it useless as a CI gate. It now exits 1 when any test fails, matching pytest/vitest conventions. This is the only non-CI change in the PR.

## Testing

- ✅ `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` — YAML parses cleanly.
- ✅ `actionlint .github/workflows/*.yml` — workflow lints cleanly.
- ✅ `cd cli && make lint` — `ty`, `ruff check`, `ruff format --check` all pass.
- ✅ `cd cli && uv run pytest --ignore=tests/nao_core/commands/sync/integration/test_mssql.py` — 605 passed, 189 skipped (the `test_mssql.py` collection error is pre-existing and unrelated, caused by missing `libodbc.so.2` in the local sandbox).
- ✅ Local end-to-end dry run of the bash steps against an editable install:
    - `nao --version` → `0.1.9`
    - `nao init --yes` with the same pre-written `nao_config.yaml` → succeeds, DuckDB connection check passes
    - `nao sync` → 8 tables synced, `databases/type=duckdb/...` directory tree populated
    - Heredoc terminator + YAML payload validated with `python3 -c "yaml.safe_load(...)"`

The chat-server / `nao test` portion of the flow requires the compiled Bun binary that is only produced inside the publish workflow's `build` job, so it cannot be exercised locally without rebuilding the wheel. The bash logic that drives it (server start, `/api` readiness poll, better-auth signup, `nao test -s total_revenue`) has been validated step by step against the source — running it under the actual wheel produced by `build` is the value the new CI job adds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20a0330e-0ac6-49a3-9d64-7f2e06abeea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20a0330e-0ac6-49a3-9d64-7f2e06abeea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

