### PR TITLE
fix(chat): prevent crash when rendering provider error objects

### DIFF
--- a/apps/frontend/src/components/chat-messages/chat-error.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-error.tsx
@@ -16,13 +16,24 @@ type ParsedError = {
 function parseError(error: Error): ParsedError {
 	try {
 		const parsed = JSON.parse(error.message);
+		const nested = parsed?.error;
+		if (nested && typeof nested === 'object') {
+			return {
+				error: asString(nested.code) ?? asString(nested.type),
+				message: asString(nested.message) ?? asString(parsed.message) ?? error.message,
+			};
+		}
 		return {
-			error: parsed.error,
-			message: parsed.message,
+			error: asString(nested),
+			message: asString(parsed?.message),
 		};
 	} catch {
 		return { message: error.message };
 	}
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 export function ChatError({ className }: Props) {


### PR DESCRIPTION
Fixes : #581 

## What I Did
Fixed a crash in ChatError when OpenAI quota  errors arrive with a nested error object instead of a plain string. parseError now unwraps `{ type, code, message, param }` and only renders string fields, so the UI shows the error.

# Before

https://github.com/user-attachments/assets/1e336038-e2fa-4769-8ab2-87badc192933


# After

https://github.com/user-attachments/assets/479ba25d-949e-4b97-bc31-577ae0276edd



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to client-side error message parsing and display with no auth, data, or API behavior changes.
> 
> **Overview**
> **Fixes chat UI crashes** when provider failures serialize `error` as a nested object (e.g. OpenAI quota responses with `code`, `type`, `message`) instead of a plain string.
> 
> `parseError` now unwraps that nested shape and maps `code`/`type` and `message` into the existing `ParsedError` fields. A new `asString` helper ensures only non-empty strings are returned for display, so React never tries to render an object in `ChatError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d07855e3dfd01f3926d2583e6c57180433033f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->