### PR TITLE
Handle missing chat routes

### DIFF
--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -56,7 +56,10 @@ function ChatPage() {
 	const { chatId } = Route.useParams();
 	const chat = useChatQuery({ chatId });
 	const title = chat.data?.title;
-	const shareQuery = useQuery(trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId: chatId ?? '' }));
+	const shareQuery = useQuery({
+		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
+		enabled: chat.isSuccess,
+	});
 	const isShared = !!shareQuery.data?.shareId;
 	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
 	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
@@ -87,7 +90,7 @@ function ChatPage() {
 
 	useEffect(() => {
 		const openStorySlug = router.state.location.state.openStorySlug;
-		if (!openStorySlug || isLoadingMessages) {
+		if (chat.isError || !openStorySlug || isLoadingMessages) {
 			return;
 		}
 
@@ -100,7 +103,11 @@ function ChatPage() {
 			});
 		});
 		return () => clearTimeout(timer);
-	}, [isLoadingMessages]); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [chat.isError, isLoadingMessages]); // eslint-disable-line react-hooks/exhaustive-deps
+
+	if (chat.isError) {
+		return <ChatNotFoundState />;
+	}
 
 	return (
 		<SidePanelProvider
@@ -215,6 +222,27 @@ function ChatPage() {
 			</SelectionProvider>
 			<ShareChatDialog open={isShareDialogOpen} onOpenChange={setIsShareDialogOpen} chatId={chatId} />
 		</SidePanelProvider>
+	);
+}
+
+function ChatNotFoundState() {
+	return (
+		<div className='flex h-full flex-1 flex-col min-w-0 overflow-hidden justify-center bg-panel'>
+			<MobileHeader />
+			<div className='flex flex-1 items-center justify-center p-6'>
+				<div className='flex max-w-sm flex-col items-center gap-4 text-center'>
+					<div className='space-y-2'>
+						<h1 className='text-lg font-medium tracking-tight'>Chat not found</h1>
+						<p className='text-sm text-muted-foreground'>
+							This chat may have been deleted, moved, or you may not have access to it.
+						</p>
+					</div>
+					<Button asChild variant='secondary'>
+						<Link to='/'>Start a new chat</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Show an explicit missing-chat state when a chat detail query fails.
- Defer chat share metadata lookup until the base chat has loaded.

### Testing
- `npm run -w @nao/frontend test`
- `npm run lint`
- Manual browser walkthrough for a nonexistent chat ID.

### Walkthrough
[missing_chat_route_flow.mp4](https://cursor.com/agents/bc-49ff7e87-7fce-4e79-b48b-7b94b8bb095c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmissing_chat_route_flow.mp4)
[Missing chat state](https://cursor.com/agents/bc-49ff7e87-7fce-4e79-b48b-7b94b8bb095c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmissing_chat_not_found_state.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49ff7e87-7fce-4e79-b48b-7b94b8bb095c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49ff7e87-7fce-4e79-b48b-7b94b8bb095c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

