### PR TITLE
Redirect to originally requested page after login/signup

### DIFF
--- a/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
+++ b/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
@@ -1,18 +1,21 @@
 import { useEffect } from 'react';
-import { useNavigate, useRouterState } from '@tanstack/react-router';
+import { useNavigate, useRouter, useRouterState } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 
 import { useSession } from '@/lib/auth-client';
 import { useAuthRoute } from '@/hooks/use-auth-route';
+import { getSafeRedirectPath } from '@/lib/safe-redirect';
 import { trpc } from '@/main';
 
 const AUTH_ROUTES = ['/login', '/forgot-password', '/reset-password'];
 
 export const useSessionOrNavigateToIndexPage = () => {
 	const navigate = useNavigate();
+	const router = useRouter();
 	const session = useSession();
 	const navigation = useAuthRoute();
 	const pathname = useRouterState({ select: (s) => s.location.pathname });
+	const searchStr = useRouterState({ select: (s) => s.location.searchStr });
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
 	const isUserSignupEnabled = config.data?.enableUserSignup === true;
 
@@ -25,17 +28,33 @@ export const useSessionOrNavigateToIndexPage = () => {
 			AUTH_ROUTES.includes(pathname) || (pathname === '/signup' && isUserSignupEnabled);
 
 		if (!session.data && !canStayUnauthenticated) {
+			const redirect = getSafeRedirectPath(`${pathname}${searchStr ?? ''}`) ?? undefined;
 			if (pathname === '/signup') {
-				navigate({ to: '/login', search: { error: 'Sign up is disabled.' } });
+				navigate({ to: '/login', search: { error: 'Sign up is disabled.', redirect } });
 			} else {
-				navigate({ to: navigation });
+				navigate({ to: navigation, search: { redirect } });
 			}
 		}
 
 		if (session.data && (AUTH_ROUTES.includes(pathname) || pathname === '/signup')) {
-			navigate({ to: '/' });
+			const redirect = getSafeRedirectPath(new URLSearchParams(searchStr ?? '').get('redirect'));
+			if (redirect) {
+				router.history.push(redirect);
+			} else {
+				navigate({ to: '/' });
+			}
 		}
-	}, [session.isPending, session.data, config.isPending, navigate, navigation, pathname, isUserSignupEnabled]);
+	}, [
+		session.isPending,
+		session.data,
+		config.isPending,
+		navigate,
+		router,
+		navigation,
+		pathname,
+		searchStr,
+		isUserSignupEnabled,
+	]);
 
 	return {
 		...session,

--- a/apps/frontend/src/hooks/useRedirectIfSmtpNotSetup.ts
+++ b/apps/frontend/src/hooks/useRedirectIfSmtpNotSetup.ts
@@ -9,7 +9,7 @@ export function useRedirectIfSmtpNotSetup() {
 
 	useEffect(() => {
 		if (isSmtpSetup.data === false) {
-			navigate({ to: '/login', search: { error: undefined } });
+			navigate({ to: '/login', search: { error: undefined, redirect: undefined } });
 		}
 	}, [isSmtpSetup.data, navigate]);
 

--- a/apps/frontend/src/lib/safe-redirect.test.ts
+++ b/apps/frontend/src/lib/safe-redirect.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeRedirectPath } from './safe-redirect';
+
+describe('getSafeRedirectPath', () => {
+	it('returns null for empty / nullish values', () => {
+		expect(getSafeRedirectPath(undefined)).toBeNull();
+		expect(getSafeRedirectPath(null)).toBeNull();
+		expect(getSafeRedirectPath('')).toBeNull();
+	});
+
+	it('rejects non-rooted and protocol-relative paths', () => {
+		expect(getSafeRedirectPath('foo')).toBeNull();
+		expect(getSafeRedirectPath('https://evil.com/x')).toBeNull();
+		expect(getSafeRedirectPath('//evil.com/x')).toBeNull();
+		expect(getSafeRedirectPath('/\\evil.com')).toBeNull();
+	});
+
+	it('rejects auth pages, including with trailing slashes or different casing', () => {
+		expect(getSafeRedirectPath('/login')).toBeNull();
+		expect(getSafeRedirectPath('/login/')).toBeNull();
+		expect(getSafeRedirectPath('/login//')).toBeNull();
+		expect(getSafeRedirectPath('/Login')).toBeNull();
+		expect(getSafeRedirectPath('/LOGIN/')).toBeNull();
+		expect(getSafeRedirectPath('/signup')).toBeNull();
+		expect(getSafeRedirectPath('/signup/?foo=bar')).toBeNull();
+		expect(getSafeRedirectPath('/forgot-password#hash')).toBeNull();
+		expect(getSafeRedirectPath('/reset-password')).toBeNull();
+	});
+
+	it('passes through safe in-app paths and preserves the original value', () => {
+		expect(getSafeRedirectPath('/')).toBe('/');
+		expect(getSafeRedirectPath('/settings/account')).toBe('/settings/account');
+		expect(getSafeRedirectPath('/settings/account?tab=profile')).toBe('/settings/account?tab=profile');
+		expect(getSafeRedirectPath('/some-chat-id#section')).toBe('/some-chat-id#section');
+		expect(getSafeRedirectPath('/login-history')).toBe('/login-history');
+	});
+});

--- a/apps/frontend/src/lib/safe-redirect.ts
+++ b/apps/frontend/src/lib/safe-redirect.ts
@@ -1,0 +1,23 @@
+const AUTH_PATHS = new Set(['/login', '/signup', '/forgot-password', '/reset-password']);
+
+/**
+ * Returns a redirect target only when it is a safe in-app path. Rejects
+ * external URLs, protocol-relative paths, and the auth pages themselves to
+ * avoid redirect loops.
+ */
+export function getSafeRedirectPath(value: string | undefined | null): string | null {
+	if (!value) {
+		return null;
+	}
+	if (!value.startsWith('/')) {
+		return null;
+	}
+	if (value.startsWith('//') || value.startsWith('/\\')) {
+		return null;
+	}
+	const pathname = value.split(/[?#]/, 1)[0];
+	if (AUTH_PATHS.has(pathname)) {
+		return null;
+	}
+	return value;
+}

--- a/apps/frontend/src/lib/safe-redirect.ts
+++ b/apps/frontend/src/lib/safe-redirect.ts
@@ -16,7 +16,8 @@ export function getSafeRedirectPath(value: string | undefined | null): string | 
 		return null;
 	}
 	const pathname = value.split(/[?#]/, 1)[0];
-	if (AUTH_PATHS.has(pathname)) {
+	const normalized = pathname.toLowerCase().replace(/\/+$/, '') || '/';
+	if (AUTH_PATHS.has(normalized)) {
 		return null;
 	}
 	return value;

--- a/apps/frontend/src/routes/forgot-password.tsx
+++ b/apps/frontend/src/routes/forgot-password.tsx
@@ -42,7 +42,11 @@ function ForgotPassword() {
 					If an account exists for that email, we sent a password reset link. Check your spam folder if you
 					don't see it.
 				</p>
-				<Link to='/login' search={{ error: undefined }} className='text-sm underline underline-offset-4'>
+				<Link
+					to='/login'
+					search={{ error: undefined, redirect: undefined }}
+					className='text-sm underline underline-offset-4'
+				>
 					Back to login
 				</Link>
 			</div>
@@ -53,7 +57,11 @@ function ForgotPassword() {
 		<AuthForm form={form} title='Forgot password' submitText='Send reset link' serverError={serverError}>
 			<FormTextField form={form} name='email' type='email' placeholder='Email' />
 			<div className='text-right'>
-				<Link to='/login' search={{ error: undefined }} className='text-sm underline underline-offset-4'>
+				<Link
+					to='/login'
+					search={{ error: undefined, redirect: undefined }}
+					className='text-sm underline underline-offset-4'
+				>
 					Back to login
 				</Link>
 			</div>

--- a/apps/frontend/src/routes/login.tsx
+++ b/apps/frontend/src/routes/login.tsx
@@ -1,14 +1,16 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate, useRouter } from '@tanstack/react-router';
 import { useForm } from '@tanstack/react-form';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { signIn } from '@/lib/auth-client';
 import { AuthForm, FormTextField } from '@/components/auth-form';
+import { getSafeRedirectPath } from '@/lib/safe-redirect';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/login')({
 	validateSearch: (search: Record<string, unknown>) => ({
 		error: typeof search.error === 'string' ? search.error : undefined,
+		redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
 	}),
 	component: Login,
 });
@@ -23,7 +25,8 @@ function buildOAuthAuthorizeUrl() {
 
 function Login() {
 	const navigate = useNavigate();
-	const { error: oauthError } = Route.useSearch();
+	const router = useRouter();
+	const { error: oauthError, redirect } = Route.useSearch();
 	const [serverError, setServerError] = useState<string | undefined>(oauthError);
 	const isSmtpSetup = useQuery(trpc.authConfig.smtp.isSetup.queryOptions());
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
@@ -32,6 +35,7 @@ function Login() {
 	const isUserSignupEnabled = config.data?.enableUserSignup;
 
 	const oauthAuthorizeUrl = buildOAuthAuthorizeUrl();
+	const safeRedirect = getSafeRedirectPath(redirect);
 
 	const form = useForm({
 		defaultValues: { email: '', password: '' },
@@ -44,6 +48,8 @@ function Login() {
 				onSuccess: () => {
 					if (oauthAuthorizeUrl) {
 						window.location.href = oauthAuthorizeUrl;
+					} else if (safeRedirect) {
+						router.history.push(safeRedirect);
 					} else {
 						navigate({ to: '/' });
 					}
@@ -60,7 +66,7 @@ function Login() {
 			submitText='Log In'
 			serverError={serverError}
 			displaySocialProviders={true}
-			socialCallbackUrl={oauthAuthorizeUrl ?? undefined}
+			socialCallbackUrl={oauthAuthorizeUrl ?? safeRedirect ?? undefined}
 			displayEmailPasswordForm={isUserLoginEnabled}
 			emailPasswordDisabledMessage='Email and password login is disabled. Use a configured sign-in provider to continue.'
 			footer={
@@ -69,7 +75,7 @@ function Login() {
 						Don&apos;t have an account?{' '}
 						<Link
 							to='/signup'
-							search={{ error: undefined }}
+							search={{ error: undefined, redirect: safeRedirect ?? undefined }}
 							className='text-foreground underline underline-offset-4'
 						>
 							Sign up

--- a/apps/frontend/src/routes/reset-password.tsx
+++ b/apps/frontend/src/routes/reset-password.tsx
@@ -31,7 +31,7 @@ function ResetPassword() {
 			if (error) {
 				setServerError(error.message);
 			} else {
-				navigate({ to: '/login', search: { error: undefined } });
+				navigate({ to: '/login', search: { error: undefined, redirect: undefined } });
 			}
 		},
 	});

--- a/apps/frontend/src/routes/signup.tsx
+++ b/apps/frontend/src/routes/signup.tsx
@@ -1,31 +1,41 @@
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate, useRouter } from '@tanstack/react-router';
 import { useForm } from '@tanstack/react-form';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { signUp } from '@/lib/auth-client';
 import { AuthForm, FormTextField } from '@/components/auth-form';
+import { getSafeRedirectPath } from '@/lib/safe-redirect';
 import { trpc } from '@/main';
 
 export const Route = createFileRoute('/signup')({
 	validateSearch: (search: Record<string, unknown>) => ({
 		error: typeof search.error === 'string' ? search.error : undefined,
+		redirect: typeof search.redirect === 'string' ? search.redirect : undefined,
 	}),
 	component: SignUp,
 });
 
 function SignUp() {
 	const navigate = useNavigate();
-	const { error: oauthError } = Route.useSearch();
+	const router = useRouter();
+	const { error: oauthError, redirect } = Route.useSearch();
 	const [serverError, setServerError] = useState<string | undefined>(oauthError);
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
 	const isUserSignupEnabled = config.data?.enableUserSignup === true;
+	const safeRedirect = getSafeRedirectPath(redirect);
 
 	const form = useForm({
 		defaultValues: { name: '', email: '', password: '', requiresPasswordReset: false, messagingProviderCode: '' },
 		onSubmit: async ({ value }) => {
 			setServerError(undefined);
 			await signUp.email(value, {
-				onSuccess: () => navigate({ to: '/' }),
+				onSuccess: () => {
+					if (safeRedirect) {
+						router.history.push(safeRedirect);
+					} else {
+						navigate({ to: '/' });
+					}
+				},
 				onError: (err) => setServerError(err.error.message),
 			});
 		},
@@ -33,9 +43,13 @@ function SignUp() {
 
 	useEffect(() => {
 		if (config.data && !isUserSignupEnabled) {
-			navigate({ to: '/login', search: { error: 'Sign up is disabled.' }, replace: true });
+			navigate({
+				to: '/login',
+				search: { error: 'Sign up is disabled.', redirect: safeRedirect ?? undefined },
+				replace: true,
+			});
 		}
-	}, [config.data, isUserSignupEnabled, navigate]);
+	}, [config.data, isUserSignupEnabled, navigate, safeRedirect]);
 
 	if (config.isLoading) {
 		return null;
@@ -52,12 +66,13 @@ function SignUp() {
 			submitText='Sign Up'
 			serverError={serverError}
 			displaySocialProviders={true}
+			socialCallbackUrl={safeRedirect ?? undefined}
 			footer={
 				<>
 					Already have an account?{' '}
 					<Link
 						to='/login'
-						search={{ error: undefined }}
+						search={{ error: undefined, redirect: safeRedirect ?? undefined }}
 						className='text-foreground underline underline-offset-4'
 					>
 						Log in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When an unauthenticated user tried to reach a protected nao page (for example `/settings/account` or a chat URL), they were bounced to `/login` (or `/signup`) and, on successful auth, **always** landed on `/` instead of the page they were originally aiming for.

The post-auth redirect was hard-coded to `/` everywhere — there was no `redirect` / `next` / `from` query parameter handled in the auth flow.

## Fix

Capture the originally-requested pathname+search as a `redirect` query parameter when the session guard bounces an unauthenticated user to the auth page, and use it as the post-auth destination across every entry point:

- `useSessionOrNavigateToIndexPage` writes `redirect=<original-path>` when redirecting to `/login` or `/signup`, and uses it to navigate after a logged-in user lands on an auth page (covers OAuth social `callbackURL` returning to `/login`).
- `/login` and `/signup` `validateSearch` accept `redirect`, and the email/password `onSuccess` handlers navigate to that target.
- Social login buttons receive the same target via `socialCallbackUrl`, so Google/GitHub/Microsoft sign-in returns to the right page.
- The "Sign up" / "Log in" cross-links between auth pages preserve `redirect` so flipping between forms doesn't lose context.

The redirect value is sanitised by `getSafeRedirectPath`: only same-origin in-app paths are allowed (rejects `//evil.com`, `/\evil`, external URLs, and the auth pages themselves) to avoid open redirects and redirect loops. The auth-page check normalizes the pathname (lowercase + strip trailing slashes) so crafted values like `/login/`, `/login//`, or `/Login` cannot bypass the block. Behavior covered by `safe-redirect.test.ts`.

The OAuth `client_id` flow on `/login` still wins over a `redirect` param (existing behaviour preserved).

## Walkthrough

[demo_login_redirects_to_originally_requested_page.mp4](https://cursor.com/agents/bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_login_redirects_to_originally_requested_page.mp4)

Logged-out user navigates to `/settings/account` → bounced to `/login?redirect=%2Fsettings%2Faccount` → after login, lands on `/settings/account` (not `/`).

[Login URL preserves the originally requested path](https://cursor.com/agents/bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_login_url_with_redirect.webp)
[After login the user lands on /settings/account](https://cursor.com/agents/bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_landed_on_settings_after_login.webp)
[Signup URL also preserves the redirect parameter](https://cursor.com/agents/bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_signup_url_preserves_redirect.webp)

## Files changed

- `apps/frontend/src/lib/safe-redirect.ts` (new) — `getSafeRedirectPath` helper with normalized auth-path matching.
- `apps/frontend/src/lib/safe-redirect.test.ts` (new) — unit tests for the helper.
- `apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx` — capture/honor `redirect`.
- `apps/frontend/src/routes/login.tsx` — accept `redirect` search, post-auth navigation.
- `apps/frontend/src/routes/signup.tsx` — accept `redirect` search, post-auth navigation.
- `apps/frontend/src/routes/forgot-password.tsx`, `reset-password.tsx`, `hooks/useRedirectIfSmtpNotSetup.ts` — keep search-typed `Link`/`navigate` calls compiling against the new schema.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd8fd880-af23-4d99-a2ad-81c89ef0242e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

