### PR TITLE
feat(cli): support HTTPS/TLS + JWT bearer auth in the Trino connector

### DIFF
--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -132,16 +132,39 @@ class TrinoConfig(DatabaseConfig):
     user: str = Field(description="Username")
     schema_name: str | None = Field(default=None, description="Default schema (optional)")
     password: str | None = Field(default=None, description="Password (optional)")
+    http_scheme: Literal["http", "https"] = Field(
+        default="http",
+        description="HTTP scheme used to reach the coordinator. Default 'http' preserves prior behaviour.",
+    )
+    verify: bool | str = Field(
+        default=True,
+        description=(
+            "TLS verification when http_scheme='https'. "
+            "True = verify with system CAs, False = disable verification, "
+            "str = path to a CA bundle. Ignored for plain http."
+        ),
+    )
 
     @classmethod
     def promptConfig(cls) -> "TrinoConfig":
         """Interactively prompt the user for Trino configuration."""
         name = ask_text("Connection name:", default="trino-prod") or "trino-prod"
         host = ask_text("Host:", default="localhost") or "localhost"
-        port_str = ask_text("Port:", default="8080") or "8080"
 
+        scheme_str = ask_text("Use HTTPS (y/n):", default="n") or "n"
+        use_https = scheme_str.strip().lower().startswith("y")
+        http_scheme: Literal["http", "https"] = "https" if use_https else "http"
+
+        default_port = "8443" if use_https else "8080"
+        port_str = ask_text("Port:", default=default_port) or default_port
         if not port_str.isdigit():
             raise InitError("Port must be a valid integer.")
+
+        verify: bool | str = True
+        if use_https:
+            ca_path = (ask_text("Custom CA bundle path (leave empty for system CAs):") or "").strip()
+            if ca_path:
+                verify = ca_path
 
         catalog = ask_text("Catalog name:", required_field=True)
         user = ask_text("Username:", required_field=True)
@@ -156,6 +179,8 @@ class TrinoConfig(DatabaseConfig):
             user=user,  # type: ignore[arg-type]
             password=password,
             schema_name=schema_name,
+            http_scheme=http_scheme,
+            verify=verify,
         )
 
     def connect(self) -> BaseBackend:
@@ -170,7 +195,11 @@ class TrinoConfig(DatabaseConfig):
             "port": self.port,
             "user": self.user,
             "database": self.catalog,
+            "http_scheme": self.http_scheme,
         }
+
+        if self.http_scheme == "https":
+            kwargs["verify"] = self.verify
 
         if self.schema_name:
             kwargs["schema"] = self.schema_name

--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -34,6 +34,12 @@ def _build_basic_auth(user: str, password: str):
     return BasicAuthentication(user, password)
 
 
+def _build_jwt_auth(token: str):
+    from trino.auth import JWTAuthentication
+
+    return JWTAuthentication(token)
+
+
 class TrinoDatabaseContext(DatabaseContext):
     """Trino context with table/column comment discovery via information_schema."""
 
@@ -144,6 +150,33 @@ class TrinoConfig(DatabaseConfig):
             "str = path to a CA bundle. Ignored for plain http."
         ),
     )
+    jwt_token: str | None = Field(
+        default=None,
+        description=(
+            "Bearer JWT for Trino's OAuth2/JWT authenticator. When set, takes "
+            "precedence over password and forces http_scheme='https'."
+        ),
+    )
+    jwt_token_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a file containing the Bearer JWT, re-read on every "
+            "connect(). Lets an external refresher rotate short-lived tokens "
+            "without rewriting the config. Takes precedence over jwt_token."
+        ),
+    )
+
+    def _resolve_jwt(self) -> str | None:
+        """Read the JWT from file (fresh each call) or fall back to the inline token."""
+        if self.jwt_token_file:
+            try:
+                with open(self.jwt_token_file, encoding="utf-8") as fh:
+                    token = fh.read().strip()
+                if token:
+                    return token
+            except OSError:
+                pass
+        return self.jwt_token
 
     @classmethod
     def promptConfig(cls) -> "TrinoConfig":
@@ -190,21 +223,29 @@ class TrinoConfig(DatabaseConfig):
         require_database_backend("trino")
         import ibis
 
+        jwt = self._resolve_jwt()
+        # A JWT requires TLS; force https so a stray http_scheme can't leak the
+        # bearer token over cleartext.
+        http_scheme = "https" if jwt else self.http_scheme
+
         kwargs: dict = {
             "host": self.host,
             "port": self.port,
             "user": self.user,
             "database": self.catalog,
-            "http_scheme": self.http_scheme,
+            "http_scheme": http_scheme,
         }
 
-        if self.http_scheme == "https":
+        if http_scheme == "https":
             kwargs["verify"] = self.verify
 
         if self.schema_name:
             kwargs["schema"] = self.schema_name
 
