### PR TITLE
fix(compaction): ignore blank summaries during rehydration

### DIFF
--- a/apps/backend/src/utils/ai.ts
+++ b/apps/backend/src/utils/ai.ts
@@ -150,7 +150,7 @@ export function findLastCompactionPart(
 ): [CompactionPart, messageIdx: number] | [undefined, undefined] {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		for (const part of messages[i].parts) {
-			if (part.type === 'data-compaction') {
+			if (part.type === 'data-compaction' && part.data.summary.trim()) {
 				return [part.data, i];
 			}
 		}

--- a/apps/backend/tests/compaction.test.ts
+++ b/apps/backend/tests/compaction.test.ts
@@ -169,4 +169,23 @@ describe('compactionService.useLastCompaction', () => {
 		expect(result[3]).toEqual(messages[4]);
 		expect(result).toHaveLength(4);
 	});
+
+	it('returns messages unchanged when the only compaction entry has a blank summary (failed compaction)', () => {
+		// Regression test for issue #950:
+		// When compaction fails, summary: '' is persisted to the DB.
+		// Re-hydrating that blank summary creates { type: 'text', text: '' } in the assistant message,
+		// which Anthropic rejects with "text content blocks must be non-empty".
+		const messages: UIMessage[] = [
+			{ id: '1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+			{
+				id: '2',
+				role: 'assistant',
+				parts: [{ type: 'data-compaction', data: { summary: '', error: 'LLM error' } }],
+			},
+			{ id: '3', role: 'user', parts: [{ type: 'text', text: 'Follow-up' }] },
+		];
+
+		const result = compactionService.useLastCompaction(messages);
+		expect(result).toBe(messages);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #950.

When conversation compaction fails, an empty summary (`summary: ""`) is persisted. During conversation reconstruction, this empty summary is treated as a valid compaction and reconstructed into an assistant message containing an empty text block.

Anthropic rejects requests containing empty text content blocks, causing the conversation to fail.

## Changes

* Ignore blank compaction summaries in `findLastCompactionPart()`.
* Add a regression test covering failed compactions with empty summaries.

## Result

Failed compactions are treated as absent during rehydration, preventing invalid empty text blocks from being constructed while preserving the existing compaction metadata.

## Testing

* Added a regression test covering failed compactions with blank summaries.
* Verified the new regression test passes.
* Confirmed no unrelated files are modified by this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

