### PR TITLE
feat(frontend): add dismissible notification dot on newsletter mail icon

### DIFF
--- a/apps/frontend/src/components/sidebar-community.tsx
+++ b/apps/frontend/src/components/sidebar-community.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Mail } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { createLocalStorage } from '@/lib/local-storage';
 import GithubIcon from '@/components/icons/github-icon.svg';
 import { NewsletterSubscribeDialog } from '@/components/newsletter-subscribe';
 import SlackIcon from '@/components/icons/slack.svg';
@@ -10,8 +11,19 @@ interface SidebarCommunityProps {
 	isCollapsed: boolean;
 }
 
+const newsletterNotificationDismissed = createLocalStorage<boolean>('newsletter-notification-dismissed', false);
+
 export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 	const [isNewsletterOpen, setIsNewsletterOpen] = useState(false);
+	const [showNotification, setShowNotification] = useState(() => !newsletterNotificationDismissed.get());
+
+	const handleNewsletterClick = () => {
+		setIsNewsletterOpen(true);
+		if (showNotification) {
+			setShowNotification(false);
+			newsletterNotificationDismissed.set(true);
+		}
+	};
 
 	if (isCollapsed) {
 		return null;
@@ -47,14 +59,20 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 				</a>
 				<button
 					type='button'
-					onClick={() => setIsNewsletterOpen(true)}
+					onClick={handleNewsletterClick}
 					className={cn(
-						'p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
+						'relative p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
 					)}
 					title='Subscribe to newsletter'
 					aria-label='Subscribe to newsletter'
 				>
 					<Mail className='size-3.5' />
+					{showNotification && (
+						<span
+							className='absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary ring-2 ring-sidebar'
+							aria-hidden='true'
+						/>
+					)}
 				</button>
 			</div>
 			<NewsletterSubscribeDialog open={isNewsletterOpen} onOpenChange={setIsNewsletterOpen} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small notification dot on the newsletter Mail icon in the sidebar's Community section to draw attention to the newsletter subscribe option. Clicking the icon (which opens the subscribe dialog) dismisses the dot, and the dismissal is persisted in `localStorage` so it does not reappear on reload.

## Changes

- `apps/frontend/src/components/sidebar-community.tsx`: render a small `bg-primary` dot at the top-right of the Mail button when not yet dismissed; on click, open the dialog and persist dismissal via the existing `createLocalStorage` helper (key `newsletter-notification-dismissed`).

## Testing

- `npm run lint` passes.
- Manually verified end-to-end: the dot shows by default, disappears after clicking the Mail icon, and stays gone after a page reload.

[newsletter_notification_dot_dismiss.mp4](https://cursor.com/agents/bc-84d9e534-bfc5-44dc-ba7d-df6bd1ca089b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnewsletter_notification_dot_dismiss.mp4)

[Mail icon with notification dot (before)](https://cursor.com/agents/bc-84d9e534-bfc5-44dc-ba7d-df6bd1ca089b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnewsletter_dot_before.webp)
[Notification dot gone after reload](https://cursor.com/agents/bc-84d9e534-bfc5-44dc-ba7d-df6bd1ca089b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnewsletter_dot_after_reload.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84d9e534-bfc5-44dc-ba7d-df6bd1ca089b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84d9e534-bfc5-44dc-ba7d-df6bd1ca089b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

