### PR TITLE
fix(databricks): Use schema for IBIS volumes when default is not writable

### DIFF
--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -117,6 +117,10 @@ class DatabricksConfig(DatabaseConfig):
         default=None,
         description="Default schema (optional)",
     )
+    temp_schema: str | None = Field(
+        default=None,
+        description="A schema you have write access to, used for temporary storage during queries (optional)",
+    )
 
     @classmethod
     def promptConfig(cls) -> "DatabricksConfig":
@@ -127,6 +131,9 @@ class DatabricksConfig(DatabaseConfig):
         access_token = ask_text("Access token:", password=True, required_field=True)
         catalog = ask_text("Unity Catalog name (optional):")
         schema = ask_text("Default schema (optional):")
+        temp_schema = ask_text(
+            "Schema with write access for temporary storage (optional, needed if your default schema is read-only):"
+        )
 
         return DatabricksConfig(
             name=name,
@@ -135,6 +142,7 @@ class DatabricksConfig(DatabaseConfig):
             access_token=access_token,  # type: ignore
             catalog=catalog,
             schema_name=schema,
+            temp_schema=temp_schema,
         )
 
     def connect(self) -> BaseBackend:
@@ -153,6 +161,11 @@ class DatabricksConfig(DatabaseConfig):
 
         if self.catalog:
             kwargs["catalog"] = self.catalog
+
+        if self.temp_schema:
+            kwargs["schema"] = self.temp_schema
+        elif self.schema_name:
+            kwargs["schema"] = self.schema_name
 
         # Ibis names its temporary UC memtable volume after the OS username, which
         # breaks when the username contains dots (interpreted as UC path separators).


### PR DESCRIPTION
After c6d9639 removed `schema=` from ibis connect to avoid creating volumes in the target schema, users whose default schema is read-only started hitting permission errors. This adds a fallback chain: 
```
temp_schema (explicit override) 
> schema_name (target) 
> catalog default
```

Also adds a `temp_schema` config field for users who need a dedicated writable schema separate from both their target and default schemas.