### PR TITLE
feat(automations): post Slack reports in a thread to avoid channel clutter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ Write simple, clean, self-explanatory, easy to read and intelligent code.
 - Place **high-level functions first** in each file, then private/helper functions below
 - Write **small, focused functions** — each does one thing; extract early rather than inline
 - Use **descriptive names** — code should read like prose; avoid abbreviations
-- **Minimize comments** — only comment complex or ambiguous logic with short JSDocs or python docstring; never describe function inputs/outputs
+- **Minimize comments** — only comment complex or ambiguous logic with short JSDocs or python docstring; never describe function inputs/outputs.
+- Important: dont use comments to describe the code inline.
 - Avoid inline function declarations without braces
 
 ### Backend Migrations (`apps/backend/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Write simple, clean, self-explanatory, easy to read and intelligent code.
 - Write **small, focused functions** — each does one thing; extract early rather than inline
 - Use **descriptive names** — code should read like prose; avoid abbreviations
 - **Minimize comments** — only comment complex or ambiguous logic with short JSDocs or python docstring; never describe function inputs/outputs.
-- Important: dont use comments to describe the code inline.
+- Important: don't use comments to describe the code inline.
 - Avoid inline function declarations without braces
 
 ### Backend Migrations (`apps/backend/`)

--- a/apps/backend/src/components/ai/automation-run-prompt.tsx
+++ b/apps/backend/src/components/ai/automation-run-prompt.tsx
@@ -40,6 +40,8 @@ function AutomationRunPrompt({ prompt, integrations, userEmail }: AutomationRunP
 			<Title>Outbound tools available for this run</Title>
 			<AutomationIntegrationsList integrations={integrations} />
 
+			{integrations.slack?.enabled ? <SlackThreadingGuidance /> : null}
+
 			<Title>Required behaviour</Title>
 			<List ordered>
 				<ListItem>
@@ -62,6 +64,34 @@ function AutomationRunPrompt({ prompt, integrations, userEmail }: AutomationRunP
 			<Title>Automation prompt</Title>
 			<Span>{prompt}</Span>
 		</Block>
+	);
+}
+
+function SlackThreadingGuidance() {
+	return (
+		<Fragment>
+			<Title>Slack posting structure</Title>
+			<Span>
+				To keep the channel uncluttered, do NOT post the whole report as one or more top-level channel messages.
+				Instead, structure the Slack delivery as a thread:
+			</Span>
+			<List ordered>
+				<ListItem>
+					Call <Code>send_automation_slack_message</Code> once with a short, descriptive headline only (e.g.
+					&quot;Weekly Commercial Performance Update Report: see thread&quot;) and no <Code>thread_id</Code>.
+					This becomes the single channel message and starts the thread.
+				</ListItem>
+				<ListItem>
+					Read the <Code>threadId</Code> returned by that call and post the full report by calling{' '}
+					<Code>send_automation_slack_message</Code> again with that value as <Code>thread_id</Code>. All
+					report content (and any follow-up parts) must go into the thread, never the channel.
+				</ListItem>
+				<ListItem>
+					Reuse the same <Code>thread_id</Code> for every additional message so the entire report stays in one
+					thread. Charts and stories are uploaded into the thread automatically.
+				</ListItem>
+			</List>
+		</Fragment>
 	);
 }
 

