### PR TITLE
Fix settings sidebar nav scrolling

### DIFF
--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -203,7 +203,7 @@ export function SidebarSettingsNav({
 	};
 
 	return (
-		<div className={cn('flex flex-col gap-1', hideIf(isCollapsed))}>
+		<div className={cn('flex flex-1 min-h-0 flex-col gap-1 overflow-y-auto', hideIf(isCollapsed))}>
 			{!isViewer && (
 				<div className='px-2 pt-2'>
 					<div className='relative'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add flex/min-height/overflow constraints to the settings sidebar nav so overflowing items can scroll within the sidebar.

## Walkthrough
[settings_sidebar_scroll_demo_trimmed.mp4](https://cursor.com/agents/bc-0c5fcf9d-ed16-41da-a378-8ddac5d12693/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_sidebar_scroll_demo_trimmed.mp4)

## Testing
- `npm run lint`
- Manual browser test at a short viewport on `/settings/account`, confirming the settings sidebar scrolls to Memory and File Explorer while the Account settings page remains stable.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c5fcf9d-ed16-41da-a378-8ddac5d12693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c5fcf9d-ed16-41da-a378-8ddac5d12693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

