### PR TITLE
Add reset password functionality to CLI and backend (#new-feature)

### DIFF
--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -243,7 +243,7 @@ async function runResetPassword(options: Record<string, string>): Promise<void> 
 		process.exit(1);
 	}
 
-	const temporaryPassword = crypto.randomUUID().slice(0, 8);
+	const temporaryPassword = crypto.randomBytes(12).toString('base64url');
 	const hashedPassword = await hashPassword(temporaryPassword);
 	await accountQueries.updateAccountPassword(account.id, hashedPassword, user.id);
 

--- a/apps/backend/src/cli.ts
+++ b/apps/backend/src/cli.ts
@@ -10,6 +10,7 @@
 
 import './env';
 
+import { hashPassword } from 'better-auth/crypto';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -17,6 +18,8 @@ import path from 'path';
 import { startServer } from './app';
 import dbConfig, { Dialect } from './db/dbConfig';
 import { runMigrations } from './db/migrate';
+import * as accountQueries from './queries/account.queries';
+import * as userQueries from './queries/user.queries';
 
 const SECRET_FILE_NAME = '.nao-secret';
 
@@ -115,8 +118,9 @@ USAGE:
     nao-chat-server <command> [options]
 
 COMMANDS:
-    serve       Run migrations and start the chat server (default)
-    migrate     Run database migrations only
+    serve           Run migrations and start the chat server (default)
+    migrate         Run database migrations only
+    reset-password  Reset a user's password directly in the local database
 
 OPTIONS:
     -h, --help  Show this help message
@@ -124,6 +128,9 @@ OPTIONS:
 SERVE OPTIONS:
     --port <port>   Port to listen on (default: 5005)
     --host <host>   Host to bind to (default: 0.0.0.0)
+
+RESET-PASSWORD OPTIONS:
+    --email <email>   Email of the user whose password should be reset
 
 ENVIRONMENT VARIABLES:
     DB_URI              Database connection URI
