### PR TITLE
Fix Bedrock Anthropic prompt caching

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -19,7 +19,7 @@ import {
 } from 'ai';
 import { z } from 'zod';
 
-import { CACHE_1H, CACHE_5M, LLM_PROVIDERS, ProviderModelResult } from '../agents/providers';
+import { LLM_PROVIDERS, ProviderModelResult } from '../agents/providers';
 import { getTools } from '../agents/tools';
 import { createWebSearchTools } from '../agents/tools/web-search';
 import { getConnections, getTableColumnsContent, getUserRules } from '../agents/user-rules';
@@ -62,6 +62,7 @@ import {
 	resolveProviderSettings,
 } from '../utils/llm';
 import { logger } from '../utils/logger';
+import { addPromptCache } from '../utils/prompt-cache';
 import { truncateMiddle } from '../utils/utils';
 import { compactionService } from './compaction';
 import { hasFeature, LICENSE_FEATURES } from './license.service';
@@ -765,37 +766,14 @@ class AgentManager {
 
 	/**
 	 * Add Anthropic cache breakpoints to messages.
-	 * Applies to the `anthropic` provider and to Claude models accessed via `vertex`
-	 * (which uses @ai-sdk/google-vertex/anthropic and reads the same `anthropic` provider options).
+	 * Applies to direct Anthropic, Vertex Claude, and Bedrock Anthropic models.
 	 *
 	 * Cache strategy:
 	 * - System message: 1h TTL (instructions rarely change)
 	 * - Last message: 5m TTL (current step's leaf for agentic caching)
 	 */
 	private _addCache(messages: ModelMessage[]): ModelMessage[] {
-		const { provider, modelId } = this._modelSelection;
-		const isAnthropicCompatible =
-			provider === 'anthropic' || (provider === 'vertex' && modelId.startsWith('claude-'));
-		if (messages.length === 0 || !isAnthropicCompatible) {
-			return messages;
-		}
-
-		const withCache = (msg: ModelMessage, cache: typeof CACHE_1H | typeof CACHE_5M): ModelMessage => ({
-			...msg,
-			providerOptions: {
-				...msg.providerOptions,
-				anthropic: { ...msg.providerOptions?.anthropic, cacheControl: cache },
-			},
-		});
-
-		const lastIndex = messages.length - 1;
-		if (messages[0].role === 'system') {
-			messages[0] = withCache(messages[0], CACHE_1H);
-		}
-		if (messages.length > 1) {
-			messages[lastIndex] = withCache(messages[lastIndex], CACHE_5M);
-		}
-		return messages;
+		return addPromptCache(messages, this._modelSelection);
 	}
 
 	/**

--- a/apps/backend/src/utils/prompt-cache.ts
+++ b/apps/backend/src/utils/prompt-cache.ts
@@ -1,0 +1,73 @@
+import type { LlmSelectedModel } from '@nao/shared/types';
+import type { ModelMessage } from 'ai';
+
+import { CACHE_1H, CACHE_5M } from '../agents/providers';
+
+const BEDROCK_CACHE_1H = { type: 'default', ttl: '1h' } as const;
+const BEDROCK_CACHE_5M = { type: 'default' } as const;
+
+type AnthropicCache = typeof CACHE_1H | typeof CACHE_5M;
+type BedrockCache = typeof BEDROCK_CACHE_1H | typeof BEDROCK_CACHE_5M;
+type PromptCacheProvider = 'anthropic' | 'bedrock';
+
+export function addPromptCache(messages: ModelMessage[], modelSelection: LlmSelectedModel): ModelMessage[] {
+	const cacheProvider = getPromptCacheProvider(modelSelection);
+	if (messages.length === 0 || !cacheProvider) {
+		return messages;
+	}
+
+	const cachedMessages = [...messages];
+	const lastIndex = cachedMessages.length - 1;
+	if (cachedMessages[0].role === 'system') {
+		cachedMessages[0] = withPromptCache(cachedMessages[0], cacheProvider, '1h');
+	}
+	if (cachedMessages.length > 1) {
+		cachedMessages[lastIndex] = withPromptCache(cachedMessages[lastIndex], cacheProvider, '5m');
+	}
+	return cachedMessages;
+}
+
+export function getPromptCacheProvider(modelSelection: LlmSelectedModel): PromptCacheProvider | null {
+	const { provider, modelId } = modelSelection;
+	if (provider === 'anthropic') {
+		return 'anthropic';
+	}
+	if (provider === 'vertex' && modelId.toLowerCase().startsWith('claude-')) {
+		return 'anthropic';
+	}
+	if (provider === 'bedrock' && isBedrockAnthropicModel(modelId)) {
+		return 'bedrock';
+	}
+	return null;
+}
+
+function withPromptCache(message: ModelMessage, provider: PromptCacheProvider, ttl: '1h' | '5m'): ModelMessage {
+	return provider === 'bedrock'
+		? withBedrockCache(message, ttl === '1h' ? BEDROCK_CACHE_1H : BEDROCK_CACHE_5M)
+		: withAnthropicCache(message, ttl === '1h' ? CACHE_1H : CACHE_5M);
+}
+
+function withAnthropicCache(message: ModelMessage, cache: AnthropicCache): ModelMessage {
+	return {
+		...message,
+		providerOptions: {
+			...message.providerOptions,
+			anthropic: { ...message.providerOptions?.anthropic, cacheControl: cache },
+		},
+	};
+}
+
+function withBedrockCache(message: ModelMessage, cache: BedrockCache): ModelMessage {
+	return {
+		...message,
+		providerOptions: {
+			...message.providerOptions,
+			bedrock: { ...message.providerOptions?.bedrock, cachePoint: cache },
+		},
+	};
+}
+
+function isBedrockAnthropicModel(modelId: string): boolean {
+	const normalized = modelId.toLowerCase();
+	return normalized.includes('anthropic') || normalized.includes('claude');
+}

--- a/apps/backend/tests/prompt-cache.test.ts
+++ b/apps/backend/tests/prompt-cache.test.ts
@@ -1,0 +1,67 @@
+import type { LlmSelectedModel } from '@nao/shared/types';
+import type { ModelMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+
+import { addPromptCache, getPromptCacheProvider } from '../src/utils/prompt-cache';
+
+describe('addPromptCache', () => {
+	const messages: ModelMessage[] = [
+		{ role: 'system', content: 'System prompt' },
+		{ role: 'user', content: 'Question' },
+	];
+
+	it('uses Anthropic cache control for direct Anthropic models', () => {
+		const cached = addPromptCache(messages, modelSelection('anthropic', 'claude-sonnet-4.5'));
+
+		expect(cached[0].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+		});
+		expect(cached[1].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral' } },
+		});
+	});
+
+	it('uses Anthropic cache control for Vertex Claude models', () => {
+		const cached = addPromptCache(messages, modelSelection('vertex', 'claude-sonnet-4.5'));
+
+		expect(cached[0].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+		});
+		expect(cached[1].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral' } },
+		});
+	});
+
+	it('uses Bedrock cache points for Bedrock Anthropic foundation models', () => {
+		const cached = addPromptCache(messages, modelSelection('bedrock', 'us.anthropic.claude-sonnet-4-6'));
+
+		expect(cached[0].providerOptions).toEqual({
+			bedrock: { cachePoint: { type: 'default', ttl: '1h' } },
+		});
+		expect(cached[1].providerOptions).toEqual({
+			bedrock: { cachePoint: { type: 'default' } },
+		});
+	});
+
+	it('uses Bedrock cache points for Anthropic inference profile ARNs', () => {
+		const modelId = 'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6';
+
+		expect(getPromptCacheProvider(modelSelection('bedrock', modelId))).toBe('bedrock');
+	});
+
+	it('uses Bedrock cache points for custom profile ARNs that identify Claude', () => {
+		const modelId = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/analytics-claude-prod';
+
+		expect(getPromptCacheProvider(modelSelection('bedrock', modelId))).toBe('bedrock');
+	});
+
+	it('does not cache Bedrock models that are not identifiable as Anthropic', () => {
+		const modelId = 'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/analytics-prod';
+
+		expect(addPromptCache(messages, modelSelection('bedrock', modelId))).toBe(messages);
+	});
+});
+
+function modelSelection(provider: LlmSelectedModel['provider'], modelId: string): LlmSelectedModel {
+	return { provider, modelId };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add shared prompt cache decoration for Anthropic-compatible models.
- Use Bedrock `cachePoint` provider options for Bedrock Anthropic/Claude model IDs and ARNs.
- Cover direct Anthropic, Vertex Claude, Bedrock foundation IDs, and Bedrock ARN detection with backend tests.

### Testing
- Pass: `npm run -w @nao/backend test -- prompt-cache.test.ts`
- Pass: `npm run lint`
- Warning: `npm run -w @nao/backend test && npm run lint` stopped during the full backend Vitest suite before lint; failures were in existing `compaction.test.ts`, `system-prompt.test.ts`, and `sqlite.test.ts` areas outside this diff.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74ba8fa2-a2d5-4abc-991c-95f87f85a1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74ba8fa2-a2d5-4abc-991c-95f87f85a1d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

