### PR TITLE
feat: configurable per-surface system prompt overrides from agent/prompts/

### DIFF
--- a/apps/backend/src/agents/system-prompts.ts
+++ b/apps/backend/src/agents/system-prompts.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import type { Provider } from '../types/messaging-provider';
+
+/** Folder in the project context repo that holds per-surface system prompt overrides. */
+const PROMPTS_FOLDER = ['agent', 'prompts'];
+
+/** Filename used to override every surface (including the nao web Bot). */
+const DEFAULT_PROMPT_FILE = 'system.md';
+
+/**
+ * Resolves the filename that overrides a given bot surface. The nao web Bot (no
+ * messaging provider) is driven by `system.md`; messaging surfaces use their own
+ * file (e.g. `slack.md`) and otherwise fall back to `system.md`.
+ */
+function getPromptFileCandidates(provider?: Provider): string[] {
+	if (!provider) {
+		return [DEFAULT_PROMPT_FILE];
+	}
+	return [`${provider}.md`, DEFAULT_PROMPT_FILE];
+}
+
+/**
+ * Reads a user-defined system prompt override from `agent/prompts/` for the given
+ * surface, or returns `undefined` when none is configured.
+ *
+ * When present, the file fully replaces the bundled product prompt for that surface,
+ * letting data teams version and review bot behavior alongside the rest of the context.
+ * `system.md` acts as a global override applied to every surface; a surface-specific
+ * file (e.g. `slack.md`) takes precedence over it.
+ */
+export function getSystemPromptOverride(projectFolder: string, provider?: Provider): string | undefined {
+	for (const filename of getPromptFileCandidates(provider)) {
+		const content = readPromptFile(projectFolder, filename);
+		if (content) {
+			return content;
+		}
+	}
+	return undefined;
+}
+
+function readPromptFile(projectFolder: string, filename: string): string | undefined {
+	const filePath = join(projectFolder, ...PROMPTS_FOLDER, filename);
+	if (!existsSync(filePath)) {
+		return undefined;
+	}
+
+	try {
+		const content = readFileSync(filePath, 'utf-8').trim();
+		return content.length > 0 ? content : undefined;
+	} catch (error) {
+		console.error(`Error reading system prompt override ${filename}:`, error);
+		return undefined;
+	}
+}

--- a/apps/backend/src/agents/system-prompts.ts
+++ b/apps/backend/src/agents/system-prompts.ts
@@ -7,6 +7,16 @@ const PROMPTS_FOLDER = ['agent', 'prompts'];
 
 const DEFAULT_PROMPT_FILE = 'system.md';
 
+const NAO_PROMPT_PATTERN = '\\{\\{\\s*nao_prompt\\s*\\}\\}';
+
+export function hasNaoPromptPlaceholder(content: string): boolean {
+	return new RegExp(NAO_PROMPT_PATTERN).test(content);
+}
+
+export function injectNaoPrompt(override: string, naoPrompt: string): string {
+	return override.replace(new RegExp(NAO_PROMPT_PATTERN, 'g'), naoPrompt);
+}
+
 function getPromptFileCandidates(provider?: Provider): string[] {
 	if (!provider) {
 		return [DEFAULT_PROMPT_FILE];

--- a/apps/backend/src/agents/system-prompts.ts
+++ b/apps/backend/src/agents/system-prompts.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, realpathSync } from 'fs';
+import { isAbsolute, join, relative } from 'path';
 
 import type { Provider } from '../types/messaging-provider';
 
@@ -41,10 +41,20 @@ function readPromptFile(projectFolder: string, filename: string): string | undef
 	}
 
 	try {
-		const content = readFileSync(filePath, 'utf-8').trim();
+		const realFilePath = realpathSync(filePath);
+		if (!isWithinDirectory(realpathSync(projectFolder), realFilePath)) {
+			console.error(`Refusing to read system prompt override outside the project folder: ${filename}`);
+			return undefined;
+		}
+		const content = readFileSync(realFilePath, 'utf-8').trim();
 		return content.length > 0 ? content : undefined;
 	} catch (error) {
 		console.error(`Error reading system prompt override ${filename}:`, error);
 		return undefined;
 	}
+}
+
+function isWithinDirectory(directory: string, target: string): boolean {
+	const rel = relative(directory, target);
+	return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }

