### PR TITLE
feat: add notification toggle for shared chat and story routes

### DIFF
--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -38,6 +38,7 @@ export const sharedChatRoutes = {
 				chatId: z.string(),
 				visibility: z.enum(['project', 'specific']).default('project'),
 				allowedUserIds: z.array(z.string()).optional(),
+				notify: z.boolean().default(false),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
@@ -65,16 +66,18 @@ export const sharedChatRoutes = {
 				sharedChatId: created.id,
 			});
 
-			notifySharedItemRecipients({
-				projectId: ctx.project.id,
-				sharerId: ctx.user.id,
-				sharerName: ctx.user.name,
-				shareId: created.id,
-				itemLabel: 'chat',
-				itemTitle: chatInfo.title,
-				visibility: input.visibility,
-				allowedUserIds: input.allowedUserIds,
-			}).catch((err) => console.error('Failed to notify shared chat recipients', err));
+			if (input.notify) {
+				notifySharedItemRecipients({
+					projectId: ctx.project.id,
+					sharerId: ctx.user.id,
+					sharerName: ctx.user.name,
+					shareId: created.id,
+					itemLabel: 'chat',
+					itemTitle: chatInfo.title,
+					visibility: input.visibility,
+					allowedUserIds: input.allowedUserIds,
+				}).catch((err) => console.error('Failed to notify shared chat recipients', err));
+			}
 
 			return created;
 		}),

--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -58,6 +58,7 @@ export const sharedStoryRoutes = {
 				visibility: z.enum(SHARE_VISIBILITY).default('project'),
 				allowedUserIds: z.array(z.string()).optional(),
 				pinAfterCreate: z.boolean().optional(),
+				notify: z.boolean().default(false),
 			}),
 		)
 		.mutation(async ({ input, ctx }) => {
@@ -101,16 +102,18 @@ export const sharedStoryRoutes = {
 				sharedStoryId: created.id,
 			});
 
-			notifySharedItemRecipients({
-				projectId: ctx.project.id,
-				sharerId: ctx.user.id,
-				sharerName: ctx.user.name,
-				shareId: created.id,
-				itemLabel: 'story',
-				itemTitle: story.title,
-				visibility: input.visibility,
-				allowedUserIds: input.allowedUserIds,
-			}).catch((err) => console.error('Failed to notify shared story recipients', err));
+			if (input.notify) {
+				notifySharedItemRecipients({
+					projectId: ctx.project.id,
+					sharerId: ctx.user.id,
+					sharerName: ctx.user.name,
+					shareId: created.id,
+					itemLabel: 'story',
+					itemTitle: story.title,
+					visibility: input.visibility,
+					allowedUserIds: input.allowedUserIds,
+				}).catch((err) => console.error('Failed to notify shared story recipients', err));
+			}
 
 			return created;
 		}),

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -288,7 +288,7 @@ function ChatInputBase({
 			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
-{allowQueueing && <ChatInputSuggestions />}
+			{allowQueueing && <ChatInputSuggestions />}
 
 			<form onSubmit={handleSubmitMessage} className='mx-auto relative'>
 				<InputGroup

--- a/apps/frontend/src/components/share-dialog.chat.tsx
+++ b/apps/frontend/src/components/share-dialog.chat.tsx
@@ -6,6 +6,7 @@ import {
 	hasAccessChanges,
 	ManageShareFooter,
 	MemberPicker,
+	NotifyPeopleToggle,
 	ShareErrorDialog,
 	ShareLoadingDialog,
 	VisibilityPicker,
@@ -73,9 +74,12 @@ function useInvalidateShareQueries(chatId: string) {
 function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps) {
 	const { data: session } = useSession();
 	const [visibility, setVisibility] = useState<Visibility>('project');
+	const [notify, setNotify] = useState(false);
 	const [isCopied, setIsCopied] = useState(false);
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const invalidateShareQueries = useInvalidateShareQueries(chatId);
+	const smtpQuery = useQuery(trpc.authConfig.smtp.isSetup.queryOptions());
+	const isSmtpEnabled = smtpQuery.data === true;
 
 	useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
@@ -89,6 +93,7 @@ function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps)
 	useEffect(() => {
 		if (open) {
 			setVisibility('project');
+			setNotify(false);
 			reset();
 			setIsCopied(false);
 		}
@@ -102,6 +107,7 @@ function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps)
 				chatId,
 				visibility,
 				allowedUserIds: visibility === 'specific' ? [...selectedUserIds] : undefined,
+				notify: isSmtpEnabled && notify,
 			})
 			.then((data) => {
 				invalidateShareQueries();
@@ -116,7 +122,16 @@ function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps)
 
 		blobPromise.catch(() => {});
 		navigator.clipboard.write([new ClipboardItem({ 'text/plain': blobPromise })]).catch(() => {});
-	}, [chatId, visibility, selectedUserIds, shareMutation, invalidateShareQueries, onOpenChange]);
+	}, [
+		chatId,
+		visibility,
+		selectedUserIds,
+		notify,
+		isSmtpEnabled,
+		shareMutation,
+		invalidateShareQueries,
+		onOpenChange,
+	]);
 
 	const canShare = visibility === 'project' || selectedUserIds.size > 0;
 
