### PR TITLE
feat: programmatic SDKs (Python + TypeScript) for the nao agent

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -29,6 +29,7 @@ import { slackRoutes } from './routes/slack';
 import { teamsRoutes } from './routes/teams';
 import { telegramRoutes } from './routes/telegram';
 import { testRoutes } from './routes/test';
+import { v1Routes } from './routes/v1';
 import { whatsappRoutes } from './routes/whatsapp';
 import { startLicenseHeartbeat } from './services/license.service';
 import { logLicenseStatus } from './services/license-startup';
@@ -141,6 +142,10 @@ app.register(fastifyTRPCPlugin, {
 
 app.register(agentRoutes, {
 	prefix: '/api/agent',
+});
+
+app.register(v1Routes, {
+	prefix: '/api/v1',
 });
 
 app.register(testRoutes, {

--- a/apps/backend/src/handlers/agent.ts
+++ b/apps/backend/src/handlers/agent.ts
@@ -1,4 +1,4 @@
-import type { ImageUploadData } from '@nao/shared/types';
+import type { ImageUploadData, LlmSelectedModel } from '@nao/shared/types';
 
 import { noProjectMessage } from '../env';
 import * as chatQueries from '../queries/chat.queries';
@@ -20,6 +20,7 @@ interface HandleAgentMessageResult {
 	chatId: string;
 	isNewChat: boolean;
 	modelId: string;
+	model: LlmSelectedModel;
 	stream: ReadableStream;
 }
 
@@ -88,6 +89,7 @@ export const handleAgentRoute = async (opts: HandleAgentMessageInput): Promise<H
 		chatId,
 		isNewChat,
 		modelId: agent.getModelId(),
+		model: agent.getModel(),
 		stream,
 	};
 };

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -24,6 +24,21 @@ export const getProjectById = async (id: string): Promise<DBProject | null> => {
 	return project ?? null;
 };
 
+export const listProjectsByOrg = async (orgId: string): Promise<DBProject[]> => {
+	return db.select().from(s.project).where(eq(s.project.orgId, orgId)).orderBy(asc(s.project.name)).execute();
+};
+
+export const getFirstProjectByOrg = async (orgId: string): Promise<DBProject | null> => {
+	const [project] = await db
+		.select()
+		.from(s.project)
+		.where(eq(s.project.orgId, orgId))
+		.orderBy(asc(s.project.name))
+		.limit(1)
+		.execute();
+	return project ?? null;
+};
+
 export const getProjectByOrgAndName = async (orgId: string, name: string): Promise<DBProject | null> => {
 	const [project] = await db
 		.select()

--- a/apps/backend/src/routes/v1.ts
+++ b/apps/backend/src/routes/v1.ts
@@ -1,0 +1,218 @@
+import type { ServerResponse } from 'node:http';
+
+import { type InferUIMessageChunk, readUIMessageStream } from 'ai';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod/v4';
+
+import type { App } from '../app';
+import type { DBProject } from '../db/abstractSchema';
+import { handleAgentRoute } from '../handlers/agent';
+import * as chatQueries from '../queries/chat.queries';
+import * as projectQueries from '../queries/project.queries';
+import { authenticateApiKey, type AuthenticatedApiKey } from '../services/api-key.service';
+import type { UIMessage, UIMessagePart } from '../types/chat';
+import { llmSelectedModelSchema } from '../types/llm';
+import { HandlerError } from '../utils/error';
+import { getProjectAvailableModels } from '../utils/llm';
+
+const SdkAgentRequestSchema = z.object({
+	prompt: z.string().min(1),
+	chatId: z.string().optional(),
+	projectId: z.string().optional(),
+	model: llmSelectedModelSchema.optional(),
+});
+
+type SdkAgentRequest = z.infer<typeof SdkAgentRequestSchema>;
+
+/**
+ * Public, programmatic REST API consumed by the nao SDKs (Python & TypeScript).
+ * Authenticated with an organization API key (`Authorization: Bearer nao_...`).
+ */
+export const v1Routes = async (app: App) => {
+	app.post('/agent', { schema: { body: SdkAgentRequestSchema } }, async (request, reply) => {
+		const { auth, project, body } = await prepareAgentRun(request);
+		const result = await handleAgentRoute({
+			userId: auth.userId,
+			projectId: project.id,
+			message: { text: body.prompt },
+			chatId: body.chatId,
+			model: body.model,
+		});
+
+		const text = await collectFinalText(result.stream);
+		return reply.send({ chatId: result.chatId, text, model: result.model });
+	});
+
+	app.post('/agent/stream', { schema: { body: SdkAgentRequestSchema } }, async (request, reply) => {
+		const { auth, project, body } = await prepareAgentRun(request);
+		const result = await handleAgentRoute({
+			userId: auth.userId,
+			projectId: project.id,
+			message: { text: body.prompt },
+			chatId: body.chatId,
+			model: body.model,
+		});
+
+		startSse(reply);
+		const raw = reply.raw;
+		writeSse(raw, 'message_start', { chatId: result.chatId, model: result.model });
+
+		try {
+			let lastText = '';
+			const seenTools = new Set<string>();
+			for await (const message of readUIMessageStream<UIMessage>({ stream: result.stream })) {
+				emitToolEvents(raw, message.parts, seenTools);
+				const text = extractText(message);
+				const delta = diffText(lastText, text);
+				if (delta) {
+					writeSse(raw, 'text', { text: delta });
+				}
+				lastText = text;
+			}
+			writeSse(raw, 'message_complete', { chatId: result.chatId, text: lastText, model: result.model });
+		} catch (err) {
+			writeSse(raw, 'error', { error: errorMessage(err) });
+		} finally {
+			raw.end();
+		}
+	});
+
+	app.get('/models', async (request, reply) => {
+		const auth = await authenticate(request);
+		const project = await resolveProject(auth, { projectId: queryParam(request, 'projectId') }, request.headers);
+		const models = await getProjectAvailableModels(project.id);
+		return reply.send({ models });
+	});
+
+	app.get('/projects', async (request, reply) => {
+		const auth = await authenticate(request);
+		const projects = await projectQueries.listProjectsByOrg(auth.org.id);
+		return reply.send({ projects: projects.map((p) => ({ id: p.id, name: p.name })) });
+	});
+};
+
+async function prepareAgentRun(
+	request: FastifyRequest,
+): Promise<{ auth: AuthenticatedApiKey; project: DBProject; body: SdkAgentRequest }> {
+	const auth = await authenticate(request);
+	const body = request.body as SdkAgentRequest;
+	const project = await resolveProject(auth, { chatId: body.chatId, projectId: body.projectId }, request.headers);
+	return { auth, project, body };
+}
+
+async function authenticate(request: FastifyRequest): Promise<AuthenticatedApiKey> {
+	const header = request.headers.authorization;
+	if (!header?.startsWith('Bearer ')) {
+		throw new HandlerError(
+			'UNAUTHORIZED',
+			'Missing or invalid Authorization header. Provide your API key as `Authorization: Bearer nao_...`.',
+		);
+	}
+
+	const auth = await authenticateApiKey(header.slice(7));
+	if (!auth) {
+		throw new HandlerError('UNAUTHORIZED', 'Invalid API key.');
+	}
+	return auth;
+}
+
+async function resolveProject(
+	auth: AuthenticatedApiKey,
+	opts: { chatId?: string; projectId?: string },
+	headers: FastifyRequest['headers'],
+): Promise<DBProject> {
+	if (opts.chatId) {
+		const projectId = await chatQueries.getChatProjectId(opts.chatId);
+		if (!projectId) {
+			throw new HandlerError('NOT_FOUND', `Chat with id ${opts.chatId} not found.`);
+		}
+		return assertProjectInOrg(await projectQueries.getProjectById(projectId), auth);
+	}
+
+	const explicitId = opts.projectId ?? headerProjectId(headers);
+	if (explicitId) {
+		return assertProjectInOrg(await projectQueries.getProjectById(explicitId), auth);
+	}
+
+	const project = await projectQueries.getFirstProjectByOrg(auth.org.id);
+	if (!project) {
+		throw new HandlerError('BAD_REQUEST', 'No project found for this organization.');
+	}
+	return project;
+}
+
+function assertProjectInOrg(project: DBProject | null, auth: AuthenticatedApiKey): DBProject {
+	if (!project || project.orgId !== auth.org.id) {
+		throw new HandlerError('NOT_FOUND', 'Project not found for this organization.');
+	}
+	return project;
+}
+
+function headerProjectId(headers: FastifyRequest['headers']): string | undefined {
+	const value = headers['x-nao-project-id'];
+	return Array.isArray(value) ? value[0] : value;
+}
+
+function queryParam(request: FastifyRequest, key: string): string | undefined {
+	const query = request.query as Record<string, string | string[] | undefined>;
+	const value = query?.[key];
+	return Array.isArray(value) ? value[0] : value;
+}
+
+async function collectFinalText(stream: ReadableStream<InferUIMessageChunk<UIMessage>>): Promise<string> {
+	let lastMessage: UIMessage | null = null;
+	for await (const message of readUIMessageStream<UIMessage>({ stream })) {
+		lastMessage = message;
+	}
+	return lastMessage ? extractText(lastMessage) : '';
+}
+
+function extractText(message: UIMessage): string {
+	return message.parts
+		.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
+		.map((p) => p.text)
+		.join('\n\n');
+}
+
+/** Return the appended suffix when `next` extends `prev`, otherwise the full new text. */
+function diffText(prev: string, next: string): string {
+	if (next === prev) {
+		return '';
+	}
+	return next.startsWith(prev) ? next.slice(prev.length) : next;
+}
+
+function emitToolEvents(raw: ServerResponse, parts: UIMessagePart[], seen: Set<string>): void {
+	for (const part of parts) {
+		if (!isToolPart(part) || seen.has(part.toolCallId)) {
+			continue;
+		}
+		if (part.state !== 'input-available' && part.state !== 'output-available') {
+			continue;
+		}
+		seen.add(part.toolCallId);
+		writeSse(raw, 'tool', { name: part.type.replace(/^tool-/, ''), status: 'running' });
+	}
+}
+
+function isToolPart(part: UIMessagePart): part is Extract<UIMessagePart, { toolCallId: string; state: string }> {
+	return typeof part.type === 'string' && part.type.startsWith('tool-') && 'toolCallId' in part && 'state' in part;
+}
+
+function startSse(reply: FastifyReply): void {
+	reply.raw.writeHead(200, {
+		'Content-Type': 'text/event-stream',
+		'Cache-Control': 'no-cache, no-transform',
+		Connection: 'keep-alive',
+		'X-Accel-Buffering': 'no',
+	});
+	reply.hijack();
+}
+
+function writeSse(raw: ServerResponse, event: string, data: unknown): void {
+	raw.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : 'Unknown error';
+}

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -776,6 +776,10 @@ class AgentManager {
 	getModelId(): string {
 		return this._modelSelection.modelId;
 	}
+
+	getModel(): LlmSelectedModel {
+		return this._modelSelection;
+	}
 }
 
 const IMAGE_URL_PATTERN = /^\/i\/([a-f0-9-]+)$/;

--- a/apps/backend/src/services/api-key.service.ts
+++ b/apps/backend/src/services/api-key.service.ts
@@ -12,6 +12,12 @@ export interface GeneratedKey {
 	prefix: string;
 }
 
+export interface AuthenticatedApiKey {
+	org: DBOrganization;
+	/** The user that created the key — used as the acting user for SDK requests. */
+	userId: string;
+}
+
 export const generateApiKey = (): GeneratedKey => {
 	const randomHex = crypto.randomBytes(KEY_RANDOM_BYTES).toString('hex');
 	const plaintext = `${KEY_PREFIX}${randomHex}`;
@@ -39,4 +45,30 @@ export const validateApiKey = async (plaintext: string): Promise<DBOrganization 
 
 	const { getOrganizationById } = await import('../queries/organization.queries');
 	return getOrganizationById(apiKey.orgId);
+};
+
+/**
+ * Validate an API key and resolve the organization plus the acting user.
+ * Returns null when the key is missing, malformed, or unknown.
+ */
+export const authenticateApiKey = async (plaintext: string): Promise<AuthenticatedApiKey | null> => {
+	if (!plaintext.startsWith(KEY_PREFIX)) {
+		return null;
+	}
+
+	const hash = hashKey(plaintext);
+	const apiKey = await apiKeyQueries.getApiKeyByHash(hash);
+	if (!apiKey) {
+		return null;
+	}
+
+	apiKeyQueries.updateApiKeyLastUsed(apiKey.id).catch(() => {});
+
+	const { getOrganizationById } = await import('../queries/organization.queries');
+	const org = await getOrganizationById(apiKey.orgId);
+	if (!org) {
+		return null;
+	}
+
+	return { org, userId: apiKey.createdBy };
 };

--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.egg-info/
+build/
+dist/
+.venv/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,76 @@
+# nao Python SDK
+
+Official Python SDK for the [nao](https://github.com/getnao/nao) analytics agent. Ask questions in natural language and get data insights back — programmatically.
+
+## Installation
+
+```bash
+pip install nao-sdk
+```
+
+## Quickstart
+
+```python
+from nao_sdk import Nao
+
+client = Nao(api_key="nao_...", base_url="https://your-nao-instance.com")
+
+# One-shot run — returns the full answer once the agent is done.
+result = client.run("How many orders were placed last month?")
+print(result.text)
+print(result.chat_id)  # reuse to continue the conversation
+```
+
+### Streaming
+
+```python
+for event in client.stream("What were our top 5 products by revenue?"):
+    if event.type == "text":
+        print(event.text, end="", flush=True)
+    elif event.type == "tool":
+        print(f"\n[running {event.name}]")
+```
+
+### Continuing a conversation
+
+```python
+first = client.run("How many customers do we have?")
+follow_up = client.run("And how many are returning?", chat_id=first.chat_id)
+```
+
+### Picking a model
+
+Only models activated for the project can be selected.
+
+```python
+# List the activated models
+for model in client.models():
+    print(model.provider, model.model_id, model.name)
+
+# Select one — as a "provider:model-id" string, a dict, or a Model object
+client.run("Summarise revenue trends", model="openai:gpt-4o")
+client.run("Summarise revenue trends", model={"provider": "openai", "modelId": "gpt-4o"})
+```
+
+### Selecting a project
+
+If your organization has multiple projects, pass `project_id` (or set it on the client).
+
+```python
+client = Nao(api_key="nao_...", project_id="<project-uuid>")
+print(client.projects())
+```
+
+## Authentication
+
+Create an organization API key from the nao app (Settings → API keys). Keys start with `nao_`.
+
+## API
+
+| Method                                                               | Description                                    |
+| -------------------------------------------------------------------- | ---------------------------------------------- |
+| `Nao(api_key, base_url=..., project_id=..., model=..., timeout=...)` | Create a client                                |
+| `client.run(prompt, *, chat_id=..., project_id=..., model=...)`      | Run and return the full response (`RunResult`) |
+| `client.stream(prompt, ...)`                                         | Stream the response as `StreamEvent`s          |
+| `client.models(project_id=...)`                                      | List activated models                          |
+| `client.projects()`                                                  | List projects for the org                      |

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "nao-sdk"
+version = "0.1.0"
+description = "Official Python SDK for the nao analytics agent"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+authors = [{ name = "nao" }]
+keywords = ["nao", "analytics", "agent", "sdk", "llm"]
+dependencies = ["requests>=2.28"]
+
+[project.urls]
+Homepage = "https://github.com/getnao/nao"
+Source = "https://github.com/getnao/nao"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nao_sdk"]

--- a/sdk/python/src/nao_sdk/__init__.py
+++ b/sdk/python/src/nao_sdk/__init__.py
@@ -1,0 +1,18 @@
+"""Official Python SDK for the nao analytics agent."""
+
+from ._errors import NaoAPIError, NaoError
+from .client import Nao
+from .types import AvailableModel, Model, Project, RunResult, StreamEvent
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "Nao",
+    "Model",
+    "AvailableModel",
+    "Project",
+    "RunResult",
+    "StreamEvent",
+    "NaoError",
+    "NaoAPIError",
+]

--- a/sdk/python/src/nao_sdk/_errors.py
+++ b/sdk/python/src/nao_sdk/_errors.py
@@ -1,0 +1,18 @@
+"""Error types raised by the nao SDK."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+class NaoError(Exception):
+    """Base class for all errors raised by the SDK."""
+
+
+class NaoAPIError(NaoError):
+    """Raised when the nao API returns a non-2xx response."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message

--- a/sdk/python/src/nao_sdk/client.py
+++ b/sdk/python/src/nao_sdk/client.py
@@ -1,0 +1,197 @@
+"""Synchronous client for the nao analytics agent."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterator, List, Optional
+
+import requests
+
+from ._errors import NaoAPIError
+from .types import (
+    AvailableModel,
+    Model,
+    ModelInput,
+    Project,
+    RunResult,
+    StreamEvent,
+    normalize_model,
+)
+
+DEFAULT_BASE_URL = "http://localhost:5005"
+DEFAULT_TIMEOUT = 600
+
+
+class Nao:
+    """A client for the nao agent.
+
+    Example:
+        >>> from nao_sdk import Nao
+        >>> client = Nao(api_key="nao_...")
+        >>> result = client.run("How many orders were placed last month?")
+        >>> print(result.text)
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        project_id: Optional[str] = None,
+        model: ModelInput = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
+        if not api_key:
+            raise ValueError("api_key is required")
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.default_project_id = project_id
+        self.default_model = model
+        self.timeout = timeout
+        self._session = requests.Session()
+
+    def run(
+        self,
+        prompt: str,
+        *,
+        chat_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        model: ModelInput = None,
+    ) -> RunResult:
+        """Send a prompt and return the agent's full response once complete."""
+        payload = self._build_payload(prompt, chat_id, project_id, model)
+        response = self._session.post(
+            f"{self.base_url}/api/v1/agent",
+            headers=self._headers(),
+            json=payload,
+            timeout=self.timeout,
+        )
+        data = self._parse_json(response)
+        return RunResult(
+            chat_id=data["chatId"],
+            text=data.get("text", ""),
+            model=Model.from_payload(data["model"]) if data.get("model") else None,
+        )
+
+    def stream(
+        self,
+        prompt: str,
+        *,
+        chat_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        model: ModelInput = None,
+    ) -> Iterator[StreamEvent]:
+        """Send a prompt and yield events as the agent responds."""
+        payload = self._build_payload(prompt, chat_id, project_id, model)
+        with self._session.post(
+            f"{self.base_url}/api/v1/agent/stream",
+            headers={**self._headers(), "Accept": "text/event-stream"},
+            json=payload,
+            stream=True,
+            timeout=self.timeout,
+        ) as response:
+            if response.status_code >= 400:
+                raise NaoAPIError(self._error_text(response), response.status_code)
+            yield from _parse_sse(response)
+
+    def models(self, *, project_id: Optional[str] = None) -> List[AvailableModel]:
+        """List the models activated for a project."""
+        params = {}
+        pid = project_id or self.default_project_id
+        if pid:
+            params["projectId"] = pid
+        response = self._session.get(
+            f"{self.base_url}/api/v1/models",
+            headers=self._headers(),
+            params=params,
+            timeout=self.timeout,
+        )
+        data = self._parse_json(response)
+        return [AvailableModel.from_payload(m) for m in data.get("models", [])]
+
+    def projects(self) -> List[Project]:
+        """List the projects available to this API key's organization."""
+        response = self._session.get(
+            f"{self.base_url}/api/v1/projects",
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        data = self._parse_json(response)
+        return [Project.from_payload(p) for p in data.get("projects", [])]
+
+    def _build_payload(
+        self,
+        prompt: str,
+        chat_id: Optional[str],
+        project_id: Optional[str],
+        model: ModelInput,
+    ) -> dict:
+        if not prompt:
+            raise ValueError("prompt must not be empty")
+        payload: dict = {"prompt": prompt}
+        if chat_id:
+            payload["chatId"] = chat_id
+        resolved_project = project_id or self.default_project_id
+        if resolved_project:
+            payload["projectId"] = resolved_project
+        resolved_model = normalize_model(model if model is not None else self.default_model)
+        if resolved_model:
+            payload["model"] = resolved_model
+        return payload
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _parse_json(self, response: requests.Response) -> dict:
+        if response.status_code >= 400:
+            raise NaoAPIError(self._error_text(response), response.status_code)
+        return response.json()
+
+    @staticmethod
+    def _error_text(response: requests.Response) -> str:
+        try:
+            body = response.json()
+            if isinstance(body, dict) and body.get("error"):
+                return str(body["error"])
+            if isinstance(body, dict) and body.get("message"):
+                return str(body["message"])
+        except ValueError:
+            pass
+        return response.text or f"Request failed with status {response.status_code}"
+
+
+def _parse_sse(response: requests.Response) -> Iterator[StreamEvent]:
+    """Parse a Server-Sent Events stream into :class:`StreamEvent` objects."""
+    event = None
+    for raw_line in response.iter_lines(decode_unicode=True):
+        if raw_line is None:
+            continue
+        line = raw_line.rstrip("\r")
+        if line == "":
+            event = None
+            continue
+        if line.startswith("event:"):
+            event = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data = line[len("data:") :].strip()
+            yield _build_event(event, data)
+
+
+def _build_event(event: Optional[str], data: str) -> StreamEvent:
+    try:
+        parsed = json.loads(data) if data else {}
+    except ValueError:
+        parsed = {}
+    model = Model.from_payload(parsed["model"]) if parsed.get("model") else None
+    return StreamEvent(
+        type=event or "message",
+        text=parsed.get("text"),
+        name=parsed.get("name"),
+        status=parsed.get("status"),
+        chat_id=parsed.get("chatId"),
+        model=model,
+        error=parsed.get("error"),
+    )

--- a/sdk/python/src/nao_sdk/types.py
+++ b/sdk/python/src/nao_sdk/types.py
@@ -1,0 +1,98 @@
+"""Public data types for the nao SDK."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+ModelInput = Union[str, "Model", dict, None]
+
+
+@dataclass
+class Model:
+    """A model selection: a provider (e.g. ``openai``) and a model id."""
+
+    provider: str
+    model_id: str
+
+    def to_payload(self) -> dict:
+        return {"provider": self.provider, "modelId": self.model_id}
+
+    @classmethod
+    def from_payload(cls, data: dict) -> "Model":
+        return cls(provider=data["provider"], model_id=data.get("modelId") or data.get("model_id"))
+
+
+@dataclass
+class AvailableModel:
+    """A model that is activated for a project and can be selected."""
+
+    provider: str
+    model_id: str
+    name: str
+
+    @classmethod
+    def from_payload(cls, data: dict) -> "AvailableModel":
+        return cls(
+            provider=data["provider"],
+            model_id=data.get("modelId") or data.get("model_id"),
+            name=data.get("name", ""),
+        )
+
+
+@dataclass
+class Project:
+    id: str
+    name: str
+
+    @classmethod
+    def from_payload(cls, data: dict) -> "Project":
+        return cls(id=data["id"], name=data.get("name", ""))
+
+
+@dataclass
+class RunResult:
+    """The result of a non-streaming agent run."""
+
+    chat_id: str
+    text: str
+    model: Optional[Model] = None
+
+
+@dataclass
+class StreamEvent:
+    """A single event emitted while streaming an agent run.
+
+    ``type`` is one of ``message_start``, ``text``, ``tool``,
+    ``message_complete`` or ``error``. Other fields are populated
+    depending on the event type.
+    """
+
+    type: str
+    text: Optional[str] = None
+    name: Optional[str] = None
+    status: Optional[str] = None
+    chat_id: Optional[str] = None
+    model: Optional[Model] = None
+    error: Optional[str] = None
+
+
+def normalize_model(model: ModelInput) -> Optional[dict]:
+    """Coerce a user-supplied model into the wire payload, or ``None``."""
+    if model is None:
+        return None
+    if isinstance(model, Model):
+        return model.to_payload()
+    if isinstance(model, dict):
+        provider = model.get("provider")
+        model_id = model.get("modelId") or model.get("model_id")
+        if not provider or not model_id:
+            raise ValueError("model dict must contain 'provider' and 'modelId'")
+        return {"provider": provider, "modelId": model_id}
+    if isinstance(model, str):
+        for sep in (":", "/"):
+            if sep in model:
+                provider, model_id = model.split(sep, 1)
+                return {"provider": provider.strip(), "modelId": model_id.strip()}
+        raise ValueError("model string must look like 'provider:model-id' (e.g. 'openai:gpt-4o')")
+    raise TypeError(f"Unsupported model type: {type(model)!r}")

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,79 @@
+# nao TypeScript SDK
+
+Official TypeScript/JavaScript SDK for the [nao](https://github.com/getnao/nao) analytics agent. Ask questions in natural language and get data insights back — programmatically.
+
+## Installation
+
+```bash
+npm install @nao/sdk
+```
+
+Requires Node.js 18+ (uses the global `fetch`).
+
+## Quickstart
+
+```ts
+import { Nao } from '@nao/sdk';
+
+const client = new Nao({ apiKey: 'nao_...', baseUrl: 'https://your-nao-instance.com' });
+
+// One-shot run — resolves once the agent is done.
+const result = await client.run('How many orders were placed last month?');
+console.log(result.text);
+console.log(result.chatId); // reuse to continue the conversation
+```
+
+### Streaming
+
+```ts
+for await (const event of client.stream('What were our top 5 products by revenue?')) {
+	if (event.type === 'text') {
+		process.stdout.write(event.text);
+	} else if (event.type === 'tool') {
+		console.log(`\n[running ${event.name}]`);
+	}
+}
+```
+
+### Continuing a conversation
+
+```ts
+const first = await client.run('How many customers do we have?');
+const followUp = await client.run('And how many are returning?', { chatId: first.chatId });
+```
+
+### Picking a model
+
+Only models activated for the project can be selected.
+
+```ts
+// List the activated models
+const models = await client.models();
+
+// Select one — as a "provider:model-id" string or a { provider, modelId } object
+await client.run('Summarise revenue trends', { model: 'openai:gpt-4o' });
+await client.run('Summarise revenue trends', { model: { provider: 'openai', modelId: 'gpt-4o' } });
+```
+
+### Selecting a project
+
+If your organization has multiple projects, pass `projectId` (or set it on the client).
+
+```ts
+const client = new Nao({ apiKey: 'nao_...', projectId: '<project-uuid>' });
+console.log(await client.projects());
+```
+
+## Authentication
+
+Create an organization API key from the nao app (Settings → API keys). Keys start with `nao_`.
+
+## API
+
+| Method                                              | Description                                          |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `new Nao({ apiKey, baseUrl?, projectId?, model? })` | Create a client                                      |
+| `client.run(prompt, options?)`                      | Run and resolve with the full response (`RunResult`) |
+| `client.stream(prompt, options?)`                   | Stream the response as `StreamEvent`s                |
+| `client.models({ projectId? })`                     | List activated models                                |
+| `client.projects()`                                 | List projects for the org                            |

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,37 @@
+{
+	"name": "@nao/sdk",
+	"version": "0.1.0",
+	"description": "Official TypeScript SDK for the nao analytics agent",
+	"type": "module",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsup src/index.ts --format esm --dts --clean",
+		"typecheck": "tsc --noEmit"
+	},
+	"keywords": [
+		"nao",
+		"analytics",
+		"agent",
+		"sdk",
+		"llm"
+	],
+	"license": "MIT",
+	"engines": {
+		"node": ">=18"
+	},
+	"devDependencies": {
+		"tsup": "^8.5.1",
+		"typescript": "^5.7.0"
+	}
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,196 @@
+import {
+	type AvailableModel,
+	type Model,
+	type ModelInput,
+	type Project,
+	type RunOptions,
+	type RunResult,
+	type StreamEvent,
+	normalizeModel,
+} from './types';
+
+const DEFAULT_BASE_URL = 'http://localhost:5005';
+
+export class NaoError extends Error {
+	readonly statusCode?: number;
+
+	constructor(message: string, statusCode?: number) {
+		super(message);
+		this.name = 'NaoError';
+		this.statusCode = statusCode;
+	}
+}
+
+export interface NaoOptions {
+	apiKey: string;
+	baseUrl?: string;
+	/** Default project used when a request does not specify one. */
+	projectId?: string;
+	/** Default model used when a request does not specify one. */
+	model?: ModelInput;
+}
+
+/**
+ * A client for the nao agent.
+ *
+ * @example
+ * const client = new Nao({ apiKey: 'nao_...' });
+ * const result = await client.run('How many orders were placed last month?');
+ * console.log(result.text);
+ */
+export class Nao {
+	private readonly apiKey: string;
+	private readonly baseUrl: string;
+	private readonly defaultProjectId?: string;
+	private readonly defaultModel?: ModelInput;
+
+	constructor(options: NaoOptions) {
+		if (!options?.apiKey) {
+			throw new Error('apiKey is required');
+		}
+		this.apiKey = options.apiKey;
+		this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+		this.defaultProjectId = options.projectId;
+		this.defaultModel = options.model;
+	}
+
+	/** Send a prompt and resolve with the agent's full response once complete. */
+	async run(prompt: string, options: RunOptions = {}): Promise<RunResult> {
+		const response = await fetch(`${this.baseUrl}/api/v1/agent`, {
+			method: 'POST',
+			headers: this.headers(),
+			body: JSON.stringify(this.buildPayload(prompt, options)),
+			signal: options.signal,
+		});
+		const data = await this.parseJson(response);
+		return { chatId: data.chatId, text: data.text ?? '', model: data.model };
+	}
+
+	/** Send a prompt and yield events as the agent responds. */
+	async *stream(prompt: string, options: RunOptions = {}): AsyncGenerator<StreamEvent> {
+		const response = await fetch(`${this.baseUrl}/api/v1/agent/stream`, {
+			method: 'POST',
+			headers: { ...this.headers(), Accept: 'text/event-stream' },
+			body: JSON.stringify(this.buildPayload(prompt, options)),
+			signal: options.signal,
+		});
+		if (!response.ok || !response.body) {
+			throw new NaoError(await this.errorText(response), response.status);
+		}
+		yield* parseSse(response.body);
+	}
+
+	/** List the models activated for a project. */
+	async models(options: { projectId?: string } = {}): Promise<AvailableModel[]> {
+		const projectId = options.projectId ?? this.defaultProjectId;
+		const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : '';
+		const response = await fetch(`${this.baseUrl}/api/v1/models${query}`, { headers: this.headers() });
+		const data = await this.parseJson(response);
+		return data.models ?? [];
+	}
+
+	/** List the projects available to this API key's organization. */
+	async projects(): Promise<Project[]> {
+		const response = await fetch(`${this.baseUrl}/api/v1/projects`, { headers: this.headers() });
+		const data = await this.parseJson(response);
+		return data.projects ?? [];
+	}
+
+	private buildPayload(prompt: string, options: RunOptions): Record<string, unknown> {
+		if (!prompt) {
+			throw new Error('prompt must not be empty');
+		}
+		const model: Model | undefined = normalizeModel(options.model ?? this.defaultModel);
+		const payload: Record<string, unknown> = { prompt };
+		if (options.chatId) {
+			payload.chatId = options.chatId;
+		}
+		const projectId = options.projectId ?? this.defaultProjectId;
+		if (projectId) {
+			payload.projectId = projectId;
+		}
+		if (model) {
+			payload.model = model;
+		}
+		return payload;
+	}
+
+	private headers(): Record<string, string> {
+		return {
+			Authorization: `Bearer ${this.apiKey}`,
+			'Content-Type': 'application/json',
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	private async parseJson(response: Response): Promise<any> {
+		if (!response.ok) {
+			throw new NaoError(await this.errorText(response), response.status);
+		}
+		return response.json();
+	}
+
+	private async errorText(response: Response): Promise<string> {
+		try {
+			const body = await response.json();
+			if (body && typeof body === 'object' && (body.error || body.message)) {
+				return String(body.error ?? body.message);
+			}
+		} catch {
+			// fall through to status text
+		}
+		return `Request failed with status ${response.status}`;
+	}
+}
+
+async function* parseSse(body: ReadableStream<Uint8Array>): AsyncGenerator<StreamEvent> {
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+			buffer += decoder.decode(value, { stream: true });
+
+			let boundary = buffer.indexOf('\n\n');
+			while (boundary !== -1) {
+				const rawEvent = buffer.slice(0, boundary);
+				buffer = buffer.slice(boundary + 2);
+				const event = parseSseBlock(rawEvent);
+				if (event) {
+					yield event;
+				}
+				boundary = buffer.indexOf('\n\n');
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+function parseSseBlock(block: string): StreamEvent | null {
+	let event: string | undefined;
+	let data = '';
+	for (const line of block.split('\n')) {
+		const trimmed = line.replace(/\r$/, '');
+		if (trimmed.startsWith('event:')) {
+			event = trimmed.slice('event:'.length).trim();
+		} else if (trimmed.startsWith('data:')) {
+			data += trimmed.slice('data:'.length).trim();
+		}
+	}
+	if (!event) {
+		return null;
+	}
+	let parsed: Record<string, unknown> = {};
+	try {
+		parsed = data ? JSON.parse(data) : {};
+	} catch {
+		parsed = {};
+	}
+	return { type: event, ...parsed } as StreamEvent;
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,3 @@
+export { Nao, NaoError } from './client';
+export type { NaoOptions } from './client';
+export type { AvailableModel, Model, ModelInput, Project, RunOptions, RunResult, StreamEvent } from './types';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,63 @@
+/** A model selection: a provider (e.g. `openai`) and a model id. */
+export interface Model {
+	provider: string;
+	modelId: string;
+}
+
+/** A model that is activated for a project and can be selected. */
+export interface AvailableModel {
+	provider: string;
+	modelId: string;
+	name: string;
+}
+
+export interface Project {
+	id: string;
+	name: string;
+}
+
+/** A model passed by the caller: a `Model` object or a `"provider:model-id"` string. */
+export type ModelInput = Model | string;
+
+export interface RunOptions {
+	/** Continue an existing conversation by id. */
+	chatId?: string;
+	/** Override the project for this request. */
+	projectId?: string;
+	/** Pick a model (must be activated for the project). */
+	model?: ModelInput;
+	/** Abort the request. */
+	signal?: AbortSignal;
+}
+
+/** The result of a non-streaming agent run. */
+export interface RunResult {
+	chatId: string;
+	text: string;
+	model?: Model;
+}
+
+export type StreamEvent =
+	| { type: 'message_start'; chatId: string; model?: Model }
+	| { type: 'text'; text: string }
+	| { type: 'tool'; name: string; status: string }
+	| { type: 'message_complete'; chatId: string; text: string; model?: Model }
+	| { type: 'error'; error: string };
+
+export function normalizeModel(model: ModelInput | undefined): Model | undefined {
+	if (model === undefined) {
+		return undefined;
+	}
+	if (typeof model === 'string') {
+		const separator = model.includes(':') ? ':' : model.includes('/') ? '/' : null;
+		if (!separator) {
+			throw new Error("model string must look like 'provider:model-id' (e.g. 'openai:gpt-4o')");
+		}
+		const [provider, modelId] = model.split(separator);
+		return { provider: provider.trim(), modelId: modelId.trim() };
+	}
+	if (!model.provider || !model.modelId) {
+		throw new Error("model must contain 'provider' and 'modelId'");
+	}
+	return { provider: model.provider, modelId: model.modelId };
+}

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"lib": ["ES2022", "DOM"],
+		"declaration": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"outDir": "dist"
+	},
+	"include": ["src"]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lets users invoke the nao agent programmatically: take an API key, instantiate a client, and prompt it — with optional model selection (when activated) and both non-streaming and streaming responses. Inspired by the Claude and Cursor agent SDKs.

This adds a small public REST surface (`/api/v1`) authenticated with an organization API key, plus thin Python and TypeScript clients over it.

## Backend — `/api/v1` (API-key auth)

Authenticated with an org API key (`Authorization: Bearer nao_...`, the same key type used for deploy):

| Endpoint | Description |
| --- | --- |
| `POST /api/v1/agent` | Run a prompt, return the full response `{ chatId, text, model }` |
| `POST /api/v1/agent/stream` | Stream the response as SSE (`message_start`, `text`, `tool`, `message_complete`, `error`) |
| `GET /api/v1/models` | List models activated for a project |
| `GET /api/v1/projects` | List the org's projects |

- New `authenticateApiKey()` resolves the org + the acting user (the key's creator).
- Project resolution order: `chatId`'s project → `projectId` (body/query) → `x-nao-project-id` header → org's first project.
- Conversations persist (visible in the UI) and can be continued by passing `chatId`, reusing the existing agent pipeline (`handleAgentRoute`).

## SDKs

Both expose the same surface: `run()`, `stream()`, `models()`, `projects()`; support picking an activated model (as a `provider:model-id` string or object), continuing a conversation via `chatId`, and streaming text/tool events.

- `sdk/python` (`nao-sdk`) — sync client, single `requests` dependency.
- `sdk/typescript` (`@nao/sdk`) — dependency-free, uses global `fetch` (Node 18+).

```python
from nao_sdk import Nao
client = Nao(api_key="nao_...")
print(client.run("How many orders were placed last month?").text)
for event in client.stream("Top 5 products by revenue?"):
    if event.type == "text": print(event.text, end="")
```

```ts
import { Nao } from '@nao/sdk';
const client = new Nao({ apiKey: 'nao_...' });
console.log((await client.run('How many orders were placed last month?')).text);
for await (const e of client.stream('Top 5 products by revenue?'))
    if (e.type === 'text') process.stdout.write(e.text);
```

## Testing

Ran a local backend (SQLite + the bundled `example/` duckdb project + OpenAI) and exercised every endpoint end-to-end with `curl` and both SDKs (auth success/failure, `projects`, `models`, non-streaming `run`, streaming with incremental text + tool events, conversation continuation via `chatId`, and model selection).

- ✅ `tsc --noEmit` (backend) and `tsc --noEmit` (TypeScript SDK)
- ✅ `npm run lint -w @nao/backend` (+ prettier format check)
- ✅ Python SDK end-to-end demo
- ✅ TypeScript SDK end-to-end demo

Python SDK demo:
[python_sdk_demo.log](https://cursor.com/agents/bc-ce2bb0b8-4e8e-4c47-a14a-39f5b7f02d86/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpython_sdk_demo.log)

TypeScript SDK demo:
[typescript_sdk_demo.log](https://cursor.com/agents/bc-ce2bb0b8-4e8e-4c47-a14a-39f5b7f02d86/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftypescript_sdk_demo.log)

> Note: the pre-commit `cli:check` (`ty check` in `cli/`) fails on a fresh VM because optional Python extras (`kubernetes`, `glom`) aren't installed; this is pre-existing and unrelated to these changes (no `cli/` files touched).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce2bb0b8-4e8e-4c47-a14a-39f5b7f02d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce2bb0b8-4e8e-4c47-a14a-39f5b7f02d86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

