### PR TITLE
Add Bedrock AWS env inheritance opt-out

### DIFF
--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -12,7 +12,13 @@ from rich.console import Console
 
 from nao_core import __version__
 from nao_core.config import NaoConfig, resolve_project_path
-from nao_core.config.llm import PROVIDER_AUTH, LLMProvider
+from nao_core.config.llm import (
+    BEDROCK_AWS_ENV_INHERITANCE_VAR,
+    PROVIDER_AUTH,
+    LLMProvider,
+    is_bedrock_aws_env_inheritance_enabled,
+    scrub_bedrock_aws_env,
+)
 from nao_core.mode import MODE
 from nao_core.tracking import track_command
 
@@ -214,6 +220,16 @@ def chat(
             env["BETTER_AUTH_SECRET"] = auth_secret
 
         if config and config.llm:
+            inherit_bedrock_aws_env = True
+            if config.llm.provider == LLMProvider.BEDROCK:
+                inherit_bedrock_aws_env = is_bedrock_aws_env_inheritance_enabled()
+                if not inherit_bedrock_aws_env:
+                    scrub_bedrock_aws_env(env)
+                    console.print(
+                        f"[bold yellow]⚠[/bold yellow] AWS Bedrock environment inheritance disabled by "
+                        f"{BEDROCK_AWS_ENV_INHERITANCE_VAR}"
+                    )
+
             auth = PROVIDER_AUTH[config.llm.provider]
             if config.llm.api_key is not None and auth.api_key != "none":
                 env[auth.env_var] = config.llm.api_key
@@ -229,11 +245,13 @@ def chat(
                 if config.llm.secret_key:
                     env["AWS_SECRET_ACCESS_KEY"] = config.llm.secret_key
                     console.print("[bold green]✓[/bold green] Set AWS_SECRET_ACCESS_KEY from config")
-                aws_profile = config.llm.aws_profile or os.environ.get("AWS_PROFILE")
+                aws_profile = config.llm.aws_profile
+                if inherit_bedrock_aws_env and not aws_profile:
+                    aws_profile = os.environ.get("AWS_PROFILE")
                 if aws_profile:
                     env["AWS_PROFILE"] = aws_profile
                     console.print("[bold green]✓[/bold green] Set AWS_PROFILE from config")
-                session_token = os.environ.get("AWS_SESSION_TOKEN")
+                session_token = os.environ.get("AWS_SESSION_TOKEN") if inherit_bedrock_aws_env else None
                 if session_token:
                     env["AWS_SESSION_TOKEN"] = session_token
                     console.print("[bold green]✓[/bold green] Set AWS_SESSION_TOKEN from environment")

--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -1,10 +1,12 @@
 import os
+from contextlib import nullcontext
 from typing import Tuple
 
 from rich.console import Console
 from rich.table import Table
 
 from nao_core.config import NaoConfig, resolve_project_path
+from nao_core.config.llm import is_bedrock_aws_env_inheritance_enabled, without_inherited_bedrock_aws_env
 from nao_core.tracking import track_command
 
 console = Console()
@@ -60,16 +62,24 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
 
         models = ollama.list().models
     elif provider == "bedrock":
-        region = llm_config.aws_region or os.environ.get("AWS_REGION", "us-east-1")
+        inherit_bedrock_aws_env = is_bedrock_aws_env_inheritance_enabled()
+        region = llm_config.aws_region
+        if not region and inherit_bedrock_aws_env:
+            region = os.environ.get("AWS_REGION")
+        region = region or "us-east-1"
         if api_key:
             return True, f"Bearer token configured (region: {region})"
 
         import boto3
 
-        profile = llm_config.aws_profile or os.environ.get("AWS_PROFILE")
-        session = boto3.Session(profile_name=profile, region_name=region)
-        client = session.client("bedrock")
-        response = client.list_foundation_models()
+        profile = llm_config.aws_profile
+        if inherit_bedrock_aws_env and not profile:
+            profile = os.environ.get("AWS_PROFILE")
+        aws_env_context = nullcontext() if inherit_bedrock_aws_env else without_inherited_bedrock_aws_env()
+        with aws_env_context:
+            session = boto3.Session(profile_name=profile, region_name=region)
+            client = session.client("bedrock")
+            response = client.list_foundation_models()
         models = response.get("modelSummaries", [])
     elif provider == "vertex":
         project = llm_config.gcp_project

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -1,3 +1,6 @@
+import os
+from collections.abc import Iterator, MutableMapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal
@@ -19,6 +22,50 @@ class LLMProvider(str, Enum):
     OLLAMA = "ollama"
     BEDROCK = "bedrock"
     VERTEX = "vertex"
+
+
+BEDROCK_AWS_ENV_INHERITANCE_VAR = "NAO_BEDROCK_INHERIT_AWS_ENV"
+DISABLED_ENV_VALUES = {"0", "false", "no", "off"}
+BEDROCK_AWS_ENV_VARS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+)
+
+
+def is_bedrock_aws_env_inheritance_enabled() -> bool:
+    value = os.environ.get(BEDROCK_AWS_ENV_INHERITANCE_VAR)
+    if value is None:
+        return True
+    return value.strip().lower() not in DISABLED_ENV_VALUES
+
+
+def scrub_bedrock_aws_env(env: MutableMapping[str, str]) -> dict[str, str]:
+    removed_env: dict[str, str] = {}
+    for env_var in BEDROCK_AWS_ENV_VARS:
+        value = env.pop(env_var, None)
+        if value is not None:
+            removed_env[env_var] = value
+    return removed_env
+
+
+@contextmanager
+def without_inherited_bedrock_aws_env() -> Iterator[None]:
+    removed_env = scrub_bedrock_aws_env(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.update(removed_env)
 
 
 @dataclass(frozen=True)

--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -1,12 +1,18 @@
 """Template engine for rendering Jinja2 templates with user overrides."""
 
 import os
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from nao_core.config.llm import LLMConfig, LLMProvider
+from nao_core.config.llm import (
+    LLMConfig,
+    LLMProvider,
+    is_bedrock_aws_env_inheritance_enabled,
+    without_inherited_bedrock_aws_env,
+)
 
 # Path to the default templates shipped with nao
 DEFAULT_TEMPLATES_DIR = Path(__file__).parent / "defaults"
@@ -291,19 +297,25 @@ class TemplateEngine:
 
         import boto3
 
-        region = self.llm_config.aws_region or os.environ.get("AWS_REGION", "us-east-1")
+        inherit_bedrock_aws_env = is_bedrock_aws_env_inheritance_enabled()
+        region = self.llm_config.aws_region
+        if not region and inherit_bedrock_aws_env:
+            region = os.environ.get("AWS_REGION")
+        region = region or "us-east-1"
 
         client_kwargs: dict[str, Any] = {"region_name": region}
         if self.llm_config.access_key and self.llm_config.secret_key:
             client_kwargs["aws_access_key_id"] = self.llm_config.access_key
             client_kwargs["aws_secret_access_key"] = self.llm_config.secret_key
 
-        client = boto3.client("bedrock-runtime", **client_kwargs)
-        response = client.converse(
-            modelId=model,
-            messages=[{"role": "user", "content": [{"text": prompt_text}]}],
-            inferenceConfig={"temperature": 0},
-        )
+        aws_env_context = nullcontext() if inherit_bedrock_aws_env else without_inherited_bedrock_aws_env()
+        with aws_env_context:
+            client = boto3.client("bedrock-runtime", **client_kwargs)
+            response = client.converse(
+                modelId=model,
+                messages=[{"role": "user", "content": [{"text": prompt_text}]}],
+                inferenceConfig={"temperature": 0},
+            )
 
         content_blocks = response.get("output", {}).get("message", {}).get("content", [])
         parts = [str(block.get("text")) for block in content_blocks if isinstance(block, dict) and block.get("text")]

--- a/cli/tests/nao_core/commands/test_chat.py
+++ b/cli/tests/nao_core/commands/test_chat.py
@@ -510,6 +510,121 @@ llm:
         env = chat_server_call.kwargs.get("env", {})
         assert env.get("OPENAI_API_KEY") == "sk-test-key-12345"
 
+    @patch("nao_core.commands.chat.webbrowser.open")
+    @patch("nao_core.commands.chat.wait_for_server")
+    @patch("nao_core.commands.chat.subprocess.Popen")
+    @patch("nao_core.commands.chat.get_fastapi_main_path")
+    @patch("nao_core.commands.chat.get_server_binary_path")
+    @patch("nao_core.commands.chat.console")
+    def test_chat_inherits_bedrock_aws_env_by_default(
+        self,
+        mock_console,
+        mock_binary_path,
+        mock_fastapi_path,
+        mock_popen,
+        mock_wait_for_server,
+        mock_webbrowser,
+        tmp_path: Path,
+        create_config,
+        clean_env,
+        monkeypatch,
+    ):
+        create_config("""\
+project_name: test-project
+llm:
+  provider: bedrock
+""")
+        monkeypatch.setenv("AWS_PROFILE", "ambient-profile")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "ambient-session-token")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-bearer-token")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "nao-chat-server").touch()
+        fastapi_dir = bin_dir / "fastapi"
+        fastapi_dir.mkdir()
+        (fastapi_dir / "main.py").touch()
+
+        mock_binary_path.return_value = bin_dir / "nao-chat-server"
+        mock_fastapi_path.return_value = bin_dir / "fastapi" / "main.py"
+        mock_wait_for_server.return_value = True
+
+        mock_process = MagicMock()
+        mock_process.stdout = iter([])
+        mock_popen.return_value = mock_process
+
+        chat()
+
+        chat_server_call = mock_popen.call_args_list[1]
+        env = chat_server_call.kwargs.get("env", {})
+        assert env.get("AWS_PROFILE") == "ambient-profile"
+        assert env.get("AWS_SESSION_TOKEN") == "ambient-session-token"
+        assert env.get("AWS_REGION") == "eu-west-1"
+        assert env.get("AWS_BEARER_TOKEN_BEDROCK") == "ambient-bearer-token"
+
+    @patch("nao_core.commands.chat.webbrowser.open")
+    @patch("nao_core.commands.chat.wait_for_server")
+    @patch("nao_core.commands.chat.subprocess.Popen")
+    @patch("nao_core.commands.chat.get_fastapi_main_path")
+    @patch("nao_core.commands.chat.get_server_binary_path")
+    @patch("nao_core.commands.chat.console")
+    def test_chat_can_disable_bedrock_aws_env_inheritance(
+        self,
+        mock_console,
+        mock_binary_path,
+        mock_fastapi_path,
+        mock_popen,
+        mock_wait_for_server,
+        mock_webbrowser,
+        tmp_path: Path,
+        create_config,
+        clean_env,
+        monkeypatch,
+    ):
+        create_config("""\
+project_name: test-project
+llm:
+  provider: bedrock
+  access_key: config-access-key
+  secret_key: config-secret-key
+  aws_profile: config-profile
+  aws_region: us-west-2
+""")
+        monkeypatch.setenv("NAO_BEDROCK_INHERIT_AWS_ENV", "false")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-access-key")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret-key")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "ambient-session-token")
+        monkeypatch.setenv("AWS_PROFILE", "ambient-profile")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "ambient-bearer-token")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "nao-chat-server").touch()
+        fastapi_dir = bin_dir / "fastapi"
+        fastapi_dir.mkdir()
+        (fastapi_dir / "main.py").touch()
+
+        mock_binary_path.return_value = bin_dir / "nao-chat-server"
+        mock_fastapi_path.return_value = bin_dir / "fastapi" / "main.py"
+        mock_wait_for_server.return_value = True
+
+        mock_process = MagicMock()
+        mock_process.stdout = iter([])
+        mock_popen.return_value = mock_process
+
+        chat()
+
+        chat_server_call = mock_popen.call_args_list[1]
+        env = chat_server_call.kwargs.get("env", {})
+        assert env.get("AWS_ACCESS_KEY_ID") == "config-access-key"
+        assert env.get("AWS_SECRET_ACCESS_KEY") == "config-secret-key"
+        assert "AWS_SESSION_TOKEN" not in env
+        assert env.get("AWS_PROFILE") == "config-profile"
+        assert env.get("AWS_REGION") == "us-west-2"
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in env
+
 
 class TestStartNgrokTunnel:
     @patch("nao_core.commands.chat.console")

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -1,6 +1,7 @@
 """Unit tests for the template engine."""
 
 import json
