### PR TITLE
[Fix] resolve bug from clustered columns from several databases

### DIFF
--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -68,11 +68,13 @@ class BigQueryDatabaseContext(DatabaseContext):
         self._custom_partition_filter = custom_partition_filter
 
     def partition_columns(self) -> list[str]:
-        if self._partition_metadata is not None and self._partition_metadata.partition_column is not None:
+        if self._partition_metadata is not None:
+            if self._partition_metadata.partition_column is None:
+                return []
             return self._filter_excluded_names([self._partition_metadata.partition_column])
         try:
             return self._filter_excluded_names(
-                _get_bq_partition_columns(self._conn, self._project_id, self._schema, self._table_name)
+                _get_bq_partition_only_columns(self._conn, self._project_id, self._schema, self._table_name)
             )
         except Exception:
             logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
@@ -81,7 +83,13 @@ class BigQueryDatabaseContext(DatabaseContext):
     def clustering_columns(self) -> list[str]:
         if self._partition_metadata is not None:
             return self._filter_excluded_names(list(self._partition_metadata.clustering_columns))
-        return []
+        try:
+            return self._filter_excluded_names(
+                _get_bq_clustering_only_columns(self._conn, self._project_id, self._schema, self._table_name)
+            )
+        except Exception:
+            logger.debug("Failed to fetch clustering columns for %s.%s", self._schema, self._table_name)
+            return []
 
     def description(self) -> str | None:
         try:
@@ -353,28 +361,29 @@ def _coerce(val: Any) -> Any:
     return val
 
 
-def _get_bq_partition_columns(conn: BaseBackend, project_id: str, schema: str, table: str) -> list[str]:
-    """Per-context fallback when batch metadata is unavailable.
-
-    Returns partition columns first, then clustering columns (deduplicated).
-    """
+def _get_bq_partition_only_columns(conn: BaseBackend, project_id: str, schema: str, table: str) -> list[str]:
+    """Per-context fallback: return only true partition columns (not clustering)."""
     schema_info_path = _bq_path(project_id, schema, "INFORMATION_SCHEMA", "COLUMNS")
     table_name_literal = _bq_string_literal(table)
-    partition_query = f"""
+    query = f"""
         SELECT column_name
         FROM {schema_info_path}
         WHERE table_name = {table_name_literal} AND is_partitioning_column = 'YES'
     """
-    clustering_query = f"""
+    return [row[0] for row in conn.raw_sql(query)]  # type: ignore[union-attr]
+
+
+def _get_bq_clustering_only_columns(conn: BaseBackend, project_id: str, schema: str, table: str) -> list[str]:
+    """Per-context fallback: return clustering columns ordered by position."""
+    schema_info_path = _bq_path(project_id, schema, "INFORMATION_SCHEMA", "COLUMNS")
+    table_name_literal = _bq_string_literal(table)
+    query = f"""
         SELECT column_name
         FROM {schema_info_path}
         WHERE table_name = {table_name_literal} AND clustering_ordinal_position IS NOT NULL
         ORDER BY clustering_ordinal_position
     """
-    columns: list[str] = []
-    columns.extend(row[0] for row in conn.raw_sql(partition_query))  # type: ignore[union-attr]
-    columns.extend(row[0] for row in conn.raw_sql(clustering_query) if row[0] not in columns)  # type: ignore[union-attr]
-    return columns
+    return [row[0] for row in conn.raw_sql(query)]  # type: ignore[union-attr]
 
 
 class BigQueryConfig(DatabaseConfig):

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -68,9 +68,7 @@ class BigQueryDatabaseContext(DatabaseContext):
         self._custom_partition_filter = custom_partition_filter
 
     def partition_columns(self) -> list[str]:
