### PR TITLE
[Fix] Improve fork process on story & chat assets

### DIFF
--- a/apps/backend/src/queries/chat.queries.ts
+++ b/apps/backend/src/queries/chat.queries.ts
@@ -448,25 +448,27 @@ export const createForkedChat = async (newChat: NewChat, messages: Array<Omit<UI
 	return db.transaction(async (t) => {
 		const [savedChat] = await t.insert(s.chat).values(newChat).returning().execute();
 
-		const baseTime = Date.now();
-		for (let i = 0; i < messages.length; i++) {
-			const message = messages[i];
-			const messageId = crypto.randomUUID();
-			await t
-				.insert(s.chatMessage)
-				.values({
-					id: messageId,
-					chatId: savedChat.id,
-					role: message.role,
-					isForked: true,
-					createdAt: new Date(baseTime + i),
-				})
-				.execute();
+		if (messages.length === 0) {
+			return savedChat;
+		}
 
-			const dbParts = remapToolCallIds(mapUIPartsToDBParts(message.parts, messageId));
-			if (dbParts.length > 0) {
-				await t.insert(s.messagePart).values(dbParts).execute();
-			}
+		const baseTime = Date.now();
+		const messageRows = messages.map((message, i) => ({
+			id: crypto.randomUUID(),
+			chatId: savedChat.id,
+			role: message.role,
+			isForked: true,
+			createdAt: new Date(baseTime + i),
+		}));
+
+		await t.insert(s.chatMessage).values(messageRows).execute();
+
+		const allParts = messages.flatMap((message, i) =>
+			remapToolCallIds(mapUIPartsToDBParts(message.parts, messageRows[i].id)),
+		);
+
+		if (allParts.length > 0) {
+			await t.insert(s.messagePart).values(allParts).execute();
 		}
 
 		return savedChat;

--- a/apps/backend/src/trpc/chat-fork.routes.ts
+++ b/apps/backend/src/trpc/chat-fork.routes.ts
@@ -8,7 +8,7 @@ import * as sharedStoryQueries from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
 import * as storyFolderQueries from '../queries/story-folder.queries';
 import { compactionService } from '../services/compaction';
-import type { ForkMetadata, UIMessage } from '../types/chat';
+import type { ForkMetadata, UIMessage, UIMessagePart } from '../types/chat';
 import { logAnalyticsEvent } from '../utils/analytics-event';
 import { buildQueryDataParts, pinStoryMessageToChat } from '../utils/chat-message-story';
 import { canSendProcedure, projectProtectedProcedure, protectedProcedure } from './trpc';
@@ -111,8 +111,6 @@ async function forkSharedChat(
 		messages,
 	);
 
-	await copyStoriesToFork(share.chatId, savedChat.id);
-
 	logAnalyticsEvent({
 		projectId: share.projectId,
 		type: 'fork',
@@ -139,16 +137,23 @@ async function forkSharedStoryItem(
 		: { type: 'story', id: share.storyId, title: share.title, authorName: share.authorName };
 
 	if (selection) {
-		const rawMessages = await chatQueries.getChatMessages(share.chatId!);
+		const [rawMessages, queryData] = await Promise.all([
+			chatQueries.getChatMessages(share.chatId!),
+			sharedStoryQueries.getQueryDataFromCode(share.chatId!, share.code),
+		]);
 		const seededMessages = compactionService.useLastCompaction(rawMessages);
-		const messages = [...seededMessages, buildSelectionContextMessage(share.title, selection)];
+		const messages = [
+			...buildQueryDataMessages(queryData),
+			buildStoryContextMessage(share.slug, share.title, share.code),
+			...seededMessages,
+			buildSelectionContextMessage(share.title, selection),
+		];
 
 		const chat = await chatQueries.createForkedChat(
 			{ projectId, userId, title: share.title, forkMetadata },
 			messages,
 		);
 
-		await copyStoriesToFork(share.chatId!, chat.id);
 		logStoryFork(share, userId, chat.id, 'selection');
 		return { chatId: chat.id };
 	}
@@ -280,26 +285,20 @@ async function createStoryInFork(
 	}
 }
 
-async function copyStoriesToFork(sourceChatId: string, forkChatId: string): Promise<void> {
-	const stories = await storyQueries.listStoriesInChat(sourceChatId);
-	if (stories.length === 0) {
-		return;
-	}
-
-	await Promise.all(
-		stories.map(async ({ slug }) => {
-			const latest = await storyQueries.getLatestVersionByChatAndSlug(sourceChatId, slug);
-			if (!latest) {
-				return;
-			}
-			await storyQueries.createStoryVersion({
-				chatId: forkChatId,
-				slug,
-				title: latest.title,
-				code: latest.code,
-				action: 'create',
-				source: 'assistant',
-			});
-		}),
-	);
+function buildStoryContextMessage(slug: string, title: string, code: string): Omit<UIMessage, 'id'> {
+	return {
+		role: 'assistant',
+		parts: [
+			{
+				type: 'tool-story',
+				toolCallId: crypto.randomUUID(),
+				toolName: 'story',
+				state: 'output-available',
+				input: { action: 'create', id: slug, title, code },
+				output: { _version: '1', success: true, id: slug, version: 1, code, title },
+				errorText: undefined,
+				providerExecuted: false,
+			} as UIMessagePart,
+		],
+	};
 }

--- a/apps/frontend/src/components/selection-chat-panel.tsx
+++ b/apps/frontend/src/components/selection-chat-panel.tsx
@@ -15,6 +15,7 @@ import { ChatMessagesContent } from '@/components/chat-messages/chat-messages';
 import { Conversation, ConversationContent, ConversationScrollButton } from '@/components/ui/conversation';
 import { SetChatInputCallbackProvider } from '@/contexts/set-chat-input-callback';
 import { useSelection } from '@/contexts/text-selection';
+import { Skeleton } from '@/components/ui/skeleton';
 import { trpc } from '@/main';
 import { ChatIdContext } from '@/hooks/use-chat-id';
 import {
@@ -220,13 +221,17 @@ function PanelContainer({
 			style={{ right: rightOffset }}
 			className='fixed top-20 bottom-10 w-[400px] z-50 flex flex-col items-center'
 		>
-			<ChatPanelContent
-				key={anchor.chatId}
-				anchor={anchor}
-				rightOffset={rightOffset}
-				handleDelete={handleDelete}
-				onClose={onClose}
-			/>
+			{anchor.pending ? (
+				<PendingPanelContent anchor={anchor} onClose={onClose} />
+			) : (
+				<ChatPanelContent
+					key={anchor.chatId}
+					anchor={anchor}
+					rightOffset={rightOffset}
+					handleDelete={handleDelete}
+					onClose={onClose}
+				/>
+			)}
 			<Button
 				onClick={onClose}
 				variant='ghost-no-hover'
@@ -243,6 +248,48 @@ function PanelContainer({
 	);
 }
 
+function PanelShell({ style, children }: { style?: React.CSSProperties; children: React.ReactNode }) {
+	return (
+		<div
+			style={style}
+			className='flex flex-col bg-background border border-border shadow-xl rounded-2xl
+					fixed top-20 bottom-15 w-[400px] z-50 overflow-hidden'
+			onMouseDown={(e) => e.stopPropagation()}
+		>
+			{children}
+		</div>
+	);
+}
+
+function SelectionExcerptCard({ anchor, text }: { anchor: SelectionAnchor; text: string }) {
+	return (
+		<div className='px-4 mt-1'>
+			<div className='px-4 py-3 border border-border bg-sidebar rounded-xl'>
+				<SelectionCitationExcerpt start={anchor.start} end={anchor.end} text={text} />
+			</div>
+		</div>
+	);
+}
+
+function PendingPanelContent({ anchor, onClose }: { anchor: SelectionAnchor; onClose: () => void }) {
+	return (
+		<PanelShell>
+			<div className='flex items-center justify-between w-full mt-2 px-4'>
+				<p className='text-sm font-medium'>Ask a question</p>
+				<Button variant='ghost' size='icon-xs' onClick={onClose} className='rounded-full -mr-1'>
+					<X />
+				</Button>
+			</div>
+			<SelectionExcerptCard anchor={anchor} text='' />
+			<div className='flex flex-col gap-3 p-4 mt-2'>
+				<Skeleton className='h-4 w-3/4' />
+				<Skeleton className='h-4 w-1/2' />
+				<Skeleton className='h-4 w-2/3' />
+			</div>
+		</PanelShell>
+	);
+}
+
 function ChatPanelContent({
 	anchor,
 	rightOffset,
@@ -255,12 +302,7 @@ function ChatPanelContent({
 	onClose: () => void;
 }) {
 	return (
-		<div
-			style={{ right: rightOffset }}
-			className='flex flex-col bg-background border border-border shadow-xl rounded-2xl
-					fixed top-20 bottom-15 w-[400px] z-50 overflow-hidden'
-			onMouseDown={(e) => e.stopPropagation()}
-		>
+		<PanelShell style={{ right: rightOffset }}>
 			<PanelHeader anchor={anchor} handleDelete={handleDelete} onClose={onClose} />
 			<SetChatInputCallbackProvider>
 				<ChatIdContext.Provider value={anchor.chatId}>
@@ -275,7 +317,7 @@ function ChatPanelContent({
 					</AgentProvider>
 				</ChatIdContext.Provider>
 			</SetChatInputCallbackProvider>
-		</div>
+		</PanelShell>
 	);
 }
 
@@ -321,11 +363,7 @@ export function PanelHeader({
 					</Button>
 				</div>
 			</div>
-			<div className='px-4 mt-1'>
-				<div className='px-4 py-3 border border-border bg-sidebar rounded-xl'>
-					<SelectionCitationExcerpt start={anchor.start} end={anchor.end} text={selectionText} />
-				</div>
-			</div>
+			<SelectionExcerptCard anchor={anchor} text={selectionText} />
 		</div>
 	);
 }

--- a/apps/frontend/src/components/selection-chat-panel.tsx
+++ b/apps/frontend/src/components/selection-chat-panel.tsx
@@ -222,7 +222,7 @@ function PanelContainer({
 			className='fixed top-20 bottom-10 w-[400px] z-50 flex flex-col items-center'
 		>
 			{anchor.pending ? (
-				<PendingPanelContent anchor={anchor} onClose={onClose} />
+				<PendingPanelContent anchor={anchor} rightOffset={rightOffset} onClose={onClose} />
 			) : (
 				<ChatPanelContent
 					key={anchor.chatId}
@@ -271,9 +271,17 @@ function SelectionExcerptCard({ anchor, text }: { anchor: SelectionAnchor; text:
 	);
 }
 
-function PendingPanelContent({ anchor, onClose }: { anchor: SelectionAnchor; onClose: () => void }) {
+function PendingPanelContent({
+	anchor,
+	rightOffset,
+	onClose,
+}: {
+	anchor: SelectionAnchor;
+	rightOffset: number;
+	onClose: () => void;
+}) {
 	return (
-		<PanelShell>
+		<PanelShell style={{ right: rightOffset }}>
 			<div className='flex items-center justify-between w-full mt-2 px-4'>
 				<p className='text-sm font-medium'>Ask a question</p>
 				<Button variant='ghost' size='icon-xs' onClick={onClose} className='rounded-full -mr-1'>

--- a/apps/frontend/src/contexts/text-selection.tsx
+++ b/apps/frontend/src/contexts/text-selection.tsx
@@ -33,6 +33,7 @@ export interface SelectionAnchor {
 	end: number;
 	rect: DOMRect;
 	containerLeft: number;
+	pending?: boolean;
 }
 
 interface SelectionContextValue {
@@ -41,7 +42,15 @@ interface SelectionContextValue {
 	containerRef: React.RefObject<HTMLDivElement | null>;
 	anchors: SelectionAnchor[];
 	openAnchorChatId: string | null;
-	addAnchor: (chatId: string, start: number, end: number, rect: DOMRect, containerLeft: number) => void;
+	addAnchor: (
+		chatId: string,
+		start: number,
+		end: number,
+		rect: DOMRect,
+		containerLeft: number,
+		pending?: boolean,
+	) => void;
+	resolveAnchor: (pendingId: string, realChatId: string) => void;
 	removeAnchor: (chatId: string) => void;
 	openAnchor: (chatId: string) => void;
 	closePanel: () => void;
@@ -134,16 +143,23 @@ export const SelectionProvider = ({
 	}, []);
 
 	const addAnchor = useCallback(
-		(chatId: string, start: number, end: number, rect: DOMRect, containerLeft: number) => {
+		(chatId: string, start: number, end: number, rect: DOMRect, containerLeft: number, pending?: boolean) => {
 			setAnchors((prev) => {
 				if (prev.some((a) => a.chatId === chatId)) {
 					return prev;
 				}
-				return [...prev, { chatId, start, end, rect, containerLeft }];
+				return [...prev, { chatId, start, end, rect, containerLeft, pending }];
 			});
 		},
 		[],
 	);
+
+	const resolveAnchor = useCallback((pendingId: string, realChatId: string) => {
+		setAnchors((prev) =>
+			prev.map((a) => (a.chatId === pendingId ? { ...a, chatId: realChatId, pending: false } : a)),
+		);
+		setOpenAnchorChatId((prev) => (prev === pendingId ? realChatId : prev));
+	}, []);
 
 	const removeAnchor = useCallback((chatId: string) => {
 		setAnchors((prev) => prev.filter((a) => a.chatId !== chatId));
@@ -174,6 +190,7 @@ export const SelectionProvider = ({
 				anchors,
 				openAnchorChatId,
 				addAnchor,
+				resolveAnchor,
 				removeAnchor,
 				openAnchor,
 				closePanel,

--- a/apps/frontend/src/hooks/use-fork-selection-ask.ts
+++ b/apps/frontend/src/hooks/use-fork-selection-ask.ts
@@ -5,25 +5,34 @@ import { useSelection } from '@/contexts/text-selection';
 import { trpc } from '@/main';
 
 export function useForkSelectionAsk(shareId: string, contentType: 'chat' | 'story') {
-	const { selection, addAnchor, openAnchor } = useSelection();
+	const { selection, addAnchor, resolveAnchor, removeAnchor, openAnchor } = useSelection();
 	const queryClient = useQueryClient();
 
 	const forkMutation = useMutation(trpc.chatFork.fork.mutationOptions());
 
-	return (data: SelectionData) => {
+	const ask = (data: SelectionData) => {
 		const captured = selection;
+		if (!captured || forkMutation.isPending) {
+			return;
+		}
+
+		const pendingId = crypto.randomUUID();
+		addAnchor(pendingId, captured.start, captured.end, captured.rect, captured.containerLeft, true);
+		openAnchor(pendingId);
+
 		forkMutation.mutate(
 			{ shareId, type: contentType, selection: data },
 			{
 				onSuccess: ({ chatId }) => {
 					queryClient.invalidateQueries({ queryKey: [['chat', 'listGrouped']] });
-					if (!captured) {
-						return;
-					}
-					addAnchor(chatId, captured.start, captured.end, captured.rect, captured.containerLeft);
-					openAnchor(chatId);
+					resolveAnchor(pendingId, chatId);
+				},
+				onError: () => {
+					removeAnchor(pendingId);
 				},
 			},
 		);
 	};
+
+	return ask;
 }

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -160,8 +160,11 @@ function ChatPage() {
 									<Badge variant='outline' className='gap-1 text-muted-foreground w-fit'>
 										<GitFork />
 										<span className='truncate'>
-											{chat.data.forkMetadata.type === 'story' ? 'Story' : 'Chat'} thread
-											from{' '}
+											{chat.data.forkMetadata.type === 'story' ||
+											chat.data.forkMetadata.type === 'story_selection'
+												? 'Story'
+												: 'Chat'}{' '}
+											thread from{' '}
 										</span>
 										<span className='text-xs text-foreground'>
 											{chat.data.forkMetadata.authorName}


### PR DESCRIPTION
## Summary

1. change of ask selection from shared assets :
- before : forked all origin chat of story or chat shared, along with all stories in that origin chat
- now : fork all origin chat but only messages with all parts and tools and don't re-create copies of stories no more

2. open the ask selection panel even when fork is proceeding 

3. resolve bug : put stories created by agent from ask selection panel into the "My private folder" in the story explorer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

