### PR TITLE
fix(chat): show actions only on last assistant message, hover for the rest

### DIFF
--- a/apps/frontend/src/components/chat-messages/assistant-message.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-message.tsx
@@ -19,12 +19,14 @@ export const AssistantMessage = memo(
 		showLoader,
 		isSettled,
 		isRunning,
+		isLastMessage,
 		storyIntroMessageId,
 	}: {
 		message: UIMessage;
 		showLoader: boolean;
 		isSettled: boolean;
 		isRunning: boolean;
+		isLastMessage: boolean;
 		storyIntroMessageId: string | undefined;
 	}) => {
 		const chatId = useChatId();
@@ -53,8 +55,12 @@ export const AssistantMessage = memo(
 							message={message}
 							chatId={chatId}
 							className={cn(
-								'opacity-0 group-last/message:opacity-100 group-hover:opacity-100 transition-opacity duration-200',
-								isRunning ? 'group-last/message:hidden' : '',
+								'transition-opacity duration-200',
+								isLastMessage
+									? isRunning
+										? 'hidden'
+										: 'opacity-100'
+									: 'opacity-0 group-hover:opacity-100',
 							)}
 						/>
 					)}

--- a/apps/frontend/src/components/chat-messages/chat-messages.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-messages.tsx
@@ -188,6 +188,7 @@ const MessageBlock = ({
 			showLoader={showLoader && isLastMessage}
 			isSettled={!isLastMessage || !isRunning}
 			isRunning={isRunning}
+			isLastMessage={isLastMessage}
 			storyIntroMessageId={storyIntroMessageId}
 		/>
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the visibility logic for assistant message actions (thumbs up, thumbs down, copy):

- **Last assistant message** in the chat: actions are always visible.
- **All other assistant messages**: actions only appear on hover.

Previously the code used `group-last/message:opacity-100`, which kept the actions visible for **every** assistant message inside the last message group (e.g. multiple assistant messages in a single turn) instead of only the very last one.

## Changes

- `apps/frontend/src/components/chat-messages/assistant-message.tsx`: replaced the `group-last/message`-based class with explicit `isLastMessage` logic. The hover-reveal pattern (`opacity-0 group-hover:opacity-100`) on the assistant message's `group` div is preserved so non-last messages reveal actions on hover (same pattern used in `user-message.tsx`).
- `apps/frontend/src/components/chat-messages/chat-messages.tsx`: forwards `isLastMessage` prop to `AssistantMessage`.

While the agent is running, the actions on the last message are still hidden (preserves prior behavior).

## Walkthrough

[Only last assistant message shows actions](https://cursor.com/agents/bc-d932ca24-aa7e-4b55-a02c-22708ef1f51c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flast_message_only_actions_visible.png)

In a chat with three assistant messages, only the last one shows the action buttons (thumbs up/down/copy). The other two reveal them on hover (verified via DevTools `:hover` force-state).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d932ca24-aa7e-4b55-a02c-22708ef1f51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d932ca24-aa7e-4b55-a02c-22708ef1f51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

