### PR TITLE
fix(clickhouse): force HTTPS interface when secure is enabled

### DIFF
--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -640,6 +640,11 @@ class ClickHouseConfig(DatabaseConfig):
             "password": self.password,
             "secure": self.secure,
         }
+        # ibis only uses `secure` to pick the default port; it never forwards it to
+        # clickhouse_connect, so the client falls back to plain HTTP on TLS-only ports.
+        # Force the HTTPS interface explicitly via **kwargs, which ibis does forward.
+        if self.secure:
+            kwargs["interface"] = "https"
         if self.port is not None:
             kwargs["port"] = self.port
         if self.connect_timeout is not None:


### PR DESCRIPTION
I just ran into this while trying to connect my own ClickHouse instance with `secure: true` in `nao_config.yaml`. `nao debug` failed with:

`Error ('Connection aborted.', ConnectionResetError(54, 'Connection reset by peer')) executing HTTP request attempt 2 (http://<host>:<port>)`

Note the `http://` despite `secure: true` — the client never switched to TLS.

---

**(The analysis below was generated with Claude, based on my local repro. I've reviewed it and it matches what I observed.)**

## Root cause

ibis's ClickHouse `do_connect` accepts a `secure` argument, but only uses it
to pick the default port (`443 if secure else 8123`). It never forwards `secure`
to `clickhouse_connect.get_client`, so the client falls back to plain HTTP and
the connection is reset on TLS-only endpoints.

Confirmed by isolating the layers:
- `clickhouse_connect.get_client(..., secure=True)` → works (HTTPS)
- `ibis.clickhouse.connect(..., secure=True)` → fails (sends HTTP)
- `ibis.clickhouse.connect(..., interface="https")` → works (ibis forwards `**kwargs`)

## Fix

When `secure` is enabled, pass `interface="https"` through the connection
kwargs, which ibis *does* forward to `clickhouse_connect`. Minimal, one-spot
change in `ClickHouseConfig.connect()`; behaviour is unchanged for non-secure
connections.

## Relation to #757 / #810

This is on the existing HTTP interface path, so it's independent from the
native TCP protocol work in #810 (which addresses #757). It does touch the same
secure-mode area as the TLS/port concern flagged on #810, and applies whether
the HTTP interface is reached via the default or the `native` protocol path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in the ClickHouse ibis connect path; no auth or data-model changes, and behavior is unchanged when `secure` is false.
> 
> **Overview**
> Fixes ClickHouse connections when `secure: true` is set in config (e.g. `nao debug` failing with HTTP attempts and connection reset on TLS-only endpoints).
> 
> **`ClickHouseConfig.connect()`** now sets `interface="https"` in the kwargs passed to `ibis.clickhouse.connect` whenever `secure` is enabled. ibis uses `secure` only for default port selection and does not pass it through to `clickhouse_connect`, which otherwise stays on plain HTTP; `interface` is forwarded via `**kwargs`. Non-secure connections are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0646fbeadb363c063e41d68044d908296f6da34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->