### PR TITLE
feat(chat): keep feedback actions visible when feedback was given

### DIFF
--- a/apps/frontend/src/components/chat-messages/assistant-message.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-message.tsx
@@ -34,6 +34,7 @@ export const AssistantMessage = memo(
 		const hasContent = useMemo(() => checkAssistantMessageHasContent(message), [message]);
 		const isCompacting = message.parts.at(-1)?.type === 'data-compactionSummaryStarted';
 		const showActions = message.id !== storyIntroMessageId;
+		const hasFeedback = message.feedback != null;
 
 		if (!message.parts.length && isSettled) {
 			return null;
@@ -60,7 +61,9 @@ export const AssistantMessage = memo(
 									? isRunning
 										? 'hidden'
 										: 'opacity-100'
-									: 'opacity-0 group-hover:opacity-100',
+									: hasFeedback
+										? 'opacity-100'
+										: 'opacity-0 group-hover:opacity-100',
 							)}
 						/>
 					)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

In a conversation, the thumbs up/down (feedback) action bar on assistant messages is hidden for non-last messages until you hover over them. This means there is no way to tell, at a glance, that feedback was already given on an earlier message.

This change keeps the action bar visible (without hovering) whenever feedback has been given on a message, so you can see that a thumbs up/down was submitted. The selected thumb is already highlighted via `text-primary`.

## How

In `assistant-message.tsx`, the action bar visibility for non-last assistant messages now checks `message.feedback`:

- Non-last message **with** feedback → `opacity-100` (always visible)
- Non-last message **without** feedback → `opacity-0 group-hover:opacity-100` (hidden until hover, unchanged)
- Last message → unchanged (always visible unless the agent is running)

## Testing

Seeded a conversation with three assistant replies (one with thumbs-down feedback on a non-last message) and inspected the rendered action-bar containers in the browser with the mouse parked away from all messages (no hover):

- Message #1 (non-last, no feedback): container class `opacity-0 group-hover:opacity-100`, computed opacity `0` → hidden.
- Message #2 (non-last, thumbs-down given): container class `opacity-100`, computed opacity `1` → visible, thumbs-down highlighted.
- Message #3 (last message): `opacity-100` → visible.

[Feedback action bar stays visible when feedback was given, no hover](https://cursor.com/agents/bc-cf979c49-36b0-4cab-b230-38bcf55b9374/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeedback_visible_when_given.png)

`npm run -w @nao/frontend lint` passes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf979c49-36b0-4cab-b230-38bcf55b9374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf979c49-36b0-4cab-b230-38bcf55b9374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

