### PR TITLE
Add Cube semantic layer integration

### DIFF
--- a/apps/backend/fastapi/main.py
+++ b/apps/backend/fastapi/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -99,6 +100,13 @@ class ExecuteSQLRequest(BaseModel):
     azure_access_token: str | None = None
 
 
+class ExecuteCubeQueryRequest(BaseModel):
+    query: dict[str, Any]
+    nao_project_folder: str
+    database_id: str | None = None
+    env_vars: dict[str, str] | None = None
+
+
 class ExecuteSQLResponse(BaseModel):
     data: list[dict]
     row_count: int
@@ -159,6 +167,67 @@ def _convert_value(v: object):
         return item_method()
 
     return v
+
+
+def _load_config(request: ExecuteSQLRequest | ExecuteCubeQueryRequest) -> NaoConfig:
+    project_path = Path(request.nao_project_folder)
+    config = NaoConfig.try_load(
+        project_path,
+        raise_on_error=True,
+        extra_env=request.env_vars,
+    )
+    assert config is not None
+    return config
+
+
+def _select_database_config(config: NaoConfig, database_id: str | None):
+    if len(config.databases) == 0:
+        raise HTTPException(
+            status_code=400,
+            detail="No databases configured in nao_config.yaml",
+        )
+
+    if len(config.databases) == 1:
+        return config.databases[0]
+
+    if database_id:
+        db_config = next(
+            (db for db in config.databases if db.name == database_id),
+            None,
+        )
+        if db_config is not None:
+            return db_config
+        available_databases = [db.name for db in config.databases]
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"Database '{database_id}' not found",
+                "available_databases": available_databases,
+            },
+        )
+
+    available_databases = [db.name for db in config.databases]
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "message": "Multiple databases configured. Please specify database_id.",
+            "available_databases": available_databases,
+        },
+    )
+
+
+def _dataframe_response(df: pd.DataFrame, dialect: str | None = None) -> ExecuteSQLResponse:
+    data = [
+        {k: _convert_value(v) for k, v in row.items()}
+        for row in df.to_dict(orient="records")
+    ]
+
+    return ExecuteSQLResponse(
+        data=data,
+        row_count=len(data),
+        columns=[str(c) for c in df.columns.tolist()],
+        dialect=dialect,
+    )
 
 
 # =============================================================================
@@ -222,45 +291,8 @@ async def refresh_context():
 @app.post("/execute_sql", response_model=ExecuteSQLResponse)
 async def execute_sql(request: ExecuteSQLRequest):
     try:
-        project_path = Path(request.nao_project_folder)
-        config = NaoConfig.try_load(
-            project_path,
-            raise_on_error=True,
-            extra_env=request.env_vars,
-        )
-        assert config is not None
-
-        if len(config.databases) == 0:
-            raise HTTPException(
-                status_code=400,
-                detail="No databases configured in nao_config.yaml",
-            )
-
-        if len(config.databases) == 1:
-            db_config = config.databases[0]
-        elif request.database_id:
-            db_config = next(
-                (db for db in config.databases if db.name == request.database_id),
-                None,
-            )
-            if db_config is None:
-                available_databases = [db.name for db in config.databases]
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "message": f"Database '{request.database_id}' not found",
-                        "available_databases": available_databases,
-                    },
-                )
-        else:
-            available_databases = [db.name for db in config.databases]
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "message": "Multiple databases configured. Please specify database_id.",
-                    "available_databases": available_databases,
-                },
-            )
+        config = _load_config(request)
+        db_config = _select_database_config(config, request.database_id)
 
         auth_mode_value = getattr(getattr(db_config, "auth_mode", None), "value", None)
 
@@ -280,17 +312,29 @@ async def execute_sql(request: ExecuteSQLRequest):
         else:
             df = db_config.execute_sql(request.sql)
 
-        data = [
-            {k: _convert_value(v) for k, v in row.items()}
-            for row in df.to_dict(orient="records")
-        ]
+        return _dataframe_response(df, dialect=db_config.type)
+    except HTTPException:
+        raise
+    except NaoConfigError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
-        return ExecuteSQLResponse(
-            data=data,
-            row_count=len(data),
-            columns=[str(c) for c in df.columns.tolist()],
-            dialect=db_config.type,
-        )
+
+@app.post("/execute_cube_query", response_model=ExecuteSQLResponse)
+async def execute_cube_query(request: ExecuteCubeQueryRequest):
+    try:
+        config = _load_config(request)
+        db_config = _select_database_config(config, request.database_id)
+        execute = getattr(db_config, "execute_cube_query", None)
+        if not callable(execute):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Database '{db_config.name}' is not a Cube connection",
+            )
+
+        df = execute(request.query)
+        return _dataframe_response(df, dialect=db_config.type)
     except HTTPException:
         raise
     except NaoConfigError as e:

--- a/apps/backend/fastapi/test_main.py
+++ b/apps/backend/fastapi/test_main.py
@@ -1,11 +1,13 @@
 import tempfile
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import yaml
 from fastapi.testclient import TestClient
 
 from main import app
+from nao_core.config.databases.cube import CubeConfig
 
 
 def assert_sql_result(
@@ -78,6 +80,55 @@ def test_execute_sql_with_cte_duckdb(duckdb_project_folder):
         columns=["id", "message"],
         expected_data=[{"id": 1, "message": "hello"}],
     )