--- a/apps/backend/src/agents/system-prompts.ts
+++ b/apps/backend/src/agents/system-prompts.ts
@@ -3,17 +3,10 @@ import { join } from 'path';
 
 import type { Provider } from '../types/messaging-provider';
 
-/** Folder in the project context repo that holds per-surface system prompt overrides. */
 const PROMPTS_FOLDER = ['agent', 'prompts'];
 
-/** Filename used to override every surface (including the nao web Bot). */
 const DEFAULT_PROMPT_FILE = 'system.md';
 
-/**
- * Resolves the filename that overrides a given bot surface. The nao web Bot (no
- * messaging provider) is driven by `system.md`; messaging surfaces use their own
- * file (e.g. `slack.md`) and otherwise fall back to `system.md`.
- */
 function getPromptFileCandidates(provider?: Provider): string[] {
 	if (!provider) {
 		return [DEFAULT_PROMPT_FILE];
@@ -21,15 +14,6 @@ function getPromptFileCandidates(provider?: Provider): string[] {
 	return [`${provider}.md`, DEFAULT_PROMPT_FILE];
 }
 
-/**
- * Reads a user-defined system prompt override from `agent/prompts/` for the given
- * surface, or returns `undefined` when none is configured.
- *
- * When present, the file fully replaces the bundled product prompt for that surface,
- * letting data teams version and review bot behavior alongside the rest of the context.
- * `system.md` acts as a global override applied to every surface; a surface-specific
- * file (e.g. `slack.md`) takes precedence over it.
- */
 export function getSystemPromptOverride(projectFolder: string, provider?: Provider): string | undefined {
 	for (const filename of getPromptFileCandidates(provider)) {
 		const content = readPromptFile(projectFolder, filename);

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -20,6 +20,7 @@ import {
 import { z } from 'zod';
 
 import { LLM_PROVIDERS, ProviderModelResult } from '../agents/providers';
+import { getSystemPromptOverride } from '../agents/system-prompts';
 import { getTools } from '../agents/tools';
 import { createWebSearchTools } from '../agents/tools/web-search';
 import { getConnections, getTableColumnsContent, getUserRules } from '../agents/user-rules';
@@ -500,6 +501,11 @@ class AgentManager {
 
 	/** Builds the standard system prompt (instructions + user rules + memories + connections). */
 	private async _buildSystemPrompt(provider?: Provider, timezone?: string, chatUrl?: string): Promise<string> {
+		const promptOverride = getSystemPromptOverride(this._toolContext.projectFolder, provider);
+		if (promptOverride) {
+			return promptOverride;
+		}
+
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -499,11 +499,6 @@ class AgentManager {
 		return modelMessages;
 	}
 
-	/**
-	 * Resolves the system prompt for a run. A context-repo override in `agent/prompts/`
-	 * replaces the built-in prompt; if it contains the `{{ nao_prompt }}` placeholder,
-	 * the built-in prompt is injected there so the override extends rather than replaces it.
-	 */
 	private async _buildSystemPrompt(provider?: Provider, timezone?: string, chatUrl?: string): Promise<string> {
 		const override = getSystemPromptOverride(this._toolContext.projectFolder, provider);
 		if (override && !hasNaoPromptPlaceholder(override)) {
@@ -514,7 +509,6 @@ class AgentManager {
 		return override ? injectNaoPrompt(override, defaultPrompt) : defaultPrompt;
 	}
 
-	/** Builds the standard system prompt (instructions + user rules + memories + connections). */
 	private async _buildDefaultSystemPrompt(provider?: Provider, timezone?: string, chatUrl?: string): Promise<string> {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -20,7 +20,7 @@ import {
 import { z } from 'zod';
 
 import { LLM_PROVIDERS, ProviderModelResult } from '../agents/providers';
-import { getSystemPromptOverride } from '../agents/system-prompts';
+import { getSystemPromptOverride, hasNaoPromptPlaceholder, injectNaoPrompt } from '../agents/system-prompts';
 import { getTools } from '../agents/tools';
 import { createWebSearchTools } from '../agents/tools/web-search';
 import { getConnections, getTableColumnsContent, getUserRules } from '../agents/user-rules';
@@ -499,13 +499,23 @@ class AgentManager {
 		return modelMessages;
 	}
 
-	/** Builds the standard system prompt (instructions + user rules + memories + connections). */
+	/**
+	 * Resolves the system prompt for a run. A context-repo override in `agent/prompts/`
+	 * replaces the built-in prompt; if it contains the `{{ nao_prompt }}` placeholder,
+	 * the built-in prompt is injected there so the override extends rather than replaces it.
+	 */
 	private async _buildSystemPrompt(provider?: Provider, timezone?: string, chatUrl?: string): Promise<string> {
-		const promptOverride = getSystemPromptOverride(this._toolContext.projectFolder, provider);
-		if (promptOverride) {
-			return promptOverride;
+		const override = getSystemPromptOverride(this._toolContext.projectFolder, provider);
+		if (override && !hasNaoPromptPlaceholder(override)) {
+			return override;
 		}
 
+		const defaultPrompt = await this._buildDefaultSystemPrompt(provider, timezone, chatUrl);
+		return override ? injectNaoPrompt(override, defaultPrompt) : defaultPrompt;
+	}
+
+	/** Builds the standard system prompt (instructions + user rules + memories + connections). */
+	private async _buildDefaultSystemPrompt(provider?: Provider, timezone?: string, chatUrl?: string): Promise<string> {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);

--- a/apps/backend/tests/system-prompts.integration.test.ts
+++ b/apps/backend/tests/system-prompts.integration.test.ts
@@ -1,0 +1,57 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getSystemPromptOverride } from '../src/agents/system-prompts';
+
+/**
+ * Exercises the override reader against the real filesystem to prove it loads
+ * prompt files from `agent/prompts/` exactly as a synced context repo would lay
+ * them out (no `fs` mock here).
+ */
+describe('getSystemPromptOverride (real filesystem)', () => {
+	let projectFolder: string;
+
+	beforeEach(() => {
+		projectFolder = mkdtempSync(join(tmpdir(), 'nao-prompts-'));
+		mkdirSync(join(projectFolder, 'agent', 'prompts'), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(projectFolder, { recursive: true, force: true });
+	});
+
+	function writePrompt(filename: string, content: string): void {
+		writeFileSync(join(projectFolder, 'agent', 'prompts', filename), content, 'utf-8');
+	}
+
+	it('returns undefined for an empty prompts folder', () => {
+		expect(getSystemPromptOverride(projectFolder)).toBeUndefined();
+		expect(getSystemPromptOverride(projectFolder, 'slack')).toBeUndefined();
+	});
+
+	it('loads system.md for the web Bot and as the global fallback', () => {
+		writePrompt('system.md', 'You are the org default analyst.');
+
+		expect(getSystemPromptOverride(projectFolder)).toBe('You are the org default analyst.');
+		expect(getSystemPromptOverride(projectFolder, 'slack')).toBe('You are the org default analyst.');
+		expect(getSystemPromptOverride(projectFolder, 'teams')).toBe('You are the org default analyst.');
+	});
+
+	it('loads a surface-specific prompt and prefers it over system.md', () => {
+		writePrompt('system.md', 'Global prompt');
+		writePrompt('slack.md', 'Slack-only prompt');
+
+		expect(getSystemPromptOverride(projectFolder, 'slack')).toBe('Slack-only prompt');
+		expect(getSystemPromptOverride(projectFolder, 'teams')).toBe('Global prompt');
+		expect(getSystemPromptOverride(projectFolder)).toBe('Global prompt');
+	});
+
+	it('ignores a README.md (not a recognized surface file)', () => {
+		writePrompt('README.md', '# How to use prompts');
+
+		expect(getSystemPromptOverride(projectFolder)).toBeUndefined();
+		expect(getSystemPromptOverride(projectFolder, 'slack')).toBeUndefined();
+	});
+});

--- a/apps/backend/tests/system-prompts.integration.test.ts
+++ b/apps/backend/tests/system-prompts.integration.test.ts
@@ -5,11 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getSystemPromptOverride } from '../src/agents/system-prompts';
 
-/**
- * Exercises the override reader against the real filesystem to prove it loads
- * prompt files from `agent/prompts/` exactly as a synced context repo would lay
- * them out (no `fs` mock here).
- */
 describe('getSystemPromptOverride (real filesystem)', () => {
 	let projectFolder: string;
 

--- a/apps/backend/tests/system-prompts.integration.test.ts
+++ b/apps/backend/tests/system-prompts.integration.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getSystemPromptOverride } from '../src/agents/system-prompts';
+import { getSystemPromptOverride, hasNaoPromptPlaceholder, injectNaoPrompt } from '../src/agents/system-prompts';
 
 describe('getSystemPromptOverride (real filesystem)', () => {
 	let projectFolder: string;
@@ -48,5 +48,16 @@ describe('getSystemPromptOverride (real filesystem)', () => {
 
 		expect(getSystemPromptOverride(projectFolder)).toBeUndefined();
 		expect(getSystemPromptOverride(projectFolder, 'slack')).toBeUndefined();
+	});
+
+	it('composes the default prompt into a file that keeps the {{ nao_prompt }} placeholder', () => {
+		writePrompt('slack.md', '{{ nao_prompt }}\n\n## House rules\n- Answer in EUR.');
+
+		const override = getSystemPromptOverride(projectFolder, 'slack');
+		expect(override).toBeDefined();
+		expect(hasNaoPromptPlaceholder(override!)).toBe(true);
+
+		const composed = injectNaoPrompt(override!, 'DEFAULT_SLACK_PROMPT');
+		expect(composed).toBe('DEFAULT_SLACK_PROMPT\n\n## House rules\n- Answer in EUR.');
 	});
 });

--- a/apps/backend/tests/system-prompts.integration.test.ts
+++ b/apps/backend/tests/system-prompts.integration.test.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getSystemPromptOverride, hasNaoPromptPlaceholder, injectNaoPrompt } from '../src/agents/system-prompts';
 
@@ -48,6 +48,24 @@ describe('getSystemPromptOverride (real filesystem)', () => {
 
 		expect(getSystemPromptOverride(projectFolder)).toBeUndefined();
 		expect(getSystemPromptOverride(projectFolder, 'slack')).toBeUndefined();
+	});
+
+	it('refuses to follow a symlink that points outside the project folder', () => {
+		const secretDir = mkdtempSync(join(tmpdir(), 'nao-secret-'));
+		const secretFile = join(secretDir, 'secret.md');
+		writeFileSync(secretFile, 'TOP SECRET HOST FILE', 'utf-8');
+		symlinkSync(secretFile, join(projectFolder, 'agent', 'prompts', 'system.md'));
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		try {
+			expect(getSystemPromptOverride(projectFolder)).toBeUndefined();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Refusing to read system prompt override outside the project folder'),
+			);
+		} finally {
+			consoleSpy.mockRestore();
+			rmSync(secretDir, { recursive: true, force: true });
+		}
 	});
 
 	it('composes the default prompt into a file that keeps the {{ nao_prompt }} placeholder', () => {

--- a/apps/backend/tests/system-prompts.test.ts
+++ b/apps/backend/tests/system-prompts.test.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('fs');
+
+import { getSystemPromptOverride } from '../src/agents/system-prompts';
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+const ROOT = '/project';
+const promptPath = (filename: string) => join(ROOT, 'agent', 'prompts', filename);
+
+/** Makes only the listed prompt files "exist" with the given content. */
+function setupPromptFiles(files: Record<string, string>): void {
+	mockExistsSync.mockImplementation((path) => Object.keys(files).some((name) => path === promptPath(name)));
+	mockReadFileSync.mockImplementation((path) => {
+		const match = Object.entries(files).find(([name]) => path === promptPath(name));
+		if (!match) {
+			throw new Error(`Unexpected read: ${String(path)}`);
+		}
+		return match[1] as unknown as ReturnType<typeof readFileSync>;
+	});
+}
+
+describe('getSystemPromptOverride', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns undefined when no override files exist', () => {
+		mockExistsSync.mockReturnValue(false);
+		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
+		expect(getSystemPromptOverride(ROOT, 'slack')).toBeUndefined();
+	});
+
+	it('uses system.md for the web Bot (no provider)', () => {
+		setupPromptFiles({ 'system.md': 'Web override' });
+		expect(getSystemPromptOverride(ROOT)).toBe('Web override');
+	});
+
+	it('does not use a surface file for the web Bot', () => {
+		setupPromptFiles({ 'slack.md': 'Slack override' });
+		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
+	});
+
+	it('prefers the surface-specific file over system.md', () => {
+		setupPromptFiles({ 'system.md': 'Global override', 'slack.md': 'Slack override' });
+		expect(getSystemPromptOverride(ROOT, 'slack')).toBe('Slack override');
+	});
+
+	it('falls back to system.md when no surface-specific file exists', () => {
+		setupPromptFiles({ 'system.md': 'Global override' });
+		expect(getSystemPromptOverride(ROOT, 'slack')).toBe('Global override');
+		expect(getSystemPromptOverride(ROOT, 'teams')).toBe('Global override');
+		expect(getSystemPromptOverride(ROOT, 'automation')).toBe('Global override');
+	});
+
+	it('trims whitespace and ignores empty files', () => {
+		setupPromptFiles({ 'system.md': '   \n  Trimmed override \n', 'slack.md': '   \n  ' });
+		expect(getSystemPromptOverride(ROOT)).toBe('Trimmed override');
+		// slack.md is blank, so slack falls back to system.md
+		expect(getSystemPromptOverride(ROOT, 'slack')).toBe('Trimmed override');
+	});
+
+	it('returns undefined and logs when reading throws', () => {
+		mockExistsSync.mockImplementation((path) => path === promptPath('system.md'));
+		mockReadFileSync.mockImplementation(() => {
+			throw new Error('Permission denied');
+		});
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
+		expect(consoleSpy).toHaveBeenCalledWith('Error reading system prompt override system.md:', expect.any(Error));
+	});
+});

--- a/apps/backend/tests/system-prompts.test.ts
+++ b/apps/backend/tests/system-prompts.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('fs');
 
-import { getSystemPromptOverride } from '../src/agents/system-prompts';
+import { getSystemPromptOverride, hasNaoPromptPlaceholder, injectNaoPrompt } from '../src/agents/system-prompts';
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
@@ -72,5 +72,29 @@ describe('getSystemPromptOverride', () => {
 
 		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
 		expect(consoleSpy).toHaveBeenCalledWith('Error reading system prompt override system.md:', expect.any(Error));
+	});
+});
+
+describe('hasNaoPromptPlaceholder', () => {
+	it('detects the placeholder with varying whitespace', () => {
+		expect(hasNaoPromptPlaceholder('before {{ nao_prompt }} after')).toBe(true);
+		expect(hasNaoPromptPlaceholder('{{nao_prompt}}')).toBe(true);
+		expect(hasNaoPromptPlaceholder('{{   nao_prompt   }}')).toBe(true);
+	});
+
+	it('returns false when the placeholder is absent', () => {
+		expect(hasNaoPromptPlaceholder('Just my own prompt')).toBe(false);
+		expect(hasNaoPromptPlaceholder('{{ other_var }}')).toBe(false);
+	});
+});
+
+describe('injectNaoPrompt', () => {
+	it('replaces every placeholder occurrence with the default prompt', () => {
+		const result = injectNaoPrompt('Header\n{{ nao_prompt }}\nFooter {{nao_prompt}}', 'DEFAULT');
+		expect(result).toBe('Header\nDEFAULT\nFooter DEFAULT');
+	});
+
+	it('leaves content unchanged when there is no placeholder', () => {
+		expect(injectNaoPrompt('No placeholder here', 'DEFAULT')).toBe('No placeholder here');
 	});
 });

--- a/apps/backend/tests/system-prompts.test.ts
+++ b/apps/backend/tests/system-prompts.test.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import { join } from 'path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('fs');
 
@@ -8,12 +8,14 @@ import { getSystemPromptOverride, hasNaoPromptPlaceholder, injectNaoPrompt } fro
 
 const mockExistsSync = vi.mocked(existsSync);
 const mockReadFileSync = vi.mocked(readFileSync);
+const mockRealpathSync = vi.mocked(realpathSync);
 
 const ROOT = '/project';
 const promptPath = (filename: string) => join(ROOT, 'agent', 'prompts', filename);
 
 function setupPromptFiles(files: Record<string, string>): void {
 	mockExistsSync.mockImplementation((path) => Object.keys(files).some((name) => path === promptPath(name)));
+	mockRealpathSync.mockImplementation((path) => path as string);
 	mockReadFileSync.mockImplementation((path) => {
 		const match = Object.entries(files).find(([name]) => path === promptPath(name));
 		if (!match) {
@@ -26,6 +28,10 @@ function setupPromptFiles(files: Record<string, string>): void {
 describe('getSystemPromptOverride', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it('returns undefined when no override files exist', () => {
@@ -65,6 +71,7 @@ describe('getSystemPromptOverride', () => {
 
 	it('returns undefined and logs when reading throws', () => {
 		mockExistsSync.mockImplementation((path) => path === promptPath('system.md'));
+		mockRealpathSync.mockImplementation((path) => path as string);
 		mockReadFileSync.mockImplementation(() => {
 			throw new Error('Permission denied');
 		});
@@ -72,6 +79,20 @@ describe('getSystemPromptOverride', () => {
 
 		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
 		expect(consoleSpy).toHaveBeenCalledWith('Error reading system prompt override system.md:', expect.any(Error));
+	});
+
+	it('refuses to read a prompt that resolves outside the project folder (symlink traversal)', () => {
+		mockExistsSync.mockImplementation((path) => path === promptPath('system.md'));
+		mockRealpathSync.mockImplementation((path) =>
+			path === promptPath('system.md') ? '/etc/passwd' : (path as string),
+		);
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(getSystemPromptOverride(ROOT)).toBeUndefined();
+		expect(mockReadFileSync).not.toHaveBeenCalled();
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('Refusing to read system prompt override outside the project folder'),
+		);
 	});
 });
 

--- a/apps/backend/tests/system-prompts.test.ts
+++ b/apps/backend/tests/system-prompts.test.ts
@@ -12,7 +12,6 @@ const mockReadFileSync = vi.mocked(readFileSync);
 const ROOT = '/project';
 const promptPath = (filename: string) => join(ROOT, 'agent', 'prompts', filename);
 
-/** Makes only the listed prompt files "exist" with the given content. */
 function setupPromptFiles(files: Record<string, string>): void {
 	mockExistsSync.mockImplementation((path) => Object.keys(files).some((name) => path === promptPath(name)));
 	mockReadFileSync.mockImplementation((path) => {

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -33,6 +33,25 @@ class CreatedFile:
     content: str | None
 
 
+_PROMPTS_README = """# System prompts
+
+Override the system prompt nao uses on each bot surface by adding a markdown file
+here. When a file is present its content fully replaces the built-in product
+prompt for that surface; remove the file to fall back to the default.
+
+- `system.md` — applies to every surface (nao web Bot, Slack, Teams, …).
+- `slack.md` — Slack Bot only.
+- `teams.md` — Microsoft Teams Bot only.
+- `telegram.md` — Telegram Bot only.
+- `whatsapp.md` — WhatsApp Bot only.
+- `automation.md` — scheduled automations only.
+
+A surface-specific file (e.g. `slack.md`) takes precedence over `system.md`.
+These files are versioned with the rest of your context, so prompt changes are
+reviewable in pull requests just like `RULES.md`.
+"""
+
+
 def setup_project_name(
     force: bool = False,
     name: str | None = None,
@@ -112,11 +131,13 @@ def create_empty_structure(project_path: Path) -> tuple[list[str], list[CreatedF
         "agent/tools",
         "agent/mcps",
         "agent/skills",
+        "agent/prompts",
         "tests",
     ]
 
     FILES = [
         CreatedFile(path=Path("RULES.md"), content=None),
+        CreatedFile(path=Path("agent/prompts/README.md"), content=_PROMPTS_README),
         CreatedFile(path=Path(".naoignore"), content="templates/\n*.j2\ntests/\n"),
         CreatedFile(
             path=Path("tests/test_example.yml"),

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -35,9 +35,13 @@ class CreatedFile:
 
 _PROMPTS_README = """# System prompts
 
-Override the system prompt nao uses on each bot surface by adding a markdown file
-here. When a file is present its content fully replaces the built-in product
-prompt for that surface; remove the file to fall back to the default.
+Customize the system prompt nao uses on each bot surface by adding a markdown
+file here. These files are versioned with the rest of your context, so prompt
+changes stay reviewable in pull requests just like `RULES.md`.
+
+## Files
+
+One file per surface:
 
 - `system.md` — applies to every surface (nao web Bot, Slack, Teams, …).
 - `slack.md` — Slack Bot only.
@@ -47,8 +51,37 @@ prompt for that surface; remove the file to fall back to the default.
 - `automation.md` — scheduled automations only.
 
 A surface-specific file (e.g. `slack.md`) takes precedence over `system.md`.
-These files are versioned with the rest of your context, so prompt changes are
-reviewable in pull requests just like `RULES.md`.
+Delete a file to fall back to nao's built-in prompt for that surface.
+
+## Replace vs. extend: `{{ nao_prompt }}`
+
+By default a prompt file **fully replaces** nao's built-in prompt for that
+surface. If instead you want to **keep** the default and only add to it, include
+the `{{ nao_prompt }}` placeholder somewhere in the file: it is replaced at
+runtime with nao's default prompt for the corresponding surface (in `slack.md`
+it expands to the default Slack prompt, in `system.md` to the web prompt, …).
+
+Example `slack.md` that extends the default instead of overriding it:
+
+```md
+{{ nao_prompt }}
+
+## House rules
+- Always answer with amounts in EUR.
+- Keep responses to 5 bullet points or fewer.
+```
+
+Without `{{ nao_prompt }}`, the file content becomes the entire prompt.
+"""
+
+_SLACK_PROMPT_EXAMPLE = """<!--
+  Slack Bot system prompt. {{ nao_prompt }} is replaced at runtime with nao's
+  built-in Slack prompt, so you extend the default instead of replacing it.
+  Add your own instructions around the placeholder, remove it to fully override,
+  or delete this file to use nao's default Slack prompt unchanged. See README.md.
+-->
+
+{{ nao_prompt }}
 """
 
 
@@ -138,6 +171,7 @@ def create_empty_structure(project_path: Path) -> tuple[list[str], list[CreatedF
     FILES = [
         CreatedFile(path=Path("RULES.md"), content=None),
         CreatedFile(path=Path("agent/prompts/README.md"), content=_PROMPTS_README),
+        CreatedFile(path=Path("agent/prompts/slack.md"), content=_SLACK_PROMPT_EXAMPLE),
         CreatedFile(path=Path(".naoignore"), content="templates/\n*.j2\ntests/\n"),
         CreatedFile(
             path=Path("tests/test_example.yml"),

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -75,15 +75,14 @@ Without `{{ nao_prompt }}`, the file content becomes the entire prompt.
 """
 
 _SLACK_PROMPT_EXAMPLE = """<!--
-  Slack Bot system prompt. {{ nao_prompt }} is replaced at runtime with nao's
-  built-in Slack prompt, so you extend the default instead of replacing it.
-  Add your own instructions around the placeholder, remove it to fully override,
+  Slack Bot system prompt. The placeholder below is replaced at runtime with
+  nao's built-in Slack prompt so you can extend the default instead of replacing
+  it entirely. Add your own instructions around it, remove it to fully override,
   or delete this file to use nao's default Slack prompt unchanged. See README.md.
 -->
 
 {{ nao_prompt }}
 """
-
 
 def setup_project_name(
     force: bool = False,

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -84,6 +84,7 @@ _SLACK_PROMPT_EXAMPLE = """<!--
 {{ nao_prompt }}
 """
 
+
 def setup_project_name(
     force: bool = False,
     name: str | None = None,

--- a/cli/tests/nao_core/commands/test_init.py
+++ b/cli/tests/nao_core/commands/test_init.py
@@ -70,6 +70,7 @@ class TestCreateEmptyStructure:
             "agent/tools",
             "agent/mcps",
             "agent/skills",
+            "agent/prompts",
             "tests",
         ]
 
@@ -86,6 +87,16 @@ class TestCreateEmptyStructure:
         rules_file = tmp_path / "RULES.md"
         assert rules_file.exists()
         assert rules_file.is_file()
+
+    def test_creates_prompts_readme_file(self, tmp_path: Path):
+        """Creates agent/prompts/README.md documenting per-surface prompt overrides."""
+        folders, files = create_empty_structure(tmp_path)
+
+        readme = tmp_path / "agent" / "prompts" / "README.md"
+        assert readme.exists()
+        content = readme.read_text()
+        assert "system.md" in content
+        assert "slack.md" in content
 
     def test_creates_naoignore_file(self, tmp_path: Path):
         """Creates .naoignore file with ignored generated paths."""

--- a/cli/tests/nao_core/commands/test_init.py
+++ b/cli/tests/nao_core/commands/test_init.py
@@ -97,6 +97,16 @@ class TestCreateEmptyStructure:
         content = readme.read_text()
         assert "system.md" in content
         assert "slack.md" in content
+        # Documents the placeholder that keeps nao's default prompt
+        assert "{{ nao_prompt }}" in content
+
+    def test_creates_example_slack_prompt_file(self, tmp_path: Path):
+        """Creates an example agent/prompts/slack.md showcasing the {{ nao_prompt }} placeholder."""
+        folders, files = create_empty_structure(tmp_path)
+
+        slack_prompt = tmp_path / "agent" / "prompts" / "slack.md"
+        assert slack_prompt.exists()
+        assert "{{ nao_prompt }}" in slack_prompt.read_text()
 
     def test_creates_naoignore_file(self, tmp_path: Path):
         """Creates .naoignore file with ignored generated paths."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Each bot surface (nao web Bot, Slack Bot, etc.) used a hard-coded system prompt baked into the product. Data teams had no way to customize or replace the prompt per surface without forking the product. Closes #681.

## What changed

Admins can now drop markdown files in an `agent/prompts/` folder in their context repo to customize the system prompt per surface. Files are versioned with the rest of the context, so prompt changes stay reviewable in PRs. No code changes needed.

### Per-surface files

- `system.md` — global, applies to every surface (nao web Bot, Slack, Teams, Telegram, WhatsApp, automations).
- `slack.md`, `teams.md`, `telegram.md`, `whatsapp.md`, `automation.md` — surface-specific.
- A surface-specific file takes precedence over `system.md`; otherwise `system.md` is used; otherwise the product default.

### Replace vs. extend — `{{ nao_prompt }}`

By default a prompt file **fully replaces** the built-in prompt for that surface. To **keep** the default and only add to it, include the `{{ nao_prompt }}` placeholder: it is replaced at runtime with nao's default prompt for the corresponding surface (in `slack.md` it expands to the default Slack prompt, in `system.md` to the web prompt, …). The placeholder tolerates whitespace variations (`{{nao_prompt}}`, `{{ nao_prompt }}`) and can appear multiple times.

This makes both use cases trivial: full override (omit the placeholder) or extend-the-default (include it).

### Implementation

- `apps/backend/src/agents/system-prompts.ts` — `getSystemPromptOverride(projectFolder, provider)` resolves the right file from `agent/prompts/` (read fresh each run, hot-reloadable like `RULES.md`), plus `hasNaoPromptPlaceholder` / `injectNaoPrompt` helpers.
- `apps/backend/src/services/agent.ts` — `_buildSystemPrompt` returns the override verbatim for a full replace, or injects the built-in prompt into `{{ nao_prompt }}` when present (built-in building extracted to `_buildDefaultSystemPrompt`). Internal runs that pass an explicit `systemPrompt` (e.g. context recommendations) are unaffected.
- `cli/nao_core/commands/init.py` — `nao init` scaffolds `agent/prompts/` with a `README.md` documenting per-surface files and the `{{ nao_prompt }}` placeholder, plus an example `slack.md` showcasing the placeholder (resolves to the default Slack prompt, so behavior is unchanged out of the box).

## Testing

- ✅ `npm run -w @nao/backend test -- system-prompts` — 16 tests (mocked-fs + real-filesystem resolution, placeholder detection/injection, and the showcase `slack.md` compose flow).
- ✅ `npm run lint` (tsc + eslint across backend/frontend/shared) — also via pre-commit hook.
- ✅ `cd cli && make lint` (ty, ruff, ruff format).
- ✅ CLI init tests: `uv run pytest tests/nao_core/commands/test_init.py` — 55 passed.
- ✅ Backend boots cleanly (`npm run dev:backend` → `Server listening at http://127.0.0.1:5005`).
- ✅ Real `nao init` scaffolds `agent/prompts/README.md` + example `slack.md` with `{{ nao_prompt }}` end-to-end.

Pre-existing unrelated test failures (`system-prompt.test.ts` missing `formatDate`/`resolveTimezone` exports, DB-dependent `query-app-db`/`sqlite`/`readonly-app-db`, etc.) reproduce on the base commit and are not touched by this change.

Note: a real LLM key was not available in the environment, so behavior is verified via unit + real-filesystem integration tests and a backend boot smoke test rather than a live chat. This is a backend/CLI config change with no UI surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08b1e49c-49fb-4f53-bf9d-367e3c0be451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08b1e49c-49fb-4f53-bf9d-367e3c0be451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

