### PR TITLE
feat(frontend): view SQL query and data behind a chart

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { buildChart, buildStoryChartBlock, labelize } from '@nao/shared';
-import { Download, FilePlus, Pencil } from 'lucide-react';
+import { Code, Download, FilePlus, Pencil } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOptionalAgentContext } from '../../contexts/agent.provider';
 import GraphLoaderAnimated from '../icons/graph-loader-animated';
@@ -13,7 +13,7 @@ import { ChartRangeSelector } from './display-chart-range-selector';
 import { DisplayChartEditDialog } from './display-chart-edit-dialog';
 import type { ToolCallComponentProps } from '.';
 import type { ChartConfig } from '../ui/chart';
-import type { displayChart } from '@nao/shared/tools';
+import type { displayChart, executeSql } from '@nao/shared/tools';
 import type { UIMessage } from '@nao/backend/chat';
 import type { DateRange } from '@/lib/charts.utils';
 import { filterByDateRange, sortByDateKey, DATE_RANGE_OPTIONS, toKey } from '@/lib/charts.utils';
@@ -21,6 +21,7 @@ import { findStoryIds } from '@/lib/story.utils';
 import { useChatId } from '@/hooks/use-chat-id';
 import { useSidePanel } from '@/contexts/side-panel';
 import { StoryViewer } from '@/components/side-panel/story-viewer';
+import { SidePanelContent } from '@/components/side-panel/sql-editor';
 import { trpc } from '@/main';
 
 const Colors = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
@@ -75,7 +76,7 @@ export const DisplayChartToolCall = ({
 		}
 	};
 
-	const sourceData = useMemo(() => {
+	const sourceQuery = useMemo<{ input?: executeSql.Input; output: executeSql.Output } | null>(() => {
 		if (!config?.query_id) {
 			return null;
 		}
@@ -83,12 +84,21 @@ export const DisplayChartToolCall = ({
 		for (const message of messages) {
 			for (const part of message.parts) {
 				if (part.type === 'tool-execute_sql' && part.output && part.output.id === config.query_id) {
-					return part.output;
+					return { input: part.input, output: part.output };
 				}
 			}
 		}
 		return null;
 	}, [messages, config?.query_id]);
+
+	const sourceData = sourceQuery?.output ?? null;
+
+	const handleViewQuery = useCallback(() => {
+		if (!sourceQuery?.input || !sourceQuery.output) {
+			return;
+		}
+		openSidePanel(<SidePanelContent input={sourceQuery.input} output={sourceQuery.output} />);
+	}, [openSidePanel, sourceQuery]);
 
 	const filteredData = useMemo(() => {
 		if (!sourceData?.data || !config) {
@@ -211,6 +221,17 @@ export const DisplayChartToolCall = ({
 							selectedRange={dataRange}
 							onRangeSelected={(range) => setDataRange(range)}
 						/>
+					)}
+					{sourceQuery?.input && (
+						<Button
+							variant='ghost'
+							size='icon-xs'
+							className='hover:rounded-full'
+							onClick={handleViewQuery}
+							title='View SQL query and data'
+						>
+							<Code className='size-4' />
+						</Button>
 					)}
 					{config.chart_type != 'kpi_card' && (
 						<Button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a way to inspect the SQL query behind a specific chart and the result data used to build it.

Each chat chart (`display_chart` tool call) references a prior `execute_sql` result by `query_id`. Previously the chart only rendered the visualization — there was no way to see the underlying query or its rows. This adds a **"View SQL query and data"** action (code `<>` icon) to the chart toolbar that opens the existing side panel showing the SQL query (top) and the result table (bottom).

## How

- In `display-chart.tsx`, the source lookup now also captures the matching `execute_sql` part's `input` (the SQL) alongside its `output` (the data) — previously only the output was kept for rendering.
- A new toolbar button opens `SidePanelContent` (the same SQL editor + `TableDisplay` used by the `execute_sql` tool call), so no new UI surface is introduced.
- The button only renders when the source query (with its SQL input) is found.

## Testing

- `npm run lint` (tsc + eslint across backend/frontend/shared) — passed.
- Manual end-to-end test: seeded a chat with an `execute_sql` part + `display_chart` part, logged into the app, opened the chart, clicked the new button, and confirmed the side panel shows the SQL query and the 6-row data table.

[chart_view_sql_and_data_demo.mp4](https://cursor.com/agents/bc-cc0145ac-7b0d-4fea-9ac9-b95bdb7a69f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchart_view_sql_and_data_demo.mp4)

[Side panel showing SQL query and data table for a chart](https://cursor.com/agents/bc-cc0145ac-7b0d-4fea-9ac9-b95bdb7a69f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchart_sql_and_data_panel.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc0145ac-7b0d-4fea-9ac9-b95bdb7a69f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc0145ac-7b0d-4fea-9ac9-b95bdb7a69f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

