### PR TITLE
fix(frontend): cap chat prompt height on large paste

### DIFF
--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -339,6 +339,12 @@ code.dollar:before {
 	transition: opacity 0.1s ease;
 }
 
+.nao-input .prompt-input {
+	max-height: 200px;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+}
+
 /* Mention menu: match select dropdown styling */
 .prompt-container .mention-menu {
 	border-radius: var(--radius-lg);


### PR DESCRIPTION
Fixes: #829 
## What I Did
Pasting a large block into the chat input made the prompt grow without limit and
pushed the layout off screen. This caps `.nao-input .prompt-input` at 200px with
internal scrolling (chat + automations prompt).

# Before

https://github.com/user-attachments/assets/37c58155-e85c-4c51-9cd4-a8d00a6f5e36



# After

https://github.com/user-attachments/assets/b0f60e77-f7ad-4e41-a5fc-60e597f29348

