### PR TITLE
feat(charts): add dual-axis combo chart mode

### DIFF
--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -12,7 +12,7 @@ export default createTool<displayChart.Input, displayChart.Output>({
 		const { chart_type: chartType, x_axis_key: xAxisKey, series } = input;
 
 		// Validate xAxisKey is provided for cartesian and polar charts
-		if (['bar', 'line', 'area', 'stacked_area', 'scatter', 'radar'].includes(chartType) && !xAxisKey) {
+		if (['bar', 'line', 'area', 'stacked_area', 'scatter', 'radar', 'combo'].includes(chartType) && !xAxisKey) {
 			return { _version: '1', success: false, error: `xAxisKey is required for ${chartType} charts.` };
 		}
 

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -101,6 +101,14 @@ export function SystemPrompt({
 					desired (similar to "line"). Use "stacked_area" to show how multiple series compose a total over
 					time (e.g. revenue by payment method, users by plan) — requires 2+ series and pivoted data.
 				</ListItem>
+				<ListItem>
+					For display_chart chart_type: use "combo" to mix chart types and/or plot metrics on two Y-axes (e.g.
+					revenue as bars on the left axis vs. conversion rate as a line on the right axis). Set each series'
+					"series_type" ("bar", "line", or "area") and "y_axis" ("left" or "right"). A right axis is drawn
+					automatically when any series uses "y_axis": "right". Use the top-level "y_axes" object to label
+					each axis (e.g. y_axes.left.label, y_axes.right.label) and to fix a scale via "domain" ("auto" or{' '}
+					{'{ min, max }'}). Prefer "combo" with a right axis when comparing metrics on very different scales.
+				</ListItem>
 				{hasClickHouse && (
 					<ListItem>
 						When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY

--- a/apps/backend/src/components/generate-chart.tsx
+++ b/apps/backend/src/components/generate-chart.tsx
@@ -7,7 +7,8 @@ import { renderToString } from 'react-dom/server';
 import { createSvg, type LegendEntry, svgToPng } from '../utils/generate-chart';
 
 export interface RenderChartInput {
-	config: Pick<displayChart.Input, 'chart_type' | 'x_axis_key' | 'x_axis_type' | 'series' | 'title'>;
+	config: Pick<displayChart.Input, 'chart_type' | 'x_axis_key' | 'x_axis_type' | 'series' | 'title'> &
+		Partial<Pick<displayChart.Input, 'y_axes'>>;
 	data: Record<string, unknown>[];
 	width?: number;
 	height?: number;
@@ -42,6 +43,7 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		xAxisKey: config.x_axis_key,
 		xAxisType: config.x_axis_type === 'number' ? 'number' : 'category',
 		series: config.series,
+		yAxes: config.y_axes,
 		colorFor,
 		labelFormatter,
 		showGrid: true,

--- a/apps/backend/src/mcp/tools/helpers.ts
+++ b/apps/backend/src/mcp/tools/helpers.ts
@@ -129,8 +129,8 @@ export async function buildChartEmbedFromArtifact(
 	ctx: McpContext,
 	opts: { chatId: string | null; callLogId: string },
 ): Promise<{ payload: ChartToolPayload; sandboxChartHtml: string | null } | { keyError: ChartKeyError } | null> {
-	const { query_id, chart_type, x_axis_key, x_axis_type, series, title } = artifact;
-	const block = buildStoryChartBlock({ query_id, chart_type, x_axis_key, x_axis_type, series, title });
+	const { query_id, chart_type, x_axis_key, x_axis_type, series, y_axes, title } = artifact;
+	const block = buildStoryChartBlock({ query_id, chart_type, x_axis_key, x_axis_type, series, y_axes, title });
 
 	const queryData = await resolveChartQueryData({
 		queryId: query_id,
@@ -159,7 +159,14 @@ export async function buildChartEmbedFromArtifact(
 			chartEmbedId: id,
 			queryId: query_id,
 			projectId: ctx.projectId,
-			chartConfig: { chartType: chart_type, xAxisKey: x_axis_key, xAxisType: x_axis_type, series, title },
+			chartConfig: {
+				chartType: chart_type,
+				xAxisKey: x_axis_key,
+				xAxisType: x_axis_type,
+				series,
+				yAxes: y_axes,
+				title,
+			},
 			sourceChatId: effectiveChatId,
 		});
 		if (inserted) {

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -329,6 +329,7 @@ function toChartConfig(chart: ParsedChartBlock) {
 		x_axis_key: chart.xAxisKey,
 		x_axis_type: chart.xAxisType as displayChart.XAxisType | null,
 		series: chart.series,
+		y_axes: chart.yAxes,
 		title: chart.title,
 	};
 }

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -503,7 +503,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 					+'<span class="nao-tooltip-value">'+formatVal(val)+'</span>'
 					+'</div>';
 			});
-			if(numericValues.length>1){
+			if(numericValues.length>1&&cfg.chartType!=='combo'){
 				var total=numericValues.reduce(function(a,b){return a+b},0);
 				html+='<div class="nao-tooltip-total">'
 					+'<span class="nao-tooltip-name">Total</span>'

--- a/apps/backend/tests/generate-chart-combo.test.tsx
+++ b/apps/backend/tests/generate-chart-combo.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RenderChartInput } from '../src/components/generate-chart';
+import { renderChartToSvg } from '../src/components/generate-chart';
+
+const data = [
+	{ month: '2024-01-01', revenue: 1000, orders: 12 },
+	{ month: '2024-02-01', revenue: 1500, orders: 18 },
+	{ month: '2024-03-01', revenue: 1200, orders: 9 },
+];
+
+function comboConfig(overrides: Partial<RenderChartInput['config']> = {}): RenderChartInput['config'] {
+	return {
+		chart_type: 'combo',
+		x_axis_key: 'month',
+		x_axis_type: 'date',
+		title: 'Revenue vs orders',
+		series: [
+			{ data_key: 'revenue', series_type: 'bar', y_axis: 'left' },
+			{ data_key: 'orders', series_type: 'line', y_axis: 'right' },
+		],
+		...overrides,
+	};
+}
+
+describe('renderChartToSvg (combo)', () => {
+	it('renders mixed bar + line series', () => {
+		const svg = renderChartToSvg({ config: comboConfig(), data });
+
+		expect(svg).toContain('recharts-bar');
+		expect(svg).toContain('recharts-line');
+	});
+
+	it('renders a second Y-axis when a series uses the right axis', () => {
+		const svg = renderChartToSvg({ config: comboConfig(), data });
+		const yAxes = svg.match(/recharts-yAxis/g) ?? [];
+		expect(yAxes.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('renders a single Y-axis when all series use the left axis', () => {
+		const svg = renderChartToSvg({
+			config: comboConfig({
+				series: [
+					{ data_key: 'revenue', series_type: 'bar', y_axis: 'left' },
+					{ data_key: 'orders', series_type: 'line', y_axis: 'left' },
+				],
+			}),
+			data,
+		});
+		const yAxes = svg.match(/recharts-yAxis/g) ?? [];
+		expect(yAxes.length).toBe(1);
+	});
+
+	it('renders axis labels from y_axes config', () => {
+		const svg = renderChartToSvg({
+			config: comboConfig({
+				y_axes: {
+					left: { label: 'Revenue USD' },
+					right: { label: 'Order count' },
+				},
+			}),
+			data,
+		});
+
+		expect(svg).toContain('Revenue USD');
+		expect(svg).toContain('Order count');
+	});
+
+	it('renders an area series in a combo chart', () => {
+		const svg = renderChartToSvg({
+			config: comboConfig({
+				series: [
+					{ data_key: 'revenue', series_type: 'bar', y_axis: 'left' },
+					{ data_key: 'orders', series_type: 'area', y_axis: 'right' },
+				],
+			}),
+			data,
+		});
+
+		expect(svg).toContain('recharts-bar');
+		expect(svg).toContain('recharts-area');
+	});
+});

--- a/apps/frontend/src/components/mcp-app/chart-app-view.tsx
+++ b/apps/frontend/src/components/mcp-app/chart-app-view.tsx
@@ -26,6 +26,8 @@ export const ChartAppView = memo(function ChartAppView({ config, data, naoUrl }:
 				data_key: s.data_key,
 				color: s.color ?? `var(--chart-${(i % 5) + 1})`,
 				label: s.label,
+				series_type: s.series_type,
+				y_axis: s.y_axis,
 			})),
 		[config.series],
 	);
@@ -54,6 +56,7 @@ export const ChartAppView = memo(function ChartAppView({ config, data, naoUrl }:
 					xAxisKey={config.xAxisKey}
 					xAxisType={xAxisType}
 					series={series}
+					yAxes={config.yAxes}
 					title={config.title}
 				/>
 			</div>

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo, useState } from 'react';
 import { Pencil } from 'lucide-react';
 import type { UIMessage } from '@nao/backend/chat';
 import type { displayChart } from '@nao/shared/tools';
+import type { ParsedChartBlock } from '@nao/shared/story-segments';
 import { Button } from '@/components/ui/button';
 import { useOptionalAgentContext } from '@/contexts/agent.provider';
 import { useStoryEmbedData } from '@/contexts/story-embed-data';
@@ -10,15 +11,7 @@ import { ChartDisplay } from '@/components/tool-calls/display-chart';
 import { ChartConfigEditDialog } from '@/components/tool-calls/display-chart-edit-dialog';
 import { sortByDateKey } from '@/lib/charts.utils';
 
-interface ChartBlock {
-	queryId: string;
-	chartType: string;
-	xAxisKey: string;
-	xAxisType: string | null;
-	series: Array<{ data_key: string; color: string; label?: string }>;
-	title: string;
-	rawTag?: string;
-}
+type ChartBlock = ParsedChartBlock;
 
 export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart: ChartBlock }) {
 	const agent = useOptionalAgentContext();
@@ -78,6 +71,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart:
 				xAxisKey={chart.xAxisKey}
 				xAxisType={xAxisType}
 				series={chart.series}
+				yAxes={chart.yAxes}
 				title={chart.title}
 			/>
 		</StoryChartEmbedShell>
@@ -109,7 +103,10 @@ export function StoryChartEmbedShell({ chart, availableColumns, children }: Stor
 				data_key: s.data_key,
 				color: s.color || undefined,
 				label: s.label,
+				series_type: s.series_type,
+				y_axis: s.y_axis,
 			})),
+			y_axes: chart.yAxes,
 			title: chart.title,
 		}),
 		[chart],

--- a/apps/frontend/src/components/story-embeds.tsx
+++ b/apps/frontend/src/components/story-embeds.tsx
@@ -81,6 +81,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 				xAxisKey={chart.xAxisKey}
 				xAxisType={chart.xAxisType === 'number' ? 'number' : 'category'}
 				series={chart.series}
+				yAxes={chart.yAxes}
 				title={chart.title}
 			/>
 		</StoryChartEmbedShell>

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -20,6 +20,18 @@ const CHART_TYPE_OPTIONS: { value: displayChart.ChartType; label: string }[] = [
 	{ value: 'kpi_card', label: 'KPI card' },
 	{ value: 'scatter', label: 'Scatter' },
 	{ value: 'radar', label: 'Radar' },
+	{ value: 'combo', label: 'Combo (dual-axis)' },
+];
+
+const SERIES_TYPE_OPTIONS: { value: displayChart.SeriesType; label: string }[] = [
+	{ value: 'bar', label: 'Bar' },
+	{ value: 'line', label: 'Line' },
+	{ value: 'area', label: 'Area' },
+];
+
+const Y_AXIS_OPTIONS: { value: displayChart.YAxisSide; label: string }[] = [
+	{ value: 'left', label: 'Left axis' },
+	{ value: 'right', label: 'Right axis' },
 ];
 
 const X_AXIS_TYPE_OPTIONS: { value: NonNullable<displayChart.XAxisType> | 'auto'; label: string }[] = [
@@ -94,6 +106,18 @@ export function ChartConfigEditDialog({
 			...prev,
 			series: prev.series.length <= 1 ? prev.series : prev.series.filter((_, i) => i !== index),
 		}));
+	};
+
+	const isCombo = draft.chart_type === 'combo';
+
+	const updateYAxisLabel = (side: displayChart.YAxisSide, label: string) => {
+		setDraft((prev) => {
+			const nextSide = { ...prev.y_axes?.[side], label: label || undefined };
+			const hasValue = nextSide.label !== undefined || nextSide.domain !== undefined;
+			const nextYAxes = { ...prev.y_axes, [side]: hasValue ? nextSide : undefined };
+			const isEmpty = nextYAxes.left === undefined && nextYAxes.right === undefined;
+			return { ...prev, y_axes: isEmpty ? undefined : nextYAxes };
+		});
 	};
 
 	const addSeries = () => {
@@ -207,43 +231,87 @@ export function ChartConfigEditDialog({
 						</div>
 						<div className='flex flex-col gap-3'>
 							{draft.series.map((series, index) => (
-								<div
-									key={index}
-									className='grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center rounded-md'
-								>
-									<ColumnSelect
-										value={series.data_key}
-										columns={availableColumns.length > 0 ? availableColumns : [series.data_key]}
-										onChange={(value) => updateSeriesAt(index, { data_key: value })}
-									/>
-									<Input
-										value={series.label ?? ''}
-										onChange={(e) => updateSeriesAt(index, { label: e.target.value || undefined })}
-										placeholder='Label (optional)'
-										className='h-8 rounded-lg text-sm bg-panel'
-									/>
-									<input
-										type='color'
-										aria-label='Series color'
-										value={normalizeHexColor(series.color)}
-										onChange={(e) => updateSeriesAt(index, { color: e.target.value })}
-										className='h-8 w-8 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 [&::-moz-color-swatch]:rounded-lg [&::-moz-color-swatch]:border-none [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-lg [&::-webkit-color-swatch]:border-none'
-									/>
-									<Button
-										type='button'
-										size='icon-sm'
-										variant='ghost-muted'
-										className='size-8'
-										onClick={() => removeSeriesAt(index)}
-										disabled={draft.series.length <= 1}
-										title='Remove series'
-									>
-										<Trash2 className='size-4' />
-									</Button>
+								<div key={index} className='flex flex-col gap-2 rounded-md'>
+									<div className='grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center'>
+										<ColumnSelect
+											value={series.data_key}
+											columns={availableColumns.length > 0 ? availableColumns : [series.data_key]}
+											onChange={(value) => updateSeriesAt(index, { data_key: value })}
+										/>
+										<Input
+											value={series.label ?? ''}
+											onChange={(e) =>
+												updateSeriesAt(index, { label: e.target.value || undefined })
+											}
+											placeholder='Label (optional)'
+											className='h-8 rounded-lg text-sm bg-panel'
+										/>
+										<input
+											type='color'
+											aria-label='Series color'
+											value={normalizeHexColor(series.color)}
+											onChange={(e) => updateSeriesAt(index, { color: e.target.value })}
+											className='h-8 w-8 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 [&::-moz-color-swatch]:rounded-lg [&::-moz-color-swatch]:border-none [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-lg [&::-webkit-color-swatch]:border-none'
+										/>
+										<Button
+											type='button'
+											size='icon-sm'
+											variant='ghost-muted'
+											className='size-8'
+											onClick={() => removeSeriesAt(index)}
+											disabled={draft.series.length <= 1}
+											title='Remove series'
+										>
+											<Trash2 className='size-4' />
+										</Button>
+									</div>
+									{isCombo && (
+										<div className='grid grid-cols-2 gap-2'>
+											<EnumSelect
+												value={series.series_type ?? 'bar'}
+												options={SERIES_TYPE_OPTIONS}
+												onChange={(value) =>
+													updateSeriesAt(index, {
+														series_type: value as displayChart.SeriesType,
+													})
+												}
+											/>
+											<EnumSelect
+												value={series.y_axis ?? 'left'}
+												options={Y_AXIS_OPTIONS}
+												onChange={(value) =>
+													updateSeriesAt(index, { y_axis: value as displayChart.YAxisSide })
+												}
+											/>
+										</div>
+									)}
 								</div>
 							))}
 						</div>
 					</div>
+
+					{isCombo && (
+						<div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+							<div className='grid gap-2'>
+								<span className='text-sm font-semibold text-foreground'>Left axis label</span>
+								<Input
+									value={draft.y_axes?.left?.label ?? ''}
+									onChange={(e) => updateYAxisLabel('left', e.target.value)}
+									placeholder='Left axis label (optional)'
+									className='h-8 bg-panel'
+								/>
+							</div>
+							<div className='grid gap-2'>
+								<span className='text-sm font-semibold text-foreground'>Right axis label</span>
+								<Input
+									value={draft.y_axes?.right?.label ?? ''}
+									onChange={(e) => updateYAxisLabel('right', e.target.value)}
+									placeholder='Right axis label (optional)'
+									className='h-8 bg-panel'
+								/>
+							</div>
+						</div>
+					)}
 
 					{error && <p className='text-xs text-destructive'>{error}</p>}
 
@@ -341,6 +409,29 @@ function ColumnSelect({ value, columns, onChange }: ColumnSelectProps) {
 				{items.map((column) => (
 					<SelectItem key={column} value={column}>
 						{column}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+interface EnumSelectProps {
+	value: string;
+	options: { value: string; label: string }[];
+	onChange: (value: string) => void;
+}
+
+function EnumSelect({ value, options, onChange }: EnumSelectProps) {
+	return (
+		<Select value={value} onValueChange={onChange}>
+			<SelectTrigger className='w-full text-sm bg-panel [&_svg]:text-foreground! [&_svg]:opacity-100!'>
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent className='bg-panel [&_svg]:text-foreground! [&_svg]:opacity-100!'>
+				{options.map((option) => (
+					<SelectItem key={option.value} value={option.value}>
+						{option.label}
 					</SelectItem>
 				))}
 			</SelectContent>

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -275,6 +275,7 @@ export const DisplayChartToolCall = ({
 				chartType={config.chart_type}
 				xAxisKey={config.x_axis_key}
 				series={config.series}
+				yAxes={config.y_axes}
 				xAxisType={config.x_axis_type === 'number' ? 'number' : 'category'}
 				title={config.title}
 			/>
@@ -289,6 +290,7 @@ export interface ChartDisplayProps {
 	xAxisType: 'number' | 'category';
 	xAxisLabelFormatter?: (value: string) => string;
 	series: displayChart.SeriesConfig[];
+	yAxes?: displayChart.YAxesConfig;
 	title?: string;
 	showGrid?: boolean;
 }
@@ -300,6 +302,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 	xAxisType,
 	xAxisLabelFormatter,
 	series,
+	yAxes,
 	title,
 	showGrid = true,
 }: ChartDisplayProps) {
@@ -366,6 +369,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 				xAxisKey,
 				xAxisType,
 				series: visibleSeries,
+				yAxes,
 				colorFor,
 				labelFormatter,
 				showGrid,
@@ -394,6 +398,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 			xAxisKey,
 			xAxisType,
 			visibleSeries,
+			yAxes,
 			colorFor,
 			labelFormatter,
 			showGrid,

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -380,7 +380,12 @@ export const ChartDisplay = memo(function ChartDisplay({
 						animationDuration={150}
 						animationEasing='linear'
 						allowEscapeViewBox={{ y: true, x: false }}
-						content={<ChartTooltipContent labelFormatter={(value) => labelize(value, dateFormat)} />}
+						content={
+							<ChartTooltipContent
+								hideTotal={chartType === 'combo'}
+								labelFormatter={(value) => labelize(value, dateFormat)}
+							/>
+						}
 					/>,
 					chartType !== 'pie' && (
 						<ChartLegend

--- a/apps/frontend/src/components/tool-calls/mcp.tsx
+++ b/apps/frontend/src/components/tool-calls/mcp.tsx
@@ -68,6 +68,7 @@ const McpChartOutput = ({ chartBlock }: { chartBlock: string }) => {
 				xAxisKey={chart.xAxisKey}
 				xAxisType={chart.xAxisType === 'number' ? 'number' : 'category'}
 				series={chart.series}
+				yAxes={chart.yAxes}
 				title={chart.title}
 			/>
 		</div>

--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -107,6 +107,7 @@ function ChartTooltipContent({
 	color,
 	nameKey,
 	labelKey,
+	hideTotal = false,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
 	React.ComponentProps<'div'> & {
 		hideLabel?: boolean;
@@ -114,6 +115,7 @@ function ChartTooltipContent({
 		indicator?: 'line' | 'dot' | 'dashed';
 		nameKey?: string;
 		labelKey?: string;
+		hideTotal?: boolean;
 	}) {
 	const { config } = useChart();
 
@@ -147,7 +149,7 @@ function ChartTooltipContent({
 	// Calculate total if there are multiple numeric values that can be summed
 	const visiblePayload = payload.filter((item) => item.type !== 'none');
 	const numericValues = visiblePayload.map((item) => item.value).filter((v): v is number => typeof v === 'number');
-	const showTotal = numericValues.length > 1;
+	const showTotal = !hideTotal && numericValues.length > 1;
 	const total = showTotal ? numericValues.reduce((sum, v) => sum + v, 0) : 0;
 
 	return (

--- a/apps/shared/src/chart-block.ts
+++ b/apps/shared/src/chart-block.ts
@@ -15,13 +15,16 @@ export type StoryChartBlockInput = Pick<
 	'query_id' | 'chart_type' | 'x_axis_key' | 'x_axis_type' | 'series'
 > & {
 	title?: displayChart.Input['title'];
+	y_axes?: displayChart.Input['y_axes'];
 };
 
 export function buildStoryChartBlock(input: StoryChartBlockInput): string {
 	const xAxisTypeAttr =
 		input.x_axis_type != null ? ` x_axis_type="${escapeDoubleQuotedStoryAttr(input.x_axis_type)}"` : '';
 	const seriesJson = escapeSingleQuotedStoryAttr(JSON.stringify(input.series));
+	const yAxesAttr =
+		input.y_axes != null ? ` y_axes='${escapeSingleQuotedStoryAttr(JSON.stringify(input.y_axes))}'` : '';
 	const titleAttr =
 		input.title != null && input.title !== '' ? ` title="${escapeDoubleQuotedStoryAttr(input.title)}"` : '';
-	return `<chart query_id="${escapeDoubleQuotedStoryAttr(input.query_id)}" chart_type="${escapeDoubleQuotedStoryAttr(input.chart_type)}" x_axis_key="${escapeDoubleQuotedStoryAttr(input.x_axis_key)}"${xAxisTypeAttr} series='${seriesJson}'${titleAttr} />`;
+	return `<chart query_id="${escapeDoubleQuotedStoryAttr(input.query_id)}" chart_type="${escapeDoubleQuotedStoryAttr(input.chart_type)}" x_axis_key="${escapeDoubleQuotedStoryAttr(input.x_axis_key)}"${xAxisTypeAttr} series='${seriesJson}'${yAxesAttr}${titleAttr} />`;
 }

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -5,7 +5,9 @@ import {
 	Bar,
 	BarChart,
 	CartesianGrid,
+	ComposedChart,
 	Customized,
+	Line,
 	Pie,
 	PieChart,
 	PolarAngleAxis,
@@ -69,6 +71,7 @@ export interface BuildChartProps {
 	margin?: { top?: number; right?: number; bottom?: number; left?: number };
 	title?: string;
 	maxXAxisTicks?: number;
+	yAxes?: displayChart.YAxesConfig;
 }
 
 /**
@@ -88,6 +91,9 @@ export function buildChart(props: BuildChartProps) {
 	}
 	if (resolved.chartType === 'line' || resolved.chartType === 'area' || resolved.chartType === 'stacked_area') {
 		return buildAreaChart(resolved);
+	}
+	if (resolved.chartType === 'combo') {
+		return buildComboChart(resolved);
 	}
 	if (resolved.chartType === 'scatter') {
 		return buildScatterChart(resolved);
@@ -284,6 +290,139 @@ function buildAreaChart(props: ResolvedProps) {
 			))}
 		</AreaChart>
 	);
+}
+
+function buildComboChart(props: ResolvedProps) {
+	const {
+		data,
+		xAxisKey,
+		xAxisType,
+		series,
+		colorFor,
+		labelFormatter,
+		showGrid,
+		children,
+		margin,
+		xAxisInterval,
+		yAxes,
+	} = props;
+
+	const hasRightAxis = series.some((s) => s.y_axis === 'right');
+	const areaSeries = series.filter((s) => s.series_type === 'area');
+
+	return (
+		<ComposedChart data={data} accessibilityLayer margin={margin}>
+			{areaSeries.length > 0 && (
+				<defs>
+					{series.map((s, i) =>
+						s.series_type === 'area' ? (
+							<linearGradient key={s.data_key} id={`grad-combo-${i}`} x1='0' y1='0' x2='0' y2='1'>
+								<stop offset='0%' stopColor={colorFor(s.data_key, i)} stopOpacity={0.25} />
+								<stop offset='100%' stopColor={colorFor(s.data_key, i)} stopOpacity={0} />
+							</linearGradient>
+						) : null,
+					)}
+				</defs>
+			)}
+			{showGrid && <CartesianGrid horizontal vertical={false} strokeDasharray='3 3' />}
+			<YAxis
+				yAxisId='left'
+				tick={AXIS_TICK}
+				tickLine={false}
+				axisLine={false}
+				minTickGap={12}
+				tickFormatter={formatYAxisTick}
+				domain={resolveAxisDomain(yAxes?.left?.domain)}
+				label={axisLabel(yAxes?.left?.label, 'left')}
+			/>
+			{hasRightAxis && (
+				<YAxis
+					yAxisId='right'
+					orientation='right'
+					tick={AXIS_TICK}
+					tickLine={false}
+					axisLine={false}
+					minTickGap={12}
+					tickFormatter={formatYAxisTick}
+					domain={resolveAxisDomain(yAxes?.right?.domain)}
+					label={axisLabel(yAxes?.right?.label, 'right')}
+				/>
+			)}
+			<XAxis
+				dataKey={xAxisKey}
+				type={xAxisType}
+				domain={['dataMin', 'dataMax']}
+				tick={AXIS_TICK}
+				tickLine
+				tickMargin={10}
+				axisLine={false}
+				minTickGap={12}
+				interval={xAxisInterval}
+				tickFormatter={labelFormatter}
+			/>
+			{children}
+			{series.map((s, i) => {
+				const color = colorFor(s.data_key, i);
+				const yAxisId = s.y_axis === 'right' ? 'right' : 'left';
+				if (s.series_type === 'line') {
+					return (
+						<Line
+							key={s.data_key}
+							yAxisId={yAxisId}
+							dataKey={s.data_key}
+							type='monotone'
+							stroke={color}
+							strokeWidth={2}
+							dot={false}
+							isAnimationActive={false}
+						/>
+					);
+				}
+				if (s.series_type === 'area') {
+					return (
+						<Area
+							key={s.data_key}
+							yAxisId={yAxisId}
+							dataKey={s.data_key}
+							type='monotone'
+							stroke={color}
+							fill={`url(#grad-combo-${i})`}
+							isAnimationActive={false}
+						/>
+					);
+				}
+				return (
+					<Bar
+						key={s.data_key}
+						yAxisId={yAxisId}
+						dataKey={s.data_key}
+						fill={color}
+						radius={[4, 4, 0, 0]}
+						isAnimationActive={false}
+					/>
+				);
+			})}
+		</ComposedChart>
+	);
+}
+
+function resolveAxisDomain(domain: displayChart.YAxisDomain | undefined): [number, number] | undefined {
+	if (domain && domain !== 'auto') {
+		return [domain.min, domain.max];
+	}
+	return undefined;
+}
+
+function axisLabel(label: string | undefined, side: 'left' | 'right') {
+	if (!label) {
+		return undefined;
+	}
+	return {
+		value: label,
+		angle: -90,
+		position: side === 'left' ? ('insideLeft' as const) : ('insideRight' as const),
+		style: { textAnchor: 'middle' as const, fontSize: 12, fill: 'var(--muted-foreground, #6b7280)' },
+	};
 }
 
 function buildScatterChart(props: ResolvedProps) {

--- a/apps/shared/src/mcp-embed.ts
+++ b/apps/shared/src/mcp-embed.ts
@@ -10,6 +10,7 @@ export type McpChartEmbedStoredConfig = {
 	xAxisKey: displayChart.Input['x_axis_key'];
 	xAxisType: displayChart.Input['x_axis_type'];
 	series: displayChart.Input['series'];
+	yAxes?: displayChart.Input['y_axes'];
 	title: string;
 };
 

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -1,9 +1,28 @@
+export interface ParsedChartSeries {
+	data_key: string;
+	color: string;
+	label?: string;
+	series_type?: 'bar' | 'line' | 'area';
+	y_axis?: 'left' | 'right';
+}
+
+export interface ParsedYAxisConfig {
+	label?: string;
+	domain?: 'auto' | { min: number; max: number };
+}
+
+export interface ParsedYAxesConfig {
+	left?: ParsedYAxisConfig;
+	right?: ParsedYAxisConfig;
+}
+
 export interface ParsedChartBlock {
 	queryId: string;
 	chartType: string;
 	xAxisKey: string;
 	xAxisType: string | null;
-	series: Array<{ data_key: string; color: string; label?: string }>;
+	series: ParsedChartSeries[];
+	yAxes?: ParsedYAxesConfig;
 	title: string;
 	/** The original `<chart ... />` tag this block was parsed from, when available. */
 	rawTag?: string;
@@ -60,8 +79,18 @@ export function parseChartBlock(attrString: string): ParsedChartBlock | null {
 		xAxisKey: attrs.x_axis_key,
 		xAxisType: attrs.x_axis_type || null,
 		series,
+		yAxes: attrs.y_axes ? (tryParseJsonObject(attrs.y_axes) as ParsedYAxesConfig | undefined) : undefined,
 		title: attrs.title || '',
 	};
+}
+
+function tryParseJsonObject(value: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(value);
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
 }
 
 export function parseTableBlock(attrString: string): ParsedTableBlock | null {

--- a/apps/shared/src/story-validation.ts
+++ b/apps/shared/src/story-validation.ts
@@ -20,6 +20,7 @@ const VALID_CHART_TYPES = new Set([
 	'kpi_card',
 	'scatter',
 	'radar',
+	'combo',
 ]);
 
 const VALID_X_AXIS_TYPES = new Set(['date', 'number', 'category']);

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -10,15 +10,48 @@ export const ChartTypeEnum = z.enum([
 	'kpi_card',
 	'scatter',
 	'radar',
+	'combo',
 ]);
 
 export const XAxisTypeEnum = z.enum(['date', 'number', 'category']);
+
+export const SeriesTypeEnum = z.enum(['bar', 'line', 'area']);
+
+export const YAxisSideEnum = z.enum(['left', 'right']);
 
 export const SeriesConfigSchema = z.object({
 	data_key: z.string().describe('Column name from SQL result to plot.'),
 	color: z.string().describe('CSS color (defaults to theme colors).').optional(),
 	label: z.string().describe('Label to display in the legend.').optional(),
+	series_type: SeriesTypeEnum.describe(
+		'For "combo" charts only: how to render this series ("bar", "line", or "area"). Defaults to "bar".',
+	).optional(),
+	y_axis: YAxisSideEnum.describe(
+		'Which Y-axis this series is plotted against ("left" or "right"). Defaults to "left". A right axis is drawn whenever any series uses "right".',
+	).optional(),
 });
+
+export const YAxisDomainSchema = z
+	.union([
+		z.literal('auto'),
+		z.object({
+			min: z.number().describe('Minimum value of the axis scale.'),
+			max: z.number().describe('Maximum value of the axis scale.'),
+		}),
+	])
+	.describe('Axis scale: "auto" to fit the data, or an explicit { min, max } range.');
+
+export const YAxisConfigSchema = z.object({
+	label: z.string().describe('Label displayed alongside this Y-axis.').optional(),
+	domain: YAxisDomainSchema.optional(),
+});
+
+export const YAxesConfigSchema = z
+	.object({
+		left: YAxisConfigSchema.optional(),
+		right: YAxisConfigSchema.optional(),
+	})
+	.describe('Optional independent configuration (label, scale) for the left and right Y-axes.');
 
 export const InputSchema = z.object({
 	query_id: z.string().describe("The id of a previous `execute_sql` tool call's output to get data from."),
@@ -31,6 +64,7 @@ export const InputSchema = z.object({
 		.array(SeriesConfigSchema)
 		.min(1)
 		.describe('Columns to plot as data series (at least one series required).'),
+	y_axes: YAxesConfigSchema.optional(),
 	title: z
 		.string()
 		.describe(
@@ -46,6 +80,11 @@ export const OutputSchema = z.object({
 
 export type ChartType = z.infer<typeof ChartTypeEnum>;
 export type XAxisType = z.infer<typeof XAxisTypeEnum>;
+export type SeriesType = z.infer<typeof SeriesTypeEnum>;
+export type YAxisSide = z.infer<typeof YAxisSideEnum>;
 export type SeriesConfig = z.infer<typeof SeriesConfigSchema>;
+export type YAxisDomain = z.infer<typeof YAxisDomainSchema>;
+export type YAxisConfig = z.infer<typeof YAxisConfigSchema>;
+export type YAxesConfig = z.infer<typeof YAxesConfigSchema>;
 export type Input = z.infer<typeof InputSchema>;
 export type Output = z.infer<typeof OutputSchema>;

--- a/apps/shared/tests/chart-block-combo.test.ts
+++ b/apps/shared/tests/chart-block-combo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildStoryChartBlock } from '../src/chart-block';
+import { parseChartBlock } from '../src/story-segments';
+import { validateStoryCode } from '../src/story-validation';
+import { InputSchema } from '../src/tools/display-chart';
+
+function attrsOf(tag: string): string {
+	return tag.match(/^<chart\s+([\s\S]*?)\s*\/?>$/)?.[1] ?? '';
+}
+
+describe('combo chart story round-trip', () => {
+	const config = {
+		query_id: 'q_1',
+		chart_type: 'combo' as const,
+		x_axis_key: 'month',
+		x_axis_type: 'date' as const,
+		series: [
+			{ data_key: 'revenue', series_type: 'bar' as const, y_axis: 'left' as const },
+			{ data_key: 'orders', series_type: 'line' as const, y_axis: 'right' as const },
+		],
+		y_axes: {
+			left: { label: 'Revenue ($)' },
+			right: { label: 'Orders', domain: { min: 0, max: 100 } as const },
+		},
+		title: 'Revenue vs orders',
+	};
+
+	it('is a valid display_chart input', () => {
+		expect(InputSchema.safeParse(config).success).toBe(true);
+	});
+
+	it('serializes and parses back series_type, y_axis and y_axes', () => {
+		const block = buildStoryChartBlock(config);
+		const parsed = parseChartBlock(attrsOf(block));
+
+		expect(parsed).not.toBeNull();
+		expect(parsed?.chartType).toBe('combo');
+		expect(parsed?.series).toEqual([
+			{ data_key: 'revenue', series_type: 'bar', y_axis: 'left' },
+			{ data_key: 'orders', series_type: 'line', y_axis: 'right' },
+		]);
+		expect(parsed?.yAxes).toEqual({
+			left: { label: 'Revenue ($)' },
+			right: { label: 'Orders', domain: { min: 0, max: 100 } },
+		});
+	});
+
+	it('passes story validation for combo chart_type', () => {
+		const block = buildStoryChartBlock(config);
+		expect(validateStoryCode(block)).toEqual([]);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements dual-axis charts with mixed bar + line (+ area) series, closing #873.

Adds a new `combo` chart type to `display_chart` in a backward-compatible way. Existing single-axis charts are unchanged; the work is concentrated in the shared schema and the single `buildChart` renderer, so chat, stories, PNG export, and MCP embeds all stay in sync.

## Walkthrough

[dual_axis_combo_chart_tooltip_demo.mp4](https://cursor.com/agents/bc-406d5152-0143-4d9c-98e1-2e23d1f291b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdual_axis_combo_chart_tooltip_demo.mp4)

Combo chart: dark-teal bars (Revenue, left axis) and an orange line (conversion rate, right axis), each with its own labeled Y-axis; tooltips show both series with no misleading cross-axis "Total".

[Dual-axis combo chart](https://cursor.com/agents/bc-406d5152-0143-4d9c-98e1-2e23d1f291b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcombo_chart_demo.png)

### How this maps to the issue's expected behavior

| Requirement | Approach |
| --- | --- |
| Secondary Y-axis | Per-series `y_axis: "left" \| "right"` (default `left`). A right `YAxis` is rendered whenever any series uses `right`. |
| Mixed bar + line | New `chart_type: "combo"`; each series sets `series_type: "bar" \| "line" \| "area"`. |
| Series → axis | `y_axis` on each `series[]` entry. |
| Independent axis labels/scales | Optional top-level `y_axes.left` / `y_axes.right` with `label` and `domain` (`"auto"` or `{ min, max }`). |

### Example tool input

```json
{
  "query_id": "query_…",
  "chart_type": "combo",
  "x_axis_key": "month",
  "x_axis_type": "date",
  "title": "Monthly revenue vs order count",
  "y_axes": {
    "left": { "label": "Revenue (USD)" },
    "right": { "label": "Orders" }
  },
  "series": [
    { "data_key": "total_revenue", "series_type": "bar", "y_axis": "left" },
    { "data_key": "order_count", "series_type": "line", "y_axis": "right" }
  ]
}
```

## Changes

- **Schema** (`apps/shared/src/tools/display-chart.ts`): `combo` chart type, per-series `series_type` + `y_axis`, top-level `y_axes` (label + domain).
- **Renderer** (`apps/shared/src/chart-builder.tsx`): `buildComboChart` using recharts `ComposedChart` with an optional right `YAxis`, per-series Bar/Line/Area geometry, and configurable axis labels/domains.
- **Story + MCP propagation**: serialize/parse/validate `y_axes` and the new series fields through story `<chart>` blocks, MCP embed config, PNG/SVG export, and story HTML export.
- **Edit dialog**: combo option plus per-series type/axis selectors and left/right axis label inputs.
- **Tooltip**: suppress the cross-axis "Total" row for combo charts (React tooltip + exported story HTML tooltip).
- **System prompt**: guidance on when and how to use combo / dual-axis charts.
- **Tests**: combo SVG rendering (mixed series, dual axis, labels) and story block round-trip + validation.

## Testing

- `npm run lint` — tsc + eslint across all workspaces (pass)
- `npm run -w @nao/shared test` — 74 pass (incl. combo story round-trip)
- `npm run -w @nao/backend test -- generate-chart-combo` — 5 pass
- Manual UI verification of the rendered interactive combo chart (see walkthrough video/screenshot).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-406d5152-0143-4d9c-98e1-2e23d1f291b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-406d5152-0143-4d9c-98e1-2e23d1f291b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

