### PR TITLE
feat(logs): date range filter, load-older pagination, expandable rows

### DIFF
--- a/apps/backend/src/queries/log.queries.ts
+++ b/apps/backend/src/queries/log.queries.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lt, or, SQL, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, isNull, lt, lte, or, SQL, sql } from 'drizzle-orm';
 
 import s, { NewLog } from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -17,6 +17,15 @@ export const listLogs = async (projectId: string, filter: LogFilter) => {
 	}
 	if (filter.source) {
 		conditions.push(eq(s.log.source, filter.source));
+	}
+	if (filter.before) {
+		conditions.push(lt(s.log.createdAt, filter.before));
+	}
+	if (filter.from) {
+		conditions.push(gte(s.log.createdAt, filter.from));
+	}
+	if (filter.to) {
+		conditions.push(lte(s.log.createdAt, filter.to));
 	}
 
 	return db

--- a/apps/backend/src/types/log.ts
+++ b/apps/backend/src/types/log.ts
@@ -10,5 +10,8 @@ export const logFilterSchema = z.object({
 	level: z.enum(LOG_LEVELS).optional(),
 	source: z.enum(LOG_SOURCES).optional(),
 	limit: z.number().int().min(1).max(500).default(100),
+	before: z.coerce.date().optional(),
+	from: z.coerce.date().optional(),
+	to: z.coerce.date().optional(),
 });
 export type LogFilter = z.infer<typeof logFilterSchema>;

