### PR TITLE
Warn the model when SQL results are truncated by a LIMIT/TOP clause

### DIFF
--- a/apps/backend/src/agents/tools/execute-sql.ts
+++ b/apps/backend/src/agents/tools/execute-sql.ts
@@ -4,7 +4,7 @@ import { executeSql as schemas } from '@nao/shared/tools';
 import { ExecuteSqlOutput, renderToModelOutput } from '../../components/tool-outputs';
 import { env } from '../../env';
 import { ToolContext } from '../../types/tools';
-import { isReadOnlySqlQuery } from '../../utils/sql-filter';
+import { detectQueryRowLimit, isReadOnlySqlQuery } from '../../utils/sql-filter';
 import { createTool } from '../../utils/tools';
 
 export async function executeQuery(
@@ -46,10 +46,13 @@ export async function executeQuery(
 
 	context.queryResults.set(id, { columns: data.columns, data: data.data });
 
+	const appliedLimit = detectQueryRowLimit(sql_query);
+
 	return {
 		_version: '1',
 		...data,
 		id,
+		...(appliedLimit !== null && { applied_limit: appliedLimit }),
 	};
 }
 

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -134,6 +134,11 @@ export function SystemPrompt({
 				<ListItem>
 					Never assume columns names, if available, use the columns.md file to get the column names.
 				</ListItem>
+				<ListItem>
+					A LIMIT/TOP clause caps how many rows are returned, not how many exist. Never state a total or an
+					"exact" count based on the number of rows a limited query returned. To count rows, run a separate
+					query using COUNT(*) (or COUNT over a subquery) without a LIMIT/TOP clause.
+				</ListItem>
 				{hasTSQL && (
 					<>
 						<ListItem>

--- a/apps/backend/src/components/tool-outputs/execute-sql.tsx
+++ b/apps/backend/src/components/tool-outputs/execute-sql.tsx
@@ -15,6 +15,9 @@ export const ExecuteSqlOutput = ({ output, maxRows = MAX_ROWS }: { output: execu
 	const visibleRows = isTruncated ? output.data.slice(0, maxRows) : output.data;
 	const remainingRows = isTruncated ? output.data.length - maxRows : 0;
 
+	const isLimitReached =
+		output.applied_limit !== undefined && output.row_count >= output.applied_limit && output.row_count > 0;
+
 	return (
 		<Block>
 			<Span>Query ID: {output.id}</Span>
@@ -28,6 +31,15 @@ export const ExecuteSqlOutput = ({ output, maxRows = MAX_ROWS }: { output: execu
 			<Title>
 				{pluralize('Row', output.row_count)} ({output.row_count})
 			</Title>
+
+			{isLimitReached && (
+				<Span>
+					Warning: this query returned exactly {output.applied_limit} rows, the maximum allowed by its
+					LIMIT/TOP clause, so the result is almost certainly truncated. This row count reflects the LIMIT,
+					NOT the total number of matching rows — do not report it as a total or "exact" count. To get the
+					true total, run a separate query with COUNT(*) (or COUNT over a subquery) and no LIMIT/TOP clause.
+				</Span>
+			)}
 
 			<QueryRows rows={visibleRows} />
 

--- a/apps/backend/src/utils/sql-filter.ts
+++ b/apps/backend/src/utils/sql-filter.ts
@@ -30,6 +30,97 @@ function isStatementReadOnly(statement: string): boolean {
 	return false;
 }
 
+/**
+ * Detect a row-count limit applied by the outermost query (`LIMIT`, `TOP`,
+ * or `FETCH FIRST ... ROWS`). Returns the maximum number of rows the query is
+ * allowed to return, or `null` when no top-level limit is present.
+ *
+ * This is a heuristic used to warn the model that a result set may be truncated
+ * by its own SQL — it deliberately ignores limits inside subqueries/CTEs.
+ */
+export function detectQueryRowLimit(sql: string): number | null {
+	const masked = maskQuotedStrings(stripComments(sql));
+	const topLevel = extractTopLevelSql(masked);
+
+	const limitOffsetComma = /\bLIMIT\s+\d+\s*,\s*(\d+)/i.exec(topLevel);
+	if (limitOffsetComma) {
+		return Number.parseInt(limitOffsetComma[1], 10);
+	}
+
+	const limit = /\bLIMIT\s+(\d+)/i.exec(topLevel);
+	if (limit) {
+		return Number.parseInt(limit[1], 10);
+	}
+
+	const fetchFirst = /\bFETCH\s+(?:FIRST|NEXT)\s+(\d+)\s+ROWS?\b/i.exec(topLevel);
+	if (fetchFirst) {
+		return Number.parseInt(fetchFirst[1], 10);
+	}
+
+	// TOP keeps its row count inside its own parentheses (TOP (20)), so detect it
+	// against the paren-preserving masked SQL. The `row_count >= applied_limit`
+	// guard at render time prevents false warnings from limits in subqueries.
+	const top = /\bTOP\s*\(?\s*(\d+)\s*\)?\s*(PERCENT)?/i.exec(masked);
+	if (top && !top[2]) {
+		return Number.parseInt(top[1], 10);
+	}
+
+	return null;
+}
+
+/** Replace the contents of string literals (and their quotes) with spaces. */
+function maskQuotedStrings(sql: string): string {
+	let result = '';
+	let quote: string | null = null;
+
+	for (let i = 0; i < sql.length; i++) {
+		const ch = sql[i];
+
+		if (quote) {
+			if (ch === quote && sql[i - 1] !== '\\') {
+				quote = null;
+			}
+			result += ' ';
+			continue;
+		}
+
+		if (ch === "'" || ch === '"' || ch === '`') {
+			quote = ch;
+			result += ' ';
+		} else {
+			result += ch;
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Replace everything inside parentheses with spaces so limit detection only
+ * sees clauses that belong to the outermost query. Expects string literals to
+ * already be masked.
+ */
+function extractTopLevelSql(sql: string): string {
+	let result = '';
+	let depth = 0;
+
+	for (const ch of sql) {
+		if (ch === '(') {
+			depth++;
+			result += ' ';
+		} else if (ch === ')') {
+			if (depth > 0) {
+				depth--;
+			}
+			result += ' ';
+		} else {
+			result += depth === 0 ? ch : ' ';
+		}
+	}
+
+	return result;
+}
+
 function stripComments(sql: string): string {
 	return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
 }

--- a/apps/backend/tests/sql-filter.test.ts
+++ b/apps/backend/tests/sql-filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isReadOnlySqlQuery } from '../src/utils/sql-filter';
+import { detectQueryRowLimit, isReadOnlySqlQuery } from '../src/utils/sql-filter';
 
 describe('isReadOnlySqlQuery', () => {
 	it('allows a simple SELECT', async () => {
@@ -55,5 +55,55 @@ describe('isReadOnlySqlQuery', () => {
 
 	it('allows a multi-statement batch of only SELECTs', async () => {
 		expect(await isReadOnlySqlQuery('SELECT 1; SELECT 2')).toBe(true);
+	});
+});
+
+describe('detectQueryRowLimit', () => {
+	it('returns null when there is no limit', () => {
+		expect(detectQueryRowLimit('SELECT * FROM games')).toBeNull();
+	});
+
+	it('detects a trailing LIMIT', () => {
+		expect(detectQueryRowLimit('SELECT * FROM games ORDER BY total_downloads DESC LIMIT 20')).toBe(20);
+	});
+
+	it('detects LIMIT regardless of case and whitespace', () => {
+		expect(detectQueryRowLimit('select * from games\n  limit   5')).toBe(5);
+	});
+
+	it('detects the count in MySQL "LIMIT offset, count" syntax', () => {
+		expect(detectQueryRowLimit('SELECT * FROM games LIMIT 40, 20')).toBe(20);
+	});
+
+	it('detects the count in "LIMIT count OFFSET n" syntax', () => {
+		expect(detectQueryRowLimit('SELECT * FROM games LIMIT 20 OFFSET 40')).toBe(20);
+	});
+
+	it('detects T-SQL TOP n', () => {
+		expect(detectQueryRowLimit('SELECT TOP 20 * FROM games')).toBe(20);
+	});
+
+	it('detects T-SQL TOP (n)', () => {
+		expect(detectQueryRowLimit('SELECT TOP (20) * FROM games')).toBe(20);
+	});
+
+	it('ignores TOP n PERCENT', () => {
+		expect(detectQueryRowLimit('SELECT TOP 10 PERCENT * FROM games')).toBeNull();
+	});
+
+	it('detects FETCH FIRST n ROWS ONLY', () => {
+		expect(detectQueryRowLimit('SELECT * FROM games ORDER BY id FETCH FIRST 20 ROWS ONLY')).toBe(20);
+	});
+
+	it('ignores a LIMIT inside a subquery', () => {
+		expect(detectQueryRowLimit('SELECT count(*) FROM (SELECT id FROM games LIMIT 20) sub')).toBeNull();
+	});
+
+	it('detects the outer LIMIT when a subquery also has one', () => {
+		expect(detectQueryRowLimit('SELECT * FROM (SELECT id FROM games LIMIT 100) sub LIMIT 20')).toBe(20);
+	});
+
+	it('ignores the word LIMIT inside a string literal', () => {
+		expect(detectQueryRowLimit("SELECT * FROM games WHERE note = 'LIMIT 5'")).toBeNull();
 	});
 });

--- a/apps/backend/tests/tool-outputs/execute-sql.test.tsx
+++ b/apps/backend/tests/tool-outputs/execute-sql.test.tsx
@@ -78,6 +78,40 @@ created_at: 2025-03-10T09:15:00Z
 		expect(result).toBe('The query was successfully executed and returned no rows.');
 	});
 
+	it('warns when the row count equals the applied LIMIT', () => {
+		const result = renderToMarkdown(
+			<ExecuteSqlOutput
+				output={{
+					id: 'query_limit',
+					columns: ['game_name'],
+					row_count: 2,
+					applied_limit: 2,
+					data: [{ game_name: 'Alpha' }, { game_name: 'Beta' }],
+				}}
+			/>,
+		);
+		printOutput('execute_sql', 'limit reached', result);
+
+		expect(result).toContain('returned exactly 2 rows');
+		expect(result).toContain('COUNT(*)');
+	});
+
+	it('does not warn when the row count is below the applied LIMIT', () => {
+		const result = renderToMarkdown(
+			<ExecuteSqlOutput
+				output={{
+					id: 'query_under_limit',
+					columns: ['game_name'],
+					row_count: 1,
+					applied_limit: 20,
+					data: [{ game_name: 'Alpha' }],
+				}}
+			/>,
+		);
+
+		expect(result).not.toContain('Warning:');
+	});
+
 	it('truncates rows with maxRows', () => {
 		const result = renderToMarkdown(
 			<ExecuteSqlOutput

--- a/apps/shared/src/tools/execute-sql.ts
+++ b/apps/shared/src/tools/execute-sql.ts
@@ -19,6 +19,12 @@ export const OutputSchema = z.object({
 	/** The id of the query result. May be referenced by the `display_chart` tool call. */
 	id: QueryIdSchema,
 	dialect: z.string().optional(),
+	/**
+	 * The row limit applied by the outermost query (LIMIT/TOP/FETCH FIRST), if any.
+	 * When `row_count` equals this value the result is likely truncated and does not
+	 * represent the total number of matching rows.
+	 */
+	applied_limit: z.number().optional(),
 });
 
 export type Input = z.infer<typeof InputSchema>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the agent writes a SQL query with a `LIMIT` clause (e.g. `LIMIT 20`), the warehouse returns exactly that many rows. The `execute_sql` tool output reports `row_count = 20`, and nothing signals to the model that the result was capped by its own SQL. The agent then confidently states things like "there are exactly 20 games added in 2026" when the true count is 509.

The system already handles its own 40-row display cap correctly (it shows the true total plus a pagination hint), but it had no way to distinguish a SQL-imposed `LIMIT` from a complete result set.

## Fix

Detect a row limit imposed by the outermost query and warn the model when the returned row count hits that limit.

- `detectQueryRowLimit()` in `sql-filter.ts` parses the outermost `LIMIT n`, `LIMIT offset, n`, `LIMIT n OFFSET m`, `TOP n` / `TOP (n)` (ignoring `TOP n PERCENT`), and `FETCH FIRST n ROWS ONLY`. It masks string literals and subquery parentheses so it only sees the outer query's limit.
- `execute_sql` now sets `applied_limit` on its output when a top-level limit is detected.
- `ExecuteSqlOutput` renders a clear warning to the model when `row_count >= applied_limit`: the count reflects the LIMIT, not the total, and the model should run a `COUNT(*)` query without a LIMIT to get the true total. The `row_count >= applied_limit` guard means aggregates over limited subqueries (e.g. `SELECT count(*) FROM (... LIMIT 20)`) do not produce false warnings.
- Added a `SQL Query Rules` system-prompt rule reinforcing that a LIMIT/TOP clause caps returned rows, not existing rows.

## Model-facing output (reproducing the reported scenario)

For `... ORDER BY total_downloads DESC LIMIT 20` returning 20 rows, the model now sees:

> Warning: this query returned exactly 20 rows, the maximum allowed by its LIMIT/TOP clause, so the result is almost certainly truncated. This row count reflects the LIMIT, NOT the total number of matching rows — do not report it as a total or "exact" count. To get the true total, run a separate query with COUNT(*) (or COUNT over a subquery) and no LIMIT/TOP clause.

[limit_warning_demo.log](https://cursor.com/agents/bc-84206491-aab1-41d3-ad96-82c5979462da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flimit_warning_demo.log)

## Testing

- `npm run -w @nao/backend test -- sql-filter execute-sql` — 30 tests pass (12 new detection cases + 2 new output cases).
- `npm run lint` — passes across backend, frontend, shared.

Pre-existing, unrelated failures in `system-prompt.test.ts` (timezone), `sqlite.test.ts` (native bindings), and `compaction.test.ts` were confirmed to fail on the clean base as well.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84206491-aab1-41d3-ad96-82c5979462da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84206491-aab1-41d3-ad96-82c5979462da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

