### PR TITLE
feat(cli): allow nao test -s to accept multiple test names

### DIFF
--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -285,20 +285,30 @@ def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
     return output_file
 
 
-def filter_test_cases(test_cases: list[TestCase], selected_test: str | None) -> list[TestCase]:
-    """Filter test cases to a single selected test, if provided."""
-    if not selected_test:
+def filter_test_cases(test_cases: list[TestCase], selected_tests: str | None) -> list[TestCase]:
+    """Filter test cases to the selected tests, if provided."""
+    if not selected_tests:
         return test_cases
 
-    matches = [tc for tc in test_cases if tc.name == selected_test or tc.file_path.stem == selected_test]
-    if not matches:
-        available = ", ".join(tc.name for tc in test_cases)
-        raise ValueError(f"Test not found: {selected_test}. Available tests: {available}")
-    if len(matches) > 1:
-        names = ", ".join(f"{tc.name} ({tc.file_path.name})" for tc in matches)
-        raise ValueError(f"Multiple tests match '{selected_test}': {names}")
+    selections = [s.strip() for s in selected_tests.split(",") if s.strip()]
 
-    return [matches[0]]
+    selected: list[TestCase] = []
+    seen: set[Path] = set()
+    for selection in selections:
+        matches = [tc for tc in test_cases if tc.name == selection or tc.file_path.stem == selection]
+        if not matches:
+            available = ", ".join(tc.name for tc in test_cases)
+            raise ValueError(f"Test not found: {selection}. Available tests: {available}")
+        if len(matches) > 1:
+            names = ", ".join(f"{tc.name} ({tc.file_path.name})" for tc in matches)
+            raise ValueError(f"Multiple tests match '{selection}': {names}")
+        match = matches[0]
+        if match.file_path in seen:
+            continue
+        seen.add(match.file_path)
+        selected.append(match)
+
+    return selected
 
 
 def test(
@@ -320,7 +330,7 @@ def test(
         str | None,
         Parameter(
             name=["-s", "--select"],
-            help="Run only one test by name or yaml filename stem.",
+            help="Run only the selected tests by name or yaml filename stem. Comma-separated (e.g. '12,13,14').",
         ),
     ] = None,
     username: Annotated[
@@ -346,6 +356,7 @@ def test(
         nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
         nao test --threads 4
         nao test -s test_name
+        nao test -s 12,13,14
         nao test -u user@example.com --password secret
     """
     email = username or os.environ.get("NAO_USERNAME")

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -291,6 +291,9 @@ def filter_test_cases(test_cases: list[TestCase], selected_tests: str | None) ->
         return test_cases
 
     selections = [s.strip() for s in selected_tests.split(",") if s.strip()]
+    if not selections:
+        available = ", ".join(tc.name for tc in test_cases)
+        raise ValueError(f"Test not found: {selected_tests}. Available tests: {available}")
 
     selected: list[TestCase] = []
     seen: set[Path] = set()

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -93,6 +93,38 @@ def test_filter_test_cases_missing():
         filter_test_cases(test_cases, "missing")
 
 
+def test_filter_test_cases_comma_separated():
+    test_cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1"),
+        NaoTestCase(name="users", prompt="p2", file_path=Path("tests/users.yml"), sql="select 1"),
+        NaoTestCase(name="revenue", prompt="p3", file_path=Path("tests/revenue.yml"), sql="select 1"),
+    ]
+
+    filtered = filter_test_cases(test_cases, "orders,revenue")
+
+    assert [tc.name for tc in filtered] == ["orders", "revenue"]
+
+
+def test_filter_test_cases_comma_separated_deduplicates():
+    test_cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1"),
+        NaoTestCase(name="users", prompt="p2", file_path=Path("tests/users.yml"), sql="select 1"),
+    ]
+
+    filtered = filter_test_cases(test_cases, "orders, orders ,users")
+
+    assert [tc.name for tc in filtered] == ["orders", "users"]
+
+
+def test_filter_test_cases_comma_separated_missing():
+    test_cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1"),
+    ]
+
+    with pytest.raises(ValueError, match="Test not found: missing"):
+        filter_test_cases(test_cases, "orders,missing")
+
+
 def test_serialize_model_costs_uses_backend_field_names():
     costs = ModelCosts(
         input_no_cache=1.0,


### PR DESCRIPTION
Closes #842.

-s now accepts a comma-separated list, e.g. nao test -s 12,13,14. Single-value usage (-s foo) is unchanged. Order of selections is preserved, duplicates and surrounding whitespace are tolerated, and an unknown name still errors with the available-tests list.

Implementation is a small change to filter_test_cases in runner.py plus three unit tests covering the new behavior. No changes to run_test, save_results, the output JSON schema, or the summary table.

Verified locally:

cd cli && uv run ty check, ruff check, ruff format --check → clean
cd cli && uv run pytest tests/nao_core/commands/test_runner.py → 11/11 passing
End-to-end against the agent backend in a temp project with three test YAMLs:
-s orders → 1 test
-s orders,users → 2 tests, in order
-s orders,revenue,users → 3 tests
-s orders,nope → Test not found: nope. Available tests: orders, revenue, users
-s " orders , orders , users " → 2 tests after strip + dedup
no -s → all 3 (unchanged behavior)

This PR was written using Claude Opus 4.7 (claude-opus-4-7).