--- a/apps/frontend/src/components/settings/logs-date-range-filter.tsx
+++ b/apps/frontend/src/components/settings/logs-date-range-filter.tsx
@@ -1,0 +1,191 @@
+import { useMemo, useState } from 'react';
+import DatePicker from 'react-datepicker';
+import { Calendar } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+
+import 'react-datepicker/dist/react-datepicker.css';
+
+export type LogsDateRange = {
+	from?: Date;
+	to?: Date;
+};
+
+type Preset = {
+	id: string;
+	label: string;
+	minutes: number;
+};
+
+const PRESETS: Preset[] = [
+	{ id: '15m', label: 'Last 15 minutes', minutes: 15 },
+	{ id: '1h', label: 'Last hour', minutes: 60 },
+	{ id: '24h', label: 'Last 24 hours', minutes: 60 * 24 },
+	{ id: '7d', label: 'Last 7 days', minutes: 60 * 24 * 7 },
+];
+
+type LogsDateRangeFilterProps = {
+	value: LogsDateRange | undefined;
+	onChange: (value: LogsDateRange | undefined) => void;
+};
+
+function formatDateTime(d: Date): string {
+	return d.toLocaleString(undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false,
+	});
+}
+
+function rangesEqual(a: LogsDateRange | undefined, b: LogsDateRange | undefined): boolean {
+	if (!a && !b) {
+		return true;
+	}
+	if (!a || !b) {
+		return false;
+	}
+	return a.from?.getTime() === b.from?.getTime() && a.to?.getTime() === b.to?.getTime();
+}
+
+export function LogsDateRangeFilter({ value, onChange }: LogsDateRangeFilterProps) {
+	const [open, setOpen] = useState(false);
+	const [customMode, setCustomMode] = useState(false);
+	const [customStart, setCustomStart] = useState<Date | null>(value?.from ?? null);
+	const [customEnd, setCustomEnd] = useState<Date | null>(value?.to ?? null);
+
+	const activePresetId = useMemo(() => {
+		if (!value?.from || value.to) {
+			return null;
+		}
+		const diffMs = Date.now() - value.from.getTime();
+		const preset = PRESETS.find((p) => Math.abs(diffMs - p.minutes * 60 * 1000) < 30 * 1000);
+		return preset?.id ?? null;
+	}, [value]);
+
+	const hasActiveFilter = Boolean(value?.from || value?.to);
+
+	const label = (() => {
+		if (!hasActiveFilter || !value) {
+			return 'All time';
+		}
+		if (activePresetId) {
+			return PRESETS.find((p) => p.id === activePresetId)?.label ?? 'Custom';
+		}
+		const fromStr = value.from ? formatDateTime(value.from) : '…';
+		const toStr = value.to ? formatDateTime(value.to) : 'now';
+		return `${fromStr} → ${toStr}`;
+	})();
+
+	const applyPreset = (preset: Preset) => {
+		const from = new Date(Date.now() - preset.minutes * 60 * 1000);
+		const next: LogsDateRange = { from };
+		if (!rangesEqual(value, next)) {
+			onChange(next);
+		}
+		setCustomMode(false);
+		setOpen(false);
+	};
+
+	const clearFilter = () => {
+		setCustomStart(null);
+		setCustomEnd(null);
+		setCustomMode(false);
+		onChange(undefined);
+		setOpen(false);
+	};
+
+	const applyCustom = (start: Date | null, end: Date | null) => {
+		setCustomStart(start);
+		setCustomEnd(end);
+		if (start && end) {
+			onChange({ from: start, to: end });
+		} else if (!start && !end) {
+			onChange(undefined);
+		}
+	};
+
+	return (
+		<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button variant='outline' size='sm' className={cn(hasActiveFilter && 'text-primary')}>
+					<Calendar className='size-3.5' />
+					<span className='truncate max-w-[220px]'>{label}</span>
+					{hasActiveFilter && (
+						<Badge variant='secondary' className='ml-1 h-4 px-1 text-[10px]'>
+							1
+						</Badge>
+					)}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align='end' className='w-auto p-0'>
+				<div className='px-2 pt-2 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide border-b border-border'>
+					Time range
+				</div>
+				{!customMode ? (
+					<div className='flex flex-col py-1 min-w-[200px]'>
+						{PRESETS.map((preset) => (
+							<button
+								key={preset.id}
+								type='button'
+								onClick={() => applyPreset(preset)}
+								className={cn(
+									'flex items-center justify-between gap-2 px-3 py-1.5 text-sm text-left hover:bg-accent hover:text-accent-foreground',
+									activePresetId === preset.id && 'text-primary',
+								)}
+							>
+								{preset.label}
+							</button>
+						))}
+						<button
+							type='button'
+							onClick={() => setCustomMode(true)}
+							className='flex items-center justify-between gap-2 px-3 py-1.5 text-sm text-left hover:bg-accent hover:text-accent-foreground'
+						>
+							Custom range…
+						</button>
+					</div>
+				) : (
+					<div className='p-2'>
+						<DatePicker
+							selected={customStart}
+							startDate={customStart ?? undefined}
+							endDate={customEnd ?? undefined}
+							selectsRange
+							showTimeSelect
+							timeIntervals={15}
+							dateFormat='MMM d, HH:mm'
+							onChange={(range: [Date | null, Date | null]) => {
+								const [start, end] = range ?? [null, null];
+								applyCustom(start, end);
+							}}
+							inline
+							popperProps={{ strategy: 'fixed' }}
+							calendarClassName='react-datepicker--no-shadow chats-replay-datepicker'
+						/>
+					</div>
+				)}
+				<div className='flex items-center justify-between gap-2 border-t border-border px-2 py-2'>
+					<button
+						type='button'
+						onClick={() => setCustomMode((m) => !m)}
+						className='text-xs text-muted-foreground hover:text-foreground'
+					>
+						{customMode ? 'Back to presets' : 'Custom range'}
+					</button>
+					<button
+						type='button'
+						className='text-right px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground'
+						onClick={clearFilter}
+					>
+						Show all
+					</button>
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/apps/frontend/src/components/settings/logs-date-range-filter.tsx
+++ b/apps/frontend/src/components/settings/logs-date-range-filter.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import DatePicker from 'react-datepicker';
 import { Calendar } from 'lucide-react';
 
@@ -57,6 +57,19 @@ export function LogsDateRangeFilter({ value, onChange }: LogsDateRangeFilterProp
 	const [customMode, setCustomMode] = useState(false);
 	const [customStart, setCustomStart] = useState<Date | null>(value?.from ?? null);
 	const [customEnd, setCustomEnd] = useState<Date | null>(value?.to ?? null);
+	const prevValueRef = useRef<LogsDateRange | undefined>(value);
+
+	useEffect(() => {
+		const prev = prevValueRef.current;
+		const sameFrom = prev?.from?.getTime() === value?.from?.getTime();
+		const sameTo = prev?.to?.getTime() === value?.to?.getTime();
+		prevValueRef.current = value;
+		if (sameFrom && sameTo) {
+			return;
+		}
+		setCustomStart(value?.from ?? null);
+		setCustomEnd(value?.to ?? null);
+	}, [value]);
 
 	const activePresetId = useMemo(() => {
 		if (!value?.from || value.to) {

--- a/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
@@ -67,6 +67,7 @@ function LogsPage() {
 	const terminalRef = useRef<HTMLDivElement>(null);
 	const loadingOlderRef = useRef(false);
 	const prevScrollHeightRef = useRef<number | null>(null);
+	const olderRequestIdRef = useRef(0);
 
 	const filterParams = useMemo(
 		() => ({
@@ -85,6 +86,9 @@ function LogsPage() {
 	});
 
 	useEffect(() => {
+		olderRequestIdRef.current += 1;
+		loadingOlderRef.current = false;
+		setIsLoadingOlder(false);
 		setOlderEntries([]);
 		setHasMoreOlder(true);
 		setExpandedIds(new Set());
@@ -128,6 +132,7 @@ function LogsPage() {
 		const oldest = sortedEntries[0];
 		const before = new Date(oldest.createdAt);
 
+		const requestId = ++olderRequestIdRef.current;
 		loadingOlderRef.current = true;
 		setIsLoadingOlder(true);
 		if (terminalRef.current) {
@@ -138,6 +143,9 @@ function LogsPage() {
 				...filterParams,
 				before,
 			})) as LogEntry[];
+			if (requestId !== olderRequestIdRef.current) {
+				return;
+			}
 			if (!data.length) {
 				setHasMoreOlder(false);
 				return;
@@ -158,8 +166,10 @@ function LogsPage() {
 		} catch {
 			// Keep hasMoreOlder true so the user can retry after a transient failure.
 		} finally {
-			loadingOlderRef.current = false;
-			setIsLoadingOlder(false);
+			if (requestId === olderRequestIdRef.current) {
+				loadingOlderRef.current = false;
+				setIsLoadingOlder(false);
+			}
 		}
 	}, [filterParams, hasMoreOlder, sortedEntries]);
 

--- a/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
@@ -26,6 +26,7 @@ const POLL_INTERVAL_MS = 5000;
 const MIN_REFRESH_MS = 400;
 const PAGE_SIZE = 200;
 const LOAD_MORE_TRIGGER_PX = 40;
+const DEFAULT_RANGE_MINUTES = 60;
 
 const LEVEL_STYLES: Record<LogLevel, string> = {
 	error: 'bg-red-500/10 text-red-500',
@@ -53,7 +54,9 @@ type LogEntry = {
 function LogsPage() {
 	const [level, setLevel] = useState<LogLevel | 'all'>('all');
 	const [source, setSource] = useState<LogSource | 'all'>('all');
-	const [range, setRange] = useState<LogsDateRange | undefined>(undefined);
+	const [range, setRange] = useState<LogsDateRange | undefined>(() => ({
+		from: new Date(Date.now() - DEFAULT_RANGE_MINUTES * 60 * 1000),
+	}));
 	const [olderEntries, setOlderEntries] = useState<LogEntry[]>([]);
 	const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 	const [isLoadingOlder, setIsLoadingOlder] = useState(false);

--- a/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
@@ -1,16 +1,19 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Copy, RefreshCw, Terminal } from 'lucide-react';
+import { ChevronDown, ChevronRight, Copy, Loader2, RefreshCw, Terminal } from 'lucide-react';
+import type { KeyboardEvent } from 'react';
 import type { LogLevel, LogSource } from '@nao/backend/log';
 
+import type { LogsDateRange } from '@/components/settings/logs-date-range-filter';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { SettingsCard, SettingsPageWrapper } from '@/components/ui/settings-card';
 import { TextShimmer } from '@/components/ui/text-shimmer';
+import { LogsDateRangeFilter } from '@/components/settings/logs-date-range-filter';
 import { cn } from '@/lib/utils';
-import { trpc } from '@/main';
+import { trpc, trpcClient } from '@/main';
 
 import { requireAdminNonCloud } from '@/lib/require-admin';
 
@@ -21,6 +24,8 @@ export const Route = createFileRoute('/_sidebar-layout/settings/logs')({
 
 const POLL_INTERVAL_MS = 5000;
 const MIN_REFRESH_MS = 400;
+const PAGE_SIZE = 200;
+const LOAD_MORE_TRIGGER_PX = 40;
 
 const LEVEL_STYLES: Record<LogLevel, string> = {
 	error: 'bg-red-500/10 text-red-500',
@@ -36,25 +41,63 @@ const SOURCE_STYLES: Record<string, string> = {
 	system: 'text-chart-4',
 };
 
+type LogEntry = {
+	id: string;
+	level: LogLevel;
+	source: LogSource;
+	message: string;
+	context?: Record<string, unknown> | null;
+	createdAt: string | Date;
+};
+
 function LogsPage() {
 	const [level, setLevel] = useState<LogLevel | 'all'>('all');
 	const [source, setSource] = useState<LogSource | 'all'>('all');
+	const [range, setRange] = useState<LogsDateRange | undefined>(undefined);
+	const [olderEntries, setOlderEntries] = useState<LogEntry[]>([]);
+	const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+	const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+	const [hasMoreOlder, setHasMoreOlder] = useState(true);
 	const [autoScroll, setAutoScroll] = useState(true);
 	const [showRefresh, setShowRefresh] = useState(false);
 	const [copied, setCopied] = useState(false);
 	const terminalRef = useRef<HTMLDivElement>(null);
+	const loadingOlderRef = useRef(false);
+	const prevScrollHeightRef = useRef<number | null>(null);
 
-	const logs = useQuery({
-		...trpc.log.listLogs.queryOptions({
+	const filterParams = useMemo(
+		() => ({
 			level: level === 'all' ? undefined : level,
 			source: source === 'all' ? undefined : source,
-			limit: 200,
+			from: range?.from,
+			to: range?.to,
+			limit: PAGE_SIZE,
 		}),
-		refetchInterval: POLL_INTERVAL_MS,
+		[level, source, range],
+	);
+
+	const logs = useQuery({
+		...trpc.log.listLogs.queryOptions(filterParams),
+		refetchInterval: range?.to ? false : POLL_INTERVAL_MS,
 	});
 
-	const entries = logs.data ?? [];
-	const sortedEntries = [...entries].reverse();
+	useEffect(() => {
+		setOlderEntries([]);
+		setHasMoreOlder(true);
+		setExpandedIds(new Set());
+	}, [filterParams]);
+
+	const sortedEntries = useMemo(() => {
+		const baseEntries = (logs.data ?? []) as LogEntry[];
+		const byId = new Map<string, LogEntry>();
+		for (const e of olderEntries) {
+			byId.set(e.id, e);
+		}
+		for (const e of baseEntries) {
+			byId.set(e.id, e);
+		}
+		return [...byId.values()].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+	}, [olderEntries, logs.data]);
 
 	useEffect(() => {
 		if (autoScroll && terminalRef.current) {
@@ -62,12 +105,70 @@ function LogsPage() {
 		}
 	}, [sortedEntries.length, autoScroll]);
 
+	useEffect(() => {
+		if (prevScrollHeightRef.current != null && terminalRef.current) {
+			const delta = terminalRef.current.scrollHeight - prevScrollHeightRef.current;
+			if (delta > 0) {
+				terminalRef.current.scrollTop = delta + terminalRef.current.scrollTop;
+			}
+			prevScrollHeightRef.current = null;
+		}
+	}, [olderEntries]);
+
+	const loadOlder = useCallback(async () => {
+		if (loadingOlderRef.current || !hasMoreOlder) {
+			return;
+		}
+		if (!sortedEntries.length) {
+			return;
+		}
+		const oldest = sortedEntries[0];
+		const before = new Date(oldest.createdAt);
+
+		loadingOlderRef.current = true;
+		setIsLoadingOlder(true);
+		if (terminalRef.current) {
+			prevScrollHeightRef.current = terminalRef.current.scrollHeight;
+		}
+		try {
+			const data = (await trpcClient.log.listLogs.query({
+				...filterParams,
+				before,
+			})) as LogEntry[];
+			if (!data.length) {
+				setHasMoreOlder(false);
+				return;
+			}
+			setOlderEntries((prev) => {
+				const map = new Map<string, LogEntry>();
+				for (const e of prev) {
+					map.set(e.id, e);
+				}
+				for (const e of data) {
+					map.set(e.id, e);
+				}
+				return [...map.values()];
+			});
+			if (data.length < PAGE_SIZE) {
+				setHasMoreOlder(false);
+			}
+		} catch {
+			setHasMoreOlder(false);
+		} finally {
+			loadingOlderRef.current = false;
+			setIsLoadingOlder(false);
+		}
+	}, [filterParams, hasMoreOlder, sortedEntries]);
+
 	const handleScroll = () => {
 		if (!terminalRef.current) {
 			return;
 		}
 		const { scrollTop, scrollHeight, clientHeight } = terminalRef.current;
 		setAutoScroll(scrollHeight - scrollTop - clientHeight < 40);
+		if (scrollTop <= LOAD_MORE_TRIGGER_PX && hasMoreOlder && !loadingOlderRef.current) {
+			void loadOlder();
+		}
 	};
 
 	const handleRefresh = useCallback(() => {
@@ -75,6 +176,18 @@ function LogsPage() {
 		logs.refetch();
 		setTimeout(() => setShowRefresh(false), MIN_REFRESH_MS);
 	}, [logs]);
+
+	const toggleExpand = useCallback((id: string) => {
+		setExpandedIds((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) {
+				next.delete(id);
+			} else {
+				next.add(id);
+			}
+			return next;
+		});
+	}, []);
 
 	const handleCopy = useCallback(async () => {
 		if (!sortedEntries.length) {
@@ -113,7 +226,7 @@ function LogsPage() {
 	return (
 		<SettingsPageWrapper>
 			<SettingsCard title='Logs' titleSize='lg' description='Real-time backend logs with auto-refresh.'>
-				<div className='flex items-center gap-2'>
+				<div className='flex items-center gap-2 flex-wrap'>
 					<Select value={level} onValueChange={(v) => setLevel(v as LogLevel | 'all')}>
 						<SelectTrigger size='sm'>
 							<SelectValue />
@@ -139,6 +252,8 @@ function LogsPage() {
 							<SelectItem value='system'>System</SelectItem>
 						</SelectContent>
 					</Select>
+
+					<LogsDateRangeFilter value={range} onChange={setRange} />
 
 					<div className='flex-1' />
 
@@ -191,38 +306,147 @@ function LogsPage() {
 						</div>
 					) : (
 						<div className='flex flex-col p-1'>
+							<LoadMoreHeader isLoading={isLoadingOlder} hasMore={hasMoreOlder} onClick={loadOlder} />
 							{sortedEntries.map((entry) => (
-								<div
+								<LogRow
 									key={entry.id}
-									className='flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors'
-								>
-									<span className='text-muted-foreground shrink-0 tabular-nums'>
-										{formatTimestamp(entry.createdAt)}
-									</span>
-									<Badge
-										variant='ghost'
-										className={cn(
-											'uppercase text-[10px] px-1.5 py-0 rounded-md font-semibold shrink-0',
-											LEVEL_STYLES[entry.level],
-										)}
-									>
-										{entry.level}
-									</Badge>
-									<span
-										className={cn(
-											'text-[10px] shrink-0 font-medium',
-											SOURCE_STYLES[entry.source] ?? 'text-muted-foreground',
-										)}
-									>
-										{entry.source}
-									</span>
-									<span className='text-foreground/80 truncate'>{entry.message}</span>
-								</div>
+									entry={entry}
+									expanded={expandedIds.has(entry.id)}
+									onToggle={() => toggleExpand(entry.id)}
+									formatTimestamp={formatTimestamp}
+								/>
 							))}
 						</div>
 					)}
 				</div>
 			</SettingsCard>
 		</SettingsPageWrapper>
+	);
+}
+
+type LoadMoreHeaderProps = {
+	isLoading: boolean;
+	hasMore: boolean;
+	onClick: () => void;
+};
+
+function LoadMoreHeader({ isLoading, hasMore, onClick }: LoadMoreHeaderProps) {
+	if (!hasMore) {
+		return (
+			<div className='flex items-center justify-center gap-2 py-2 text-[11px] text-muted-foreground'>
+				No more older logs
+			</div>
+		);
+	}
+	return (
+		<button
+			type='button'
+			onClick={onClick}
+			disabled={isLoading}
+			className='flex items-center justify-center gap-2 py-2 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors rounded-md cursor-pointer disabled:cursor-default'
+		>
+			{isLoading ? (
+				<>
+					<Loader2 className='size-3 animate-spin' />
+					Loading older logs…
+				</>
+			) : (
+				<>Pull down or click to load older logs</>
+			)}
+		</button>
+	);
+}
+
+type LogRowProps = {
+	entry: LogEntry;
+	expanded: boolean;
+	onToggle: () => void;
+	formatTimestamp: (ts: string | Date) => string;
+};
+
+function LogRow({ entry, expanded, onToggle, formatTimestamp }: LogRowProps) {
+	const messageRef = useRef<HTMLSpanElement>(null);
+	const [isTruncated, setIsTruncated] = useState(false);
+	const hasContext = Boolean(entry.context && Object.keys(entry.context).length);
+	const isClickable = isTruncated || hasContext;
+
+	useEffect(() => {
+		const el = messageRef.current;
+		if (!el) {
+			return;
+		}
+		setIsTruncated(el.scrollWidth > el.clientWidth + 1);
+	}, [entry.message]);
+
+	const handleClick = () => {
+		if (isClickable) {
+			onToggle();
+		}
+	};
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		if (!isClickable) {
+			return;
+		}
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			onToggle();
+		}
+	};
+
+	return (
+		<div
+			role={isClickable ? 'button' : undefined}
+			tabIndex={isClickable ? 0 : undefined}
+			aria-expanded={isClickable ? expanded : undefined}
+			onClick={handleClick}
+			onKeyDown={handleKeyDown}
+			className={cn(
+				'flex flex-col gap-1 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors',
+				isClickable && 'cursor-pointer',
+			)}
+		>
+			<div className='flex items-start gap-2'>
+				<span className='text-muted-foreground shrink-0 tabular-nums leading-5'>
+					{formatTimestamp(entry.createdAt)}
+				</span>
+				<Badge
+					variant='ghost'
+					className={cn(
+						'uppercase text-[10px] px-1.5 py-0 rounded-md font-semibold shrink-0 mt-0.5',
+						LEVEL_STYLES[entry.level],
+					)}
+				>
+					{entry.level}
+				</Badge>
+				<span
+					className={cn(
+						'text-[10px] shrink-0 font-medium leading-5',
+						SOURCE_STYLES[entry.source] ?? 'text-muted-foreground',
+					)}
+				>
+					{entry.source}
+				</span>
+				<span
+					ref={messageRef}
+					className={cn(
+						'text-foreground/80 min-w-0 flex-1',
+						expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
+					)}
+				>
+					{entry.message}
+				</span>
+				{isClickable && (
+					<span className='text-muted-foreground shrink-0 mt-0.5'>
+						{expanded ? <ChevronDown className='size-3.5' /> : <ChevronRight className='size-3.5' />}
+					</span>
+				)}
+			</div>
+			{expanded && hasContext && (
+				<pre className='mt-1 ml-[7.5rem] max-w-full overflow-x-auto rounded-md border border-border bg-muted/40 p-2 text-[11px] whitespace-pre-wrap break-words text-foreground/80'>
+					{JSON.stringify(entry.context, null, 2)}
+				</pre>
+			)}
+		</div>
 	);
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
@@ -378,8 +378,15 @@ function LogRow({ entry, expanded, onToggle, formatTimestamp }: LogRowProps) {
 		if (!el) {
 			return;
 		}
-		setIsTruncated(el.scrollWidth > el.clientWidth + 1);
-	}, [entry.message]);
+		if (expanded) {
+			return;
+		}
+		const measure = () => setIsTruncated(el.scrollWidth > el.clientWidth + 1);
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [entry.message, expanded]);
 
 	const handleClick = () => {
 		if (isClickable) {

--- a/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx
@@ -156,7 +156,7 @@ function LogsPage() {
 				setHasMoreOlder(false);
 			}
 		} catch {
-			setHasMoreOlder(false);
+			// Keep hasMoreOlder true so the user can retry after a transient failure.
 		} finally {
 			loadingOlderRef.current = false;
 			setIsLoadingOlder(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds three improvements to `settings/logs` plus a default filter to keep the initial page light:

1. **Pull older logs from the top** — a header inside the terminal area auto-loads older entries when scrolled near the top (or clicked). Pagination is cursor-based using the oldest visible timestamp.
2. **Time range filter** — new `LogsDateRangeFilter` dropdown with quick presets (15m, 1h, 24h, 7d) and a custom date+time range picker. **Defaults to "Last hour"** so the page only loads recent logs on first render.
3. **Expandable rows** — log rows whose message is truncated, or that carry contextual metadata, are now clickable. Expanding shows the full message (with wrapping) and a pretty-printed `context` JSON block. Truncation is detected via `ResizeObserver`, so chevrons appear/disappear correctly when the row's available width changes (window resize, sidebar collapse, etc.).

## Implementation notes

- **Backend** (`apps/backend/src/types/log.ts`, `apps/backend/src/queries/log.queries.ts`): `logFilterSchema` gains optional `before`, `from`, and `to` (`z.coerce.date()`); `listLogs` applies them via `lt` / `gte` / `lte`. Polling pauses while a closed (with `to`) date range is selected.
- **Frontend** (`apps/frontend/src/routes/_sidebar-layout.settings.logs.tsx`): rewrites the route to merge polled "latest" results with paginated "older" results in a deduped, ascending-sorted list. Scroll position is preserved when older rows are prepended. Initial range defaults to `{ from: now - 1h }`. `LogRow` measures truncation via a `ResizeObserver` on the message span and skips re-measurement while expanded so the expanded layout doesn't clobber the previously detected state.
- **Frontend** (`apps/frontend/src/components/settings/logs-date-range-filter.tsx`): new dropdown reusing existing UI primitives and the `chats-replay-datepicker` styles.

## Walkthrough

Default filter is "Last hour":
[logs_default_last_hour.mp4](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_default_last_hour.mp4)

[Toolbar showing Last hour as default filter](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_default_last_hour_toolbar.webp)
[Date range popover with Last hour highlighted](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_filter_popover_last_hour.webp)

Resize-aware truncation: chevrons stay correct as the window changes width.
[logs_resize_truncation_fix.mp4](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_resize_truncation_fix.mp4)

[Narrow window: short rows have no chevron, long row has chevron](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_resize_narrow.webp)
[Wide window: chevrons still match actual fit at the new width](https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flogs_resize_wide.webp)

## Testing

- `npm run lint` passes (tsc + eslint across backend, frontend, shared).
- `npm run format:check` passes.
- Backend test suite has pre-existing failures unrelated to this change (`tests/compaction.test.ts`, `tests/sqlite.test.ts`, `tests/system-prompt.test.ts`) — confirmed identical failures on `main`.
- Manually verified in browser: default "Last hour" preselected on load; rows correctly recompute truncation/clickability on window resize.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ca5a5c9-8040-46ba-828e-a0cb60c60ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

