### PR TITLE
Fix Redshift datashare schema discovery

### DIFF
--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -381,13 +381,14 @@ class RedshiftConfig(DatabaseConfig):
         if self.schema_name:
             return [self.schema_name]
 
-        # Query system catalog directly to get all schemas
+        # svv_all_schemas includes schemas shared through Redshift datashares.
         query = """
-            SELECT nspname 
-            FROM pg_catalog.pg_namespace
-            WHERE nspname NOT LIKE 'pg_%' 
-              AND nspname != 'information_schema'
-            ORDER BY nspname
+            SELECT DISTINCT schema_name
+            FROM svv_all_schemas
+            WHERE schema_name NOT LIKE 'pg_%'
+              AND schema_name != 'information_schema'
+              AND database_name = current_database()
+            ORDER BY schema_name
         """
         try:
             result = conn.raw_sql(query).fetchall()  # type: ignore[union-attr]

--- a/cli/tests/nao_core/config/test_redshift.py
+++ b/cli/tests/nao_core/config/test_redshift.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+from nao_core.config.databases.redshift import RedshiftConfig
+
+
+def test_get_schemas_uses_datashare_visible_catalog_view():
+    cfg = RedshiftConfig(
+        name="rs",
+        host="redshift.example",
+        database="analytics",
+        user="alice",
+        password="secret",
+    )
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = [("marts",), ("public",)]
+    conn.raw_sql.return_value = cursor
+
+    schemas = cfg.get_schemas(conn)
+
+    assert schemas == ["marts", "public"]
+    sql = " ".join(conn.raw_sql.call_args.args[0].split())
+    assert sql.startswith("SELECT DISTINCT schema_name FROM svv_all_schemas")
+    assert "schema_name NOT LIKE 'pg_%'" in sql
+    assert "schema_name != 'information_schema'" in sql
+    assert "database_name = current_database()" in sql
+    assert sql.endswith("ORDER BY schema_name")
+
+
+def test_get_schemas_returns_configured_schema_without_querying():
+    cfg = RedshiftConfig(
+        name="rs",
+        host="redshift.example",
+        database="analytics",
+        user="alice",
+        password="secret",
+        schema_name="marts",
+    )
+    conn = MagicMock()
+
+    schemas = cfg.get_schemas(conn)
+
+    assert schemas == ["marts"]
+    conn.raw_sql.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use `svv_all_schemas` for Redshift schema discovery so datashare consumer schemas are visible.
- Add unit coverage for the schema discovery query and explicit-schema bypass.

## Testing
- `uv run pytest tests/nao_core/config/test_redshift.py`
- `make lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

fixes #898 