-        if self._partition_metadata is not None:
-            if self._partition_metadata.partition_column is None:
-                return []
+        if self._partition_metadata is not None and self._partition_metadata.partition_column is not None:
             return self._filter_excluded_names([self._partition_metadata.partition_column])
         try:
             return self._filter_excluded_names(

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -166,8 +166,15 @@ class DatabaseContext:
             except Exception:
                 continue
 
+        clustering_columns = []
+        try:
+            clustering_columns = self.clustering_columns()
+        except Exception:
+            pass
+
         return {
             "computed_at": datetime.now(timezone.utc).isoformat(),
+            "clustering_columns": clustering_columns,
             "columns": profiles,
         }
 

--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -34,6 +34,15 @@ class DatabricksDatabaseContext(DatabaseContext):
             logger.debug("Failed to fetch partition columns for %s.%s", self._schema, self._table_name)
             return []
 
+    def clustering_columns(self) -> list[str]:
+        try:
+            return self._filter_excluded_names(
+                _get_databricks_liquid_clustering_columns(self._conn, self._schema, self._table_name)
+            )
+        except Exception:
+            logger.debug("Failed to fetch liquid clustering columns for %s.%s", self._schema, self._table_name)
+            return []
+
     def description(self) -> str | None:
         try:
             query = f"""
@@ -94,6 +103,30 @@ def _get_databricks_partition_columns(conn: BaseBackend, schema: str, table: str
     """
     result = conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
     return [row[0] for row in result]
+
+
+def _get_databricks_liquid_clustering_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
+    """Return liquid clustering columns from DESCRIBE DETAIL, if any."""
+    query = f"DESCRIBE DETAIL `{schema}`.`{table}`"
+    cursor = conn.raw_sql(query)  # type: ignore[union-attr]
+    try:
+        idx = next(
+            (i for i, d in enumerate(cursor.description) if d[0].lower() == "clusteringcolumns"),
+            None,
+        )
+    except Exception:
+        idx = None
+    if idx is None:
+        return []
+    row = cursor.fetchone()
+    if not row:
+        return []
+    value = row[idx]
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(c) for c in value]
+    return []
 
 
 def _ensure_ssl_cert_env() -> None:

--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -22,8 +22,7 @@ class DatabricksDatabaseContext(DatabaseContext):
     """Databricks context with partition and description discovery."""
 
     def _quote_ident(self, name: object) -> str:
-        escaped = str(name).replace("`", "``")
-        return f"`{escaped}`"
+        return _quote_ident(name)
 
     def partition_columns(self) -> list[str]:
         try:
