### PR TITLE
feat: add custom executable tools support for agent/tools/

### DIFF
--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -1,6 +1,7 @@
 export { isPythonAvailable } from './execute-python';
 export { isSandboxAvailable } from './execute-sandboxed-code';
 
+import { customToolService } from '../../services/custom-tool';
 import { mcpService } from '../../services/mcp';
 import { AgentSettings } from '../../types/agent-settings';
 import clarification from './clarification';
@@ -42,6 +43,7 @@ export const getTools = (
 	} = {},
 ) => {
 	const mcpTools = options.mcpEnabled === false ? {} : mcpService.getMcpTools(options.mcpServers);
+	const customTools = customToolService.getTools();
 
 	const {
 		execute_python,
@@ -56,6 +58,7 @@ export const getTools = (
 		...baseTools,
 		...(!options.testMode && { clarification: clarificationTool }),
 		...mcpTools,
+		...customTools,
 		...(agentSettings?.experimental?.pythonSandboxing && execute_python && { execute_python }),
 		...(agentSettings?.experimental?.sandboxes && execute_sandboxed_code && { execute_sandboxed_code }),
 		...extraTools,

--- a/apps/backend/src/handlers/agent.ts
+++ b/apps/backend/src/handlers/agent.ts
@@ -4,6 +4,7 @@ import { noProjectMessage } from '../env';
 import * as chatQueries from '../queries/chat.queries';
 import * as imageQueries from '../queries/image.queries';
 import { agentService } from '../services/agent';
+import { customToolService } from '../services/custom-tool';
 import { mcpService } from '../services/mcp';
 import { skillService } from '../services/skill';
 import { AgentRequest, AgentRequestUserMessage, UIMessagePart } from '../types/chat';
@@ -58,6 +59,7 @@ export const handleAgentRoute = async (opts: HandleAgentMessageInput): Promise<H
 
 	await mcpService.initializeMcpState(projectId);
 	await skillService.initializeSkills(projectId);
+	await customToolService.initialize(projectId);
 
 	const agent = await agentService.create({ ...chat, userId, projectId }, model);
 

--- a/apps/backend/src/handlers/automation.handler.ts
+++ b/apps/backend/src/handlers/automation.handler.ts
@@ -14,6 +14,7 @@ import {
 	createAutomationTools,
 	getAutomationIntegrationToolNames,
 } from '../services/automation-tools';
+import { customToolService } from '../services/custom-tool';
 import { mcpService } from '../services/mcp';
 import { skillService } from '../services/skill';
 import type { AutomationIntegrationResult } from '../types/automation';
@@ -111,6 +112,7 @@ async function finishAutomationRun(automation: AutomationWithSchedule, run: DBAu
 			await mcpService.initializeMcpState(automation.projectId);
 		}
 		await skillService.initializeSkills(automation.projectId);
+		await customToolService.initialize(automation.projectId);
 
 		const githubToken = await userQueries.getGithubToken(automation.userId);
 		const expectedTools = getAutomationIntegrationToolNames(automation.integrations);

--- a/apps/backend/src/mcp/tools/agent.ts
+++ b/apps/backend/src/mcp/tools/agent.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as chatQueries from '../../queries/chat.queries';
 import { agentService } from '../../services/agent';
+import { customToolService } from '../../services/custom-tool';
 import { mcpService } from '../../services/mcp';
 import { skillService } from '../../services/skill';
 import type { UIMessage, UIMessagePart } from '../../types/chat';
@@ -46,6 +47,7 @@ export function registerAgentTools(server: McpServer, ctx: McpContext): void {
 			async ({ question, chatId }, extra) => {
 				await mcpService.initializeMcpState(ctx.projectId);
 				await skillService.initializeSkills(ctx.projectId);
+				await customToolService.initialize(ctx.projectId);
 
 				const { chat, uiMessages } = await buildChatContext(ctx.projectId, ctx.userId, question, chatId);
 

--- a/apps/backend/src/services/custom-tool.ts
+++ b/apps/backend/src/services/custom-tool.ts
@@ -1,0 +1,174 @@
+import type { Tool } from '@ai-sdk/provider-utils';
+import { debounce } from '@nao/shared';
+import { jsonSchema } from 'ai';
+import { execFile } from 'child_process';
+import { existsSync, readdirSync, readFileSync, statSync, watch } from 'fs';
+import { join } from 'path';
+
+import * as projectQueries from '../queries/project.queries';
+import { logger } from '../utils/logger';
+import { sanitizeTools } from '../utils/tools';
+
+export interface CustomToolSpec {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	command: string;
+	args: string[];
+	input: 'stdin' | 'args';
+	env?: Record<string, string>;
+}
+
+class CustomToolService {
+	private _projectPath: string = '';
+	private _toolsFolderPath: string = '';
+	private _tools: Record<string, Tool> = {};
+	private _fileWatcher: ReturnType<typeof watch> | null = null;
+	private _debouncedReload: () => void;
+	private _initialized = false;
+
+	constructor() {
+		this._debouncedReload = debounce(() => {
+			this._loadTools();
+		}, 2000);
+	}
+
+	public async initialize(projectId: string): Promise<void> {
+		if (this._initialized) {
+			return;
+		}
+		this._initialized = true;
+
+		const project = await projectQueries.retrieveProjectById(projectId);
+		this._projectPath = project.path || '';
+		this._toolsFolderPath = join(this._projectPath, 'agent', 'tools');
+
+		this._loadTools();
+		this._setupFileWatcher();
+	}
+
+	public getTools(): Record<string, Tool> {
+		return this._tools;
+	}
+
+	private _loadTools(): void {
+		try {
+			if (!existsSync(this._toolsFolderPath)) {
+				this._tools = {};
+				return;
+			}
+
+			if (!statSync(this._toolsFolderPath).isDirectory()) {
+				logger.error(`Custom tools path is not a directory: ${this._toolsFolderPath}`, { source: 'tool' });
+				this._tools = {};
+				return;
+			}
+
+			const files = readdirSync(this._toolsFolderPath).filter((f) => f.endsWith('.json'));
+			const tools: Record<string, Tool> = {};
+
+			for (const file of files) {
+				const spec = this._readSpec(file);
+				if (!spec) continue;
+
+				tools[spec.name] = this._buildTool(spec);
+			}
+
+			this._tools = tools;
+			logger.info(`Loaded ${Object.keys(tools).length} custom tool(s)`, { source: 'tool' });
+		} catch (error) {
+			logger.error(`Failed to load custom tools: ${String(error)}`, { source: 'tool' });
+			this._tools = {};
+		}
+	}
+
+	private _readSpec(filename: string): CustomToolSpec | null {
+		const filePath = join(this._toolsFolderPath, filename);
+		try {
+			const raw = readFileSync(filePath, 'utf8');
+			const parsed = JSON.parse(raw);
+
+			if (!parsed.name || !parsed.command) {
+				logger.warn(`Custom tool spec missing required fields (name, command): ${filename}`, { source: 'tool' });
+				return null;
+			}
+
+			return {
+				name: parsed.name,
+				description: parsed.description || '',
+				inputSchema: parsed.inputSchema || { type: 'object', properties: {} },
+				command: parsed.command,
+				args: parsed.args || [],
+				input: parsed.input === 'args' ? 'args' : 'stdin',
+				env: parsed.env || {},
+			};
+		} catch (error) {
+			logger.error(`Failed to parse custom tool spec ${filename}: ${String(error)}`, { source: 'tool' });
+			return null;
+		}
+	}
+
+	private _buildTool(spec: CustomToolSpec): Tool {
+		return {
+			description: spec.description,
+			inputSchema: jsonSchema(sanitizeTools(spec.inputSchema)),
+			execute: async (input: unknown) => {
+				return this._executeTool(spec, input);
+			},
+		} as Tool;
+	}
+
+	private _executeTool(spec: CustomToolSpec, input: unknown): Promise<unknown> {
+		return new Promise((resolve, reject) => {
+			const inputJson = JSON.stringify(input);
+			const args = spec.input === 'args' ? [...spec.args, inputJson] : [...spec.args];
+
+			const child = execFile(
+				spec.command,
+				args,
+				{
+					cwd: this._projectPath,
+					env: { ...process.env, ...spec.env },
+					timeout: 30_000,
+					maxBuffer: 10 * 1024 * 1024,
+				},
+				(error, stdout, stderr) => {
+					if (error) {
+						const message = stderr.trim() || error.message;
+						reject(new Error(`Custom tool "${spec.name}" failed: ${message}`));
+						return;
+					}
+
+					try {
+						resolve(JSON.parse(stdout));
+					} catch {
+						resolve({ output: stdout.trim() });
+					}
+				},
+			);
+
+			if (spec.input === 'stdin' && child.stdin) {
+				child.stdin.write(inputJson);
+				child.stdin.end();
+			}
+		});
+	}
+
+	private _setupFileWatcher(): void {
+		if (!this._toolsFolderPath || !existsSync(this._toolsFolderPath)) {
+			return;
+		}
+
+		try {
+			this._fileWatcher = watch(this._toolsFolderPath, { recursive: true }, (eventType) => {
+				if (eventType === 'change' || eventType === 'rename') {
+					this._debouncedReload();
+				}
+			});
+		} catch (error) {
+			logger.error(`Custom tools file watcher setup failed: ${String(error)}`, { source: 'tool' });
+		}
+	}
+}
+
+export const customToolService = new CustomToolService();

--- a/cli/nao_core/config/tools/__init__.py
+++ b/cli/nao_core/config/tools/__init__.py
@@ -1,0 +1,44 @@
+"""Custom tools configuration module."""
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from nao_core.ui import UI, ask_confirm
+
+from .template import generate_get_order_tool
+
+
+class ToolsConfig(BaseModel):
+    """Custom tools configuration."""
+
+    folder_path: str = Field(description="Path to the tools folder")
+
+    @classmethod
+    def promptConfig(cls, project_name: str) -> None:
+        """Prompt for custom tools configuration."""
+        folder_path = "./agent/tools/"
+
+        path = Path(folder_path).expanduser()
+        if not path.is_absolute():
+            base_path = Path(project_name) if project_name else Path.cwd()
+            absolute_path = (base_path / path).resolve()
+        else:
+            absolute_path = path.resolve()
+
+        if not absolute_path.exists():
+            absolute_path.mkdir(parents=True, exist_ok=True)
+
+            if ask_confirm(
+                "Setup tools folder with get-order example tool?",
+                default=True,
+            ):
+                tool_file = absolute_path / "get-order.json"
+                tool_file.write_text(json.dumps(generate_get_order_tool(), indent=2) + "\n")
+                UI.success(f"Created tools folder with get-order example: {absolute_path}")
+            else:
+                UI.success(f"Created empty tools folder: {absolute_path}")
+
+        elif not absolute_path.is_dir():
+            raise ValueError(f"Tools path exists but is not a directory: {absolute_path}")

--- a/cli/nao_core/config/tools/template.py
+++ b/cli/nao_core/config/tools/template.py
@@ -1,0 +1,18 @@
+"""Custom tools configuration template generator."""
+
+
+def generate_get_order_tool() -> dict:
+    """Generate example get-order tool spec."""
+    return {
+        "name": "get_order",
+        "description": "Get order details by order ID",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"order_id": {"type": "string", "description": "The order ID to look up"}},
+            "required": ["order_id"],
+        },
+        "command": "python",
+        "args": ["scripts/get_order.py"],
+        "input": "stdin",
+        "env": {},
+    }


### PR DESCRIPTION
#### Drop a JSON file in agent/tools/ and the agent can call it — no MCP server needed.

- Backend spawns the declared command, pipes input via stdin, reads JSON from stdout
- File watcher reloads on changes (same pattern as skills)
- Merges into existing getTools() alongside MCP tools
- CLI config module with optional example template

fix : #833