### PR TITLE
[fix] 950 : restore and update compaction function & completes PR 985

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -332,26 +332,26 @@ class AgentManager {
 	}
 
 	private async _prepareStep(messages: ModelMessage[]): Promise<{ messages: ModelMessage[] }> {
-		// await compactionService.compactConversationIfNeeded({
-		// 	chat: this.chat,
-		// 	provider: this._modelSelection.provider,
-		// 	messages,
-		// 	tools: this._agentTools,
-		// 	maxOutputTokens: MAX_OUTPUT_TOKENS,
-		// 	contextWindow: this._modelConfig.contextWindow,
-		// 	onCompactionStarted: () => {
-		// 		this._streamWriter?.write({
-		// 			type: 'data-compactionSummaryStarted',
-		// 			data: undefined,
-		// 		});
-		// 	},
-		// 	onCompactionFinished: (result) => {
-		// 		this._streamWriter?.write({
-		// 			type: 'data-compaction',
-		// 			data: result,
-		// 		});
-		// 	},
-		// });
+		await compactionService.compactConversationIfNeeded({
+			chat: this.chat,
+			provider: this._modelSelection.provider,
+			messages,
+			tools: this._agentTools,
+			maxOutputTokens: MAX_OUTPUT_TOKENS,
+			contextWindow: this._modelConfig.contextWindow,
+			onCompactionStarted: () => {
+				this._streamWriter?.write({
+					type: 'data-compactionSummaryStarted',
+					data: undefined,
+				});
+			},
+			onCompactionFinished: (result) => {
+				this._streamWriter?.write({
+					type: 'data-compaction',
+					data: result,
+				});
+			},
+		});
 
 		return { messages: this._addCache(this._pruneMessages(messages)) };
 	}
@@ -893,7 +893,6 @@ async function resolveImageUrls<T extends MessageLike>(messages: T[]): Promise<T
 				return part;
 			}
 			const base64Data = imageDataMap.get(match[1]);
-			console.log(`[debug] base64Data for ${match[1]}: ${base64Data}`);
 			if (!base64Data) {
 				return part;
 			}

--- a/apps/backend/src/services/token-counter.ts
+++ b/apps/backend/src/services/token-counter.ts
@@ -5,6 +5,13 @@ import { getJsonSchema } from '../utils/tools';
 
 const ESTIMATED_TOKENS_PER_IMAGE = 1000;
 
+function isImagePart(part: Record<string, unknown>): boolean {
+	if (typeof part.data === 'string' && part.data.startsWith('data:')) {
+		return true;
+	}
+	return typeof part.mediaType === 'string' && part.mediaType.startsWith('image/');
+}
+
 export interface ITokenCounter {
 	estimateMessages(messages: ModelMessage[]): number;
 	estimateTools(tools: Record<string, Tool>): Promise<number>;
@@ -32,7 +39,7 @@ export class TokenCounter implements ITokenCounter {
 
 		let imageCount = 0;
 		const sanitizedContent = (message.content as Record<string, unknown>[]).map((part) => {
-			if (part.type === 'file' && typeof part.data === 'string' && part.data.startsWith('data:')) {
+			if (part.type === 'file' && typeof part.data === 'string' && isImagePart(part)) {
 				imageCount++;
 				return { ...part, data: '[image]' };
 			}

--- a/apps/backend/tests/compaction.test.ts
+++ b/apps/backend/tests/compaction.test.ts
@@ -8,11 +8,13 @@ import type { AgentTools, UIMessage } from '../src/types/chat';
 const mocks = vi.hoisted(() => ({
 	compactMock: vi.fn(),
 	resolveProviderModelMock: vi.fn(),
+	resolveAnnotationModelIdMock: vi.fn(),
 	scheduleSaveMock: vi.fn(),
 }));
 
 vi.mock('../src/utils/llm', () => ({
 	resolveProviderModel: mocks.resolveProviderModelMock,
+	resolveAnnotationModelId: mocks.resolveAnnotationModelIdMock,
 }));
 
 vi.mock('../src/utils/schedule-task', () => ({
@@ -43,6 +45,7 @@ describe('compactionService.compactConversationIfNeeded', () => {
 			tokenCounter,
 		});
 		mocks.resolveProviderModelMock.mockResolvedValue({ model: {} });
+		mocks.resolveAnnotationModelIdMock.mockResolvedValue('gpt-4.1-mini');
 		mocks.compactMock.mockResolvedValue({
 			summary: 'Conversation summary',
 			usage: { totalTokens: 123 },

--- a/apps/frontend/src/components/chat-messages/assistant-compaction.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-compaction.tsx
@@ -2,29 +2,28 @@ import { memo, useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Conversation, ConversationContent } from '../ui/conversation';
 import { ErrorMessage } from '../ui/error-message';
+import { TextShimmer } from '../ui/text-shimmer';
 import type { CompactionPart } from '@nao/backend/chat';
 import { Expandable } from '@/components/ui/expandable';
 
 export const AssistantCompaction = memo(({ part }: { part?: CompactionPart }) => {
 	const [isExpanded, setIsExpanded] = useState(false);
 
-	const title = !part ? 'Compacting conversation' : part.error ? 'Compaction failed' : 'Compacted conversation';
+	if (!part) {
+		return <TextShimmer showLogo text='Compacting conversation' />;
+	}
+
+	const title = part.error ? 'Compaction failed' : 'Compacted conversation';
 
 	return (
-		<Expandable
-			title={title}
-			expanded={isExpanded}
-			disabled={!part}
-			isLoading={!part}
-			onExpandedChange={setIsExpanded}
-		>
+		<Expandable title={title} expanded={isExpanded} onExpandedChange={setIsExpanded}>
 			<div className='text-muted-foreground markdown-small'>
 				<Conversation className='p-0'>
 					<ConversationContent className='p-0 max-h-[200px]'>
-						{part?.error ? (
+						{part.error ? (
 							<ErrorMessage message={part.error} />
 						) : (
-							<Streamdown mode='static'>{part?.summary}</Streamdown>
+							<Streamdown mode='static'>{part.summary}</Streamdown>
 						)}
 					</ConversationContent>
 				</Conversation>


### PR DESCRIPTION
## Summary

- re-enables conversation compaction, which was temporarily disabled when image upload was introduced
- fixes image token counting so compaction no longer kicks in too aggressively when a chat contains images
- shows the animated nao logo while a conversation is being compacted, for consistency with the main loader
- removes a leftover debug log

## Related issue

#950 

## Which completes PR

#985 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

