### PR TITLE
feat(frontend): floating suggestion panel above chat input

### DIFF
--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -24,25 +24,94 @@ const STORY_SUGGESTION_MESSAGE = 'Create a story from the charts in this convers
 const storyProposalDisabledStorage = createLocalStorage<boolean>('nao-story-proposal-disabled', false);
 
 /**
- * A floating panel that sits above the chat input and surfaces contextual
- * prompts: asking for feedback after a lull, or offering to turn charts into a
- * story once the conversation has produced a few.
+ * A floating panel that sits above the chat input and surfaces a single
+ * contextual prompt. Only one suggestion is shown at a time — the story
+ * suggestion takes priority over the conversation feedback prompt.
  */
 export function ChatInputSuggestions() {
 	const { isReadonly } = useAgentContext();
+	const story = useStorySuggestion();
+	const feedback = useConversationFeedback();
+
 	if (isReadonly) {
 		return null;
 	}
 
-	return (
-		<>
-			<StorySuggestionPrompt />
-			<ConversationFeedbackPrompt />
-		</>
-	);
+	if (story.isVisible) {
+		return (
+			<SuggestionCard
+				icon={<StoryIcon className='size-4 shrink-0 text-primary' />}
+				message='Would you want to create a story?'
+			>
+				<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={story.accept}>
+					Yes
+				</Button>
+				<Button variant='ghost' size='sm' className='rounded-full' onClick={story.dismiss}>
+					No
+				</Button>
+				<Button
+					variant='ghost'
+					size='sm'
+					className='rounded-full text-muted-foreground'
+					onClick={story.neverPropose}
+				>
+					Do not propose again
+				</Button>
+			</SuggestionCard>
+		);
+	}
+
+	if (feedback.showThanks) {
+		return <SuggestionCard message='Thanks for your feedback!' />;
+	}
+
+	if (feedback.isVisible) {
+		return (
+			<SuggestionCard message='How was this conversation?'>
+				<Button
+					variant='ghost'
+					size='icon-sm'
+					className='hover:rounded-full'
+					onClick={() => feedback.vote('up')}
+					disabled={feedback.isPending}
+					aria-label='Good conversation'
+				>
+					<ThumbsUp className='size-4' />
+				</Button>
+				<Button
+					variant='ghost'
+					size='icon-sm'
+					className='hover:rounded-full'
+					onClick={() => feedback.vote('down')}
+					disabled={feedback.isPending}
+					aria-label='Bad conversation'
+				>
+					<ThumbsDown className='size-4' />
+				</Button>
+				<Button
+					variant='ghost'
+					size='icon-sm'
+					className='hover:rounded-full text-muted-foreground'
+					onClick={feedback.dismiss}
+					aria-label='Dismiss'
+				>
+					<X className='size-4' />
+				</Button>
+			</SuggestionCard>
+		);
+	}
+
+	return null;
 }
 
