### PR TITLE
feat: allow 'viewer' as DEFAULT_USER_ROLE for new users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ GITHUB_CLIENT_SECRET=
 # When SSO is enabled, restrict login to this comma-separated list of GitHub
 # usernames. In CI, the PR author is appended automatically.
 GITHUB_ALLOWED_USERS=
-# Role assigned to new users joining via social auth (admin or user, defaults to user)
+# Role assigned to new users (admin, user, or viewer — defaults to user)
 # DEFAULT_USER_ROLE=user
 
 # Microsoft / Azure AD SSO (Enterprise — requires NAO_LICENSE with the 'sso' feature)

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -58,7 +58,7 @@ const envSchema = z.object({
 		.default('false')
 		.transform((val) => val === 'true'),
 
-	DEFAULT_USER_ROLE: z.enum(['admin', 'user']).default('user'),
+	DEFAULT_USER_ROLE: z.enum(['admin', 'user', 'viewer']).default('user'),
 
 	OIDC_PROVIDER_ID: z.string().optional(),
 	OIDC_PROVIDER_NAME: z.string().optional(),

--- a/apps/backend/src/services/team-member.ts
+++ b/apps/backend/src/services/team-member.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { hashPassword } from 'better-auth/crypto';
 
 import type { User } from '../db/abstractSchema';
+import { env } from '../env';
 import * as projectQueries from '../queries/project.queries';
 import * as userQueries from '../queries/user.queries';
 import type { CreatedEmail } from '../types/email';
@@ -49,7 +50,7 @@ export async function addTeamMember({
 		await emailService.sendEmail(newUser.email, buildEmail(newUser, password));
 
 		return {
-			newUser: { id: newUser.id, name: newUser.name, email: newUser.email, role: 'user' },
+			newUser: { id: newUser.id, name: newUser.name, email: newUser.email, role: env.DEFAULT_USER_ROLE },
 			password,
 		};
 	}
@@ -63,7 +64,7 @@ export async function addTeamMember({
 	await emailService.sendEmail(user.email, buildEmail(user));
 
 	return {
-		newUser: { id: user.id, name: user.name, email: user.email, role: 'user' },
+		newUser: { id: user.id, name: user.name, email: user.email, role: env.DEFAULT_USER_ROLE },
 	};
 }
 
@@ -95,7 +96,7 @@ export async function ensureMessagingProviderUser({
 
 	const projectMember = await projectQueries.getProjectMember(projectId, user.id);
 	if (!projectMember) {
-		await projectQueries.addProjectMember({ projectId, userId: user.id, role: 'user' });
+		await projectQueries.addProjectMember({ projectId, userId: user.id, role: env.DEFAULT_USER_ROLE });
 	}
 
 	const alreadyHadAccess = !!existingUser && !!projectMember;

--- a/apps/backend/src/trpc/organization.routes.ts
+++ b/apps/backend/src/trpc/organization.routes.ts
@@ -7,6 +7,7 @@ import * as orgQueries from '../queries/organization.queries';
 import * as userQueries from '../queries/user.queries';
 import { emailService } from '../services/email';
 import { addTeamMember } from '../services/team-member';
+import { env } from '../env';
 import { ORG_ROLES } from '../types/organization';
 import { buildResetPasswordEmail, buildUserAddedEmail } from '../utils/email-builders';
 import { protectedProcedure } from './trpc';
@@ -68,7 +69,7 @@ export const organizationRoutes = {
 				name: input.name,
 				checkExisting: async (userId) => !!(await orgQueries.getOrgMember(orgId, userId)),
 				addMember: async (userId) => {
-					await orgQueries.addOrgMember({ orgId, userId, role: 'user' });
+					await orgQueries.addOrgMember({ orgId, userId, role: env.DEFAULT_USER_ROLE });
 				},
 				buildEmail: (user, password) => buildUserAddedEmail(user, ctx.org.name, 'organization', password),
 			});

--- a/apps/backend/src/trpc/user.routes.ts
+++ b/apps/backend/src/trpc/user.routes.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
+import { env } from '../env';
 import * as memoryQueries from '../queries/memory';
 import * as projectQueries from '../queries/project.queries';
 import * as userQueries from '../queries/user.queries';
@@ -70,7 +71,7 @@ export const userRoutes = {
 				name: input.name,
 				checkExisting: async (userId) => !!(await projectQueries.getProjectMember(projectId, userId)),
 				addMember: async (userId) => {
-					await projectQueries.addProjectMember({ userId, projectId, role: 'user' });
+					await projectQueries.addProjectMember({ userId, projectId, role: env.DEFAULT_USER_ROLE });
 				},
 				buildEmail: (user, password) => buildUserAddedEmail(user, ctx.project.name, 'project', password),
 			});


### PR DESCRIPTION
## Summary

- Expands `DEFAULT_USER_ROLE` env var to accept `'viewer'` in addition to `'admin'` and `'user'`
- Makes all user onboarding paths (admin invite to org, admin invite to project, messaging provider auto-onboard) respect `DEFAULT_USER_ROLE` instead of hardcoding `'user'`
- No behavior change when the env var is unset — still defaults to `'user'`

## Motivation

Deployments that want new users to have read-only access by default currently have no way to achieve this. The `viewer` role already exists with proper permission mappings (no message sending, no sharing, no new chats), but it was never wirable as a default. This is a common requirement for analytics platforms where most consumers should observe rather than interact.

## Changes

| File | Change |
|---|---|
| `apps/backend/src/env.ts` | Zod enum: `['admin', 'user']` → `['admin', 'user', 'viewer']` |
| `apps/backend/src/trpc/organization.routes.ts` | Org invite reads `env.DEFAULT_USER_ROLE` |
| `apps/backend/src/trpc/user.routes.ts` | Project invite reads `env.DEFAULT_USER_ROLE` |
| `apps/backend/src/services/team-member.ts` | Messaging provider onboarding + return values read `env.DEFAULT_USER_ROLE` |
| `.env.example` | Updated comment to document `viewer` as valid |

## Test plan

- [ ] Set `DEFAULT_USER_ROLE=viewer`, sign up via social auth → user gets `viewer` role
- [ ] Admin invites user to org → user gets `viewer` role  
- [ ] Admin invites user to project → user gets `viewer` role
- [ ] Slack message from unknown user → auto-created user gets `viewer` role
- [ ] Unset `DEFAULT_USER_ROLE` → all paths default to `user` (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default role assignment for new members across org/project/messaging flows; misconfiguration could grant broader (`admin`) or narrower (`viewer`) access than intended, though unset env stays `user`.
> 
> **Overview**
> Adds **`viewer`** as a valid value for **`DEFAULT_USER_ROLE`** and routes org invites, project invites, and messaging-provider onboarding through that setting instead of always using **`user`**.
> 
> **`env.ts`** widens the Zod enum to `admin | user | viewer` (default still **`user`**). **`.env.example`** documents the new option. Invite mutations in **`organization.routes`** / **`user.routes`**, **`addTeamMember`** return payloads, and **`ensureMessagingProviderUser`** project membership now read **`env.DEFAULT_USER_ROLE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b99895581a96b75e6a8c986f666079b7236f4d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->