--- a/apps/backend/src/components/ai/automation-run-prompt.tsx
+++ b/apps/backend/src/components/ai/automation-run-prompt.tsx
@@ -45,6 +45,10 @@ function AutomationRunPrompt({ prompt, integrations, userEmail }: AutomationRunP
 			<Title>Required behaviour</Title>
 			<List ordered>
 				<ListItem>
+					Call <Code>get_automation_run_history</Code> if you need to see previous runs, and focus on what is
+					new since then.
+				</ListItem>
+				<ListItem>
 					Investigate the request below using the data tools (execute_sql, list, read, search, MCP tools,
 					etc.).
 				</ListItem>

--- a/apps/backend/src/components/ai/automation-run-prompt.tsx
+++ b/apps/backend/src/components/ai/automation-run-prompt.tsx
@@ -72,8 +72,9 @@ function SlackThreadingGuidance() {
 		<Fragment>
 			<Title>Slack posting structure</Title>
 			<Span>
-				To keep the channel uncluttered, do NOT post the whole report as one or more top-level channel messages.
-				Instead, structure the Slack delivery as a thread:
+				To keep the channel uncluttered, do NOT post the whole report as more than one top-level channel
+				message. Especially if the message is longer than 1000 characters. Instead, structure the Slack delivery
+				as a thread:
 			</Span>
 			<List ordered>
 				<ListItem>

--- a/apps/backend/src/handlers/automation.handler.ts
+++ b/apps/backend/src/handlers/automation.handler.ts
@@ -129,6 +129,8 @@ async function finishAutomationRun(automation: AutomationWithSchedule, run: DBAu
 						{
 							...(webTools ?? {}),
 							...createAutomationTools({
+								automationId: automation.id,
+								currentRunId: run.id,
 								projectId: automation.projectId,
 								chatId: chat.id,
 								githubToken,

--- a/apps/backend/src/queries/automation.queries.ts
+++ b/apps/backend/src/queries/automation.queries.ts
@@ -1,5 +1,5 @@
 import { displayChart, executeSql } from '@nao/shared/tools';
-import { and, asc, desc, eq, inArray, isNull, lte } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, lte, ne } from 'drizzle-orm';
 
 import s, {
 	type ActivityTrigger,
@@ -174,6 +174,44 @@ export const listAutomationRuns = async (
 		.orderBy(desc(s.automationRun.startedAt))
 		.execute();
 	return rows.map((row) => row.run);
+};
+
+export type AutomationRunHistoryEntry = {
+	id: string;
+	status: DBAutomationRun['status'];
+	startedAt: Date;
+	completedAt: Date | null;
+	errorMessage: string | null;
+	summary: string | null;
+	integrationResults: AutomationIntegrationResult[];
+};
+
+export const getAutomationRunHistory = async (
+	automationId: string,
+	options?: { limit?: number; excludeRunId?: string },
+): Promise<AutomationRunHistoryEntry[]> => {
+	const conditions = [eq(s.automationRun.automationId, automationId)];
+	if (options?.excludeRunId) {
+		conditions.push(ne(s.automationRun.id, options.excludeRunId));
+	}
+	const runs = await db
+		.select()
+		.from(s.automationRun)
+		.where(and(...conditions))
+		.orderBy(desc(s.automationRun.startedAt))
+		.limit(options?.limit ?? 10)
+		.execute();
+
+	const outputs = await loadAutomationRunOutputs(runs);
+	return runs.map((run) => ({
+		id: run.id,
+		status: run.status,
+		startedAt: run.startedAt,
+		completedAt: run.completedAt,
+		errorMessage: run.errorMessage,
+		summary: outputs.get(run.id)?.text ?? null,
+		integrationResults: run.integrationResults,
+	}));
 };
 
 export const getAutomationRunByChatId = async (

--- a/apps/backend/src/services/automation-tools.ts
+++ b/apps/backend/src/services/automation-tools.ts
@@ -147,16 +147,34 @@ function createSlackTools(
 		return {};
 	}
 
+	// Charts/stories accumulate across the run; track which ones were already
+	// uploaded so multiple thread replies don't re-attach the same files.
+	const uploadedArtifacts = new Set<string>();
+
 	return {
 		send_automation_slack_message: createTool({
 			description: getSlackToolDescription(config.channelId),
 			inputSchema: z.object({
 				text: z.string().min(1),
+				thread_id: z
+					.string()
+					.optional()
+					.describe(
+						'Reuse the `threadId` returned by a previous call to post this message inside that thread instead of the channel.',
+					),
 			}),
-			execute: async ({ text }, context: ToolContext) => {
-				const result = await slackService.postMessage(projectId, config.channelId, text, { chatId });
-				const attachments = await buildGeneratedArtifactAttachments(projectId, context);
+			execute: async ({ text, thread_id }, context: ToolContext) => {
+				const result = await slackService.postMessage(projectId, config.channelId, text, {
+					chatId,
+					threadId: thread_id,
+				});
+				const attachments = (await buildGeneratedArtifactAttachments(projectId, context)).filter(
+					(attachment) => !uploadedArtifacts.has(attachment.filename),
+				);
 				await slackService.uploadFiles(projectId, result.threadId, attachments.map(toSlackFileUpload));
+				for (const attachment of attachments) {
+					uploadedArtifacts.add(attachment.filename);
+				}
 				return { ok: true, ...result, attachments: attachments.map((attachment) => attachment.filename) };
 			},
 		}),
@@ -168,7 +186,12 @@ function getEmailToolDescription(): string {
 }
 
 function getSlackToolDescription(channelId: string): string {
-	return `Post a message in the Slack channel ${channelId}. Provide the markdown-friendly text to post. Use @slack-handle to mention a Slack user.`;
+	return [
+		`Post a message in the Slack channel ${channelId}. Provide the markdown-friendly text to post. Use @slack-handle to mention a Slack user.`,
+		'To avoid cluttering the channel, post a single short headline message first (no thread_id), then reply with the full report inside its thread by passing the returned threadId as thread_id.',
+		'The call returns a threadId; reuse it as thread_id for every follow-up message so they stay in the same thread.',
+		'Generated charts and stories are uploaded to the thread automatically.',
+	].join(' ');
 }
 
 type GeneratedArtifactAttachment = Omit<EmailAttachment, 'content'> & {

--- a/apps/backend/src/services/automation-tools.ts
+++ b/apps/backend/src/services/automation-tools.ts
@@ -3,6 +3,7 @@ import type { displayChart } from '@nao/shared/tools';
 import { z } from 'zod/v4';
 
 import { generateChartImage } from '../components/generate-chart';
+import * as automationQueries from '../queries/automation.queries';
 import * as projectQueries from '../queries/project.queries';
 import * as storyQueries from '../queries/story.queries';
 import type { AutomationIntegrationConfig } from '../types/automation';
@@ -41,15 +42,48 @@ type AutomationToolInput = {
 	chatId: string;
 	githubToken: string | null;
 	integrations: AutomationIntegrationConfig;
+	automationId?: string;
+	currentRunId?: string;
 };
 
 export function createAutomationTools(input: AutomationToolInput): Record<string, unknown> {
 	return {
+		...createHistoryTools(input.automationId, input.currentRunId),
 		...createEmailTools(input.projectId, input.integrations),
 		...createSlackTools(input.projectId, input.chatId, input.integrations),
 		...createGithubAutomationTools({
 			githubToken: input.githubToken,
 			config: input.integrations.github ?? { enabled: false, repositories: [] },
+		}),
+	};
+}
+
+function createHistoryTools(automationId?: string, currentRunId?: string): Record<string, unknown> {
+	if (!automationId) {
+		return {};
+	}
+
+	return {
+		get_automation_run_history: createTool({
+			description: [
+				'Look up what previous runs of THIS automation already did, so you avoid repeating work',
+				'If the user asks for the history, review it before deciding what is new and worth reporting.',
+			].join(' '),
+			inputSchema: z.object({
+				limit: z
+					.number()
+					.int()
+					.min(1)
+					.max(50)
+					.default(10)
+					.describe('How many of the most recent past runs to return.'),
+			}),
+			execute: async ({ limit }) => ({
+				runs: await automationQueries.getAutomationRunHistory(automationId, {
+					limit,
+					excludeRunId: currentRunId,
+				}),
+			}),
 		}),
 	};
 }

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -59,6 +59,12 @@ type SlackBotWebhooks = NonNullable<Chat['webhooks']>;
 type SlackPostMessageOptions = {
 	chatId?: string;
 	subscribeThread?: boolean;
+	/**
+	 * Thread to reply into. Pass the `threadId` returned by a previous
+	 * `postMessage` call to keep follow-up messages inside the same thread
+	 * instead of cluttering the channel with new top-level messages.
+	 */
+	threadId?: string;
 };
 type SlackPostMessageResult = {
 	channel: string;
@@ -149,11 +155,12 @@ class ProjectSlackBot {
 		await this.stopSocketMode();
 	}
 
-	public async postMessage(channelId: string, text: string): Promise<SlackPostMessageResult> {
+	public async postMessage(channelId: string, text: string, threadTs?: string): Promise<SlackPostMessageResult> {
 		const resolvedText = await this._resolveSlackUserMentions(text);
 		const result = await this._slackClient.chat.postMessage({
 			channel: channelId,
 			text: formatSlackMessageText(resolvedText),
+			thread_ts: threadTs,
 		});
 
 		if (!result.ok) {
@@ -163,7 +170,9 @@ class ProjectSlackBot {
 			throw new Error('Slack did not return a channel and timestamp for the posted message.');
 		}
 
-		const threadId = getSlackThreadId(result.channel, result.ts);
+		// When replying inside a thread, keep the thread root timestamp so files
+		// and subscriptions stay attached to the original thread rather than the reply.
+		const threadId = getSlackThreadId(result.channel, threadTs ?? result.ts);
 		return { channel: result.channel, ts: result.ts, threadId };
 	}
 
@@ -870,12 +879,18 @@ class SlackService {
 		}
 
 		const bot = await this._getOrCreateBot(config);
-		const result = await bot.postMessage(channelId, text);
-		if (options.chatId) {
-			await chatQueries.attachSlackThread(options.chatId, result.threadId);
-		}
-		if (options.subscribeThread ?? !!options.chatId) {
-			await bot.subscribeThread(result.threadId);
+		const threadTs = options.threadId ? parseSlackThreadTs(options.threadId) : undefined;
+		const result = await bot.postMessage(channelId, text, threadTs);
+
+		// Only link/subscribe when starting a new thread. Replies share the same
+		// thread root, so the chat is already attached and subscribed.
+		if (!options.threadId) {
+			if (options.chatId) {
+				await chatQueries.attachSlackThread(options.chatId, result.threadId);
+			}
+			if (options.subscribeThread ?? !!options.chatId) {
+				await bot.subscribeThread(result.threadId);
+			}
 		}
 		return result;
 	}
@@ -982,6 +997,12 @@ class SlackService {
 
 function getSlackThreadId(channelId: string, threadTs: string): string {
 	return `slack:${channelId}:${threadTs}`;
+}
+
+/** Extracts the thread timestamp from a `slack:channelId:threadTs` thread id. */
+function parseSlackThreadTs(threadId: string): string | undefined {
+	const [, , threadTs] = threadId.split(':');
+	return threadTs || undefined;
 }
 
 function extractSlackUserMentionHandles(text: string): string[] {

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -59,11 +59,6 @@ type SlackBotWebhooks = NonNullable<Chat['webhooks']>;
 type SlackPostMessageOptions = {
 	chatId?: string;
 	subscribeThread?: boolean;
-	/**
-	 * Thread to reply into. Pass the `threadId` returned by a previous
-	 * `postMessage` call to keep follow-up messages inside the same thread
-	 * instead of cluttering the channel with new top-level messages.
-	 */
 	threadId?: string;
 };
 type SlackPostMessageResult = {
@@ -170,8 +165,6 @@ class ProjectSlackBot {
 			throw new Error('Slack did not return a channel and timestamp for the posted message.');
 		}
 
-		// When replying inside a thread, keep the thread root timestamp so files
-		// and subscriptions stay attached to the original thread rather than the reply.
 		const threadId = getSlackThreadId(result.channel, threadTs ?? result.ts);
 		return { channel: result.channel, ts: result.ts, threadId };
 	}
@@ -882,9 +875,7 @@ class SlackService {
 		const threadTs = options.threadId ? parseSlackThreadTs(options.threadId) : undefined;
 		const result = await bot.postMessage(channelId, text, threadTs);
 
-		// Only link/subscribe when starting a new thread. Replies share the same
-		// thread root, so the chat is already attached and subscribed.
-		if (!options.threadId) {
+		if (!threadTs) {
 			if (options.chatId) {
 				await chatQueries.attachSlackThread(options.chatId, result.threadId);
 			}
@@ -999,7 +990,6 @@ function getSlackThreadId(channelId: string, threadTs: string): string {
 	return `slack:${channelId}:${threadTs}`;
 }
 
-/** Extracts the thread timestamp from a `slack:channelId:threadTs` thread id. */
 function parseSlackThreadTs(threadId: string): string | undefined {
 	const [, , threadTs] = threadId.split(':');
 	return threadTs || undefined;

--- a/apps/backend/tests/automation-slack-thread.test.ts
+++ b/apps/backend/tests/automation-slack-thread.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderAutomationRunPrompt } from '../src/components/ai/automation-run-prompt';
+import type { AutomationIntegrationConfig } from '../src/types/automation';
+import type { ToolContext } from '../src/types/tools';
+
+// The db module imports bun:sqlite, which is unavailable under the node-based
+// vitest runner; stub it so the automation-tools import chain can load.
+vi.mock('../src/db/db', () => ({ db: {} }));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getDisplaySettings: vi.fn(async () => ({ dateFormat: null })),
+}));
+
+vi.mock('../src/components/generate-chart', () => ({
+	generateChartImage: vi.fn(() => Buffer.from('png')),
+}));
+
+vi.mock('../src/services/query-result.service', () => ({
+	getQueryResult: vi.fn(async () => ({ columns: ['a'], data: [{ a: 1 }] })),
+}));
+
+vi.mock('../src/services/slack', () => ({
+	slackService: {
+		postMessage: vi.fn(),
+		uploadFiles: vi.fn(async () => undefined),
+	},
+}));
+
+import { createAutomationTools } from '../src/services/automation-tools';
+import { slackService } from '../src/services/slack';
+
+const CHANNEL_ID = 'C123';
+const ROOT_THREAD_ID = `slack:${CHANNEL_ID}:111.222`;
+
+function slackIntegrations(): AutomationIntegrationConfig {
+	return { slack: { enabled: true, channelId: CHANNEL_ID } };
+}
+
+function emptyContext(): ToolContext {
+	return {
+		projectFolder: '/tmp',
+		chatId: 'chat-1',
+		userId: 'user-1',
+		projectId: 'project-1',
+		agentSettings: null,
+		envVars: {},
+		azureAccessToken: null,
+		queryResults: new Map(),
+		generatedArtifacts: { charts: [], stories: [] },
+	};
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function runTool(tool: any, input: Record<string, unknown>, context: ToolContext) {
+	return tool.execute(input, { experimental_context: context, toolCallId: 'call-1', messages: [] });
+}
+
+describe('renderAutomationRunPrompt slack threading guidance', () => {
+	it('includes the threading structure when slack is enabled', () => {
+		const prompt = renderAutomationRunPrompt({
+			prompt: 'Generate the weekly report',
+			integrations: slackIntegrations(),
+			userEmail: 'dennis@example.com',
+		});
+		expect(prompt).toContain('Slack posting structure');
+		expect(prompt).toContain('thread_id');
+		expect(prompt).toContain('starts the thread');
+	});
+
+	it('omits the threading structure when slack is disabled', () => {
+		const prompt = renderAutomationRunPrompt({
+			prompt: 'Generate the weekly report',
+			integrations: { email: { enabled: true, recipients: ['a@b.com'] } },
+			userEmail: 'dennis@example.com',
+		});
+		expect(prompt).not.toContain('Slack posting structure');
+	});
+});
+
+describe('send_automation_slack_message threading', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('starts a thread on the first call and replies into it afterwards', async () => {
+		vi.mocked(slackService.postMessage)
+			.mockResolvedValueOnce({ channel: CHANNEL_ID, ts: '111.222', threadId: ROOT_THREAD_ID })
+			.mockResolvedValueOnce({ channel: CHANNEL_ID, ts: '333.444', threadId: ROOT_THREAD_ID });
+
+		const tools = createAutomationTools({
+			projectId: 'project-1',
+			chatId: 'chat-1',
+			githubToken: null,
+			integrations: slackIntegrations(),
+		});
+		const tool = tools.send_automation_slack_message;
+		const context = emptyContext();
+
+		const headline = await runTool(tool, { text: 'Weekly Report: see thread' }, context);
+		expect(headline).toMatchObject({ ok: true, threadId: ROOT_THREAD_ID });
+		expect(vi.mocked(slackService.postMessage).mock.calls[0]).toEqual([
+			'project-1',
+			CHANNEL_ID,
+			'Weekly Report: see thread',
+			{ chatId: 'chat-1', threadId: undefined },
+		]);
+
+		await runTool(tool, { text: 'Full report body', thread_id: headline.threadId }, context);
+		expect(vi.mocked(slackService.postMessage).mock.calls[1]).toEqual([
+			'project-1',
+			CHANNEL_ID,
+			'Full report body',
+			{ chatId: 'chat-1', threadId: ROOT_THREAD_ID },
+		]);
+	});
+
+	it('uploads each generated chart only once across multiple thread messages', async () => {
+		vi.mocked(slackService.postMessage).mockResolvedValue({
+			channel: CHANNEL_ID,
+			ts: '111.222',
+			threadId: ROOT_THREAD_ID,
+		});
+
+		const tools = createAutomationTools({
+			projectId: 'project-1',
+			chatId: 'chat-1',
+			githubToken: null,
+			integrations: slackIntegrations(),
+		});
+		const tool = tools.send_automation_slack_message;
+		const context = emptyContext();
+		context.generatedArtifacts.charts = [
+			{ type: 'bar', title: 'Revenue', query_id: 'q1' } as ToolContext['generatedArtifacts']['charts'][number],
+		];
+
+		const first = await runTool(tool, { text: 'Headline' }, context);
+		expect(first.attachments).toEqual(['revenue.png']);
+
+		const second = await runTool(tool, { text: 'Body', thread_id: ROOT_THREAD_ID }, context);
+		expect(second.attachments).toEqual([]);
+
+		const uploadedFiles = vi.mocked(slackService.uploadFiles).mock.calls.flatMap((call) => call[2]);
+		expect(uploadedFiles).toHaveLength(1);
+		expect(uploadedFiles[0].filename).toBe('revenue.png');
+	});
+});

--- a/apps/frontend/src/components/automations-form.tsx
+++ b/apps/frontend/src/components/automations-form.tsx
@@ -865,6 +865,9 @@ function PromptMentionHints({
 			<p className='text-xs text-muted-foreground'>
 				The LLM knows your email address{email ? ` (${email})` : ''}, so you can say "send an email to me".
 			</p>
+			<p className='text-xs text-muted-foreground'>
+				Automation have previous runs history access to avoid repeating work if asked to do so.
+			</p>
 		</>
 	);
 }

--- a/apps/frontend/src/components/automations-form.tsx
+++ b/apps/frontend/src/components/automations-form.tsx
@@ -866,7 +866,7 @@ function PromptMentionHints({
 				The LLM knows your email address{email ? ` (${email})` : ''}, so you can say "send an email to me".
 			</p>
 			<p className='text-xs text-muted-foreground'>
-				Automation have previous runs history access to avoid repeating work if asked to do so.
+				Automations have access to their previous run history to avoid repeating work when asked.
 			</p>
 		</>
 	);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

A user (Dennis) reported that automation reports posted to Slack clutter the channel: when a report is long, the agent posts multiple top-level channel messages. The desired behaviour (agreed with Christophe) is to post a single short headline to the channel that **starts a thread**, then post the full report **inside that thread**.

> "post the report name to the channel, i.e. starting a new thread and then post everything from the report in the thread instead. This would not clutter the channel as much."

The plan was to "give the capabilities to the LLM to create a first message then to post to the thread" and instruct it via the prompt to structure delivery that way.

## Changes

- **`send_automation_slack_message` now accepts an optional `thread_id`** (`automation-tools.ts`). Omitting it starts a new thread (a top-level channel message); passing the `threadId` returned by a previous call posts the message as a reply inside that thread.
- **Slack posting supports threads** (`slack.ts`): `ProjectSlackBot.postMessage` forwards `thread_ts`, and `SlackService.postMessage` accepts a `threadId` option. The returned `threadId` always points at the thread root, so file uploads and thread subscription stay attached to the original thread. The chat is linked/subscribed only when the root message is created.
- **Generated charts/stories are deduplicated** across multiple thread replies so the same files aren't re-uploaded on each call.
- **Automation run prompt** (`automation-run-prompt.tsx`) now includes a "Slack posting structure" section (only when Slack is enabled) instructing the agent to: post a short headline first (no `thread_id`), then post the full report into the returned thread, reusing the same `thread_id` for follow-ups.
- The tool description advertises the threaded workflow to the LLM.

The automations feed UI already collapses multiple integration results by type, so multiple Slack tool calls render as a single Slack status icon — no UI change needed.

## Testing

- `apps/backend/tests/automation-slack-thread.test.ts` (new): verifies the prompt guidance is rendered only when Slack is enabled, that `thread_id` is threaded through to `slackService.postMessage`, and that charts are uploaded only once across multiple thread messages.
- ✅ `npm run lint`
- ✅ `npm run -w @nao/backend test -- automation-slack-thread` (4 passed)
- Full backend suite: 4 new tests pass; the 22 remaining failures are pre-existing and unrelated (they fail loading `bun:sqlite` under the node vitest runner on `main`).

Manual end-to-end Slack posting was not exercised because it requires a live Slack workspace + bot token, which isn't available in this environment. The change is backend-only with no UI surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56e1050f-7ec0-4e3f-87e3-4e677d0502ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56e1050f-7ec0-4e3f-87e3-4e677d0502ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

