### PR TITLE
Add Claude Fable Anthropic model

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -12,6 +12,12 @@ export const PROVIDER_META: ProviderMetaMap = {
 		summaryModelId: 'claude-sonnet-4-5',
 		models: [
 			{
+				id: 'claude-fable-5',
+				name: 'Claude Fable 5',
+				contextWindow: 1_000_000,
+				costPerM: { inputNoCache: 10, inputCacheRead: 1, inputCacheWrite: 12.5, output: 50 },
+			},
+			{
 				id: 'claude-opus-4-8',
 				name: 'Claude Opus 4.8',
 				contextWindow: 200_000,

--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -14,7 +14,7 @@ export const PROVIDER_META: ProviderMetaMap = {
 			{
 				id: 'claude-fable-5',
 				name: 'Claude Fable 5',
-				contextWindow: 1_000_000,
+				contextWindow: 300_000,
 				costPerM: { inputNoCache: 10, inputCacheRead: 1, inputCacheWrite: 12.5, output: 50 },
 			},
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add Claude Fable 5 to the Anthropic provider model catalog.
- Configure Claude Fable 5 as non-default with a 300k context window and $10/M input, $50/M output pricing.

### Testing
- `npx tsx --eval "..."` confirms `claude-fable-5` exists, remains non-default, preserves the Anthropic default as `claude-sonnet-4-6`, uses a 300k context window, and exposes the requested pricing.
- `npm run lint` passes across backend, frontend, and shared workspaces.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e29564-8ca0-4b1d-9977-8e54fb82b6a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e29564-8ca0-4b1d-9977-8e54fb82b6a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