+
+
+@pytest.fixture
+def cube_project_folder():
+    """Create a temporary project folder with a Cube config."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {
+            "project_name": "test-project",
+            "databases": [
+                {
+                    "name": "test-cube",
+                    "type": "cube",
+                    "url": "https://cube.example.com/cubejs-api",
+                    "api_token": "secret",
+                }
+            ],
+        }
+        config_path = Path(tmpdir) / "nao_config.yaml"
+        with config_path.open("w") as f:
+            yaml.dump(config, f)
+        yield tmpdir
+
+
+def test_execute_cube_query(cube_project_folder, monkeypatch):
+    """Test execute_cube_query endpoint with a Cube JSON query."""
+
+    def execute_cube_query(self, query):
+        assert query == {"measures": ["Orders.count"], "dimensions": ["Orders.status"]}
+        return pd.DataFrame([{"Orders.status": "completed", "Orders.count": 12}])
+
+    monkeypatch.setattr(CubeConfig, "execute_cube_query", execute_cube_query)
+    client = TestClient(app)
+
+    response = client.post(
+        "/execute_cube_query",
+        json={
+            "query": {"measures": ["Orders.count"], "dimensions": ["Orders.status"]},
+            "nao_project_folder": cube_project_folder,
+        },
+    )
+
+    assert response.status_code == 200
+    assert_sql_result(
+        response.json(),
+        row_count=1,
+        columns=["Orders.status", "Orders.count"],
+        expected_data=[{"Orders.status": "completed", "Orders.count": 12}],
+    )
+    assert response.json()["dialect"] == "cube"
 
 
 # BigQuery tests (requires SSO authentication)

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -44,6 +44,7 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 						clearToolInputs: false,
 						excludeTools: [
 							'display_chart',
+							'execute_cube_query',
 							'execute_python',
 							'execute_sql',
 							'execute_sandboxed_code',

--- a/apps/backend/src/agents/tools/execute-cube-query.ts
+++ b/apps/backend/src/agents/tools/execute-cube-query.ts
@@ -1,0 +1,51 @@
+import type { executeCubeQuery } from '@nao/shared/tools';
+import { executeCubeQuery as schemas } from '@nao/shared/tools';
+
+import { ExecuteSqlOutput, renderToModelOutput } from '../../components/tool-outputs';
+import { env } from '../../env';
+import { ToolContext } from '../../types/tools';
+import { createTool } from '../../utils/tools';
+
+export async function executeQuery(
+	{ cube_query, database_id }: executeCubeQuery.Input,
+	context: ToolContext,
+): Promise<executeCubeQuery.Output> {
+	const envVars = context.envVars;
+	const response = await fetch(`http://localhost:${env.FASTAPI_PORT}/execute_cube_query`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			query: cube_query,
+			nao_project_folder: context.projectFolder,
+			...(database_id && { database_id }),
+			...(Object.keys(envVars).length > 0 && { env_vars: envVars }),
+		}),
+	});
+
+	if (!response.ok) {
+		const errorData = await response.json().catch(() => ({ detail: response.statusText }));
+		throw new Error(`Error executing Cube query: ${JSON.stringify(errorData.detail)}`);
+	}
+
+	const data = await response.json();
+	const id = `query_${crypto.randomUUID().slice(0, 8)}` as const;
+
+	context.queryResults.set(id, { columns: data.columns, data: data.data });
+
+	return {
+		_version: '1',
+		...data,
+		id,
+	};
+}
+
+export default createTool<executeCubeQuery.Input, executeCubeQuery.Output>({
+	description:
+		'Execute a Cube semantic layer query JSON object against a Cube connection and return the results. If multiple Cube connections are configured, specify the database_id.',
+	inputSchema: schemas.InputSchema,
+	outputSchema: schemas.OutputSchema,
+	execute: executeQuery,
+	toModelOutput: ({ output }) => renderToModelOutput(ExecuteSqlOutput({ output }), output),
+});

--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -5,6 +5,7 @@ import { mcpService } from '../../services/mcp';
 import { AgentSettings } from '../../types/agent-settings';
 import clarification from './clarification';
 import displayChart from './display-chart';
+import executeCubeQuery from './execute-cube-query';
 import executePython from './execute-python';
 import executeSandboxedCode from './execute-sandboxed-code';
 import executeSql from './execute-sql';
@@ -20,6 +21,7 @@ export const tools = {
 	story,
 	clarification,
 	display_chart: displayChart,
+	execute_cube_query: executeCubeQuery,
 	...(executePython && { execute_python: executePython }),
 	...(executeSandboxedCode && { execute_sandboxed_code: executeSandboxedCode }),
 	execute_sql: executeSql,

--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -40,6 +40,7 @@ export const getTools = (
 		testMode?: boolean;
 		mcpEnabled?: boolean;
 		mcpServers?: string[] | null;
+		cubeEnabled?: boolean;
 		excludeFollowUps?: boolean;
 	} = {},
 ) => {
@@ -48,6 +49,7 @@ export const getTools = (
 	const {
 		execute_python,
 		execute_sandboxed_code,
+		execute_cube_query,
 		clarification: clarificationTool,
 		suggest_follow_ups,
 		...rest
@@ -58,6 +60,7 @@ export const getTools = (
 		...baseTools,
 		...(!options.testMode && { clarification: clarificationTool }),
 		...mcpTools,
+		...(options.cubeEnabled && { execute_cube_query }),
 		...(agentSettings?.experimental?.pythonSandboxing && execute_python && { execute_python }),
 		...(agentSettings?.experimental?.sandboxes && execute_sandboxed_code && { execute_sandboxed_code }),
 		...extraTools,

--- a/apps/backend/src/agents/tools/read-query-result.ts
+++ b/apps/backend/src/agents/tools/read-query-result.ts
@@ -9,14 +9,14 @@ const DEFAULT_LIMIT = 20;
 
 export default createTool<readQueryResult.Input, readQueryResult.Output>({
 	description:
-		'Read more rows from a previously executed `execute_sql` query result, by `query_id`. Use this when the rows shown in an `execute_sql` output were truncated and you need to inspect more of the data — it does not re-run the SQL, it pages through the cached result. Works for any query run earlier in this chat (including previous turns).',
+		'Read more rows from a previously executed `execute_sql` or `execute_cube_query` query result, by `query_id`. Use this when the rows shown in a query output were truncated and you need to inspect more of the data — it does not re-run the query, it pages through the cached result. Works for any query run earlier in this chat (including previous turns).',
 	inputSchema: schemas.InputSchema,
 	outputSchema: schemas.OutputSchema,
 	execute: async ({ query_id, offset = 0, limit = DEFAULT_LIMIT }, context) => {
 		const stored = await getQueryResult(context, query_id);
 		if (!stored) {
 			throw new Error(
-				`Query result not found for id "${query_id}". The id must come from an execute_sql tool call earlier in this chat.`,
+				`Query result not found for id "${query_id}". The id must come from an execute_sql or execute_cube_query tool call earlier in this chat.`,
 			);
 		}
 

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -35,6 +35,7 @@ export function SystemPrompt({
 	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
 	const hasBigQuery = connections.some((connection) => connection.type.toLowerCase() === 'bigquery');
 	const hasMySQL = connections.some((connection) => connection.type.toLowerCase() === 'mysql');
+	const hasCube = connections.some((connection) => connection.type.toLowerCase() === 'cube');
 
 	return (
 		<Block>
@@ -97,6 +98,12 @@ export function SystemPrompt({
 					researching.
 				</ListItem>
 				<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>
+				{hasCube && (
+					<ListItem>
+						For Cube semantic layer connections, use execute_cube_query with a Cube query JSON object
+						instead of SQL.
+					</ListItem>
+				)}
 				{!testMode && (
 					<ListItem>
 						Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
@@ -134,6 +141,12 @@ export function SystemPrompt({
 				<ListItem>
 					Never assume columns names, if available, use the columns.md file to get the column names.
 				</ListItem>
+				{hasCube && (
+					<ListItem>
+						<Bold>Cube semantic layer:</Bold> Query dimensions and measures by their full Cube member names
+						from columns.md, for example {`{"measures":["Orders.count"],"dimensions":["Orders.status"]}`}.
+					</ListItem>
+				)}
 				{hasTSQL && (
 					<>
 						<ListItem>
@@ -187,7 +200,10 @@ export function SystemPrompt({
 				<ListItem>
 					The column_name must match the column in the SELECT output that produced the number.
 				</ListItem>
-				<ListItem>The Query ID is shown in the execute_sql tool output (e.g., Query ID: query_a1b2).</ListItem>
+				<ListItem>
+					The Query ID is shown in the execute_sql or execute_cube_query tool output (e.g., Query ID:
+					query_a1b2).
+				</ListItem>
 			</List>
 			<Title level={2}>Formatting Rules</Title>
 			<List>

--- a/apps/backend/src/components/tool-outputs/execute-sql.tsx
+++ b/apps/backend/src/components/tool-outputs/execute-sql.tsx
@@ -1,12 +1,13 @@
 import { pluralize } from '@nao/shared';
-import type { executeSql } from '@nao/shared/tools';
+import type { executeCubeQuery, executeSql } from '@nao/shared/tools';
 
 import { Block, ListItem, Span, Title, TitledList } from '../../lib/markdown';
 import { QueryRows } from './query-rows';
 
 const MAX_ROWS = 40;
+type QueryOutput = executeSql.Output | executeCubeQuery.Output;
 
-export const ExecuteSqlOutput = ({ output, maxRows = MAX_ROWS }: { output: executeSql.Output; maxRows?: number }) => {
+export const ExecuteSqlOutput = ({ output, maxRows = MAX_ROWS }: { output: QueryOutput; maxRows?: number }) => {
 	if (output.data.length === 0) {
 		return <Block>The query was successfully executed and returned no rows.</Block>;
 	}

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -166,12 +166,15 @@ export class AgentService {
 		const modelConfig = await this._getModelConfig(chat.projectId, resolvedLlmSelectedModel);
 		const agentSettings = await projectQueries.getAgentSettings(chat.projectId);
 		const toolContext = await this._getToolContext(chat.projectId, chat.id, chat.userId, agentSettings);
+		const connections = getConnections(toolContext.projectFolder);
+		const cubeEnabled = hasConnectionType(connections, 'cube');
 		const webTools = await this._resolveWebTools(chat.projectId, resolvedLlmSelectedModel.provider, agentSettings);
 		const extraTools = { ...(webTools ?? {}), ...(options.extraTools ?? {}) };
 		const agentTools = getTools(agentSettings, extraTools, {
 			testMode: chat.testMode,
 			mcpEnabled: options.mcpEnabled,
 			mcpServers: options.mcpServers,
+			cubeEnabled,
 			excludeFollowUps: options.excludeFollowUps,
 		});
 		const stopWhen: StopCondition<AgentTools>[] = options.excludeFollowUps
@@ -264,6 +267,10 @@ export class AgentService {
 		}
 		return result;
 	}
+}
+
+function hasConnectionType(connections: ReturnType<typeof getConnections>, type: string): boolean {
+	return connections?.some((connection) => connection.type.toLowerCase() === type) ?? false;
 }
 
 export const MAX_OUTPUT_TOKENS = 16_000;

--- a/apps/backend/tests/tools.test.ts
+++ b/apps/backend/tests/tools.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/services/mcp', () => ({
+	mcpService: {
+		getMcpTools: () => ({}),
+	},
+}));
+vi.mock('../src/agents/tools/story', () => ({ default: {} }));
+vi.mock('../src/agents/tools/clarification', () => ({ default: {} }));
+vi.mock('../src/agents/tools/display-chart', () => ({ default: {} }));
+vi.mock('../src/agents/tools/execute-cube-query', () => ({ default: {} }));
+vi.mock('../src/agents/tools/execute-python', () => ({ default: {} }));
+vi.mock('../src/agents/tools/execute-sandboxed-code', () => ({ default: {} }));
+vi.mock('../src/agents/tools/execute-sql', () => ({ default: {} }));
+vi.mock('../src/agents/tools/grep', () => ({ default: {} }));
+vi.mock('../src/agents/tools/list', () => ({ default: {} }));
+vi.mock('../src/agents/tools/read', () => ({ default: {} }));
+vi.mock('../src/agents/tools/read-query-result', () => ({ default: {} }));
+vi.mock('../src/agents/tools/search', () => ({ default: {} }));
+vi.mock('../src/agents/tools/suggest-follow-ups', () => ({ default: {} }));
+
+import { getTools } from '../src/agents/tools';
+
+describe('getTools', () => {
+	it('does not expose the Cube query tool by default', () => {
+		const tools = getTools(null, undefined, { mcpEnabled: false });
+
+		expect(Object.keys(tools)).toContain('execute_sql');
+		expect(Object.keys(tools)).not.toContain('execute_cube_query');
+	});
+
+	it('exposes the Cube query tool when Cube is enabled', () => {
+		const tools = getTools(null, undefined, { mcpEnabled: false, cubeEnabled: true });
+
+		expect(Object.keys(tools)).toContain('execute_sql');
+		expect(Object.keys(tools)).toContain('execute_cube_query');
+	});
+});

--- a/apps/shared/src/tools/execute-cube-query.ts
+++ b/apps/shared/src/tools/execute-cube-query.ts
@@ -1,0 +1,25 @@
+import z from 'zod/v3';
+
+import { QueryIdSchema } from './query-id';
+
+export const InputSchema = z.object({
+	cube_query: z.record(z.any()).describe('The Cube query JSON object to execute against the Cube API'),
+	database_id: z
+		.string()
+		.optional()
+		.describe('The Cube database name/id to use. Required if multiple databases are configured.'),
+	name: z.string().optional().describe('A descriptive name for the query that will be used to show in the UI.'),
+});
+
+export const OutputSchema = z.object({
+	_version: z.literal('1').optional(),
+	data: z.array(z.any()),
+	row_count: z.number(),
+	columns: z.array(z.string()),
+	/** The id of the query result. May be referenced by the `display_chart` tool call. */
+	id: QueryIdSchema,
+	dialect: z.string().optional(),
+});
+
+export type Input = z.infer<typeof InputSchema>;
+export type Output = z.infer<typeof OutputSchema>;

--- a/apps/shared/src/tools/index.ts
+++ b/apps/shared/src/tools/index.ts
@@ -1,5 +1,6 @@
 export * as clarification from './clarification';
 export * as displayChart from './display-chart';
+export * as executeCubeQuery from './execute-cube-query';
 export * as executePython from './execute-python';
 export * as executeSandboxedCode from './execute-sandboxed-code';
 export * as executeSql from './execute-sql';

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -6,7 +6,7 @@ import re
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
@@ -35,15 +35,12 @@ from nao_core.templates.engine import get_template_engine
 
 from ..base import SyncProvider, SyncResult
 
-if TYPE_CHECKING:
-    from ibis import BaseBackend
-
 console = Console()
 
 TEMPLATE_PREFIX = "databases"
 
 
-def _filter_templates_by_config(templates: list[str], db_config: AnyDatabaseConfig) -> list[str]:
+def _filter_templates_by_config(templates: list[str], db_config: DatabaseConfig) -> list[str]:
     """Keep only templates whose stem matches the configured templates."""
     allowed = {a.value for a in db_config.templates}
     return [t for t in templates if Path(t).stem.replace(".md", "") in allowed]
@@ -65,7 +62,7 @@ def _fmt_error(error: Exception) -> str:
     return escape(str(error))
 
 
-def _fetch_query_history(db_config: DatabaseConfig, conn: BaseBackend) -> list[str]:
+def _fetch_query_history(db_config: DatabaseConfig, conn: Any) -> list[str]:
     """Fetch query history over the already-open sync connection.
 
     Reusing the sync connection keeps history fetching on the same credentials