-function StorySuggestionPrompt() {
+interface StorySuggestion {
+	isVisible: boolean;
+	accept: () => void;
+	dismiss: () => void;
+	neverPropose: () => void;
+}
+
+function useStorySuggestion(): StorySuggestion {
 	const { messages, isRunning, queueOrSendMessage } = useAgentContext();
 	const chatId = useChatId();
 
@@ -54,7 +123,7 @@ function StorySuggestionPrompt() {
 
 	const isPersistedChat = !!chatId && chatId !== NEW_CHAT_ID;
 	const isDismissed = !!chatId && dismissedChats.has(chatId);
-	const isEligible =
+	const isVisible =
 		isPersistedChat &&
 		!isRunning &&
 		!neverPropose &&
@@ -62,50 +131,34 @@ function StorySuggestionPrompt() {
 		!isDismissed &&
 		chartCount >= STORY_CHART_THRESHOLD;
 
-	const dismissForChat = useCallback(() => {
+	const dismiss = useCallback(() => {
 		if (chatId) {
 			setDismissedChats((prev) => new Set(prev).add(chatId));
 		}
 	}, [chatId]);
 
-	const handleAccept = useCallback(() => {
+	const accept = useCallback(() => {
 		void queueOrSendMessage({ text: STORY_SUGGESTION_MESSAGE });
-		dismissForChat();
-	}, [queueOrSendMessage, dismissForChat]);
+		dismiss();
+	}, [queueOrSendMessage, dismiss]);
 
 	const handleNeverPropose = useCallback(() => {
 		setNeverPropose(true);
 		storyProposalDisabledStorage.set(true);
 	}, []);
 
-	if (!isEligible) {
-		return null;
-	}
-
-	return (
-		<SuggestionCard
-			icon={<StoryIcon className='size-4 shrink-0 text-primary' />}
-			message='Would you want to create a story?'
-		>
-			<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={handleAccept}>
-				Yes
-			</Button>
-			<Button variant='ghost' size='sm' className='rounded-full' onClick={dismissForChat}>
-				No
-			</Button>
-			<Button
-				variant='ghost'
-				size='sm'
-				className='rounded-full text-muted-foreground'
-				onClick={handleNeverPropose}
-			>
-				Do not propose again
-			</Button>
-		</SuggestionCard>
-	);
+	return { isVisible, accept, dismiss, neverPropose: handleNeverPropose };
 }
 
-function ConversationFeedbackPrompt() {
+interface ConversationFeedback {
+	isVisible: boolean;
+	showThanks: boolean;
+	isPending: boolean;
+	vote: (vote: 'up' | 'down') => void;
+	dismiss: () => void;
+}
+
+function useConversationFeedback(): ConversationFeedback {
 	const { messages, isRunning } = useAgentContext();
 	const chatId = useChatId();
 
@@ -157,64 +210,30 @@ function ConversationFeedbackPrompt() {
 		return () => window.clearTimeout(timer);
 	}, [showThanks, chatId]);
 
-	const submitVote = useCallback(
-		(vote: 'up' | 'down') => {
+	const vote = useCallback(
+		(value: 'up' | 'down') => {
 			if (!chatId || !lastAssistantMessage) {
 				return;
 			}
-			submitFeedback.mutate({ chatId, messageId: lastAssistantMessage.id, vote });
+			submitFeedback.mutate({ chatId, messageId: lastAssistantMessage.id, vote: value });
 			setThanksForChat(chatId);
 		},
 		[chatId, lastAssistantMessage, submitFeedback],
 	);
 
-	const dismissForChat = useCallback(() => {
+	const dismiss = useCallback(() => {
 		if (chatId) {
 			setDismissedChats((prev) => new Set(prev).add(chatId));
 		}
 	}, [chatId]);
 
-	if (showThanks) {
-		return <SuggestionCard message='Thanks for your feedback!' />;
-	}
-
-	if (!isEligible || !isTriggered) {
-		return null;
-	}
-
-	return (
-		<SuggestionCard message='How was this conversation?'>
-			<Button
-				variant='ghost'
-				size='icon-sm'
-				className='hover:rounded-full'
-				onClick={() => submitVote('up')}
-				disabled={submitFeedback.isPending}
-				aria-label='Good conversation'
-			>
-				<ThumbsUp className='size-4' />
-			</Button>
-			<Button
-				variant='ghost'
-				size='icon-sm'
-				className='hover:rounded-full'
-				onClick={() => submitVote('down')}
-				disabled={submitFeedback.isPending}
-				aria-label='Bad conversation'
-			>
-				<ThumbsDown className='size-4' />
-			</Button>
-			<Button
-				variant='ghost'
-				size='icon-sm'
-				className='hover:rounded-full text-muted-foreground'
-				onClick={dismissForChat}
-				aria-label='Dismiss'
-			>
-				<X className='size-4' />
-			</Button>
-		</SuggestionCard>
-	);
+	return {
+		isVisible: isEligible && isTriggered,
+		showThanks,
+		isPending: submitFeedback.isPending,
+		vote,
+		dismiss,
+	};
 }
 
 function SuggestionCard({

--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -46,7 +46,7 @@ export function ChatInputSuggestions() {
 				<Button
 					variant='ghost'
 					size='sm'
-					className='hidden rounded-full text-muted-foreground group-hover:inline-flex'
+					className='rounded-full text-muted-foreground'
 					onClick={story.neverPropose}
 				>
 					Do not propose again

--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { ThumbsDown, ThumbsUp, X } from 'lucide-react';
+import { Check, MessageSquare, ThumbsDown, ThumbsUp, X } from 'lucide-react';
 import { Button } from './ui/button';
 import StoryIcon from './ui/story-icon';
 import type { UIMessage } from '@nao/backend/chat';
@@ -40,7 +40,8 @@ export function ChatInputSuggestions() {
 	if (story.isVisible) {
 		return (
 			<SuggestionCard
-				icon={<StoryIcon className='size-4 shrink-0 text-primary' />}
+				tone='primary'
+				icon={<StoryIcon className='size-4 text-primary' />}
 				message='Would you want to create a story?'
 			>
 				<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={story.accept}>
@@ -62,12 +63,21 @@ export function ChatInputSuggestions() {
 	}
 
 	if (feedback.showThanks) {
-		return <SuggestionCard message='Thanks for your feedback!' />;
+		return (
+			<SuggestionCard
+				tone='primary'
+				icon={<Check className='size-4 text-primary' />}
+				message='Thanks for your feedback!'
+			/>
+		);
 	}
 
 	if (feedback.isVisible) {
 		return (
-			<SuggestionCard message='How was this conversation?'>
+			<SuggestionCard
+				icon={<MessageSquare className='size-4 text-muted-foreground' />}
+				message='How was this conversation?'
+			>
 				<Button
 					variant='ghost'
 					size='icon-sm'
@@ -238,23 +248,31 @@ function useConversationFeedback(): ConversationFeedback {
 
 function SuggestionCard({
 	icon,
+	tone = 'muted',
 	message,
 	children,
 }: {
 	icon?: React.ReactNode;
+	tone?: 'muted' | 'primary';
 	message: string;
 	children?: React.ReactNode;
 }) {
 	return (
-		<div
-			className={cn(
-				'mb-2 flex items-center gap-2.5 rounded-2xl border border-input/50 bg-muted/50 px-3 py-2 text-sm',
-				'text-muted-foreground animate-in fade-in slide-in-from-bottom-2 duration-200',
+		<div className='mb-2 flex items-center gap-3 rounded-lg border bg-background px-3 py-2.5 shadow-xs animate-in fade-in slide-in-from-bottom-2 duration-200'>
+			{icon && (
+				<div
+					className={cn(
+						'flex size-9 shrink-0 items-center justify-center rounded-lg border',
+						tone === 'primary'
+							? 'border-primary/20 bg-gradient-to-br from-primary/15 to-primary/5'
+							: 'border-border bg-muted/50',
+					)}
+				>
+					{icon}
+				</div>
 			)}
-		>
-			{icon}
-			<p className='flex-1 min-w-0'>{message}</p>
-			{children && <div className='flex items-center gap-1'>{children}</div>}
+			<p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{message}</p>
+			{children && <div className='flex shrink-0 items-center gap-1'>{children}</div>}
 		</div>
 	);
 }

--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { ThumbsDown, ThumbsUp, X } from 'lucide-react';
+import { Button } from './ui/button';
+import StoryIcon from './ui/story-icon';
+import type { UIMessage } from '@nao/backend/chat';
+import { useAgentContext } from '@/contexts/agent.provider';
+import { useChatId } from '@/hooks/use-chat-id';
+import { useInactivityTrigger } from '@/hooks/use-inactivity-trigger';
+import { checkAssistantMessageHasContent, NEW_CHAT_ID } from '@/lib/ai';
+import { countDisplayCharts } from '@/lib/charts.utils';
+import { createLocalStorage } from '@/lib/local-storage';
+import { findStoryIds } from '@/lib/story.utils';
+import { cn } from '@/lib/utils';
+import { trpc } from '@/main';
+
+/** Milliseconds of inactivity before we ask the user how the conversation went. */
+const FEEDBACK_INACTIVITY_MS = 10_000;
+/** How many charts must exist in a chat before we offer to turn them into a story. */
+const STORY_CHART_THRESHOLD = 2;
+/** Message sent on behalf of the user when they accept the story suggestion. */
+const STORY_SUGGESTION_MESSAGE = 'Create a story from the charts in this conversation.';
+
+const storyProposalDisabledStorage = createLocalStorage<boolean>('nao-story-proposal-disabled', false);
+
+/**
+ * A floating panel that sits above the chat input and surfaces contextual
+ * prompts: asking for feedback after a lull, or offering to turn charts into a
+ * story once the conversation has produced a few.
+ */
+export function ChatInputSuggestions() {
+	const { isReadonly } = useAgentContext();
+	if (isReadonly) {
+		return null;
+	}
+
+	return (
+		<>
+			<StorySuggestionPrompt />
+			<ConversationFeedbackPrompt />
+		</>
+	);
+}
+
+function StorySuggestionPrompt() {
+	const { messages, isRunning, queueOrSendMessage } = useAgentContext();
+	const chatId = useChatId();
+
+	const [neverPropose, setNeverPropose] = useState(() => storyProposalDisabledStorage.get() ?? false);
+	const [dismissedChats, setDismissedChats] = useState<ReadonlySet<string>>(() => new Set());
+
+	const chartCount = useMemo(() => countDisplayCharts(messages), [messages]);
+	const hasStory = useMemo(() => findStoryIds(messages).length > 0, [messages]);
+
+	const isPersistedChat = !!chatId && chatId !== NEW_CHAT_ID;
+	const isDismissed = !!chatId && dismissedChats.has(chatId);
+	const isEligible =
+		isPersistedChat &&
+		!isRunning &&
+		!neverPropose &&
+		!hasStory &&
+		!isDismissed &&
+		chartCount >= STORY_CHART_THRESHOLD;
+
+	const dismissForChat = useCallback(() => {
+		if (chatId) {
+			setDismissedChats((prev) => new Set(prev).add(chatId));
+		}
+	}, [chatId]);
+
+	const handleAccept = useCallback(() => {
+		void queueOrSendMessage({ text: STORY_SUGGESTION_MESSAGE });
+		dismissForChat();
+	}, [queueOrSendMessage, dismissForChat]);
+
+	const handleNeverPropose = useCallback(() => {
+		setNeverPropose(true);
+		storyProposalDisabledStorage.set(true);
+	}, []);
+
+	if (!isEligible) {
+		return null;
+	}
+
+	return (
+		<SuggestionCard
+			icon={<StoryIcon className='size-4 shrink-0 text-primary' />}
+			message='Would you want to create a story?'
+		>
+			<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={handleAccept}>
+				Yes
+			</Button>
+			<Button variant='ghost' size='sm' className='rounded-full' onClick={dismissForChat}>
+				No
+			</Button>
+			<Button
+				variant='ghost'
+				size='sm'
+				className='rounded-full text-muted-foreground'
+				onClick={handleNeverPropose}
+			>
+				Do not propose again
+			</Button>
+		</SuggestionCard>
+	);
+}
+
+function ConversationFeedbackPrompt() {
+	const { messages, isRunning } = useAgentContext();
+	const chatId = useChatId();
+
+	const [dismissedChats, setDismissedChats] = useState<ReadonlySet<string>>(() => new Set());
+	const [thanksForChat, setThanksForChat] = useState<string | null>(null);
+
+	const submitFeedback = useMutation(
+		trpc.feedback.submit.mutationOptions({
+			onSuccess: (data, variables, _, ctx) => {
+				ctx.client.setQueryData(trpc.chat.get.queryKey({ chatId: variables.chatId }), (prev) =>
+					prev
+						? {
+								...prev,
+								messages: prev.messages.map((message) =>
+									message.id === variables.messageId ? { ...message, feedback: data } : message,
+								),
+							}
+						: prev,
+				);
+			},
+		}),
+	);
+
+	const lastAssistantMessage = useMemo(() => findLastAssistantWithContent(messages), [messages]);
+
+	const isPersistedChat = !!chatId && chatId !== NEW_CHAT_ID;
+	const isDismissed = !!chatId && dismissedChats.has(chatId);
+	const hasFeedback = !!lastAssistantMessage?.feedback;
+	const isEligible = isPersistedChat && !isRunning && !!lastAssistantMessage && !hasFeedback && !isDismissed;
+
+	const isTriggered = useInactivityTrigger({
+		enabled: isEligible,
+		delayMs: FEEDBACK_INACTIVITY_MS,
+		resetKey: `${chatId}:${messages.length}`,
+	});
+
+	const showThanks = !!chatId && thanksForChat === chatId;
+
+	useEffect(() => {
+		if (!showThanks) {
+			return;
+		}
+		const timer = window.setTimeout(() => {
+			if (chatId) {
+				setDismissedChats((prev) => new Set(prev).add(chatId));
+			}
+			setThanksForChat(null);
+		}, 2_500);
+		return () => window.clearTimeout(timer);
+	}, [showThanks, chatId]);
+
+	const submitVote = useCallback(
+		(vote: 'up' | 'down') => {
+			if (!chatId || !lastAssistantMessage) {
+				return;
+			}
+			submitFeedback.mutate({ chatId, messageId: lastAssistantMessage.id, vote });
+			setThanksForChat(chatId);
+		},
+		[chatId, lastAssistantMessage, submitFeedback],
+	);
+
+	const dismissForChat = useCallback(() => {
+		if (chatId) {
+			setDismissedChats((prev) => new Set(prev).add(chatId));
+		}
+	}, [chatId]);
+
+	if (showThanks) {
+		return <SuggestionCard message='Thanks for your feedback!' />;
+	}
+
+	if (!isEligible || !isTriggered) {
+		return null;
+	}
+
+	return (
+		<SuggestionCard message='How was this conversation?'>
+			<Button
+				variant='ghost'
+				size='icon-sm'
+				className='hover:rounded-full'
+				onClick={() => submitVote('up')}
+				disabled={submitFeedback.isPending}
+				aria-label='Good conversation'
+			>
+				<ThumbsUp className='size-4' />
+			</Button>
+			<Button
+				variant='ghost'
+				size='icon-sm'
+				className='hover:rounded-full'
+				onClick={() => submitVote('down')}
+				disabled={submitFeedback.isPending}
+				aria-label='Bad conversation'
+			>
+				<ThumbsDown className='size-4' />
+			</Button>
+			<Button
+				variant='ghost'
+				size='icon-sm'
+				className='hover:rounded-full text-muted-foreground'
+				onClick={dismissForChat}
+				aria-label='Dismiss'
+			>
+				<X className='size-4' />
+			</Button>
+		</SuggestionCard>
+	);
+}
+
+function SuggestionCard({
+	icon,
+	message,
+	children,
+}: {
+	icon?: React.ReactNode;
+	message: string;
+	children?: React.ReactNode;
+}) {
+	return (
+		<div
+			className={cn(
+				'mb-2 flex items-center gap-2.5 rounded-2xl border border-input/50 bg-muted/50 px-3 py-2 text-sm',
+				'text-muted-foreground animate-in fade-in slide-in-from-bottom-2 duration-200',
+			)}
+		>
+			{icon}
+			<p className='flex-1 min-w-0'>{message}</p>
+			{children && <div className='flex items-center gap-1'>{children}</div>}
+		</div>
+	);
+}
+
+function findLastAssistantWithContent(messages: UIMessage[]): UIMessage | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const message = messages[i];
+		if (message.role === 'assistant' && checkAssistantMessageHasContent(message)) {
+			return message;
+		}
+	}
+	return undefined;
+}

--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { Check, MessageSquare, ThumbsDown, ThumbsUp, X } from 'lucide-react';
+import { MessageSquare, X, ThumbsDown, ThumbsUp, Check } from 'lucide-react';
+import { NegativeFeedbackDialog } from './chat-messages/assistant-message-actions';
 import { Button } from './ui/button';
 import StoryIcon from './ui/story-icon';
 import type { UIMessage } from '@nao/backend/chat';
@@ -11,7 +12,6 @@ import { checkAssistantMessageHasContent, NEW_CHAT_ID } from '@/lib/ai';
 import { countDisplayCharts } from '@/lib/charts.utils';
 import { createLocalStorage } from '@/lib/local-storage';
 import { findStoryIds } from '@/lib/story.utils';
-import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
 
 /** Milliseconds of inactivity before we ask the user how the conversation went. */
@@ -40,74 +40,75 @@ export function ChatInputSuggestions() {
 	if (story.isVisible) {
 		return (
 			<SuggestionCard
-				tone='primary'
-				icon={<StoryIcon className='size-4 text-primary' />}
+				icon={<StoryIcon className='size-5 text-primary' />}
 				message='Would you want to create a story?'
 			>
-				<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={story.accept}>
-					Yes
+				<Button
+					variant='ghost'
+					size='sm'
+					className='hidden rounded-full text-muted-foreground group-hover:inline-flex'
+					onClick={story.neverPropose}
+				>
+					Do not propose again
 				</Button>
 				<Button variant='ghost' size='sm' className='rounded-full' onClick={story.dismiss}>
 					No
 				</Button>
-				<Button
-					variant='ghost'
-					size='sm'
-					className='rounded-full text-muted-foreground'
-					onClick={story.neverPropose}
-				>
-					Do not propose again
+				<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={story.accept}>
+					Yes
 				</Button>
 			</SuggestionCard>
 		);
 	}
 
 	if (feedback.showThanks) {
-		return (
-			<SuggestionCard
-				tone='primary'
-				icon={<Check className='size-4 text-primary' />}
-				message='Thanks for your feedback!'
-			/>
-		);
+		return <SuggestionCard icon={<Check className='size-4 text-primary' />} message='Thanks for your feedback!' />;
 	}
 
 	if (feedback.isVisible) {
 		return (
-			<SuggestionCard
-				icon={<MessageSquare className='size-4 text-muted-foreground' />}
-				message='How was this conversation?'
-			>
-				<Button
-					variant='ghost'
-					size='icon-sm'
-					className='hover:rounded-full'
-					onClick={() => feedback.vote('up')}
-					disabled={feedback.isPending}
-					aria-label='Good conversation'
+			<>
+				<SuggestionCard
+					icon={<MessageSquare className='size-4 text-muted-foreground' />}
+					message='How did this conversation go?'
 				>
-					<ThumbsUp className='size-4' />
-				</Button>
-				<Button
-					variant='ghost'
-					size='icon-sm'
-					className='hover:rounded-full'
-					onClick={() => feedback.vote('down')}
-					disabled={feedback.isPending}
-					aria-label='Bad conversation'
-				>
-					<ThumbsDown className='size-4' />
-				</Button>
-				<Button
-					variant='ghost'
-					size='icon-sm'
-					className='hover:rounded-full text-muted-foreground'
-					onClick={feedback.dismiss}
-					aria-label='Dismiss'
-				>
-					<X className='size-4' />
-				</Button>
-			</SuggestionCard>
+					<Button
+						variant='ghost'
+						size='icon-sm'
+						className='hover:rounded-full'
+						onClick={() => feedback.vote('up')}
+						disabled={feedback.isPending}
+						aria-label='Good conversation'
+					>
+						<ThumbsUp className='size-4' />
+					</Button>
+					<Button
+						variant='ghost'
+						size='icon-sm'
+						className='hover:rounded-full'
+						onClick={() => feedback.setFeedbackDialogOpen(true)}
+						disabled={feedback.isPending}
+						aria-label='Bad conversation'
+					>
+						<ThumbsDown className='size-4' />
+					</Button>
+					<Button
+						variant='ghost'
+						size='icon-sm'
+						className='hover:rounded-full text-muted-foreground'
+						onClick={feedback.dismiss}
+						aria-label='Dismiss'
+					>
+						<X className='size-4' />
+					</Button>
+				</SuggestionCard>
+				<NegativeFeedbackDialog
+					open={feedback.feedbackDialogOpen}
+					onOpenChange={feedback.setFeedbackDialogOpen}
+					onSubmit={(explanation) => feedback.vote('down', explanation)}
+					isPending={feedback.isPending}
+				/>
+			</>
 		);
 	}
 
@@ -164,8 +165,10 @@ interface ConversationFeedback {
 	isVisible: boolean;
 	showThanks: boolean;
 	isPending: boolean;
-	vote: (vote: 'up' | 'down') => void;
+	vote: (vote: 'up' | 'down', explanation?: string) => void;
 	dismiss: () => void;
+	feedbackDialogOpen: boolean;
+	setFeedbackDialogOpen: (open: boolean) => void;
 }
 
 function useConversationFeedback(): ConversationFeedback {
@@ -174,6 +177,7 @@ function useConversationFeedback(): ConversationFeedback {
 
 	const [dismissedChats, setDismissedChats] = useState<ReadonlySet<string>>(() => new Set());
 	const [thanksForChat, setThanksForChat] = useState<string | null>(null);
+	const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false);
 
 	const submitFeedback = useMutation(
 		trpc.feedback.submit.mutationOptions({
@@ -221,12 +225,13 @@ function useConversationFeedback(): ConversationFeedback {
 	}, [showThanks, chatId]);
 
 	const vote = useCallback(
-		(value: 'up' | 'down') => {
+		(value: 'up' | 'down', explanation?: string) => {
 			if (!chatId || !lastAssistantMessage) {
 				return;
 			}
-			submitFeedback.mutate({ chatId, messageId: lastAssistantMessage.id, vote: value });
+			submitFeedback.mutate({ chatId, messageId: lastAssistantMessage.id, vote: value, explanation });
 			setThanksForChat(chatId);
+			setFeedbackDialogOpen(false);
 		},
 		[chatId, lastAssistantMessage, submitFeedback],
 	);
@@ -243,34 +248,23 @@ function useConversationFeedback(): ConversationFeedback {
 		isPending: submitFeedback.isPending,
 		vote,
 		dismiss,
+		feedbackDialogOpen,
+		setFeedbackDialogOpen,
 	};
 }
 
 function SuggestionCard({
 	icon,
-	tone = 'muted',
 	message,
 	children,
 }: {
 	icon?: React.ReactNode;
-	tone?: 'muted' | 'primary';
 	message: string;
 	children?: React.ReactNode;
 }) {
 	return (
-		<div className='mb-2 flex items-center gap-3 rounded-lg border bg-background px-3 py-2.5 shadow-xs animate-in fade-in slide-in-from-bottom-2 duration-200'>
-			{icon && (
-				<div
-					className={cn(
-						'flex size-9 shrink-0 items-center justify-center rounded-lg border',
-						tone === 'primary'
-							? 'border-primary/20 bg-gradient-to-br from-primary/15 to-primary/5'
-							: 'border-border bg-muted/50',
-					)}
-				>
-					{icon}
-				</div>
-			)}
+		<div className='group mb-2 flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2 animate-in fade-in slide-in-from-bottom-2 duration-200'>
+			{icon && <div className='flex size-9 shrink-0 items-center justify-center'>{icon}</div>}
 			<p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{message}</p>
 			{children && <div className='flex shrink-0 items-center gap-1'>{children}</div>}
 		</div>

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -288,7 +288,7 @@ function ChatInputBase({
 			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
-			<ChatInputSuggestions />
+{allowQueueing && <ChatInputSuggestions />}
 
 			<form onSubmit={handleSubmitMessage} className='mx-auto relative'>
 				<InputGroup

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -28,6 +28,7 @@ import { messageQueueStore } from '@/stores/chat-message-queue';
 import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useChatPendingCitation } from '@/hooks/use-chat-pending-citation';
 import { SelectionCitationBanner } from '@/components/selection-citation-banner';
+import { ChatInputSuggestions } from '@/components/chat-input-suggestions';
 
 type ChatInputBaseProps = {
 	promptRef: React.RefObject<PromptHandle | null>;
@@ -287,6 +288,7 @@ function ChatInputBase({
 			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
+			<ChatInputSuggestions />
 
 			<form onSubmit={handleSubmitMessage} className='mx-auto relative'>
 				<InputGroup

--- a/apps/frontend/src/components/chat-messages/assistant-message-actions.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-message-actions.tsx
@@ -124,7 +124,7 @@ interface NegativeFeedbackDialogProps {
 	isPending: boolean;
 }
 
-function NegativeFeedbackDialog({ open, onOpenChange, onSubmit, isPending }: NegativeFeedbackDialogProps) {
+export function NegativeFeedbackDialog({ open, onOpenChange, onSubmit, isPending }: NegativeFeedbackDialogProps) {
 	const [explanation, setExplanation] = useState('');
 
 	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {

--- a/apps/frontend/src/hooks/use-inactivity-trigger.ts
+++ b/apps/frontend/src/hooks/use-inactivity-trigger.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+interface InactivityTriggerOptions {
+	enabled: boolean;
+	delayMs: number;
+	resetKey: string;
+}
+
+/**
+ * Returns `true` once `enabled` has stayed continuously true for `delayMs`.
+ * The countdown restarts whenever `enabled` flips or `resetKey` changes, so any
+ * fresh activity (new message, chat switch) postpones the trigger.
+ */
+export function useInactivityTrigger({ enabled, delayMs, resetKey }: InactivityTriggerOptions): boolean {
+	const [triggered, setTriggered] = useState(false);
+
+	useEffect(() => {
+		setTriggered(false);
+		if (!enabled) {
+			return;
+		}
+		const timer = window.setTimeout(() => setTriggered(true), delayMs);
+		return () => window.clearTimeout(timer);
+	}, [enabled, delayMs, resetKey]);
+
+	return triggered;
+}

--- a/apps/frontend/src/lib/charts.utils.ts
+++ b/apps/frontend/src/lib/charts.utils.ts
@@ -1,4 +1,6 @@
+import { getToolName, isToolUIPart } from './ai';
 import { hashValue } from './hash';
+import type { UIMessage } from '@nao/backend/chat';
 
 export { labelize } from '@nao/shared';
 
@@ -87,3 +89,21 @@ function isValidDate(date: Date): boolean {
 export const toKey = (value: string) => {
 	return hashValue(value);
 };
+
+/** Counts the successfully rendered `display_chart` tool calls across a conversation. */
+export function countDisplayCharts(messages: UIMessage[]): number {
+	let count = 0;
+	for (const message of messages) {
+		for (const part of message.parts) {
+			if (
+				isToolUIPart(part) &&
+				getToolName(part) === 'display_chart' &&
+				part.state === 'output-available' &&
+				!(part.output as { error?: string } | undefined)?.error
+			) {
+				count++;
+			}
+		}
+	}
+	return count;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a floating element that sits directly above the chat input and surfaces a contextual prompt. It currently hosts two suggestion cards, both of which are easy to extend later:

1. **Conversation feedback** — after ~10s of inactivity following an assistant response, a card asks "How was this conversation?" with thumbs up/down. Submitting reuses the existing `feedback.submit` flow (keyed to the last assistant message), shows a brief "Thanks for your feedback!", then disappears. Dismissable via an `X`.
2. **Create a story** — once a chat has produced **2+ charts** (`display_chart` tool calls), a card asks "Would you want to create a story?" with `Yes` / `No` / `Do not propose again`:
   - `Yes` auto-sends "Create a story from the charts in this conversation." via the agent.
   - `No` dismisses it for the current chat.
   - `Do not propose again` persists a global opt-out in `localStorage`.

**Only one suggestion is shown at a time** — the story suggestion takes priority over the feedback prompt. The cards are **styled like the app's story tool-call block**: white background, defined border, rounded corners, and a left icon tile.

Both cards are gated so they never appear while the agent is running, on unpersisted/new chats, or in readonly views.

## Changes
- `apps/frontend/src/components/chat-input-suggestions.tsx` — new floating panel; renders at most one card (story prioritized) via `useStorySuggestion` / `useConversationFeedback` hooks plus a presentational `SuggestionCard` styled like the story block.
- `apps/frontend/src/hooks/use-inactivity-trigger.ts` — reusable hook that fires after a delay of continuous inactivity, resetting on new activity.
- `apps/frontend/src/lib/charts.utils.ts` — `countDisplayCharts()` helper.
- `apps/frontend/src/components/chat-input.tsx` — mount `<ChatInputSuggestions />` above the input form.

## Testing
Verified end-to-end against the bundled `example` (jaffle shop) project with backend + frontend + FastAPI sidecar running locally.

### Restyled cards (story-block look)
[restyled_suggestion_cards_demo.mp4](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frestyled_suggestion_cards_demo.mp4)

[Restyled story suggestion card](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frestyled_story_card.webp)
[Restyled feedback card](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frestyled_feedback_card.webp)

### Single suggestion at a time (story prioritized)
[single_suggestion_story_priority_demo.mp4](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsingle_suggestion_story_priority_demo.mp4)

Only the story card shows while charts exist; clicking `No` reveals the feedback card in its place — never both at once.

### Feedback after inactivity (no charts) & create-a-story (2 charts)
[feedback_inactivity_card_demo.mp4](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeedback_inactivity_card_demo.mp4)
[story_suggestion_card_demo.mp4](https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstory_suggestion_card_demo.mp4)

- `npm run lint` — passes
- `prettier --check` on changed files — passes

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f80fdefc-bd06-4353-abfb-5e82f0da4f08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

