### PR TITLE
feat: enhance messaging provider with table support and text block cr…

### DIFF
--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -4,7 +4,7 @@ import { createSlackAdapter } from '@chat-adapter/slack';
 import { createMemoryState } from '@chat-adapter/state-memory';
 import { CITATION_TAG_REGEX } from '@nao/shared';
 import type { LlmSelectedModel } from '@nao/shared/types';
-import { WebClient } from '@slack/web-api';
+import { type ChatPostMessageArguments, WebClient } from '@slack/web-api';
 import { InferUIMessageChunk, readUIMessageStream } from 'ai';
 import { Card, Chat, deriveChannelId, Message, SentMessage, Thread, ThreadImpl } from 'chat';
 
@@ -25,6 +25,7 @@ import { createChatTitle } from '../utils/ai';
 import { buildUserAddedEmail } from '../utils/email-builders';
 import { logger } from '../utils/logger';
 import {
+	buildSlackTableBlocks,
 	createCompletionCard,
 	createFeedbackModal,
 	createImageBlock,
@@ -32,7 +33,7 @@ import {
 	createStopButtonCard,
 	createSummaryToolCalls,
 	createTextBlock,
-	escapeCsvCell,
+	createTextBlocks,
 	EXCLUDED_TOOLS,
 	FEEDBACK_MODAL_CALLBACK_ID,
 	formatMessagingError,
@@ -152,11 +153,16 @@ class ProjectSlackBot {
 
 	public async postMessage(channelId: string, text: string, threadTs?: string): Promise<SlackPostMessageResult> {
 		const resolvedText = await this._resolveSlackUserMentions(text);
-		const result = await this._slackClient.chat.postMessage({
+		const args: ChatPostMessageArguments = {
 			channel: channelId,
 			text: formatSlackMessageText(resolvedText),
 			thread_ts: threadTs,
-		});
+		};
+		const blocks = buildSlackTableBlocks(resolvedText);
+		if (blocks) {
+			(args as { blocks?: unknown }).blocks = blocks;
+		}
+		const result = await this._slackClient.chat.postMessage(args);
 
 		if (!result.ok) {
 			throw new Error(result.error ?? 'Failed to post Slack message.');
@@ -405,6 +411,7 @@ class ProjectSlackBot {
 			convMessage: null,
 			blocks: [],
 			textBlockIndex: -1,
+			textBlockCount: 0,
 			isNewChat: false,
 			modelId: undefined,
 			timezone: undefined,
@@ -620,16 +627,12 @@ class ProjectSlackBot {
 		const stream = await this._createAgentStream(chat, ctx);
 		const stopCard = await ctx.thread.post(createStopButtonCard());
 
-		let state: StreamState | undefined;
 		try {
-			state = await this._readStreamAndUpdateSlackMessage(stream, ctx);
+			await this._readStreamAndUpdateSlackMessage(stream, ctx);
 		} finally {
 			await stopCard.delete().catch(() => {});
 		}
 
-		if (state) {
-			await this._uploadLastSqlResultAsCsv(state, ctx);
-		}
 		await this._lastCompletionCard.get(ctx.thread.id)?.card.delete();
 		const chatUrl = new URL(ctx.chatId, this._redirectUrl).toString();
 		const card = await ctx.thread.post(createCompletionCard(chatUrl));
@@ -746,6 +749,7 @@ class ProjectSlackBot {
 
 			const imageUrl = new URL(`c/${ctx.chatId}/${chartId}.png`, this._redirectUrl).toString();
 			ctx.textBlockIndex = -1;
+			ctx.textBlockCount = 0;
 			ctx.blocks.push(createImageBlock(imageUrl));
 			await ctx.convMessage?.edit(Card({ children: ctx.blocks }));
 		} catch (error) {
@@ -804,6 +808,8 @@ class ProjectSlackBot {
 		ctx.blocks[state.toolGroupBlockIndex] = createSummaryToolCalls(state.toolGroup);
 		state.toolGroup = new Map();
 		state.toolGroupBlockIndex = -1;
+		ctx.textBlockIndex = -1;
+		ctx.textBlockCount = 0;
 	}
 
 	private async _sendFinalText(ctx: ConversationContext): Promise<void> {
@@ -814,36 +820,17 @@ class ProjectSlackBot {
 	}
 
 	private _updateTextBlock(text: string, ctx: ConversationContext): void {
-		const block = createTextBlock(text.replace(CITATION_TAG_REGEX, ''));
+		const blocks = createTextBlocks(text.replace(CITATION_TAG_REGEX, ''));
+		if (blocks.length === 0) {
+			return;
+		}
 		if (ctx.textBlockIndex === -1) {
 			ctx.textBlockIndex = ctx.blocks.length;
-			ctx.blocks.push(block);
+			ctx.blocks.push(...blocks);
 		} else {
-			ctx.blocks[ctx.textBlockIndex] = block;
+			ctx.blocks.splice(ctx.textBlockIndex, ctx.textBlockCount, ...blocks);
 		}
-	}
-
-	private async _uploadLastSqlResultAsCsv(state: StreamState, ctx: ConversationContext): Promise<void> {
-		if (state.sqlOutputs.size === 0) {
-			return;
-		}
-		const { name, rows } = [...state.sqlOutputs.values()].at(-1)!;
-		if (rows.length === 0) {
-			return;
-		}
-		const columns = Object.keys(rows[0]);
-		const header = columns.join(',');
-		const body = rows.map((row) => columns.map((col) => escapeCsvCell(row[col])).join(',')).join('\n');
-		const csv = `${header}\n${body}`;
-		const filename = name ? `${name.toLowerCase().replace(/\s+/g, '_')}.csv` : 'data.csv';
-
-		const [, channelId, threadTs] = ctx.thread.id.split(':');
-		await this._slackClient.files.uploadV2({
-			channel_id: channelId,
-			thread_ts: threadTs,
-			filename,
-			content: csv,
-		});
+		ctx.textBlockCount = blocks.length;
 	}
 
 	private async _getLastAssistantMessageId(threadId: string): Promise<string | null> {

--- a/apps/backend/src/services/teams.ts
+++ b/apps/backend/src/services/teams.ts
@@ -147,6 +147,7 @@ class TeamsService {
 			convMessage: null,
 			blocks: [],
 			textBlockIndex: -1,
+			textBlockCount: 0,
 			isNewChat: false,
 			modelId: undefined,
 			timezone: undefined,

--- a/apps/backend/src/services/telegram.ts
+++ b/apps/backend/src/services/telegram.ts
@@ -132,6 +132,7 @@ class TelegramService {
 			convMessage: null,
 			blocks: [],
 			textBlockIndex: -1,
+			textBlockCount: 0,
 			isNewChat: false,
 			modelId: undefined,
 			timezone: undefined,

--- a/apps/backend/src/services/whatsapp.ts
+++ b/apps/backend/src/services/whatsapp.ts
@@ -242,6 +242,7 @@ class WhatsappService {
 			convMessage: null,
 			blocks: [],
 			textBlockIndex: -1,
+			textBlockCount: 0,
 			isNewChat: false,
 			modelId: undefined,
 			timezone: undefined,

--- a/apps/backend/src/types/messaging-provider.ts
+++ b/apps/backend/src/types/messaging-provider.ts
@@ -10,6 +10,7 @@ export type ConversationContext = {
 	convMessage: SentMessage | null;
 	blocks: CardChild[];
 	textBlockIndex: number;
+	textBlockCount: number;
 	isNewChat: boolean;
 	modelId: string | undefined;
 	timezone: string | undefined;

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -1,6 +1,7 @@
+import { cardToBlockKit } from '@chat-adapter/slack';
 import { CITATION_TAG_REGEX, pluralize, TOOL_LABELS } from '@nao/shared';
 import type { CardChild, CardElement, ModalElement } from 'chat';
-import { Actions, Button, Card, CardText, Image, LinkButton } from 'chat';
+import { Actions, Button, Card, CardText, Image, LinkButton, Table } from 'chat';
 
 import { ToolCallEntry } from '../types/messaging-provider';
 import { BudgetExceededError } from './error';
@@ -105,6 +106,30 @@ export const createTextBlock = (text: string): CardChild => {
 	return CardText(rendered || text);
 };
 
+export const createTextBlocks = (text: string): CardChild[] => {
+	const blocks: CardChild[] = [];
+	for (const segment of splitMarkdownSegments(text)) {
+		if (segment.type === 'table') {
+			blocks.push(Table({ headers: segment.headers, rows: segment.rows }));
+			continue;
+		}
+		const rendered = mdToMrkdwn(segment.text).trim();
+		if (rendered) {
+			blocks.push(CardText(rendered));
+		}
+	}
+	return blocks;
+};
+
+export function buildSlackTableBlocks(text: string): ReturnType<typeof cardToBlockKit> | null {
+	const sanitized = text.replace(CITATION_TAG_REGEX, '');
+	const children = createTextBlocks(sanitized);
+	if (!children.some((child) => child.type === 'table')) {
+		return null;
+	}
+	return cardToBlockKit(Card({ children }));
+}
+
 export function formatSlackMessageText(text: string): string {
 	const sanitized = text.replace(CITATION_TAG_REGEX, '');
 	return mdToMrkdwn(sanitized) || sanitized;
@@ -117,6 +142,135 @@ export const createImageBlock = (url: string): CardChild => {
 export const createPlainTextBlock = (text: string): CardChild => {
 	return CardText(stripMarkdown(text));
 };
+
+type MarkdownSegment = { type: 'text'; text: string } | { type: 'table'; headers: string[]; rows: string[][] };
+
+const FENCE_REGEX = /^\s*(```|~~~)/;
+const SEPARATOR_CELL_REGEX = /^:?-+:?$/;
+
+function splitMarkdownSegments(text: string): MarkdownSegment[] {
+	const lines = text.split('\n');
+	const segments: MarkdownSegment[] = [];
+	let textLines: string[] = [];
+	let inFence = false;
+
+	const flushText = (): void => {
+		if (textLines.length > 0) {
+			segments.push({ type: 'text', text: textLines.join('\n') });
+			textLines = [];
+		}
+	};
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		if (FENCE_REGEX.test(line)) {
+			inFence = !inFence;
+			textLines.push(line);
+			continue;
+		}
+		const table = inFence ? null : parseTableAt(lines, i);
+		if (table) {
+			flushText();
+			segments.push(table.segment);
+			i = table.nextIndex - 1;
+			continue;
+		}
+		textLines.push(line);
+	}
+
+	flushText();
+	return segments;
+}
+
+function parseTableAt(lines: string[], start: number): { segment: MarkdownSegment; nextIndex: number } | null {
+	const headerLine = lines[start];
+	if (!headerLine.includes('|') || start + 1 >= lines.length) {
+		return null;
+	}
+	const headers = splitTableRow(headerLine);
+	if (tableSeparatorColumns(lines[start + 1]) !== headers.length) {
+		return null;
+	}
+
+	const rows: string[][] = [];
+	let index = start + 2;
+	for (; index < lines.length; index++) {
+		const line = lines[index];
+		if (line.trim() === '' || !line.includes('|') || FENCE_REGEX.test(line)) {
+			break;
+		}
+		rows.push(normalizeRow(splitTableRow(line), headers.length));
+	}
+
+	return {
+		segment: {
+			type: 'table',
+			headers: headers.map(cleanTableCell),
+			rows: rows.map((row) => row.map(cleanTableCell)),
+		},
+		nextIndex: index,
+	};
+}
+
+function tableSeparatorColumns(line: string): number {
+	if (!line.includes('-')) {
+		return -1;
+	}
+	const cells = splitTableRow(line);
+	if (cells.length === 0 || cells.some((cell) => !SEPARATOR_CELL_REGEX.test(cell))) {
+		return -1;
+	}
+	return cells.length;
+}
+
+function splitTableRow(line: string): string[] {
+	let content = line.trim();
+	if (content.startsWith('|')) {
+		content = content.slice(1);
+	}
+	if (content.endsWith('|') && !content.endsWith('\\|')) {
+		content = content.slice(0, -1);
+	}
+
+	const cells: string[] = [];
+	let current = '';
+	for (let i = 0; i < content.length; i++) {
+		const char = content[i];
+		if (char === '\\' && content[i + 1] === '|') {
+			current += '|';
+			i++;
+			continue;
+		}
+		if (char === '|') {
+			cells.push(current.trim());
+			current = '';
+			continue;
+		}
+		current += char;
+	}
+	cells.push(current.trim());
+	return cells;
+}
+
+function normalizeRow(cells: string[], length: number): string[] {
+	const row = cells.slice(0, length);
+	while (row.length < length) {
+		row.push('');
+	}
+	return row;
+}
+
+function cleanTableCell(cell: string): string {
+	return cell
+		.replace(/`([^`]+)`/g, '$1')
+		.replace(/\*\*(.+?)\*\*/g, '$1')
+		.replace(/__(.+?)__/g, '$1')
+		.replace(/\*(.+?)\*/g, '$1')
+		.replace(/~~(.+?)~~/g, '$1')
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+		.replace(/<br\s*\/?>/gi, ' ')
+		.trim();
+}
 
 function mdToMrkdwn(text: string): string {
 	// Split on fenced and inline code spans so we never mutate literal content
@@ -135,12 +289,6 @@ function mdToMrkdwn(text: string): string {
 		})
 		.join('');
 }
-
-export const escapeCsvCell = (value: unknown): string => {
-	const str = value === null || value === undefined ? '' : String(value);
-	const sanitized = /^[=+\-@]/.test(str.trimStart()) ? `'${str}` : str;
-	return /[,"\n]/.test(sanitized) ? `"${sanitized.replace(/"/g, '""')}"` : sanitized;
-};
 
 function stripMarkdown(text: string): string {
 	const newtext = text

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -152,7 +152,7 @@ function splitMarkdownSegments(text: string): MarkdownSegment[] {
 	const lines = text.split('\n');
 	const segments: MarkdownSegment[] = [];
 	let textLines: string[] = [];
-	let inFence = false;
+	let openFenceChar: string | null = null;
 
 	const flushText = (): void => {
 		if (textLines.length > 0) {
@@ -163,12 +163,17 @@ function splitMarkdownSegments(text: string): MarkdownSegment[] {
 
 	for (let i = 0; i < lines.length; i++) {
 		const line = lines[i];
-		if (FENCE_REGEX.test(line)) {
-			inFence = !inFence;
+		const fenceChar = fenceMarker(line);
+		if (fenceChar) {
+			if (openFenceChar === null) {
+				openFenceChar = fenceChar;
+			} else if (fenceChar === openFenceChar) {
+				openFenceChar = null;
+			}
 			textLines.push(line);
 			continue;
 		}
-		const table = inFence ? null : parseTableAt(lines, i);
+		const table = openFenceChar !== null ? null : parseTableAt(lines, i);
 		if (table) {
 			flushText();
 			segments.push(table.segment);
@@ -180,6 +185,11 @@ function splitMarkdownSegments(text: string): MarkdownSegment[] {
 
 	flushText();
 	return segments;
+}
+
+function fenceMarker(line: string): string | null {
+	const match = FENCE_REGEX.exec(line);
+	return match ? match[1][0] : null;
 }
 
 function parseTableAt(lines: string[], start: number): { segment: MarkdownSegment; nextIndex: number } | null {

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -75,6 +75,23 @@ describe('createTextBlocks', () => {
 		expect(blocks.map((block) => block.type)).toEqual(['text']);
 		expect(tableChild(blocks)).toBeUndefined();
 	});
+
+	it('keeps a mismatched fence marker as literal content inside a code block', () => {
+		const text = ['```', '~~~', '| A | B |', '|---|---|', '| 1 | 2 |', '```'].join('\n');
+		const blocks = createTextBlocks(text);
+		expect(blocks.map((block) => block.type)).toEqual(['text']);
+		expect(tableChild(blocks)).toBeUndefined();
+	});
+
+	it('parses a real table that follows a closed code block', () => {
+		const text = ['```', 'code', '```', '', '| A | B |', '|---|---|', '| 1 | 2 |'].join('\n');
+		const table = tableChild(createTextBlocks(text));
+		expect(table).toEqual({
+			type: 'table',
+			headers: ['A', 'B'],
+			rows: [['1', '2']],
+		});
+	});
 });
 
 describe('buildSlackTableBlocks', () => {

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSlackTableBlocks, createTextBlocks } from '../src/utils/messaging-provider';
+
+type AnyBlock = { type: string; [key: string]: unknown };
+
+function tableChild(blocks: ReturnType<typeof createTextBlocks>) {
+	return blocks.find((block) => block.type === 'table') as
+		| { type: 'table'; headers: string[]; rows: string[][] }
+		| undefined;
+}
+
+describe('createTextBlocks', () => {
+	it('returns a single text block when there is no table', () => {
+		const blocks = createTextBlocks('Just a plain answer with **bold**.');
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]).toMatchObject({ type: 'text', content: 'Just a plain answer with *bold*.' });
+	});
+
+	it('splits a markdown table into a Table element with text around it', () => {
+		const text = [
+			'Here is your table:',
+			'',
+			'| Column A | Column B |',
+			'|----------|----------|',
+			'| Hello | World |',
+			'| Foo | Bar |',
+			'',
+			'Let me know!',
+		].join('\n');
+
+		const blocks = createTextBlocks(text);
+
+		expect(blocks.map((block) => block.type)).toEqual(['text', 'table', 'text']);
+		expect(tableChild(blocks)).toEqual({
+			type: 'table',
+			headers: ['Column A', 'Column B'],
+			rows: [
+				['Hello', 'World'],
+				['Foo', 'Bar'],
+			],
+		});
+		expect(blocks[0]).toMatchObject({ content: 'Here is your table:' });
+		expect(blocks[2]).toMatchObject({ content: 'Let me know!' });
+	});
+
+	it('handles tables without outer pipes and alignment markers', () => {
+		const text = ['Revenue | Region', ':---|---:', 'Hello | World'].join('\n');
+		const table = tableChild(createTextBlocks(text));
+		expect(table).toEqual({
+			type: 'table',
+			headers: ['Revenue', 'Region'],
+			rows: [['Hello', 'World']],
+		});
+	});
+
+	it('strips inline markdown and links inside table cells', () => {
+		const text = ['| Name | Link |', '|------|------|', '| **Bob** | [docs](https://x.dev) |'].join('\n');
+		const table = tableChild(createTextBlocks(text));
+		expect(table?.rows).toEqual([['Bob', 'docs']]);
+	});
+
+	it('pads and truncates rows to match the header column count', () => {
+		const text = ['| A | B | C |', '|---|---|---|', '| 1 | 2 |', '| 1 | 2 | 3 | 4 |'].join('\n');
+		const table = tableChild(createTextBlocks(text));
+		expect(table?.rows).toEqual([
+			['1', '2', ''],
+			['1', '2', '3'],
+		]);
+	});
+
+	it('does not treat pipe tables inside fenced code blocks as tables', () => {
+		const text = ['```', '| A | B |', '|---|---|', '| 1 | 2 |', '```'].join('\n');
+		const blocks = createTextBlocks(text);
+		expect(blocks.map((block) => block.type)).toEqual(['text']);
+		expect(tableChild(blocks)).toBeUndefined();
+	});
+});
+
+describe('buildSlackTableBlocks', () => {
+	it('returns null when the message contains no table', () => {
+		expect(buildSlackTableBlocks('No tables here, just text.')).toBeNull();
+	});
+
+	it('builds an official Slack table block from a markdown table', () => {
+		const text = ['| Column A | Column B |', '|----------|----------|', '| Hello | World |', '| Foo | Bar |'].join(
+			'\n',
+		);
+
+		const blocks = buildSlackTableBlocks(text) as AnyBlock[] | null;
+		expect(blocks).not.toBeNull();
+
+		const tableBlock = blocks!.find((block) => block.type === 'table') as
+			| { type: 'table'; rows: { type: string; text: string }[][] }
+			| undefined;
+		expect(tableBlock).toBeDefined();
+		expect(tableBlock!.rows).toEqual([
+			[
+				{ type: 'raw_text', text: 'Column A' },
+				{ type: 'raw_text', text: 'Column B' },
+			],
+			[
+				{ type: 'raw_text', text: 'Hello' },
+				{ type: 'raw_text', text: 'World' },
+			],
+			[
+				{ type: 'raw_text', text: 'Foo' },
+				{ type: 'raw_text', text: 'Bar' },
+			],
+		]);
+	});
+});


### PR DESCRIPTION
before:
<img width="580" height="341" alt="Screenshot 2026-06-24 at 10 58 43" src="https://github.com/user-attachments/assets/1e045820-f297-42b0-a7ae-7fceeb25c485" />


after:
<img width="561" height="416" alt="Screenshot 2026-06-24 at 10 58 12" src="https://github.com/user-attachments/assets/8b541676-b45e-4afa-ad39-142487c7a1ba" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

