### PR TITLE
feat(email): add optional SMTP_USER to decouple auth username from SMTP_MAIL_FROM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,9 @@ SMTP_HOST=              # smtp.yourservice.com
 SMTP_SSL=false
 SMTP_PORT=              # Default to 587
 SMTP_MAIL_FROM=
+# Optional SMTP auth username — falls back to SMTP_MAIL_FROM when unset.
+# Set this when the login username differs from the "From" address (e.g. AWS SES).
+# SMTP_USER=
 SMTP_PASSWORD=
 
 # GOOGLE OAuth Configuration

--- a/apps/backend/scripts/send-test-email.mjs
+++ b/apps/backend/scripts/send-test-email.mjs
@@ -10,7 +10,7 @@ dotenv.config({
 	path: path.join(process.cwd(), '..', '..', '.env'),
 });
 
-const { SMTP_HOST, SMTP_PORT, SMTP_SSL, SMTP_MAIL_FROM, SMTP_PASSWORD } = process.env;
+const { SMTP_HOST, SMTP_PORT, SMTP_SSL, SMTP_USER, SMTP_MAIL_FROM, SMTP_PASSWORD } = process.env;
 
 const to = process.argv[2] || SMTP_MAIL_FROM;
 
@@ -35,7 +35,7 @@ const transporter = nodemailer.createTransport({
 	port: Number(SMTP_PORT) || 587,
 	secure: SMTP_SSL === 'true',
 	auth: {
-		user: SMTP_MAIL_FROM,
+		user: SMTP_USER || SMTP_MAIL_FROM,
 		pass: SMTP_PASSWORD,
 	},
 });

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -72,6 +72,7 @@ const envSchema = z.object({
 	SMTP_PASSWORD: z.string().optional(),
 	SMTP_HOST: z.string().optional(),
 	SMTP_PORT: z.string().optional(),
+	SMTP_USER: z.string().optional(),
 	SMTP_MAIL_FROM: z.string().optional(),
 	SMTP_SSL: z.enum(['true', 'false']).optional(),
 

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -14,7 +14,7 @@ class EmailService {
 	}
 
 	private _initialize() {
-		const { SMTP_HOST, SMTP_PORT, SMTP_MAIL_FROM, SMTP_PASSWORD, SMTP_SSL } = env;
+		const { SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_MAIL_FROM, SMTP_PASSWORD, SMTP_SSL } = env;
 
 		if (!SMTP_HOST || !SMTP_MAIL_FROM || !SMTP_PASSWORD) {
 			return;
@@ -26,7 +26,7 @@ class EmailService {
 				port: Number(SMTP_PORT) || 587,
 				secure: SMTP_SSL === 'true',
 				auth: {
-					user: SMTP_MAIL_FROM,
+					user: SMTP_USER || SMTP_MAIL_FROM,
 					pass: SMTP_PASSWORD,
 				},
 			});

--- a/apps/backend/tests/email.test.ts
+++ b/apps/backend/tests/email.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnv: Record<string, unknown> = {};
+
+vi.mock('../src/env', () => ({
+	get env() {
+		return mockEnv;
+	},
+}));
+
+const { createTransport } = vi.hoisted(() => ({ createTransport: vi.fn() }));
+
+vi.mock('nodemailer', () => ({
+	default: { createTransport },
+}));
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}));
+
+function setSmtpEnv(overrides: Record<string, string | undefined> = {}): void {
+	mockEnv.SMTP_HOST = 'smtp.example.com';
+	mockEnv.SMTP_MAIL_FROM = 'from@example.com';
+	mockEnv.SMTP_PASSWORD = 'secret';
+	Object.assign(mockEnv, overrides);
+}
+
+async function loadEmailService() {
+	vi.resetModules();
+	return import('../src/services/email');
+}
+
+describe('email.service SMTP auth user', () => {
+	beforeEach(() => {
+		Object.keys(mockEnv).forEach((key) => delete mockEnv[key]);
+		createTransport.mockReset();
+		createTransport.mockReturnValue({ sendMail: vi.fn() });
+	});
+
+	it('uses SMTP_MAIL_FROM as the auth user when SMTP_USER is unset', async () => {
+		setSmtpEnv();
+		const { emailService } = await loadEmailService();
+
+		expect(emailService.isEnabled()).toBe(true);
+		expect(createTransport).toHaveBeenCalledWith(
+			expect.objectContaining({ auth: { user: 'from@example.com', pass: 'secret' } }),
+		);
+	});
+
+	it('uses SMTP_USER as the auth user when set', async () => {
+		setSmtpEnv({ SMTP_USER: 'AKIAIOSFODNN7EXAMPLE' });
+		const { emailService } = await loadEmailService();
+
+		expect(emailService.isEnabled()).toBe(true);
+		expect(createTransport).toHaveBeenCalledWith(
+			expect.objectContaining({ auth: { user: 'AKIAIOSFODNN7EXAMPLE', pass: 'secret' } }),
+		);
+	});
+
+	it('does not initialize the transporter when SMTP config is incomplete', async () => {
+		mockEnv.SMTP_HOST = 'smtp.example.com';
+		const { emailService } = await loadEmailService();
+
+		expect(emailService.isEnabled()).toBe(false);
+		expect(createTransport).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

The email service hardcoded the SMTP authentication username to `SMTP_MAIL_FROM`, assuming the login username equals the "From" address. This breaks providers where they differ — e.g. AWS SES, whose SMTP username is a 20-char credential ID (derived from IAM) rather than an email address, while the "From" must be a verified identity.

Closes #993.

### Change

Add an optional `SMTP_USER` env var and fall back to `SMTP_MAIL_FROM` when it's unset, so the change is fully backward compatible.

- `apps/backend/src/env.ts` — add optional `SMTP_USER` to the env schema.
- `apps/backend/src/services/email.ts` — use `SMTP_USER || SMTP_MAIL_FROM` as the auth user.
- `apps/backend/scripts/send-test-email.mjs` — apply the same fallback in the test-email script for consistency.
- `.env.example` — document the new optional variable.
- `apps/backend/tests/email.test.ts` — new tests covering the fallback and the explicit-user cases.

### Testing

- `npm run -w @nao/backend test -- tests/email.test.ts` — 3/3 passing (fallback to `SMTP_MAIL_FROM`, explicit `SMTP_USER`, and incomplete-config no-init).
- `npm run lint` — passes across backend, frontend, and shared.
- `npm run format:check` — passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14d3-9f4e-7987-8f08-22e1945aa2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14d3-9f4e-7987-8f08-22e1945aa2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