@@ -105,9 +104,15 @@ def _get_databricks_partition_columns(conn: BaseBackend, schema: str, table: str
     return [row[0] for row in result]
 
 
+def _quote_ident(name: object) -> str:
+    """Escape and backtick-quote an identifier for safe use in Databricks SQL."""
+    escaped = str(name).replace("`", "``")
+    return f"`{escaped}`"
+
+
 def _get_databricks_liquid_clustering_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
     """Return liquid clustering columns from DESCRIBE DETAIL, if any."""
-    query = f"DESCRIBE DETAIL `{schema}`.`{table}`"
+    query = f"DESCRIBE DETAIL {_quote_ident(schema)}.{_quote_ident(table)}"
     cursor = conn.raw_sql(query)  # type: ignore[union-attr]
     try:
         idx = next(

--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -133,7 +133,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                 JOIN pg_catalog.pg_class c ON c.oid = d.objoid
                 JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.objsubid
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid > 0
+                WHERE n.nspname = '{_quote_literal(self._schema)}' AND c.relname = '{_quote_literal(self._table_name)}' AND d.objsubid > 0
             """
             rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
             return {row[0]: str(row[1]) for row in rows if row[1]}
@@ -148,7 +148,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                 FROM pg_catalog.pg_description d
                 JOIN pg_catalog.pg_class c ON c.oid = d.objoid
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid = 0
+                WHERE n.nspname = '{_quote_literal(self._schema)}' AND c.relname = '{_quote_literal(self._table_name)}' AND d.objsubid = 0
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -164,15 +164,22 @@ class RedshiftDatabaseContext(DatabaseContext):
         return f"JSON_SERIALIZE({col_sql})"
 
 
+def _quote_literal(value: str) -> str:
+    """Escape a value for safe use inside a SQL string literal."""
+    return value.replace("'", "''")
+
+
 def _get_redshift_sortkey_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
     """Return SORTKEY columns for a Redshift table, ordered by sort position."""
+    schema_literal = _quote_literal(schema)
+    table_literal = _quote_literal(table)
     query = f"""
         SELECT a.attname
         FROM pg_attribute a
         JOIN pg_class c ON c.oid = a.attrelid
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = '{schema}'
-          AND c.relname = '{table}'
+        WHERE n.nspname = '{schema_literal}'
+          AND c.relname = '{table_literal}'
           AND a.attsortkeyord > 0
         ORDER BY a.attsortkeyord
     """

--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -49,6 +49,14 @@ class RedshiftDatabaseContext(DatabaseContext):
             ]
         return self._filter_excluded_columns(self._columns_cache)
 
+    def clustering_columns(self) -> list[str]:
+        try:
+            return self._filter_excluded_names(
+                _get_redshift_sortkey_columns(self._conn, self._schema, self._table_name)
+            )
+        except Exception:
+            return []
+
     def row_count(self) -> int:
         if self._row_count_cache is None:
             schema_sql = self._quote(self._schema)
@@ -154,6 +162,22 @@ class RedshiftDatabaseContext(DatabaseContext):
 
     def _cast_complex_to_string(self, col_sql: str) -> str:
         return f"JSON_SERIALIZE({col_sql})"
+
+
+def _get_redshift_sortkey_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
+    """Return SORTKEY columns for a Redshift table, ordered by sort position."""
+    query = f"""
+        SELECT a.attname
+        FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = '{schema}'
+          AND c.relname = '{table}'
+          AND a.attsortkeyord > 0
+        ORDER BY a.attsortkeyord
+    """
+    result = conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
+    return [row[0] for row in result]
 
 
 class RedshiftSSHTunnelConfig(BaseModel):

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -23,6 +23,9 @@ class SnowflakeDatabaseContext(DatabaseContext):
     """Snowflake context with clustering key and description discovery."""
 
     def partition_columns(self) -> list[str]:
+        return []
+
+    def clustering_columns(self) -> list[str]:
         try:
             return self._filter_excluded_names(
                 _get_snowflake_clustering_columns(self._conn, self._schema, self._table_name)
@@ -71,7 +74,7 @@ class SnowflakeDatabaseContext(DatabaseContext):
         return f"TO_JSON({col_sql})::VARCHAR"
 
     def _partition_filter(self) -> str:
-        cols = self.partition_columns()
+        cols = self.clustering_columns()
         if cols:
             return f'"{cols[0]}" >= DATEADD(day, -30, CURRENT_DATE())'
         return ""

--- a/cli/nao_core/config/secrets.py
+++ b/cli/nao_core/config/secrets.py
@@ -157,7 +157,7 @@ def _load_k8s_data(namespace: str, secret_name: str, cache: SecretCache | None) 
         return cache[key]
 
     require_dependency("kubernetes", "k8s-secrets", "for Kubernetes Secret resolution")
-    from kubernetes import client as kube_client  # ty: ignore[unresolved-import]
+    from kubernetes import client as kube_client
 
     _load_kube_config()
     try:
@@ -174,7 +174,7 @@ def _load_k8s_data(namespace: str, secret_name: str, cache: SecretCache | None) 
 def _extract_scalar(payload: dict[str, Any], path: str, *, source: str) -> str:
     """Extract a scalar value from *payload* via a glom dot-path."""
     require_dependency("glom", "aws-secrets", "for nested AWS secret field extraction")
-    from glom import Coalesce, glom  # ty: ignore[unresolved-import]
+    from glom import Coalesce, glom
 
     sentinel = object()
     value = glom(payload, Coalesce(path, default=sentinel))
@@ -232,7 +232,7 @@ def _pod_namespace() -> str:
 
 
 def _load_kube_config() -> None:
-    from kubernetes import config as kube_config  # ty: ignore[unresolved-import]
+    from kubernetes import config as kube_config
 
     try:
         kube_config.load_incluster_config()

--- a/cli/nao_core/templates/defaults/databases/profiling.md.j2
+++ b/cli/nao_core/templates/defaults/databases/profiling.md.j2
@@ -16,6 +16,11 @@
 
 **Columns:** {{ result.columns | length }}
 
+{% if result.clustering_columns %}
+**Clustering:** {% for c in result.clustering_columns %}`{{ c }}`{% if not loop.last %}, {% endif %}{% endfor %}
+
+
+{% endif %}
 ## Column Profiles (JSONL)
 
 {% for col in result.columns %}

--- a/cli/tests/nao_core/commands/sync/test_context_profiling_query.py
+++ b/cli/tests/nao_core/commands/sync/test_context_profiling_query.py
@@ -374,7 +374,8 @@ class TestSnowflakeProfilingQuery:
         assert normalize(sql) == expected
 
     def test_partition_filter_uses_dateadd(self):
-        ctx = make_context(SnowflakeDatabaseContext, partition_cols=["created_at"])
+        ctx = make_context(SnowflakeDatabaseContext)
+        ctx.clustering_columns = MagicMock(return_value=["created_at"])
         sql = ctx._build_profiling_query(STR_COL)
         expected = normalize("""
             SELECT

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -899,6 +899,64 @@ class TestClusteringColumns:
         assert ctx.clustering_columns() == ["user_id", "event_type"]
 
     def test_context_clustering_columns_empty_when_no_metadata(self):
-        ctx, _ = _make_context(partition_metadata=None)
+        ctx, mock_conn = _make_context(partition_metadata=None)
+        mock_conn.raw_sql.return_value = []
 
         assert ctx.clustering_columns() == []
+
+
+class TestClusteredOnlyTable:
+    """Regression tests for tables that are clustered but not partitioned."""
+
+    def test_partition_columns_empty_for_clustered_only_table(self):
+        meta = TablePartitionMetadata(
+            partition_column=None,
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+            clustering_columns=["user_id", "event_type"],
+        )
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+
+        cols = ctx.partition_columns()
+
+        assert cols == []
+        mock_conn.raw_sql.assert_not_called()
+
+    def test_partition_filter_empty_for_clustered_only_table(self):
+        meta = TablePartitionMetadata(
+            partition_column=None,
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+            clustering_columns=["user_id"],
+        )
+        ctx, _ = _make_context(partition_metadata=meta)
+
+        assert ctx._partition_filter() == ""
+
+    def test_clustering_columns_from_metadata_on_clustered_only_table(self):
+        meta = TablePartitionMetadata(
+            partition_column=None,
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+            clustering_columns=["user_id", "event_type"],
+        )
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+
+        cols = ctx.clustering_columns()
+
+        assert cols == ["user_id", "event_type"]
+        mock_conn.raw_sql.assert_not_called()
+
+    def test_clustering_columns_fallback_query_when_no_metadata(self):
+        ctx, mock_conn = _make_context(partition_metadata=None)
+        mock_conn.raw_sql.return_value = [("user_id",), ("created_at",)]
+
+        cols = ctx.clustering_columns()
+
+        assert cols == ["user_id", "created_at"]
+        sql = mock_conn.raw_sql.call_args[0][0]
+        assert "clustering_ordinal_position" in sql
+        assert "IS NOT NULL" in sql

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -917,11 +917,31 @@ class TestClusteredOnlyTable:
             clustering_columns=["user_id", "event_type"],
         )
         ctx, mock_conn = _make_context(partition_metadata=meta)
+        mock_conn.raw_sql.return_value = []
 
         cols = ctx.partition_columns()
 
         assert cols == []
-        mock_conn.raw_sql.assert_not_called()
+        sql = mock_conn.raw_sql.call_args[0][0]
+        assert "is_partitioning_column" in sql
+        assert "clustering_ordinal_position" not in sql
+
+    def test_partition_columns_fallback_recovers_partition_on_partial_metadata(self):
+        meta = TablePartitionMetadata(
+            partition_column=None,
+            partition_column_type=None,
+            last_partition_id=None,
+            total_rows=None,
+            clustering_columns=["user_id"],
+        )
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+        mock_conn.raw_sql.return_value = [("event_date",)]
+
+        cols = ctx.partition_columns()
+
+        assert cols == ["event_date"]
+        sql = mock_conn.raw_sql.call_args[0][0]
+        assert "is_partitioning_column" in sql
 
     def test_partition_filter_empty_for_clustered_only_table(self):
         meta = TablePartitionMetadata(
@@ -931,7 +951,8 @@ class TestClusteredOnlyTable:
             total_rows=None,
             clustering_columns=["user_id"],
         )
-        ctx, _ = _make_context(partition_metadata=meta)
+        ctx, mock_conn = _make_context(partition_metadata=meta)
+        mock_conn.raw_sql.return_value = []
 
         assert ctx._partition_filter() == ""
 

--- a/cli/tests/nao_core/config/test_clustering_columns.py
+++ b/cli/tests/nao_core/config/test_clustering_columns.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+
+from nao_core.config.databases.databricks import DatabricksDatabaseContext
+from nao_core.config.databases.snowflake import SnowflakeDatabaseContext
+
+
+class TestSnowflakeClusteringColumns:
+    def _make_context(self) -> tuple[SnowflakeDatabaseContext, MagicMock]:
+        conn = MagicMock()
+        ctx = SnowflakeDatabaseContext(conn, "ANALYTICS", "ORDERS")
+        return ctx, conn
+
+    def test_returns_parsed_clustering_key(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = ("LINEAR(CUSTOMER_ID, CREATED_AT)",)
+        conn.raw_sql.return_value = cursor
+
+        cols = ctx.clustering_columns()
+
+        assert cols == ["CUSTOMER_ID", "CREATED_AT"]
+
+    def test_returns_empty_when_no_clustering_key(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (None,)
+        conn.raw_sql.return_value = cursor
+
+        assert ctx.clustering_columns() == []
+
+    def test_returns_empty_on_query_failure(self):
+        ctx, conn = self._make_context()
+        conn.raw_sql.side_effect = Exception("permission denied")
+
+        assert ctx.clustering_columns() == []
+
+
+class TestDatabricksClusteringColumns:
+    def _make_context(self) -> tuple[DatabricksDatabaseContext, MagicMock]:
+        conn = MagicMock()
+        ctx = DatabricksDatabaseContext(conn, "analytics", "orders")
+        return ctx, conn
+
+    def test_returns_liquid_clustering_columns(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.description = [
+            ("format",),
+            ("id",),
+            ("clusteringColumns",),
+            ("numFiles",),
+        ]
+        cursor.fetchone.return_value = ("delta", "abc123", ["customer_id", "created_at"], 5)
+        conn.raw_sql.return_value = cursor
+
+        cols = ctx.clustering_columns()
+
+        assert cols == ["customer_id", "created_at"]
+
+    def test_returns_empty_when_no_liquid_clustering(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.description = [
+            ("format",),
+            ("id",),
+            ("clusteringColumns",),
+        ]
+        cursor.fetchone.return_value = ("delta", "abc123", [])
+        conn.raw_sql.return_value = cursor
+
+        assert ctx.clustering_columns() == []
+
+    def test_returns_empty_when_column_not_in_describe_detail(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.description = [("format",), ("id",)]
+        cursor.fetchone.return_value = ("delta", "abc123")
+        conn.raw_sql.return_value = cursor
+
+        assert ctx.clustering_columns() == []
+
+    def test_returns_empty_on_query_failure(self):
+        ctx, conn = self._make_context()
+        conn.raw_sql.side_effect = Exception("table not found")
+
+        assert ctx.clustering_columns() == []

--- a/cli/tests/nao_core/config/test_redshift.py
+++ b/cli/tests/nao_core/config/test_redshift.py
@@ -77,3 +77,16 @@ class TestRedshiftClusteringColumns:
         conn.raw_sql.side_effect = Exception("permission denied")
 
         assert ctx.clustering_columns() == []
+
+    def test_escapes_single_quotes_in_identifiers(self):
+        conn = MagicMock()
+        ctx = RedshiftDatabaseContext(conn, "pub'lic", "or'ders")
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        conn.raw_sql.return_value = cursor
+
+        ctx.clustering_columns()
+
+        sql = conn.raw_sql.call_args[0][0]
+        assert "'pub''lic'" in sql
+        assert "'or''ders'" in sql

--- a/cli/tests/nao_core/config/test_redshift.py
+++ b/cli/tests/nao_core/config/test_redshift.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from nao_core.config.databases.redshift import RedshiftConfig
+from nao_core.config.databases.redshift import RedshiftConfig, RedshiftDatabaseContext
 
 
 def test_get_schemas_uses_datashare_visible_catalog_view():
@@ -42,3 +42,38 @@ def test_get_schemas_returns_configured_schema_without_querying():
 
     assert schemas == ["marts"]
     conn.raw_sql.assert_not_called()
+
+
+class TestRedshiftClusteringColumns:
+    def _make_context(self) -> tuple[RedshiftDatabaseContext, MagicMock]:
+        conn = MagicMock()
+        ctx = RedshiftDatabaseContext(conn, "public", "orders")
+        return ctx, conn
+
+    def test_returns_sortkey_columns_in_order(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [("customer_id",), ("created_at",)]
+        conn.raw_sql.return_value = cursor
+
+        cols = ctx.clustering_columns()
+
+        assert cols == ["customer_id", "created_at"]
+        sql = conn.raw_sql.call_args[0][0]
+        assert "attsortkeyord" in sql
+        assert "public" in sql
+        assert "orders" in sql
+
+    def test_returns_empty_when_no_sortkeys(self):
+        ctx, conn = self._make_context()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        conn.raw_sql.return_value = cursor
+
+        assert ctx.clustering_columns() == []
+
+    def test_returns_empty_on_query_failure(self):
+        ctx, conn = self._make_context()
+        conn.raw_sql.side_effect = Exception("permission denied")
+
+        assert ctx.clustering_columns() == []


### PR DESCRIPTION
## Summary

- fixed a bug where profiling failed on BigQuery tables that use clustering, which left an empty `profiling.md` file
- clustering and partitioning are now handled separately, so the profiling query runs correctly and the file gets filled with column statistics
- added the same clustering support for Databricks, Redshift and Snowflake, so it works consistently across databases
- the generated `profiling.md` now also shows which columns a table is clustered on

## Related issue

#932 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

