### PR TITLE
fix(frontend): wrap long clarification suggestion pills

### DIFF
--- a/apps/frontend/src/components/tool-calls/clarification.tsx
+++ b/apps/frontend/src/components/tool-calls/clarification.tsx
@@ -79,10 +79,10 @@ export const ClarificationToolCall = memo(({ toolPart }: ToolCallComponentProps<
 								size='sm'
 								disabled={!canSubmit && !isSelected}
 								onClick={() => handleSelect(option)}
-								className='rounded-full'
+								className='rounded-2xl h-auto min-h-7 max-w-full whitespace-normal py-1 text-left'
 							>
-								{isSelected && <Check className='size-3.5' />}
-								<span className='truncate max-w-[28ch]'>{option}</span>
+								{isSelected && <Check className='size-3.5 shrink-0' />}
+								<span className='break-words whitespace-normal'>{option}</span>
 							</Button>
 						);
 					})}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the agent produces clarification suggestion options whose text is longer than ~28 characters, the pill buttons in `ClarificationToolCall` were truncated with an ellipsis (e.g. `Use collection downloads as a p...`), making them unreadable.

This was caused by the inner span using `truncate max-w-[28ch]`, combined with the button's default `whitespace-nowrap` and fixed `h-7` height.

## Fix

Allow each pill to grow vertically and wrap its text onto multiple lines so the user can read the full option:

- Drop `truncate max-w-[28ch]` on the option text.
- On the button, override `whitespace-nowrap` with `whitespace-normal`, allow it to grow with `h-auto min-h-7`, cap at `max-w-full`, left-align the text, and switch from `rounded-full` to `rounded-2xl` (looks consistent for both single- and multi-line pills).
- Add `shrink-0` to the check icon and `break-words whitespace-normal` to the text span for safe wrapping.

## Walkthrough

[clarification_pills_multiline_demo.mp4](https://cursor.com/agents/bc-5cdc9306-f2ab-44bb-9664-77fcc34ed72c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclarification_pills_multiline_demo.mp4)

Single-line behavior preserved when there is enough horizontal space:

[Pills full text without truncation](https://cursor.com/agents/bc-5cdc9306-f2ab-44bb-9664-77fcc34ed72c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclarification_pills_multiline_after.png)

Multi-line wrap kicks in inside narrow containers (no more ellipses):

[Pills wrapping to multiple lines in narrow container](https://cursor.com/agents/bc-5cdc9306-f2ab-44bb-9664-77fcc34ed72c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclarification_pills_narrow_xs_multiline.png)

## Testing

- `npm run lint` (backend, frontend, shared) — passes.
- Manually rendered the component via a temporary preview route at `/embed/clarification-preview` (since removed) at multiple container widths to verify both single-line and multi-line behavior.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cdc9306-f2ab-44bb-9664-77fcc34ed72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cdc9306-f2ab-44bb-9664-77fcc34ed72c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

