### PR TITLE
fix(backend): serialize list_stories timestamps to ISO strings

### DIFF
--- a/apps/backend/src/mcp/tools/asset-tools.ts
+++ b/apps/backend/src/mcp/tools/asset-tools.ts
@@ -17,6 +17,7 @@ import {
 	resolveStory,
 } from './helpers';
 import { registerAgentToolAsMcp, registerMcpTool } from './register-mcp-tool';
+import { STORY_LIST_ITEM_SCHEMA, toStoryListItem } from './story-list-item';
 
 const DISPLAY_CHART_DESCRIPTION =
 	'Render an interactive chart embed from a previously executed query.\n\n' +
@@ -175,17 +176,7 @@ function registerStoryManagementTools(server: McpServer, ctx: McpContext): void 
 		},
 		outputSchema: {
 			stories: z
-				.array(
-					z.object({
-						id: z.string().describe('Story UUID.'),
-						title: z.string().describe('Story title.'),
-						url: z.url().describe('URL to open the story in the nao UI.'),
-						chatUrl: z.url().nullable().describe('Source chat URL, or null for standalone stories.'),
-						archived: z.boolean().describe('True if soft-deleted via `archive_story` (still recoverable).'),
-						createdAt: z.string().describe('ISO timestamp of creation.'),
-						updatedAt: z.string().describe('ISO timestamp of last edit.'),
-					}),
-				)
+				.array(STORY_LIST_ITEM_SCHEMA)
 				.describe('Stories visible to the current user in this project, newest first.'),
 		},
 		handler: async ({ limit, archived }) => {
@@ -193,15 +184,9 @@ function registerStoryManagementTools(server: McpServer, ctx: McpContext): void 
 				archived,
 				limit,
 			});
-			const result = stories.map((story) => ({
-				id: story.id,
-				title: story.title,
-				createdAt: story.createdAt,
-				updatedAt: story.updatedAt,
-				archived: story.archivedAt !== null,
-				url: storyUrl(story),
-				chatUrl: storyChatUrl(story),
-			}));
+			const result = stories.map((story) =>
+				toStoryListItem(story, { url: storyUrl(story), chatUrl: storyChatUrl(story) }),
+			);
 			const output = { stories: result };
 			return {
 				content: [{ type: 'text' as const, text: JSON.stringify(output) }],

--- a/apps/backend/src/mcp/tools/story-list-item.ts
+++ b/apps/backend/src/mcp/tools/story-list-item.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import type { UserStoryRow } from '../../queries/story.queries';
+
+export const STORY_LIST_ITEM_SCHEMA = z.object({
+	id: z.string().describe('Story UUID.'),
+	title: z.string().describe('Story title.'),
+	url: z.url().describe('URL to open the story in the nao UI.'),
+	chatUrl: z.url().nullable().describe('Source chat URL, or null for standalone stories.'),
+	archived: z.boolean().describe('True if soft-deleted via `archive_story` (still recoverable).'),
+	createdAt: z.string().describe('ISO timestamp of creation.'),
+	updatedAt: z.string().describe('ISO timestamp of last edit.'),
+});
+
+export type StoryListItem = z.infer<typeof STORY_LIST_ITEM_SCHEMA>;
+
+export function toStoryListItem(story: UserStoryRow, urls: { url: string; chatUrl: string | null }): StoryListItem {
+	return {
+		id: story.id,
+		title: story.title,
+		url: urls.url,
+		chatUrl: urls.chatUrl,
+		archived: story.archivedAt !== null,
+		createdAt: story.createdAt.toISOString(),
+		updatedAt: story.updatedAt.toISOString(),
+	};
+}

--- a/apps/backend/tests/story-list-item.test.ts
+++ b/apps/backend/tests/story-list-item.test.ts
@@ -34,4 +34,15 @@ describe('list_stories output mapping', () => {
 		expect(item.updatedAt).toBe('2024-01-02T03:04:05.000Z');
 		expect(() => STORY_LIST_ITEM_SCHEMA.parse(item)).not.toThrow();
 	});
+
+	it('marks archived stories and preserves chatUrl', () => {
+		const item = toStoryListItem(buildStoryRow({ archivedAt: new Date('2024-02-01T00:00:00.000Z') }), {
+			url: 'http://localhost:5005/stories/standalone/story-1',
+			chatUrl: 'http://localhost:5005/chats/chat-1',
+		});
+
+		expect(item.archived).toBe(true);
+		expect(item.chatUrl).toBe('http://localhost:5005/chats/chat-1');
+		expect(() => STORY_LIST_ITEM_SCHEMA.parse(item)).not.toThrow();
+	});
 });