@@ -130,6 +145,9 @@ function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps)
 
 				<div className='flex flex-col gap-4'>
 					<VisibilityPicker visibility={visibility} onChange={setVisibility} />
+					{isSmtpEnabled && (
+						<NotifyPeopleToggle checked={notify} onCheckedChange={setNotify} itemLabel='chat' />
+					)}
 					{visibility === 'specific' && (
 						<MemberPicker
 							members={filteredMembers}

--- a/apps/frontend/src/components/share-dialog.story.tsx
+++ b/apps/frontend/src/components/share-dialog.story.tsx
@@ -6,6 +6,7 @@ import {
 	hasAccessChanges,
 	ManageShareFooter,
 	MemberPicker,
+	NotifyPeopleToggle,
 	ShareLoadingDialog,
 	VisibilityPicker,
 	VisibilitySummary,
@@ -77,10 +78,13 @@ function useInvalidateShareQueries(chatId: string, storySlug: string) {
 function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'share' }: ShareStoryDialogProps) {
 	const { data: session } = useSession();
 	const [visibility, setVisibility] = useState<Visibility>('project');
+	const [notify, setNotify] = useState(false);
 	const [isConfirmed, setIsConfirmed] = useState(false);
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const invalidateShareQueries = useInvalidateShareQueries(chatId, storySlug);
 	const isPinIntent = intent === 'pin';
+	const smtpQuery = useQuery(trpc.authConfig.smtp.isSetup.queryOptions());
+	const isSmtpEnabled = smtpQuery.data === true;
 
 	useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
@@ -94,6 +98,7 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 	useEffect(() => {
 		if (open) {
 			setVisibility('project');
+			setNotify(false);
 			reset();
 			setIsConfirmed(false);
 		}
@@ -109,6 +114,7 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 				visibility,
 				allowedUserIds: visibility === 'specific' ? [...selectedUserIds] : undefined,
 				pinAfterCreate: isPinIntent,
+				notify: isSmtpEnabled && notify,
 			})
 			.then((data) => {
 				invalidateShareQueries();
@@ -135,6 +141,8 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 		storySlug,
 		visibility,
 		selectedUserIds,
+		notify,
+		isSmtpEnabled,
 		shareMutation,
 		invalidateShareQueries,
 		onOpenChange,
@@ -166,6 +174,9 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 						</div>
 					)}
 					<VisibilityPicker visibility={visibility} onChange={setVisibility} />
+					{isSmtpEnabled && (
+						<NotifyPeopleToggle checked={notify} onCheckedChange={setNotify} itemLabel='story' />
+					)}
 					{visibility === 'specific' && (
 						<MemberPicker
 							members={filteredMembers}

--- a/apps/frontend/src/components/share-dialog.tsx
+++ b/apps/frontend/src/components/share-dialog.tsx
@@ -13,6 +13,7 @@ import {
 	DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 
 export function ShareLoadingDialog({
@@ -93,6 +94,28 @@ export function VisibilityPicker({
 				description='Choose who can view'
 				onClick={() => onChange('specific')}
 			/>
+		</div>
+	);
+}
+
+export function NotifyPeopleToggle({
+	checked,
+	onCheckedChange,
+	itemLabel,
+}: {
+	checked: boolean;
+	onCheckedChange: (checked: boolean) => void;
+	itemLabel: string;
+}) {
+	return (
+		<div className='flex items-center justify-between gap-3 rounded-lg border p-3'>
+			<div className='flex flex-col'>
+				<label htmlFor='notify-people' className='text-md font-medium'>
+					Notify people
+				</label>
+				<p className='text-xs text-muted-foreground'>Send an email letting them know about this {itemLabel}</p>
+			</div>
+			<Switch id='notify-people' checked={checked} onCheckedChange={onCheckedChange} />
 		</div>
 	);
 }


### PR DESCRIPTION
- Introduced a `notify` boolean field in the shared chat and story routes, defaulting to false.
- Updated mutation logic to conditionally notify recipients based on the `notify` input.
- Added a `NotifyPeopleToggle` component in the share dialog for both chat and story, allowing users to enable or disable notifications.
- Enhanced state management in the share dialog to handle the new notification feature.

This update improves user control over notification settings when sharing chats and stories.

asked in Slack: https://naolabs.slack.com/archives/C08C5CZ3CT1/p1782277035396849

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

