### PR TITLE
Add configurable Slack reply mode

### DIFF
--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -5,7 +5,7 @@ import s, { DBProject } from '../db/abstractSchema';
 import { db } from '../db/db';
 import { env } from '../env';
 import { llmProviderSchema } from '../types/llm';
-import { SlackTransportMode } from '../types/messaging-provider';
+import { SlackReplyMode, SlackTransportMode } from '../types/messaging-provider';
 import { takeFirstOrThrow } from '../utils/queries';
 
 function toLlmSelectedModel(
@@ -46,6 +46,7 @@ export const getProjectSlackConfig = async (projectId: string): Promise<SlackCon
 		autoCreateUsersDomains: settings.autoCreateUsersDomains ?? [],
 		transportMode,
 		appToken: settings.slackAppToken ?? '',
+		replyMode: toSlackReplyMode(settings.slackReplyMode),
 	};
 };
 
@@ -63,6 +64,7 @@ export const upsertProjectSlackConfig = async (data: {
 	transportMode: SlackTransportMode;
 	appToken: string;
 	modelSelection?: LlmSelectedModel;
+	replyMode: SlackReplyMode;
 }> => {
 	const updated = await db.transaction(async (tx) => {
 		const project = await takeFirstOrThrow(
@@ -84,6 +86,7 @@ export const upsertProjectSlackConfig = async (data: {
 						autoCreateUsersDomains: existing?.autoCreateUsersDomains ?? [],
 						slackTransportMode: data.transportMode,
 						slackAppToken: data.appToken ?? '',
+						slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
 					},
 				})
 				.where(eq(s.project.id, data.projectId))
@@ -100,6 +103,7 @@ export const upsertProjectSlackConfig = async (data: {
 		transportMode: settings?.slackTransportMode === 'socket' ? 'socket' : 'webhook',
 		appToken: settings?.slackAppToken || '',
 		modelSelection: toLlmSelectedModel(settings?.slackllmProvider, settings?.slackllmModelId),
+		replyMode: toSlackReplyMode(settings?.slackReplyMode),
 	};
 };
 
@@ -127,6 +131,31 @@ export const updateProjectSlackModel = async (
 					autoCreateUsersDomains: existing?.autoCreateUsersDomains ?? [],
 					slackTransportMode: existing?.slackTransportMode ?? 'webhook',
 					slackAppToken: existing?.slackAppToken ?? '',
+					slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
+				},
+			})
+			.where(eq(s.project.id, projectId))
+			.execute();
+	});
+};
+
+export const updateProjectSlackReplyMode = async (projectId: string, replyMode: SlackReplyMode): Promise<void> => {
+	await db.transaction(async (tx) => {
+		const project = await takeFirstOrThrow(
+			tx.select().from(s.project).where(eq(s.project.id, projectId)).execute(),
+			`Project not found: ${projectId}`,
+		);
+		const existing = project.slackSettings;
+		if (!existing) {
+			throw new Error(`Slack is not configured for project ${projectId}`);
+		}
+
+		await tx
+			.update(s.project)
+			.set({
+				slackSettings: {
+					...existing,
+					slackReplyMode: replyMode,
 				},
 			})
 			.where(eq(s.project.id, projectId))
@@ -177,6 +206,7 @@ export interface SlackConfig {
 	autoCreateUsersDomains: string[];
 	transportMode: SlackTransportMode;
 	appToken: string;
+	replyMode: SlackReplyMode;
 }
 
 export const listSocketModeSlackConfigs = async (): Promise<SlackConfig[]> => {
@@ -197,10 +227,15 @@ export const listSocketModeSlackConfigs = async (): Promise<SlackConfig[]> => {
 			autoCreateUsersDomains: settings.autoCreateUsersDomains ?? [],
 			transportMode: 'socket',
 			appToken: settings.slackAppToken,
+			replyMode: toSlackReplyMode(settings.slackReplyMode),
 		});
 	}
 	return configs;
 };
+
+function toSlackReplyMode(replyMode: string | null | undefined): SlackReplyMode {
+	return replyMode === 'mention' ? 'mention' : 'thread';
+}
 
 // Re-export DBProject for backward compatibility where needed
 export type { DBProject };

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -38,6 +38,7 @@ import {
 	formatMessagingError,
 	formatSlackMessageText,
 } from '../utils/messaging-provider';
+import { shouldReplyToSlackThreadMessage } from '../utils/slack-reply-policy';
 import { isEmailDomainAllowed } from '../utils/utils';
 import { agentService } from './agent';
 import { posthog, PostHogEvent } from './posthog';
@@ -273,18 +274,21 @@ class ProjectSlackBot {
 	private _registerHandlers(): void {
 		this._bot.onNewMention(async (thread, message) => {
 			const startsThread = await this._isThreadStarter(thread.id);
-			if (startsThread) {
+			if (startsThread && this._config.replyMode === 'thread') {
 				await thread.subscribe();
 			}
 			await this._handleWorkFlow(thread, message, { fetchUnseenMessages: true });
 		});
 
 		this._bot.onSubscribedMessage(async (thread, message) => {
+			if (!shouldReplyToSlackThreadMessage(this._config.replyMode, message)) {
+				return;
+			}
 			await this._handleWorkFlow(thread, message, { fetchUnseenMessages: false });
 		});
 
 		this._bot.onNewMessage(/[\s\S]+/, async (thread, message) => {
-			if (message.isMention || message.author.isMe || message.author.isBot) {
+			if (message.isMention || !shouldReplyToSlackThreadMessage(this._config.replyMode, message)) {
 				return;
 			}
 			const existingChat = await chatQueries.getChatBySlackThread(thread.id);
@@ -962,6 +966,7 @@ class SlackService {
 			previous.redirectUrl !== next.redirectUrl ||
 			previous.transportMode !== next.transportMode ||
 			previous.appToken !== next.appToken ||
+			previous.replyMode !== next.replyMode ||
 			previous.autoCreateUsersEnabled !== next.autoCreateUsersEnabled ||
 			previous.autoCreateUsersDomains.join('\0') !== next.autoCreateUsersDomains.join('\0') ||
 			previous.modelSelection?.provider !== next.modelSelection?.provider ||

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -213,6 +213,7 @@ export const projectRoutes = {
 					modelSelection: config.modelSelection,
 					autoCreateUsersEnabled: config.autoCreateUsersEnabled,
 					autoCreateUsersDomains: config.autoCreateUsersDomains,
+					replyMode: config.replyMode,
 				}
 			: null;
 
@@ -272,6 +273,7 @@ export const projectRoutes = {
 				appTokenPreview: config.appToken ? config.appToken.slice(0, 4) + '...' + config.appToken.slice(-4) : '',
 				transportMode: config.transportMode,
 				modelSelection: config.modelSelection,
+				replyMode: config.replyMode,
 			};
 		}),
 
@@ -290,6 +292,15 @@ export const projectRoutes = {
 			);
 			const refreshedConfig = await slackConfigQueries.getProjectSlackConfig(ctx.project.id);
 			await slackService.syncProjectSocketMode(refreshedConfig, ctx.project.id);
+		}),
+
+	updateSlackReplyMode: adminProtectedProcedure
+		.input(z.object({ replyMode: z.enum(['thread', 'mention']) }))
+		.mutation(async ({ ctx, input }) => {
+			await slackConfigQueries.updateProjectSlackReplyMode(ctx.project.id, input.replyMode);
+			const refreshedConfig = await slackConfigQueries.getProjectSlackConfig(ctx.project.id);
+			await slackService.syncProjectSocketMode(refreshedConfig, ctx.project.id);
+			return { replyMode: input.replyMode };
 		}),
 
 	updateSlackAutoCreateUsers: adminProtectedProcedure

--- a/apps/backend/src/types/messaging-provider.ts
+++ b/apps/backend/src/types/messaging-provider.ts
@@ -39,6 +39,9 @@ export type Provider = 'slack' | 'teams' | 'telegram' | 'whatsapp' | 'automation
 export const SLACK_TRANSPORT_MODES = ['webhook', 'socket'] as const;
 export type SlackTransportMode = (typeof SLACK_TRANSPORT_MODES)[number];
 
+export const SLACK_REPLY_MODES = ['thread', 'mention'] as const;
+export type SlackReplyMode = (typeof SLACK_REPLY_MODES)[number];
+
 export type SlackSettings = {
 	slackBotToken: string;
 	slackSigningSecret: string;
@@ -48,6 +51,7 @@ export type SlackSettings = {
 	autoCreateUsersDomains?: string[];
 	slackTransportMode?: SlackTransportMode;
 	slackAppToken?: string;
+	slackReplyMode?: SlackReplyMode;
 };
 
 export type TeamsSettings = {

--- a/apps/backend/src/utils/slack-reply-policy.ts
+++ b/apps/backend/src/utils/slack-reply-policy.ts
@@ -1,0 +1,16 @@
+import type { SlackReplyMode } from '../types/messaging-provider';
+
+interface SlackReplyPolicyMessage {
+	isMention: boolean;
+	author: {
+		isMe: boolean;
+		isBot: boolean;
+	};
+}
+
+export function shouldReplyToSlackThreadMessage(replyMode: SlackReplyMode, message: SlackReplyPolicyMessage): boolean {
+	if (replyMode === 'mention') {
+		return false;
+	}
+	return !message.author.isMe && !message.author.isBot;
+}

--- a/apps/backend/src/utils/slack-reply-policy.ts
+++ b/apps/backend/src/utils/slack-reply-policy.ts
@@ -1,10 +1,9 @@
 import type { SlackReplyMode } from '../types/messaging-provider';
 
 interface SlackReplyPolicyMessage {
-	isMention: boolean;
 	author: {
-		isMe: boolean;
-		isBot: boolean;
+		isMe: boolean | string;
+		isBot: boolean | string;
 	};
 }
 

--- a/apps/backend/tests/slack-reply-policy.test.ts
+++ b/apps/backend/tests/slack-reply-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldReplyToSlackThreadMessage } from '../src/utils/slack-reply-policy';
+
+describe('shouldReplyToSlackThreadMessage', () => {
+	it('allows user thread replies in thread mode', () => {
+		expect(shouldReplyToSlackThreadMessage('thread', createMessage())).toBe(true);
+	});
+
+	it('does not allow ordinary thread replies in mention mode', () => {
+		expect(shouldReplyToSlackThreadMessage('mention', createMessage())).toBe(false);
+	});
+
+	it('allows mention messages in thread mode', () => {
+		expect(shouldReplyToSlackThreadMessage('thread', createMessage({ isMention: true }))).toBe(true);
+	});
+
+	it('does not allow bot or self messages', () => {
+		expect(shouldReplyToSlackThreadMessage('thread', createMessage({ isBot: true }))).toBe(false);
+		expect(shouldReplyToSlackThreadMessage('thread', createMessage({ isMe: true }))).toBe(false);
+	});
+});
+
+function createMessage(overrides: { isMention?: boolean; isBot?: boolean; isMe?: boolean } = {}) {
+	return {
+		isMention: overrides.isMention ?? false,
+		author: {
+			isBot: overrides.isBot ?? false,
+			isMe: overrides.isMe ?? false,
+		},
+	};
+}

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -254,6 +254,15 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 	{
 		page: '/settings/project/slack',
 		pageLabel: 'Slack',
+		title: 'Reply only when mentioned',
+		description:
+			'Control whether nao answers every message in active Slack threads or only messages that tag the bot.',
+		keywords: ['reply mode', 'mentions', 'tagged', 'thread replies', 'bot behavior'],
+		adminOnly: true,
+	},
+	{
+		page: '/settings/project/slack',
+		pageLabel: 'Slack',
 		title: 'Slack transport mode',
 		description: 'Switch between Webhook and Socket Mode for Slack delivery.',
 		keywords: [

--- a/apps/frontend/src/components/settings/slack-config-section.tsx
+++ b/apps/frontend/src/components/settings/slack-config-section.tsx
@@ -29,6 +29,7 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 	const projectConfig = slackConfig.data?.projectConfig;
 	const webhookUrl = slackConfig.data?.webhookUrl ?? '';
 	const transportMode = projectConfig?.transportMode ?? 'webhook';
+	const replyMode = projectConfig?.replyMode ?? 'thread';
 
 	useEffect(() => {
 		if (!availableModels || availableModels.length === 0) {
@@ -43,6 +44,7 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 
 	const upsertSlackConfig = useMutation(trpc.project.upsertSlackConfig.mutationOptions());
 	const updateSlackModel = useMutation(trpc.project.updateSlackModelConfig.mutationOptions());
+	const updateSlackReplyMode = useMutation(trpc.project.updateSlackReplyMode.mutationOptions());
 	const deleteSlackConfig = useMutation(trpc.project.deleteSlackConfig.mutationOptions());
 
 	const handleSubmit = async (values: {
@@ -87,6 +89,14 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 		[availableModels, queryClient],
 	);
 
+	const handleReplyModeChange = useCallback(
+		async (onlyWhenMentioned: boolean) => {
+			await updateSlackReplyMode.mutateAsync({ replyMode: onlyWhenMentioned ? 'mention' : 'thread' });
+			queryClient.invalidateQueries(trpc.project.getSlackConfig.queryOptions());
+		},
+		[queryClient, updateSlackReplyMode],
+	);
+
 	if (!isAdmin) {
 		return (
 			<SettingsCard title='Connection' description='Your Slack app credentials'>
@@ -95,6 +105,10 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 						<span className='text-sm font-medium text-foreground'>Slack App</span>
 						<span className='text-xs text-muted-foreground'>
 							Transport: {transportMode === 'socket' ? 'Socket Mode' : 'Webhook'}
+						</span>
+						<span className='text-xs text-muted-foreground'>
+							Replies:{' '}
+							{replyMode === 'mention' ? 'Only when mentioned' : 'Every message in active threads'}
 						</span>
 						<span className='text-xs font-mono text-muted-foreground'>
 							Bot Token: {projectConfig.botTokenPreview}
@@ -142,6 +156,10 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 						<span className='text-sm font-medium text-foreground'>Slack App</span>
 						<span className='text-xs text-muted-foreground'>
 							Transport: {transportMode === 'socket' ? 'Socket Mode' : 'Webhook'}
+						</span>
+						<span className='text-xs text-muted-foreground'>
+							Replies:{' '}
+							{replyMode === 'mention' ? 'Only when mentioned' : 'Every message in active threads'}
 						</span>
 						<span className='text-xs font-mono text-muted-foreground'>
 							Bot Token: {projectConfig.botTokenPreview}
@@ -193,45 +211,62 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 			)}
 
 			<SettingsCard title='Settings' description='Configure how the Slack bot behaves'>
-				<div className='grid gap-2'>
-					<label className='text-sm font-medium text-foreground'>Model</label>
-					<p className='text-xs text-muted-foreground'>The model used to answer questions asked in Slack.</p>
-					{hasMultipleModels ? (
-						<Select
-							value={selectedModel ? `${selectedModel.provider}:${selectedModel.modelId}` : undefined}
-							onValueChange={handleModelChange}
-							disabled={updateSlackModel.isPending}
-						>
-							<SelectTrigger className='w-full'>
-								<SelectValue>
-									{selectedModel && (
-										<div className='flex items-center gap-2'>
-											<LlmProviderIcon provider={selectedModel.provider} className='size-4' />
-											{selectedModel.name}
-										</div>
-									)}
-								</SelectValue>
-							</SelectTrigger>
-							<SelectContent>
-								{availableModels?.map((model) => (
-									<SelectItem
-										key={`${model.provider}-${model.modelId}`}
-										value={`${model.provider}:${model.modelId}`}
-									>
-										<LlmProviderIcon provider={model.provider} className='size-4' />
-										{model.name}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					) : (
-						selectedModel && (
-							<div className='flex items-center gap-2 text-sm text-muted-foreground'>
-								<LlmProviderIcon provider={selectedModel.provider} className='size-4' />
-								<span>{selectedModel.name}</span>
-							</div>
-						)
-					)}
+				<div className='grid gap-6'>
+					<SettingsControlRow
+						id='slack-reply-only-when-mentioned'
+						label='Reply only when mentioned'
+						description='When enabled, nao reads thread context but only answers messages that tag the bot.'
+						control={
+							<Switch
+								id='slack-reply-only-when-mentioned'
+								checked={replyMode === 'mention'}
+								onCheckedChange={handleReplyModeChange}
+								disabled={updateSlackReplyMode.isPending}
+							/>
+						}
+					/>
+					<div className='grid gap-2'>
+						<label className='text-sm font-medium text-foreground'>Model</label>
+						<p className='text-xs text-muted-foreground'>
+							The model used to answer questions asked in Slack.
+						</p>
+						{hasMultipleModels ? (
+							<Select
+								value={selectedModel ? `${selectedModel.provider}:${selectedModel.modelId}` : undefined}
+								onValueChange={handleModelChange}
+								disabled={updateSlackModel.isPending}
+							>
+								<SelectTrigger className='w-full'>
+									<SelectValue>
+										{selectedModel && (
+											<div className='flex items-center gap-2'>
+												<LlmProviderIcon provider={selectedModel.provider} className='size-4' />
+												{selectedModel.name}
+											</div>
+										)}
+									</SelectValue>
+								</SelectTrigger>
+								<SelectContent>
+									{availableModels?.map((model) => (
+										<SelectItem
+											key={`${model.provider}-${model.modelId}`}
+											value={`${model.provider}:${model.modelId}`}
+										>
+											<LlmProviderIcon provider={model.provider} className='size-4' />
+											{model.name}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						) : (
+							selectedModel && (
+								<div className='flex items-center gap-2 text-sm text-muted-foreground'>
+									<LlmProviderIcon provider={selectedModel.provider} className='size-4' />
+									<span>{selectedModel.name}</span>
+								</div>
+							)
+						)}
+					</div>
 				</div>
 			</SettingsCard>
 

--- a/apps/frontend/src/components/settings/slack-config-section.tsx
+++ b/apps/frontend/src/components/settings/slack-config-section.tsx
@@ -91,8 +91,14 @@ export function SlackConfigSection({ isAdmin }: SlackConfigSectionProps) {
 
 	const handleReplyModeChange = useCallback(
 		async (onlyWhenMentioned: boolean) => {
-			await updateSlackReplyMode.mutateAsync({ replyMode: onlyWhenMentioned ? 'mention' : 'thread' });
-			queryClient.invalidateQueries(trpc.project.getSlackConfig.queryOptions());
+			updateSlackReplyMode.mutate(
+				{ replyMode: onlyWhenMentioned ? 'mention' : 'thread' },
+				{
+					onSuccess: () => {
+						void queryClient.invalidateQueries(trpc.project.getSlackConfig.queryOptions());
+					},
+				},
+			);
 		},
 		[queryClient, updateSlackReplyMode],
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a persisted Slack reply mode so admins can choose between replying to every active thread message or only messages that mention the bot.
- Wire the mode through Slack config queries, tRPC, bot instance refresh, and the Slack settings UI.
- Add focused backend tests for the reply policy.

### Testing
- Passed `npm run -w @nao/backend test -- slack-reply-policy.test.ts slack-socket-bridge.test.ts`.
- Passed `npm run lint`.
- Passed `npm run -w @nao/frontend build` with Vite's existing large-chunk warning.
- Commit hook passed `npm run lint`, `npm run format:check`, `npm run db:check-migrations -w @nao/backend`, and `npm run cli:check`.
- Full `npm run -w @nao/backend test` still has unrelated existing failures in `compaction.test.ts`, `system-prompt.test.ts`, and `sqlite.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3c337d8-c7b4-4707-b69d-6d2493807954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3c337d8-c7b4-4707-b69d-6d2493807954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