+import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -260,6 +261,39 @@ class TestTemplateEngine:
 
         with pytest.raises(RuntimeError, match="Bedrock configuration is incomplete"):
             engine._generate_bedrock("anthropic.claude-3-5-sonnet-20241022-v2:0", "summarize this")
+
+    def test_generate_bedrock_can_disable_aws_env_inheritance(self, tmp_path: Path, monkeypatch):
+        llm_config = LLMConfig(
+            provider=LLMProvider.BEDROCK,
+            api_key=None,
+            annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        )
+        engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
+        monkeypatch.setenv("NAO_BEDROCK_INHERIT_AWS_ENV", "false")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-access-key")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret-key")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+
+        fake_client = MagicMock()
+        fake_client.converse.return_value = {"output": {"message": {"content": [{"text": "Bedrock summary"}]}}}
+        fake_boto3 = MagicMock()
+
+        def client_factory(*args, **kwargs):
+            assert "AWS_ACCESS_KEY_ID" not in os.environ
+            assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+            assert "AWS_REGION" not in os.environ
+            return fake_client
+
+        fake_boto3.client.side_effect = client_factory
+        monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+        rendered = engine._generate_bedrock("anthropic.claude-3-5-sonnet-20241022-v2:0", "summarize this")
+
+        assert rendered == "Bedrock summary"
+        fake_boto3.client.assert_called_once_with("bedrock-runtime", region_name="us-east-1")
+        assert os.environ["AWS_ACCESS_KEY_ID"] == "ambient-access-key"
+        assert os.environ["AWS_SECRET_ACCESS_KEY"] == "ambient-secret-key"
+        assert os.environ["AWS_REGION"] == "eu-west-1"
 
     def test_generate_anthropic_forwards_base_url(self, tmp_path: Path, monkeypatch):
         """Anthropic client should receive base_url when configured."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds `NAO_BEDROCK_INHERIT_AWS_ENV` to keep Bedrock AWS environment inheritance enabled by default and disable it with `false`, `0`, `no`, or `off`.
- Applies the opt-out to `nao chat`, Bedrock model debug checks, and template engine Bedrock calls while preserving explicit config credentials.
- Adds tests for default inheritance and disabled inheritance behavior.

### Testing
- `uv run pytest tests/nao_core/commands/test_chat.py tests/nao_core/templates/test_engine.py -q`
- `make lint`
- `uv run pytest tests -q`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8063f9d-ac66-4991-87c2-dbcfa5ff74ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8063f9d-ac66-4991-87c2-dbcfa5ff74ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

