### PR TITLE
feat(provider-meta): add Claude Opus 4.8 and fix Opus pricing

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -21,7 +21,7 @@ export const PROVIDER_META: ProviderMetaMap = {
 				id: 'claude-opus-4-7',
 				name: 'Claude Opus 4.7',
 				contextWindow: 200_000,
-				costPerM: { inputNoCache: 3, inputCacheRead: 0.3, inputCacheWrite: 3.75, output: 15 },
+				costPerM: { inputNoCache: 5, inputCacheRead: 0.5, inputCacheWrite: 6.25, output: 25 },
 			},
 			{
 				id: 'claude-sonnet-4-6',

--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -12,6 +12,12 @@ export const PROVIDER_META: ProviderMetaMap = {
 		summaryModelId: 'claude-sonnet-4-5',
 		models: [
 			{
+				id: 'claude-opus-4-8',
+				name: 'Claude Opus 4.8',
+				contextWindow: 200_000,
+				costPerM: { inputNoCache: 5, inputCacheRead: 0.5, inputCacheWrite: 6.25, output: 25 },
+			},
+			{
 				id: 'claude-opus-4-7',
 				name: 'Claude Opus 4.7',
 				contextWindow: 200_000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Changes
- Add `Claude Opus 4.8` (id `claude-opus-4-8`) as the first Anthropic model entry — 200K context, Opus-tier pricing.
- Fix `Claude Opus 4.7` pricing, which was incorrectly set to Sonnet-tier (`$3 / $0.3 / $3.75 / $15`). Updated to Opus-tier (`$5 / $0.5 / $6.25 / $25`) so all Opus 4.5 – 4.8 entries are consistent and match Anthropic's published table.

`claude-opus-4-5` and `claude-opus-4-6` were already at the correct Opus-tier pricing — no change needed there.

### Testing
- ✅ `npm run lint` (tsc + eslint across backend, frontend, shared)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3738a844-03c3-4e4e-b71a-a0c0061e99e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3738a844-03c3-4e4e-b71a-a0c0061e99e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

