### PR TITLE
Wrap SQL queries in a nested list

### DIFF
--- a/apps/frontend/src/lib/ai.ts
+++ b/apps/frontend/src/lib/ai.ts
@@ -72,7 +72,6 @@ export const checkIsAgentRunning = (agent: Pick<UseChatHelpers<UIMessage>, 'stat
 /** Tools that should NOT be collapsed (important UI elements) */
 export const NON_COLLAPSIBLE_TOOLS: StaticToolName[] = [
 	'story',
-	'execute_sql',
 	'display_chart',
 	'suggest_follow_ups',
 	'clarification',


### PR DESCRIPTION
## Issue

Fixes #831

## Changes

This PR removes the `execute_sql` from the `NON_COLLAPSIBLE_TOOL` list in the `ai.ts` file, so that the SQL executions are grouped into the same tool container as other tool activity instead of rendering as standalone chat items.

The change was verified by running a script locally, which calls the `groupToolCalls()` with a resoning part and a tool-execute_sql part. The before and after outputs are shown below, verifing the wraping of SQL queries in a nested list like the other tool calls (i.e. the output will now become a single `tool-group` wrapper.

## Testing

Script runned to verify - 
```
bun -e "import { groupToolCalls } from './apps/frontend/src/lib/ai.ts'; const parts=[{type:'reasoning', text:'think', state:'completed'},{type:'tool-execute_sql', toolName:'execute_sql', toolCallId:'q1', state:'output-available', input:{}, output:{}}]; console.log(JSON.stringify(groupToolCalls(parts as any), null, 2));"
```

Output before the implementation

```
[
  {
    "type": "reasoning",
    "text": "think",
    "state": "completed"
  },
  {
    "type": "tool-execute_sql",
    "toolName": "execute_sql",
    "toolCallId": "q1",
    "state": "output-available",
    "input": {},
    "output": {}
  }
]
```

Output after the implementation

```
[
  {
    "type": "tool-group",
    "parts": [
      {
        "type": "reasoning",
        "text": "think",
        "state": "completed"
      },
      {
        "type": "tool-execute_sql",
        "toolName": "execute_sql",
        "toolCallId": "q1",
        "state": "output-available",
        "input": {},
        "output": {}
      }
    ]
  }
]
```

This PR was written with the help of Claude Opus 4.7