-        if self.password:
+        # Auth precedence: JWT (OAuth2/JWT authenticator) > basic password.
+        if jwt:
+            kwargs["auth"] = _build_jwt_auth(jwt)
+        elif self.password:
             kwargs["auth"] = _build_basic_auth(self.user, self.password)
 
         return ibis.trino.connect(**kwargs)

--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -167,7 +167,12 @@ class TrinoConfig(DatabaseConfig):
     )
 
     def _resolve_jwt(self) -> str | None:
-        """Read the JWT from file (fresh each call) or fall back to the inline token."""
+        """Read the JWT from file (fresh each call) or fall back to the inline token.
+
+        Both sources are stripped; a blank or whitespace-only value resolves to
+        None so it can't spuriously force https, enable JWT auth, or block the
+        password fallback.
+        """
         if self.jwt_token_file:
             try:
                 with open(self.jwt_token_file, encoding="utf-8") as fh:
@@ -176,7 +181,11 @@ class TrinoConfig(DatabaseConfig):
                     return token
             except OSError:
                 pass
-        return self.jwt_token
+        if self.jwt_token:
+            token = self.jwt_token.strip()
+            if token:
+                return token
+        return None
 
     @classmethod
     def promptConfig(cls) -> "TrinoConfig":

--- a/cli/tests/nao_core/config/test_trino.py
+++ b/cli/tests/nao_core/config/test_trino.py
@@ -275,6 +275,24 @@ def test_connect_jwt_uses_jwt_auth_and_forces_https(base_config: TrinoConfig) ->
     assert isinstance(call_kw.get("auth"), JWTAuthentication)
 
 
+def test_connect_blank_jwt_token_is_ignored(base_config: TrinoConfig) -> None:
+    """A whitespace-only inline jwt_token must not force https, enable JWT auth,
+    or block the password fallback."""
+    from trino.auth import BasicAuthentication
+
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"jwt_token": "   \n", "password": "secret"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["http_scheme"] == "http"  # not forced to https by a blank token
+    assert isinstance(call_kw.get("auth"), BasicAuthentication)  # password fallback intact
+
+
 def test_connect_jwt_takes_precedence_over_password(base_config: TrinoConfig) -> None:
     from trino.auth import JWTAuthentication
 

--- a/cli/tests/nao_core/config/test_trino.py
+++ b/cli/tests/nao_core/config/test_trino.py
@@ -257,3 +257,57 @@ def test_connect_http_ignores_verify_field(base_config: TrinoConfig) -> None:
     call_kw = mock_connect.call_args.kwargs
     assert call_kw["http_scheme"] == "http"
     assert "verify" not in call_kw
+
+
+def test_connect_jwt_uses_jwt_auth_and_forces_https(base_config: TrinoConfig) -> None:
+    from trino.auth import JWTAuthentication
+
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"jwt_token": "eyJhbGciOi.payload.sig"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["http_scheme"] == "https"  # forced even though base_config is http
+    assert isinstance(call_kw.get("auth"), JWTAuthentication)
+
+
+def test_connect_jwt_takes_precedence_over_password(base_config: TrinoConfig) -> None:
+    from trino.auth import JWTAuthentication
+
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"jwt_token": "tok", "password": "secret"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    assert isinstance(mock_connect.call_args.kwargs.get("auth"), JWTAuthentication)
+
+
+def test_connect_jwt_token_file_is_read_fresh(base_config: TrinoConfig, tmp_path) -> None:
+    from trino.auth import JWTAuthentication
+
+    token_file = tmp_path / "trino-token"
+    token_file.write_text("file-token-123")
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"jwt_token_file": str(token_file)})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    assert isinstance(mock_connect.call_args.kwargs.get("auth"), JWTAuthentication)
+    # Rotating the file is picked up on the next connect (fresh read).
+    token_file.write_text("rotated-token-456")
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+    assert mock_connect.call_count == 2

--- a/cli/tests/nao_core/config/test_trino.py
+++ b/cli/tests/nao_core/config/test_trino.py
@@ -302,12 +302,18 @@ def test_connect_jwt_token_file_is_read_fresh(base_config: TrinoConfig, tmp_path
     ):
         cfg.connect()
 
-    assert isinstance(mock_connect.call_args.kwargs.get("auth"), JWTAuthentication)
-    # Rotating the file is picked up on the next connect (fresh read).
+    first_auth = mock_connect.call_args.kwargs.get("auth")
+    assert isinstance(first_auth, JWTAuthentication)
+    assert first_auth.token == "file-token-123"
+
+    # Rotating the file must be picked up on the next connect — assert the
+    # bearer token actually changed, so a "read once and cache" bug fails.
     token_file.write_text("rotated-token-456")
     with (
         patch("nao_core.deps.require_database_backend"),
         patch("ibis.trino.connect", mock_connect),
     ):
         cfg.connect()
