### PR TITLE
fix(lint): disable type-aware ESLint rules in frontend to prevent heap OOM

### DIFF
--- a/apps/frontend/eslint.config.js
+++ b/apps/frontend/eslint.config.js
@@ -2,12 +2,25 @@
 
 import { tanstackConfig } from '@tanstack/eslint-config';
 import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
 
 import rootConfig from '../../eslint.config.js';
 
 export default [
 	...rootConfig,
 	...tanstackConfig,
+	// @tanstack/eslint-config enables type-aware rules (parserOptions.project=true)
+	// which load the full TypeScript program and cause heap OOM on 16 GB dev machines.
+	// Disable all type-aware rules and prevent parser from loading the TS program.
+	tseslint.configs.disableTypeChecked,
+	{
+		languageOptions: {
+			parserOptions: {
+				project: false,
+				tsconfigRootDir: import.meta.dirname,
+			},
+		},
+	},
 	{
 		plugins: {
 			'react-hooks': reactHooks,


### PR DESCRIPTION
## Summary

- Disable type-aware ESLint rules in `apps/frontend/eslint.config.js` to prevent heap OOM crashes on dev machines
- `@tanstack/eslint-config` enables `parserOptions.project=true` which loads the full TypeScript program during lint, causing `FATAL ERROR: Ineffective mark-compacts near heap limit` on 16 GB machines

## Details

The fix adds `tseslint.configs.disableTypeChecked` and explicitly sets `parserOptions.project: false` with `tsconfigRootDir`. Type checking still runs via `tsc --noEmit` in CI — only the ESLint type-aware rules are disabled to avoid the OOM.

We hit this in our fork and have been running with this fix for ~2 weeks without issues.

## Test plan

- [x] `npm run lint:frontend` completes without OOM
- [x] No new lint warnings or errors from disabling type-aware rules
- [ ] Verify `tsc --noEmit` still catches type errors (separate from lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)