--- a/apps/backend/tests/story-list-item.test.ts
+++ b/apps/backend/tests/story-list-item.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { STORY_LIST_ITEM_SCHEMA, toStoryListItem } from '../src/mcp/tools/story-list-item';
+import type { UserStoryRow } from '../src/queries/story.queries';
+
+function buildStoryRow(overrides: Partial<UserStoryRow> = {}): UserStoryRow {
+	return {
+		id: 'story-1',
+		chatId: null,
+		projectId: 'project-1',
+		userId: 'user-1',
+		slug: 'revenue-dashboard',
+		title: 'Revenue Dashboard',
+		isLive: false,
+		isLiveTextDynamic: true,
+		cacheSchedule: null,
+		cacheScheduleDescription: null,
+		archivedAt: null,
+		createdAt: new Date('2024-01-01T00:00:00.000Z'),
+		updatedAt: new Date('2024-01-02T03:04:05.000Z'),
+		code: '# Revenue\n',
+		...overrides,
+	};
+}
+
+describe('list_stories output mapping', () => {
+	it('serializes createdAt/updatedAt as ISO strings that satisfy the output schema', () => {
+		const item = toStoryListItem(buildStoryRow(), {
+			url: 'http://localhost:5005/stories/standalone/story-1',
+			chatUrl: null,
+		});
+
+		expect(item.createdAt).toBe('2024-01-01T00:00:00.000Z');
+		expect(item.updatedAt).toBe('2024-01-02T03:04:05.000Z');
+		expect(() => STORY_LIST_ITEM_SCHEMA.parse(item)).not.toThrow();
+	});
+});


### PR DESCRIPTION
## What this does

`list_stories` was returning Drizzle `Date` objects for `createdAt`/`updatedAt` in its MCP `structuredContent`, while the tool's output schema declares them as `z.string()`. The SDK validates structured output against that schema, so the call failed validation and the tool was unusable for listing stories.

This serializes both timestamps to ISO strings. I pulled the row->item mapping out of the handler into a small typed `toStoryListItem()` (in `story-list-item.ts`) that returns the schema's inferred type, so a `Date`/`string` mismatch is now a compile error. The mapper takes the two URLs as arguments so it stays free of the `bun:sqlite` DB chain and is unit-testable under vitest.

The `text` content is unchanged — `JSON.stringify` already rendered the Dates as ISO strings; only the `structuredContent` path was broken. It's isolated to `list_stories`; the other story tools build structured content from a slim, string-only payload. Both timestamp columns are `NOT NULL` in the SQLite and Postgres schemas, so `.toISOString()` is always safe.

## How I tested

- Added a vitest unit test that maps a row with `Date` timestamps and asserts the result parses against the tool's actual output schema (the same Zod object the SDK validates). Watched it fail on the `Date` first, then pass after the fix.
- `tsc --noEmit` + eslint clean; the full pre-commit hook (lint/format/migrations/cli) is green.
- I didn't run a live MCP round-trip — there's no MCP integration harness in the repo and no warehouse/LLM-backed instance here — but the unit test exercises the exact schema validation that was failing.

Fixes #914

This PR was written using Claude Opus 4.8 (claude-opus-4-8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to `list_stories` response shaping and shared list-item types; no auth, persistence, or other story tool behavior changes.
> 
> **Overview**
> Fixes **`list_stories`** MCP failures where SDK validation rejected `structuredContent` because `createdAt`/`updatedAt` were Drizzle **`Date`** values while the output schema expects **`z.string()`** ISO timestamps. The text JSON path was already fine via `JSON.stringify`; only structured output was broken.
> 
> Introduces **`story-list-item.ts`** with shared **`STORY_LIST_ITEM_SCHEMA`**, **`toStoryListItem()`** (maps rows and calls **`.toISOString()`** on both timestamps), and a typed return so date/string mismatches fail at compile time. **`list_stories`** in `asset-tools.ts` now uses that helper instead of inline mapping.
> 
> Adds a vitest test that asserts ISO serialization and that the mapped item parses against the real output schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34721ccd0f4527e62f62a2d940cf70c0bbced80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