@@ -166,7 +173,7 @@ function parseArgs(args: string[]): { command: string; options: Record<string, s
 			}
 		} else if (!arg.startsWith('-')) {
 			// First non-flag argument is the command
-			if (command === 'serve' && (arg === 'migrate' || arg === 'serve')) {
+			if (command === 'serve' && (arg === 'migrate' || arg === 'serve' || arg === 'reset-password')) {
 				command = arg;
 			}
 			i++;
@@ -217,6 +224,35 @@ async function runServe(options: Record<string, string>): Promise<void> {
 	}
 }
 
+async function runResetPassword(options: Record<string, string>): Promise<void> {
+	const email = options['email']?.trim();
+	if (!email) {
+		console.error('❌ Missing required option: --email <email>');
+		process.exit(1);
+	}
+
+	const user = (await userQueries.getUser({ email })) ?? (await userQueries.getUser({ email: email.toLowerCase() }));
+	if (!user) {
+		console.error(`❌ No user found with email "${email}"`);
+		process.exit(1);
+	}
+
+	const account = await accountQueries.getAccountById(user.id);
+	if (!account?.password) {
+		console.error(`❌ ${user.email} signs in via SSO/OAuth and has no password to reset.`);
+		process.exit(1);
+	}
+
+	const temporaryPassword = crypto.randomUUID().slice(0, 8);
+	const hashedPassword = await hashPassword(temporaryPassword);
+	await accountQueries.updateAccountPassword(account.id, hashedPassword, user.id);
+
+	console.log(`\n✓ Password reset for ${user.email}`);
+	console.log(`   Temporary password: ${temporaryPassword}`);
+	console.log(`   You'll be prompted to choose a new password after logging in.\n`);
+	process.exit(0);
+}
+
 async function runMigrateCommand(): Promise<void> {
 	const migrationsPath = getMigrationsPath(dbConfig.dialect);
 
@@ -246,6 +282,9 @@ async function main(): Promise<void> {
 	switch (command) {
 		case 'migrate':
 			await runMigrateCommand();
+			break;
+		case 'reset-password':
+			await runResetPassword(options);
 			break;
 		case 'serve':
 			await runServe(options);

--- a/apps/backend/src/queries/account.queries.ts
+++ b/apps/backend/src/queries/account.queries.ts
@@ -1,13 +1,15 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
+
+const CREDENTIAL_PROVIDER_ID = 'credential';
 
 export const getAccountById = async (userId: string): Promise<{ id: string; password: string | null } | null> => {
 	const [account] = await db
 		.select({ id: s.account.id, password: s.account.password })
 		.from(s.account)
-		.where(eq(s.account.userId, userId))
+		.where(and(eq(s.account.userId, userId), eq(s.account.providerId, CREDENTIAL_PROVIDER_ID)))
 		.execute();
 
 	return account ?? null;

--- a/cli/nao_core/commands/__init__.py
+++ b/cli/nao_core/commands/__init__.py
@@ -3,9 +3,10 @@ from nao_core.commands.debug import debug
 from nao_core.commands.deploy import deploy
 from nao_core.commands.docs import docs
 from nao_core.commands.init import init
+from nao_core.commands.reset_password import reset_password
 from nao_core.commands.skills import skills
 from nao_core.commands.sync import sync
 from nao_core.commands.test import test
 from nao_core.commands.upgrade import upgrade
 
-__all__ = ["chat", "debug", "deploy", "docs", "init", "skills", "sync", "test", "upgrade"]
+__all__ = ["chat", "debug", "deploy", "docs", "init", "reset_password", "skills", "sync", "test", "upgrade"]

--- a/cli/nao_core/commands/reset_password.py
+++ b/cli/nao_core/commands/reset_password.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import sys
+
+from nao_core.commands.chat import get_server_binary_path
+from nao_core.tracking import track_command
+
+
+@track_command("reset-password")
+def reset_password(email: str):
+    """Reset a local nao user's password.
+
+    Generates a temporary password for the given email by updating the local
+    nao database directly. The user is prompted to choose a new password on
+    their next login. Works offline — no running chat server required.
+
+    Parameters
+    ----------
+    email : str
+        Email address of the account whose password should be reset.
+    """
+    binary_path = get_server_binary_path()
+    bin_dir = binary_path.parent
+
+    result = subprocess.run(
+        [str(binary_path), "reset-password", "--email", email],
+        cwd=str(bin_dir),
+        env=os.environ.copy(),
+    )
+
+    if result.returncode != 0:
+        sys.exit(result.returncode)

--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -5,7 +5,18 @@ load_dotenv()
 from cyclopts import App  # noqa: E402
 
 from nao_core import __version__  # noqa: E402
-from nao_core.commands import chat, debug, deploy, docs, init, skills, sync, test, upgrade  # noqa: E402
+from nao_core.commands import (  # noqa: E402
+    chat,
+    debug,
+    deploy,
+    docs,
+    init,
+    reset_password,
+    skills,
+    sync,
+    test,
+    upgrade,
+)
 from nao_core.version import check_for_updates  # noqa: E402
 
 app = App(version=__version__)
@@ -15,6 +26,7 @@ app.command(debug)
 app.command(deploy)
 app.command(docs)
 app.command(init)
+app.command(reset_password)
 app.command(skills)
 app.command(sync)
 app.command(test)

--- a/cli/tests/nao_core/commands/test_reset_password.py
+++ b/cli/tests/nao_core/commands/test_reset_password.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nao_core.commands.reset_password import reset_password
+
+
+def _fake_binary(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    binary = bin_dir / "nao-chat-server"
+    binary.touch()
+    return binary
+
+
+@patch("nao_core.commands.reset_password.subprocess.run")
+@patch("nao_core.commands.reset_password.get_server_binary_path")
+def test_reset_password_invokes_binary(mock_binary_path, mock_run, tmp_path: Path):
+    binary = _fake_binary(tmp_path)
+    mock_binary_path.return_value = binary
+    mock_run.return_value = MagicMock(returncode=0)
+
+    reset_password("user@example.com")
+
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] == [str(binary), "reset-password", "--email", "user@example.com"]
+    assert kwargs["cwd"] == str(binary.parent)
+
+
+@patch("nao_core.commands.reset_password.subprocess.run")
+@patch("nao_core.commands.reset_password.get_server_binary_path")
+def test_reset_password_propagates_binary_failure(mock_binary_path, mock_run, tmp_path: Path):
+    binary = _fake_binary(tmp_path)
+    mock_binary_path.return_value = binary
+    mock_run.return_value = MagicMock(returncode=1)
+
+    with pytest.raises(SystemExit) as exc_info:
+        reset_password("user@example.com")
+
+    assert exc_info.value.code == 1


### PR DESCRIPTION
fixes #574 

* Introduced a new command `reset-password` in the CLI to allow users to reset their passwords directly in the local database.
* Updated the main CLI file to include the new command and its options.
* Implemented the password reset logic, including temporary password generation and hashing.
* Added corresponding command handling in the Python CLI.
* Created a new module for the reset password command and included tests to ensure functionality.

This feature enhances user account management by providing a way to reset passwords without requiring server access.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