@@ -79,7 +76,7 @@ def _fetch_query_history(db_config: DatabaseConfig, conn: BaseBackend) -> list[s
         return []
 
     try:
-        cursor = conn.raw_sql(history_sql)  # type: ignore[union-attr]
+        cursor = conn.raw_sql(history_sql)
         queries = _extract_query_texts(cursor)
         fetched = len(queries)
         queries = db_config.filter_query_history(queries)
@@ -155,7 +152,7 @@ def _should_refresh_profiling(
 
 
 def sync_database(
-    db_config: AnyDatabaseConfig,
+    db_config: DatabaseConfig,
     base_path: Path,
     progress: Progress,
     project_path: Path | None = None,

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError, model_validator
 from rich.console import Console
-
-if TYPE_CHECKING:
-    from ibis import BaseBackend
 
 from nao_core.ui import UI, ask_confirm, ask_select
 
@@ -306,15 +303,15 @@ class NaoConfig(BaseModel):
         data = yaml.safe_load(processed_content)
         return cls.model_validate(data)
 
-    def get_connection(self, name: str) -> BaseBackend:
-        """Get an Ibis connection by database name."""
+    def get_connection(self, name: str) -> Any:
+        """Get a connection by database name."""
         for db in self.databases:
             if db.name == name:
                 return db.connect()
         raise ValueError(f"Database '{name}' not found in configuration")
 
-    def get_all_connections(self) -> dict[str, BaseBackend]:
-        """Get all Ibis connections as a dict keyed by name."""
+    def get_all_connections(self) -> dict[str, Any]:
+        """Get all database connections as a dict keyed by name."""
         return {db.name: db.connect() for db in self.databases}
 
     @classmethod

--- a/cli/nao_core/config/databases/__init__.py
+++ b/cli/nao_core/config/databases/__init__.py
@@ -6,6 +6,7 @@ from .athena import AthenaConfig
 from .base import DatabaseAccessor, DatabaseConfig, DatabaseTemplate, DatabaseType
 from .bigquery import BigQueryConfig
 from .clickhouse import ClickHouseConfig
+from .cube import CubeConfig
 from .databricks import DatabricksConfig
 from .duckdb import DuckDBConfig
 from .fabric import FabricConfig
@@ -26,6 +27,7 @@ AnyDatabaseConfig = Annotated[
         Annotated[AthenaConfig, Tag("athena")],
         Annotated[BigQueryConfig, Tag("bigquery")],
         Annotated[ClickHouseConfig, Tag("clickhouse")],
+        Annotated[CubeConfig, Tag("cube")],
         Annotated[DatabricksConfig, Tag("databricks")],
         Annotated[FabricConfig, Tag("fabric")],
         Annotated[SnowflakeConfig, Tag("snowflake")],
@@ -46,6 +48,7 @@ DATABASE_CONFIG_CLASSES: Dict[DatabaseType, Type[object]] = {
     DatabaseType.ATHENA: AthenaConfig,
     DatabaseType.BIGQUERY: BigQueryConfig,
     DatabaseType.CLICKHOUSE: ClickHouseConfig,
+    DatabaseType.CUBE: CubeConfig,
     DatabaseType.DUCKDB: DuckDBConfig,
     DatabaseType.DATABRICKS: DatabricksConfig,
     DatabaseType.FABRIC: FabricConfig,
@@ -78,6 +81,7 @@ __all__ = [
     "AthenaConfig",
     "BigQueryConfig",
     "ClickHouseConfig",
+    "CubeConfig",
     "DATABASE_CONFIG_CLASSES",
     "DatabaseAccessor",
     "DatabaseConfig",

--- a/cli/nao_core/config/databases/athena.py
+++ b/cli/nao_core/config/databases/athena.py
@@ -41,7 +41,7 @@ class AthenaDatabaseContext(DatabaseContext):
             LIMIT 10
         """
         try:
-            rows = self._fetchall(self._conn.raw_sql(query))  # type: ignore[union-attr]
+            rows = self._fetchall(self._conn.raw_sql(query))
             return [
                 {"value": self._json_safe_value(r[0]), "count": int(r[1])}
                 for r in rows

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -5,14 +5,13 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import questionary
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 if TYPE_CHECKING:
     import pandas as pd
-    from ibis import BaseBackend
 
 
 class DatabaseType(str, Enum):
@@ -21,6 +20,7 @@ class DatabaseType(str, Enum):
     ATHENA = "athena"
     BIGQUERY = "bigquery"
     CLICKHOUSE = "clickhouse"
+    CUBE = "cube"
     DUCKDB = "duckdb"
     DATABRICKS = "databricks"
     FABRIC = "fabric"
@@ -149,8 +149,8 @@ class DatabaseConfig(BaseModel, ABC):
         ...
 
     @abstractmethod
-    def connect(self) -> BaseBackend:
-        """Create an Ibis connection for this database."""
+    def connect(self) -> Any:
+        """Create a connection for this database."""
         ...
 
     def execute_sql(self, sql: str) -> pd.DataFrame:
@@ -159,7 +159,7 @@ class DatabaseConfig(BaseModel, ABC):
 
         conn = self.connect()
         try:
-            cursor = conn.raw_sql(sql)  # type: ignore[union-attr]
+            cursor = conn.raw_sql(sql)
 
             if hasattr(cursor, "fetchdf"):
                 return cursor.fetchdf()
@@ -215,7 +215,7 @@ class DatabaseConfig(BaseModel, ABC):
         """Get the database name for this database type."""
         ...
 
-    def get_schemas(self, conn: BaseBackend) -> list[str]:
+    def get_schemas(self, conn: Any) -> list[str]:
         """Return the list of schemas to sync. Override in subclasses for custom behavior."""
         # Prefer schemas (dataset-like) when available.
         list_schemas = getattr(conn, "list_schemas", None)
@@ -235,13 +235,13 @@ class DatabaseConfig(BaseModel, ABC):
 
         return []
 
-    def create_context(self, conn: BaseBackend, schema: str, table_name: str):
+    def create_context(self, conn: Any, schema: str, table_name: str):
         """Create a DatabaseContext for this table. Override in subclasses for custom metadata."""
         from nao_core.config.databases.context import DatabaseContext
 
         return DatabaseContext(conn, schema, table_name)
 
-    def get_semantic_views(self, conn: "BaseBackend", schema: str) -> list[dict[str, str]]:
+    def get_semantic_views(self, conn: Any, schema: str) -> list[dict[str, str]]:
         """Fetch semantic views for a schema. Override in subclasses that support semantic views."""
         return []
 

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from ibis import BaseBackend
+from typing import Any
 
 
 class DatabaseContext:
@@ -19,7 +16,7 @@ class DatabaseContext:
     to fetch warehouse-specific metadata (e.g. BigQuery partition info).
     """
 
-    def __init__(self, conn: BaseBackend, schema: str, table_name: str):
+    def __init__(self, conn: Any, schema: str, table_name: str):
         self._conn = conn
         self._schema = schema
         self._table_name = table_name
@@ -130,7 +127,7 @@ class DatabaseContext:
         is_date = any(t in col_type.lower() for t in ("date", "timestamp", "time"))
 
         query = self._build_profiling_query(col)
-        row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
+        row = self._fetchone(self._conn.raw_sql(query))
         if not row:
             return None
 
@@ -160,7 +157,7 @@ class DatabaseContext:
         where_clause = f"WHERE {partition_filter}" if partition_filter else ""
 
         query = f"SELECT {self._null_count_sql(col_sql)} AS null_count FROM {table_sql} {where_clause}".strip()
-        row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
+        row = self._fetchone(self._conn.raw_sql(query))
         if not row:
             return None
 
@@ -182,9 +179,7 @@ class DatabaseContext:
             val_where = "WHERE " + " AND ".join(base_conditions + ["val IS NOT NULL"])
             try:
                 row = self._fetchone(
-                    self._conn.raw_sql(  # type: ignore[union-attr]
-                        f"SELECT COUNT(DISTINCT val) FROM {unnest_from} {base_where}".strip()
-                    )
+                    self._conn.raw_sql(f"SELECT COUNT(DISTINCT val) FROM {unnest_from} {base_where}".strip())
                 )
                 if row and row[0] is not None:
                     profile["distinct_count"] = int(row[0])
@@ -193,7 +188,7 @@ class DatabaseContext:
             if profile["distinct_count"] and profile["distinct_count"] <= 50:
                 try:
                     rows = self._fetchall(
-                        self._conn.raw_sql(  # type: ignore[union-attr]
+                        self._conn.raw_sql(
                             f"SELECT val, COUNT(*) AS cnt FROM {unnest_from} {val_where} "
                             f"GROUP BY val ORDER BY cnt DESC, val ASC LIMIT 10".strip()
                         )
@@ -210,7 +205,7 @@ class DatabaseContext:
             if string_expr:
                 try:
                     row = self._fetchone(
-                        self._conn.raw_sql(  # type: ignore[union-attr]
+                        self._conn.raw_sql(
                             f"SELECT COUNT(DISTINCT {string_expr}) FROM {table_sql} {where_clause}".strip()
                         )
                     )
@@ -224,7 +219,7 @@ class DatabaseContext:
                         conditions.append(f"{string_expr} IS NOT NULL")
                         top_where = "WHERE " + " AND ".join(conditions)
                         rows = self._fetchall(
-                            self._conn.raw_sql(  # type: ignore[union-attr]
+                            self._conn.raw_sql(
                                 f"SELECT {string_expr} AS val, COUNT(*) AS cnt FROM {table_sql} {top_where} "
                                 f"GROUP BY {string_expr} ORDER BY COUNT(*) DESC, {string_expr} ASC LIMIT 10".strip()
                             )
@@ -335,7 +330,7 @@ class DatabaseContext:
     def _fetch_top_values(self, col: dict) -> list[dict]:
         query = self._build_top_values_query(col)
         try:
-            rows = self._fetchall(self._conn.raw_sql(query))  # type: ignore[union-attr]
+            rows = self._fetchall(self._conn.raw_sql(query))
             return [
                 {"value": self._json_safe_value(r[0]), "count": int(r[1])}
                 for r in rows

--- a/cli/nao_core/config/databases/cube.py
+++ b/cli/nao_core/config/databases/cube.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import httpx
+import pandas as pd
+from pydantic import Field
+
+from nao_core.config.exceptions import InitError
+from nao_core.ui import ask_text
+
+from .base import DatabaseConfig, DatabaseTemplate
+from .context import DatabaseContext
+
+DEFAULT_SCHEMA = "default"
+
+
+class CubeBackend:
+    """Lightweight backend adapter over the Cube REST API."""
+
+    def __init__(
+        self,
+        url: str,
+        api_token: str,
+        *,
+        default_schema: str = DEFAULT_SCHEMA,
+        headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self._url = url.rstrip("/")
+        self._api_token = api_token
+        self._default_schema = default_schema
+        self._headers = headers or {}
+        self._timeout = timeout
+        self._client = client or httpx.Client(timeout=timeout)
+        self._owns_client = client is None
+        self._meta_cache: dict[str, Any] | None = None
+
+    def list_schemas(self) -> list[str]:
+        schemas = {self.get_cube_schema(cube) for cube in self.cubes()}
+        return sorted(schemas)
+
+    def list_tables(self, database: str) -> list[str]:
+        return sorted(cube["name"] for cube in self.cubes() if self.get_cube_schema(cube) == database)
+
+    def get_cube(self, schema: str, table_name: str) -> dict[str, Any]:
+        for cube in self.cubes():
+            if self.get_cube_schema(cube) == schema and cube.get("name") == table_name:
+                return cube
+        raise ValueError(f"Cube '{schema}.{table_name}' not found in metadata")
+
+    def get_cube_schema(self, cube: dict[str, Any]) -> str:
+        value = cube.get("schema") or cube.get("namespace") or self._default_schema
+        return str(value)
+
+    def cubes(self) -> list[dict[str, Any]]:
+        meta = self.meta()
+        cubes = meta.get("cubes", [])
+        if not isinstance(cubes, list):
+            raise TypeError("Cube metadata response must contain a 'cubes' list")
+        return [cube for cube in cubes if isinstance(cube, dict) and cube.get("name")]
+
+    def meta(self) -> dict[str, Any]:
+        if self._meta_cache is None:
+            payload = self._request("GET", "/v1/meta")
+            if not isinstance(payload, dict):
+                raise TypeError("Cube metadata response must be a JSON object")
+            self._meta_cache = payload
+        return self._meta_cache
+
+    def execute_cube_query(self, query: dict[str, Any]) -> pd.DataFrame:
+        payload = query if "query" in query else {"query": query}
+        response = self._request("POST", "/v1/load", json=payload)
+        data = response.get("data", []) if isinstance(response, dict) else []
+        if not isinstance(data, list):
+            raise TypeError("Cube load response must contain a 'data' list")
+        columns = _query_columns(payload.get("query", {}))
+        df = pd.DataFrame(data)
+        return df.reindex(columns=columns) if columns else df
+
+    def disconnect(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def _request(self, method: str, path: str, **kwargs) -> Any:
+        headers = {
+            "Authorization": self._api_token,
+            **self._headers,
+        }
+        response = self._client.request(
+            method,
+            f"{self._url}{path}",
+            headers=headers,
+            timeout=self._timeout,
+            **kwargs,
+        )
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            detail = response.text.strip()
+            message = f"Cube API request failed with status {response.status_code}"
+            raise RuntimeError(f"{message}: {detail}") from e
+        return response.json()
+
+
+class CubeDatabaseContext(DatabaseContext):
+    """Cube context using semantic layer metadata and load queries."""
+
+    def __init__(self, conn: CubeBackend, schema: str, table_name: str):
+        super().__init__(conn, schema, table_name)
+        self._cube_cache: dict[str, Any] | None = None
+
+    @property
+    def cube(self) -> dict[str, Any]:
+        if self._cube_cache is None:
+            self._cube_cache = self._conn.get_cube(self._schema, self._table_name)
+        return self._cube_cache
+
+    def columns(self) -> list[dict[str, Any]]:
+        if self._columns_cache is None:
+            self._columns_cache = [
+                self._member_to_column(member, "dimension") for member in self.cube.get("dimensions", [])
+            ] + [self._member_to_column(member, "measure") for member in self.cube.get("measures", [])]
+        return self._columns_cache
+
+    def row_count(self) -> int:
+        if self._row_count_cache is not None:
+            return self._row_count_cache
+
+        count_measure = self._first_measure(("count", "number"))
+        if not count_measure:
+            self._row_count_cache = 0
+            return self._row_count_cache
+
+        try:
+            df = self._conn.execute_cube_query({"measures": [count_measure]})
+            value = df.iloc[0][count_measure] if not df.empty and count_measure in df.columns else 0
+            self._row_count_cache = int(value or 0)
+        except Exception:
+            self._row_count_cache = 0
+        return self._row_count_cache
+
+    def preview(self, limit: int = 10) -> list[dict[str, Any]]:
+        query = self._preview_query(limit)
+        if not query:
+            return []
+        try:
+            df = self._conn.execute_cube_query(query)
+        except Exception:
+            return []
+        return [_json_safe_record(row) for row in df.to_dict(orient="records")]
+
+    def description(self) -> str | None:
+        description = self.cube.get("description")
+        if description:
+            return str(description)
+        title = self.cube.get("title")
+        return str(title) if title else None
+
+    def profiling(self) -> dict[str, Any] | None:
+        return None
+
+    def _preview_query(self, limit: int) -> dict[str, Any] | None:
+        dimensions = [member["name"] for member in self.cube.get("dimensions", []) if member.get("name")]
+        measures = [member["name"] for member in self.cube.get("measures", []) if member.get("name")]
+        query: dict[str, Any] = {"limit": max(0, int(limit))}
+        if dimensions:
+            query["dimensions"] = dimensions[:5]
+        if measures:
+            query["measures"] = measures[:1]
+        return query if "dimensions" in query or "measures" in query else None
+
+    def _first_measure(self, preferred_types: tuple[str, ...]) -> str | None:
+        measures = [member for member in self.cube.get("measures", []) if member.get("name")]
+        for preferred_type in preferred_types:
+            for member in measures:
+                if str(member.get("type", "")).lower() == preferred_type:
+                    return str(member["name"])
+        return str(measures[0]["name"]) if measures else None
+
+    @staticmethod
+    def _member_to_column(member: dict[str, Any], kind: str) -> dict[str, Any]:
+        member_type = str(member.get("type") or kind)
+        description_parts = [kind.capitalize()]
+        if title := member.get("title"):
+            description_parts.append(str(title))
+        if description := member.get("description"):
+            description_parts.append(str(description))
+        return {
+            "name": str(member.get("name", "")),
+            "type": member_type,
+            "nullable": True,
+            "description": " - ".join(description_parts),
+        }
+
+
+class CubeConfig(DatabaseConfig):
+    """Cube semantic layer configuration using the Cube REST API."""
+
+    type: Literal["cube"] = "cube"
+    url: str = Field(description="Cube API base URL, for example https://cube.example.com/cubejs-api")
+    api_token: str = Field(description="Cube API token")
+    default_schema: str = Field(default=DEFAULT_SCHEMA, description="Schema folder name for cubes without a namespace")
+    headers: dict[str, str] = Field(default_factory=dict, description="Additional HTTP headers for Cube API requests")
+    timeout: float = Field(default=30.0, gt=0, description="Cube API request timeout in seconds")
+    templates: list[DatabaseTemplate] = Field(
+        default_factory=lambda: [DatabaseTemplate.COLUMNS, DatabaseTemplate.PREVIEW],
+        description="Which default templates to render per cube. Defaults to ['columns', 'preview'].",
+    )
+
+    @classmethod
+    def promptConfig(cls) -> "CubeConfig":
+        name = ask_text("Connection name:", default="cube-prod") or "cube-prod"
+        url = ask_text("Cube API URL:", default="http://localhost:4000/cubejs-api") or ""
+        if not url:
+            raise InitError("Cube API URL is required.")
+        api_token = ask_text("Cube API token:", password=True, required_field=True)
+        default_schema = (
+            ask_text("Default schema for cubes without namespace:", default=DEFAULT_SCHEMA) or DEFAULT_SCHEMA
+        )
+        return CubeConfig(
+            name=name,
+            url=url,
+            api_token=api_token,  # type: ignore[arg-type]
+            default_schema=default_schema,
+        )
+
+    def connect(self) -> CubeBackend:
+        return CubeBackend(
+            self.url,
+            self.api_token,
+            default_schema=self.default_schema,
+            headers=self.headers,
+            timeout=self.timeout,
+        )
+
+    def get_database_name(self) -> str:
+        return self.name
+
+    def get_schemas(self, conn: CubeBackend) -> list[str]:
+        return conn.list_schemas()
+
+    def create_context(self, conn: CubeBackend, schema: str, table_name: str) -> CubeDatabaseContext:
+        return CubeDatabaseContext(conn, schema, table_name)
+
+    def execute_cube_query(self, query: dict[str, Any]) -> pd.DataFrame:
+        conn = self.connect()
+        try:
+            return conn.execute_cube_query(query)
+        finally:
+            conn.disconnect()
+
+    def execute_sql(self, sql: str) -> pd.DataFrame:
+        try:
+            query = json.loads(sql)
+        except json.JSONDecodeError as e:
+            raise ValueError("Cube queries must be JSON objects, not SQL strings") from e
+        if not isinstance(query, dict):
+            raise ValueError("Cube query JSON must be an object")
+        return self.execute_cube_query(query)
+
+    def check_connection(self) -> tuple[bool, str]:
+        conn = None
+        try:
+            conn = self.connect()
+            schemas = self.get_schemas(conn)
+            cube_count = sum(len(conn.list_tables(schema)) for schema in schemas)
+            return True, f"Connected successfully ({cube_count} cubes across {len(schemas)} schemas found)"
+        except Exception as e:
+            return False, str(e)
+        finally:
+            if conn is not None:
+                conn.disconnect()
+
+
+def _query_columns(query: Any) -> list[str]:
+    if not isinstance(query, dict):
+        return []
+    columns: list[str] = []
+    for key in ("dimensions", "measures", "segments"):
+        values = query.get(key, [])
+        if isinstance(values, list):
+            columns.extend(str(value) for value in values)
+    time_dimensions = query.get("timeDimensions", [])
+    if isinstance(time_dimensions, list):
+        columns.extend(
+            str(item["dimension"]) for item in time_dimensions if isinstance(item, dict) and item.get("dimension")
+        )
+    return columns
+
+
+def _json_safe_record(row: dict[str, Any]) -> dict[str, Any]:
+    safe: dict[str, Any] = {}
+    for key, value in row.items():
+        if value is None or isinstance(value, (str, int, float, bool, list, dict)):
+            safe[key] = value
+        else:
+            safe[key] = str(value)
+    return safe

--- a/cli/nao_core/config/databases/mysql.py
+++ b/cli/nao_core/config/databases/mysql.py
@@ -29,7 +29,7 @@ class MysqlDatabaseContext(DatabaseContext):
                 FROM information_schema.TABLES
                 WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
             """
-            row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
+            row = self._conn.raw_sql(query).fetchone()
             if row and row[0]:
                 return str(row[0]).strip() or None
         except Exception:
@@ -53,7 +53,7 @@ class MysqlDatabaseContext(DatabaseContext):
             FROM information_schema.COLUMNS
             WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
         """
-        rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
+        rows = self._conn.raw_sql(query).fetchall()
         return {row[0]: str(row[1]) for row in rows if row[1]}
 
 

--- a/cli/nao_core/config/databases/postgres.py
+++ b/cli/nao_core/config/databases/postgres.py
@@ -26,7 +26,7 @@ class PostgresDatabaseContext(DatabaseContext):
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
                 WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid = 0
             """
-            row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
+            row = self._conn.raw_sql(query).fetchone()
             if row and row[0]:
                 return str(row[0]).strip() or None
         except Exception:
@@ -53,7 +53,7 @@ class PostgresDatabaseContext(DatabaseContext):
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid > 0
         """
-        rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
+        rows = self._conn.raw_sql(query).fetchall()
         return {row[0]: str(row[1]) for row in rows if row[1]}
 
     def _cast_float(self, expr: str) -> str:

--- a/cli/nao_core/config/databases/starrocks.py
+++ b/cli/nao_core/config/databases/starrocks.py
@@ -105,13 +105,13 @@ class StarRocksDatabaseContext(DatabaseContext):
               AND TABLE_NAME = {_quote_literal(self._table_name)}
             LIMIT 1
         """
-        row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
+        row = self._conn.raw_sql(query).fetchone()
         if row and row[0]:
             return str(row[0]).strip() or None
         return None
 
     def _description_from_show_create(self) -> str | None:
-        row = self._conn.raw_sql(self._show_create_table_sql()).fetchone()  # type: ignore[union-attr]
+        row = self._conn.raw_sql(self._show_create_table_sql()).fetchone()
         if not row:
             return None
         ddl = str(row[-1]).strip() if row[-1] else ""
@@ -141,7 +141,7 @@ class StarRocksDatabaseContext(DatabaseContext):
               AND TABLE_NAME = {_quote_literal(self._table_name)}
             ORDER BY ORDINAL_POSITION
         """
-        rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
+        rows = self._conn.raw_sql(query).fetchall()
         return [
             {
                 "name": str(row[0]),
@@ -153,7 +153,7 @@ class StarRocksDatabaseContext(DatabaseContext):
         ]
 
     def _columns_from_show_full_columns(self) -> list[dict[str, Any]]:
-        cursor = self._conn.raw_sql(f"SHOW FULL COLUMNS FROM {self._qualified_table_sql()}")  # type: ignore[union-attr]
+        cursor = self._conn.raw_sql(f"SHOW FULL COLUMNS FROM {self._qualified_table_sql()}")
         rows = cursor.fetchall()
         description = getattr(cursor, "description", None) or []
         columns = {str(desc[0]).lower(): idx for idx, desc in enumerate(description) if desc and desc[0]}
@@ -186,14 +186,14 @@ class StarRocksDatabaseContext(DatabaseContext):
 
     def row_count(self) -> int:
         try:
-            row = self._conn.raw_sql(f"SELECT COUNT(*) FROM {self._qualified_table_sql()}").fetchone()  # type: ignore[union-attr]
+            row = self._conn.raw_sql(f"SELECT COUNT(*) FROM {self._qualified_table_sql()}").fetchone()
             return int(row[0]) if row and row[0] is not None else 0
         except Exception:
             return 0
 
     def preview(self, limit: int = 10) -> list[dict[str, Any]]:
         safe_limit = max(0, int(limit))
-        cursor = self._conn.raw_sql(f"SELECT * FROM {self._qualified_table_sql()} LIMIT {safe_limit}")  # type: ignore[union-attr]
+        cursor = self._conn.raw_sql(f"SELECT * FROM {self._qualified_table_sql()} LIMIT {safe_limit}")
         rows = cursor.fetchall()
         columns = [desc[0] for desc in cursor.description] if cursor.description else []
         out: list[dict[str, Any]] = []

--- a/cli/tests/nao_core/config/test_cube.py
+++ b/cli/tests/nao_core/config/test_cube.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+from rich.progress import Progress
+
+from nao_core.commands.sync.providers.databases.provider import sync_database
+from nao_core.config.base import NaoConfig
+from nao_core.config.databases.cube import CubeBackend, CubeConfig, CubeDatabaseContext
+
+
+def test_cube_config_loads_from_yaml_dict():
+    config = NaoConfig.model_validate(
+        {
+            "project_name": "cube-project",
+            "databases": [
+                {
+                    "name": "cube-prod",
+                    "type": "cube",
+                    "url": "https://cube.example.com/cubejs-api",
+                    "api_token": "secret",
+                }
+            ],
+        }
+    )
+
+    db = config.databases[0]
+    assert isinstance(db, CubeConfig)
+    assert db.get_database_name() == "cube-prod"
+
+
+def test_cube_backend_discovers_metadata_and_executes_query():
+    backend = _backend_with_responses(
+        {
+            ("GET", "https://cube.example.com/cubejs-api/v1/meta"): {
+                "cubes": [
+                    {
+                        "name": "Orders",
+                        "schema": "sales",
+                        "dimensions": [{"name": "Orders.status", "type": "string"}],
+                        "measures": [{"name": "Orders.count", "type": "number"}],
+                    }
+                ]
+            },
+            ("POST", "https://cube.example.com/cubejs-api/v1/load"): {
+                "data": [{"Orders.status": "completed", "Orders.count": 12}]
+            },
+        }
+    )
+
+    assert backend.list_schemas() == ["sales"]
+    assert backend.list_tables("sales") == ["Orders"]
+
+    df = backend.execute_cube_query({"measures": ["Orders.count"], "dimensions": ["Orders.status"]})
+
+    assert df.to_dict(orient="records") == [{"Orders.status": "completed", "Orders.count": 12}]
+    assert df.columns.tolist() == ["Orders.status", "Orders.count"]
+
+
+def test_cube_context_maps_dimensions_and_measures_to_columns():
+    backend = _backend_with_responses(
+        {
+            ("GET", "https://cube.example.com/cubejs-api/v1/meta"): {
+                "cubes": [
+                    {
+                        "name": "Orders",
+                        "title": "Orders cube",
+                        "dimensions": [
+                            {"name": "Orders.status", "title": "Status", "type": "string"},
+                        ],
+                        "measures": [
+                            {"name": "Orders.count", "title": "Count", "type": "number"},
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+    ctx = CubeDatabaseContext(backend, "default", "Orders")
+
+    assert ctx.description() == "Orders cube"
+    assert ctx.columns() == [
+        {
+            "name": "Orders.status",
+            "type": "string",
+            "nullable": True,
+            "description": "Dimension - Status",
+        },
+        {
+            "name": "Orders.count",
+            "type": "number",
+            "nullable": True,
+            "description": "Measure - Count",
+        },
+    ]
+
+
+def test_cube_sync_renders_metadata_files(tmp_path: Path, monkeypatch):
+    backend = _backend_with_responses(
+        {
+            ("GET", "https://cube.example.com/cubejs-api/v1/meta"): {
+                "cubes": [
+                    {
+                        "name": "Orders",
+                        "dimensions": [{"name": "Orders.status", "type": "string"}],
+                        "measures": [{"name": "Orders.count", "type": "number"}],
+                    }
+                ]
+            },
+            ("POST", "https://cube.example.com/cubejs-api/v1/load"): {
+                "data": [{"Orders.status": "completed", "Orders.count": 12}]
+            },
+        }
+    )
+    config = CubeConfig(name="cube-prod", url="https://cube.example.com/cubejs-api", api_token="secret")
+    monkeypatch.setattr(CubeConfig, "connect", lambda self: backend)
+
+    with Progress(transient=True) as progress:
+        state = sync_database(config, tmp_path, progress)
+
+    table_path = tmp_path / "type=cube" / "database=cube-prod" / "schema=default" / "table=Orders"
+    assert state.tables_synced == 1
+    assert "Orders.status (string" in (table_path / "columns.md").read_text()
+    assert '"Orders.count": 12' in (table_path / "preview.md").read_text()
+
+
+def _backend_with_responses(responses: dict[tuple[str, str], dict]) -> CubeBackend:
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = (request.method, str(request.url))
+        if key not in responses:
+            return httpx.Response(404, json={"error": f"Unhandled request {key}"})
+        return httpx.Response(200, json=responses[key])
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    return CubeBackend("https://cube.example.com/cubejs-api", "secret", client=client)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a Cube database config and REST adapter for syncing Cube metadata into the existing database context tree.
- Adds runtime Cube JSON query execution through FastAPI and an `execute_cube_query` agent tool.
- Gates `execute_cube_query` so it is only exposed when the current project has a Cube connection.
- Adds focused Cube sync/config tests, FastAPI endpoint coverage, and tool-surface gating tests.

### Verification
- `uv run pytest tests/nao_core/config/test_cube.py`
- `uv run pytest ../apps/backend/fastapi/test_main.py -q -k "duckdb or cube"`
- `npm run -w @nao/backend test -- tests/tools.test.ts`
- `make lint` from `cli/`
- `npm run lint`
- `npm run format:check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f3faf14-ba18-4f41-852f-0288acbc03e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f3faf14-ba18-4f41-852f-0288acbc03e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

