### PR TITLE
Set GPT 5.5 as default provider model

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -68,7 +68,13 @@ export const PROVIDER_META: ProviderMetaMap = {
 				name: 'GPT 5.5',
 				default: true,
 				contextWindow: 400_000,
-				costPerM: { inputNoCache: 1.75, inputCacheRead: 0.175, inputCacheWrite: 0, output: 14 },
+				costPerM: { inputNoCache: 5, inputCacheRead: 0.5, inputCacheWrite: 0, output: 30 },
+			},
+			{
+				id: 'gpt-5.4',
+				name: 'GPT 5.4',
+				contextWindow: 400_000,
+				costPerM: { inputNoCache: 2.5, inputCacheRead: 0.25, inputCacheWrite: 0, output: 15 },
 			},
 			{
 				id: 'gpt-5.2',

--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -64,8 +64,8 @@ export const PROVIDER_META: ProviderMetaMap = {
 		summaryModelId: 'gpt-4.1-mini',
 		models: [
 			{
-				id: 'gpt-5.4',
-				name: 'GPT 5.4',
+				id: 'gpt-5.5',
+				name: 'GPT 5.5',
 				default: true,
 				contextWindow: 400_000,
 				costPerM: { inputNoCache: 1.75, inputCacheRead: 0.175, inputCacheWrite: 0, output: 14 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add GPT 5.5 as the default OpenAI provider model.
- Keep GPT 5.4 available and update GPT 5.5/GPT 5.4 pricing metadata from the provided table.

## Testing
- `npx tsx -e "import { getDefaultModelId, PROVIDER_META } from '@nao/backend/provider-meta'; const models = PROVIDER_META.openai.models; const selected = models.filter((model) => ['gpt-5.5', 'gpt-5.4'].includes(model.id)); console.log(JSON.stringify({ defaultModel: getDefaultModelId('openai'), selected }, null, 2)); const byId = Object.fromEntries(selected.map((model) => [model.id, model])); if (getDefaultModelId('openai') !== 'gpt-5.5') process.exit(1); if (!byId['gpt-5.4']) process.exit(1); if (byId['gpt-5.5']?.costPerM?.inputNoCache !== 5 || byId['gpt-5.5']?.costPerM?.inputCacheRead !== 0.5 || byId['gpt-5.5']?.costPerM?.output !== 30) process.exit(1); if (byId['gpt-5.4']?.costPerM?.inputNoCache !== 2.5 || byId['gpt-5.4']?.costPerM?.inputCacheRead !== 0.25 || byId['gpt-5.4']?.costPerM?.output !== 15) process.exit(1);"`
- `npm run lint`
- Pre-commit hook during commit: `npm run lint`, `npm run format:check`, `npm run db:check-migrations -w @nao/backend`, `npm run cli:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2430013c-d24b-4b4e-b270-d6d6c80072d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2430013c-d24b-4b4e-b270-d6d6c80072d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