-    assert mock_connect.call_count == 2
+    second_auth = mock_connect.call_args.kwargs.get("auth")
+    assert isinstance(second_auth, JWTAuthentication)
+    assert second_auth.token == "rotated-token-456"

--- a/cli/tests/nao_core/config/test_trino.py
+++ b/cli/tests/nao_core/config/test_trino.py
@@ -190,3 +190,70 @@ def test_connect_includes_schema_when_set(base_config: TrinoConfig) -> None:
         cfg.connect()
 
     assert mock_connect.call_args.kwargs["schema"] == "analytics"
+
+
+def test_connect_defaults_to_http_scheme_without_verify(base_config: TrinoConfig) -> None:
+    """Default scheme is http (backwards-compatible); verify must not be forwarded."""
+    mock_connect = MagicMock()
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        base_config.connect()
+
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["http_scheme"] == "http"
+    assert "verify" not in call_kw
+
+
+def test_connect_https_forwards_verify_true_by_default(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"http_scheme": "https"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["http_scheme"] == "https"
+    assert call_kw["verify"] is True
+
+
+def test_connect_https_with_custom_ca_bundle_path(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"http_scheme": "https", "verify": "/etc/ssl/internal-ca.pem"})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    assert mock_connect.call_args.kwargs["verify"] == "/etc/ssl/internal-ca.pem"
+
+
+def test_connect_https_with_verify_disabled(base_config: TrinoConfig) -> None:
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"http_scheme": "https", "verify": False})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    assert mock_connect.call_args.kwargs["verify"] is False
+
+
+def test_connect_http_ignores_verify_field(base_config: TrinoConfig) -> None:
+    """Setting `verify` while scheme stays 'http' must not leak it into the connect call."""
+    mock_connect = MagicMock()
+    cfg = base_config.model_copy(update={"verify": False})
+    with (
+        patch("nao_core.deps.require_database_backend"),
+        patch("ibis.trino.connect", mock_connect),
+    ):
+        cfg.connect()
+
+    call_kw = mock_connect.call_args.kwargs
+    assert call_kw["http_scheme"] == "http"
+    assert "verify" not in call_kw


### PR DESCRIPTION
## Summary

`TrinoConfig.connect()` built the ibis kwargs without `http_scheme` or `verify`, so `trino-python-client` always defaulted to cleartext HTTP. HTTPS-only coordinators (Stackable, Starburst, OPA-authorized OSS Trino) were unreachable, and password auth was also unusable because `BasicAuthentication` refuses to attach over plain http.

## Change

Two new fields on `TrinoConfig`:

- `http_scheme: Literal["http", "https"] = "http"` — default preserves prior behaviour, no migration needed for existing configs.
- `verify: bool | str = True` — `True` = system CAs, `False` = disable, `str` = path to a CA bundle (useful for clusters with an internal CA).

Both are forwarded to `ibis.trino.connect`; `verify` is only passed when the scheme is `https`, so existing http deployments stay byte-identical. `promptConfig` asks for the scheme first, defaults the port to `8443` when https is chosen, and accepts an optional CA-bundle path.

## Tests

Added five unit tests mirroring the existing `test_connect_*` mock pattern:
- Default scheme is `http` and `verify` is not forwarded.
- `https` forwards `verify=True` by default.
- `https` forwards a custom CA-bundle path.
- `https` forwards `verify=False` when verification is intentionally disabled.
- `verify` set on an `http` config is ignored (never leaked into the connect call).

Full CLI suite green: `make lint` clean, `pytest tests/ --ignore=...integration` → 599 passed.

## Backwards compatibility

Both new fields are optional with defaults that reproduce current behaviour exactly. Existing `nao_config.yaml` files load and connect identically.

Fixes #857

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection credentials, TLS verification, and auth precedence; mistakes could leak tokens or weaken TLS, though defaults preserve prior HTTP behavior and JWT forces HTTPS.
> 
> **Overview**
> Extends **`TrinoConfig`** so the CLI can reach HTTPS-only Trino coordinators and use JWT/OAuth-style auth, while keeping plain HTTP configs unchanged by default.
> 
> **`connect()`** now passes **`http_scheme`** and, for HTTPS only, **`verify`** (system CAs, disabled, or a CA bundle path) into **`ibis.trino.connect`**. JWT auth via **`JWTAuthentication`** takes precedence over password basic auth; any resolved JWT **forces `https`** so bearer tokens are not sent over cleartext. Tokens come from **`jwt_token`** or **`jwt_token_file`**, with **`_resolve_jwt()`** stripping blanks and re-reading the file on each connect for rotation.
> 
> **`promptConfig`** asks for HTTPS, adjusts the default port (`8443` vs `8080`), and optionally collects a custom CA path.
> 
> Unit tests cover HTTP defaults, HTTPS/`verify` forwarding, JWT precedence and HTTPS forcing, blank JWT ignoring, and fresh reads from the token file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ee43160f48e9c15458690b8a364db3c9717e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->