### PR TITLE
Replace deprecated `gemini-3-pro-preview` with `gemini-3.1-pro-preview`

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -92,8 +92,8 @@ export const PROVIDER_META: ProviderMetaMap = {
 		summaryModelId: 'gemini-2.5-flash',
 		models: [
 			{
-				id: 'gemini-3-pro-preview',
-				name: 'Gemini 3 Pro',
+				id: 'gemini-3.1-pro-preview',
+				name: 'Gemini 3.1 Pro',
 				default: true,
 				contextWindow: 1_000_000,
 				costPerM: { inputNoCache: 2, inputCacheRead: 0.2, inputCacheWrite: 0, output: 12 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`gemini-3-pro-preview` has been deprecated. This PR swaps the default Google model in `apps/backend/src/agents/provider-meta.ts` to `gemini-3.1-pro-preview` (display name: "Gemini 3.1 Pro"), keeping it as the default for the `google` provider.

## Changes

- `apps/backend/src/agents/provider-meta.ts`: replace the `gemini-3-pro-preview` model entry with `gemini-3.1-pro-preview` / "Gemini 3.1 Pro"; pricing and context window unchanged.

## Testing

- `npm run lint` (tsc + eslint across backend/frontend/shared) — passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd6ff11d-d058-42c0-84b9-ecb727ac2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd6ff11d-d058-42c0-84b9-ecb727ac2895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

