### PR TITLE
fix: ship libmariadb3 in runtime image and clarify missing-system-library error (#988)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fontconfig \
     fonts-dejavu-core \
     git \
+    libmariadb3 \
     libpq5 \
     openssh-client \
     supervisor \

--- a/cli/nao_core/deps.py
+++ b/cli/nao_core/deps.py
@@ -52,6 +52,24 @@ _PROVIDER_ALIASES: dict[str, str] = {
     "vertex": "gemini",
 }
 
+# Native system libraries required by certain backends, keyed by ibis backend
+# name. Used to give an actionable hint when the Python package is installed but
+# the shared library it links against is missing from the host.
+_SYSTEM_LIBRARY_HINTS: dict[str, str] = {
+    "mysql": "the MySQL/MariaDB client library (on Debian/Ubuntu: 'apt-get install libmariadb3')",
+    "postgres": "the PostgreSQL client library (on Debian/Ubuntu: 'apt-get install libpq5')",
+    "mssql": "the unixODBC driver manager (on Debian/Ubuntu: 'apt-get install unixodbc')",
+}
+
+# Substrings found in ImportError messages when a native shared library cannot
+# be loaded, across Linux, macOS and Windows.
+_SHARED_LIBRARY_ERROR_MARKERS: tuple[str, ...] = (
+    "cannot open shared object file",
+    "library not loaded",
+    "image not found",
+    "dll load failed",
+)
+
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -76,12 +94,33 @@ class MissingDependencyError(ImportError):
         super().__init__(message)
 
 
+class MissingSystemLibraryError(ImportError):
+    """Raised when a dependency is installed but a native library it links
+    against cannot be loaded (e.g. a missing shared object on the host)."""
+
+    def __init__(self, component: str, original_error: BaseException, hint: str | None = None):
+        self.component = component
+        self.original_error = original_error
+        lines = [
+            f"The '{component}' backend is installed but a required system library could not be loaded:",
+            f"  {original_error}",
+            "This is a missing system (native) library, not a missing Python package.",
+        ]
+        if hint:
+            lines.append(f"Install {hint} and try again.")
+        super().__init__("\n".join(lines))
+
+
 def require_dependency(package: str, extra: str, purpose: str = "") -> None:
     """Verify that *package* is importable, raising a helpful error if not."""
     try:
         importlib.import_module(package)
-    except ImportError:
-        raise MissingDependencyError(package, extra, purpose) from None
+    except ModuleNotFoundError as error:
+        raise MissingDependencyError(package, extra, purpose) from error
+    except ImportError as error:
+        if _is_missing_shared_library(error):
+            raise MissingSystemLibraryError(package, error) from error
+        raise
 
 
 def require_database_backend(backend: str, *, extra: str | None = None, database_type: str | None = None) -> None:
@@ -90,12 +129,16 @@ def require_database_backend(backend: str, *, extra: str | None = None, database
     display_type = database_type or backend
     try:
         importlib.import_module(f"ibis.backends.{backend}")
-    except (ImportError, ModuleNotFoundError):
+    except ModuleNotFoundError as error:
         raise MissingDependencyError(
             f"ibis-framework[{backend}]",
             install_extra,
             f"to connect to {display_type} databases",
-        ) from None
+        ) from error
+    except ImportError as error:
+        if _is_missing_shared_library(error):
+            raise MissingSystemLibraryError(display_type, error, _SYSTEM_LIBRARY_HINTS.get(backend)) from error
+        raise
 
 
 def get_required_extras(config: NaoConfig) -> list[str]:
@@ -168,6 +211,12 @@ def install_extras(extras: list[str]) -> bool:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _is_missing_shared_library(error: ImportError) -> bool:
+    """Heuristically detect an ImportError caused by a missing native library."""
+    message = str(error).lower()
+    return any(marker in message for marker in _SHARED_LIBRARY_ERROR_MARKERS)
 
 
 def _resolve_extra(provider_or_type: str) -> str | None:

--- a/cli/tests/nao_core/test_deps.py
+++ b/cli/tests/nao_core/test_deps.py
@@ -1,6 +1,11 @@
 import pytest
 
-from nao_core.deps import MissingDependencyError, require_database_backend
+from nao_core.deps import (
+    MissingDependencyError,
+    MissingSystemLibraryError,
+    require_database_backend,
+    require_dependency,
+)
 
 
 def test_require_database_backend_uses_public_extra_for_shared_ibis_backend(monkeypatch):
@@ -17,3 +22,59 @@ def test_require_database_backend_uses_public_extra_for_shared_ibis_backend(monk
     assert "to connect to redshift databases" in message
     assert "pip install 'nao-core[redshift]'" in message
     assert "uv pip install 'nao-core[redshift]'" in message
+
+
+def test_require_database_backend_reports_missing_system_library(monkeypatch):
+    def raise_missing_shared_lib(module_name: str):
+        assert module_name == "ibis.backends.mysql"
+        raise ImportError("libmariadb.so.3: cannot open shared object file: No such file or directory")
+
+    monkeypatch.setattr("nao_core.deps.importlib.import_module", raise_missing_shared_lib)
+
+    with pytest.raises(MissingSystemLibraryError) as exc_info:
+        require_database_backend("mysql")
+
+    message = str(exc_info.value)
+    assert "libmariadb.so.3" in message
+    assert "system" in message
+    assert "libmariadb3" in message
+    assert "pip install 'nao-core[mysql]'" not in message
+
+
+def test_require_database_backend_does_not_mask_unrelated_import_errors(monkeypatch):
+    def raise_unrelated(module_name: str):
+        raise ImportError("some unrelated import failure")
+
+    monkeypatch.setattr("nao_core.deps.importlib.import_module", raise_unrelated)
+
+    with pytest.raises(ImportError) as exc_info:
+        require_database_backend("mysql")
+
+    assert not isinstance(exc_info.value, (MissingDependencyError, MissingSystemLibraryError))
+
+
+def test_require_dependency_reports_missing_system_library(monkeypatch):
+    def raise_missing_shared_lib(module_name: str):
+        raise ImportError("libfoo.so.1: cannot open shared object file: No such file or directory")
+
+    monkeypatch.setattr("nao_core.deps.importlib.import_module", raise_missing_shared_lib)
+
+    with pytest.raises(MissingSystemLibraryError) as exc_info:
+        require_dependency("some_package", "some-extra")
+
+    message = str(exc_info.value)
+    assert "libfoo.so.1" in message
+    assert "system" in message
+
+
+def test_require_dependency_reports_missing_python_package(monkeypatch):
+    def raise_missing_module(module_name: str):
+        raise ModuleNotFoundError(f"No module named '{module_name}'")
+
+    monkeypatch.setattr("nao_core.deps.importlib.import_module", raise_missing_module)
+
+    with pytest.raises(MissingDependencyError) as exc_info:
+        require_dependency("some_package", "some-extra", "for testing")
+
+    message = str(exc_info.value)
+    assert "pip install 'nao-core[some-extra]'" in message


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #988 — the `getnao/nao` Docker image bundled `mysqlclient` (built against MariaDB Connector/C) but not its runtime shared library `libmariadb.so.3`, so any MySQL datasource failed at import time with a misleading "package required" message.

Two changes:

1. **`Dockerfile`** — install `libmariadb3` in the runtime stage so `import MySQLdb` (and thus the ibis MySQL backend) works out of the box. The builder stage already installs `libmariadb-dev`; only the runtime lib was missing.
2. **`cli/nao_core/deps.py`** — `require_database_backend` / `require_dependency` previously caught any `ImportError` and reported `pip install 'nao-core[mysql]'`, even when the real cause was a missing native library. They now distinguish the two cases:
   - `ModuleNotFoundError` → the Python package is genuinely missing → existing `MissingDependencyError` (pip/uv install hint).
   - Plain `ImportError` from a failed shared-object load → new `MissingSystemLibraryError` that surfaces the real loader error (e.g. `libmariadb.so.3: cannot open shared object file`) and suggests installing the system library.
   - Any other `ImportError` is re-raised unchanged instead of being masked.

## Root cause

```
$ python -c "import ibis.backends.mysql"
ImportError: libmariadb.so.3: cannot open shared object file: No such file or directory
```

`ibis/backends/mysql/__init__.py` imports `MySQLdb` at module load; `MySQLdb._mysql` links `libmariadb.so.3`. With the lib absent, the import raises `ImportError`, which `require_database_backend("mysql")` masked behind the "package required" message.

## Testing

- ✅ `uv run pytest tests/nao_core/test_deps.py` — 5 passed (incl. new system-library / unrelated-error cases)
- ✅ `uv run pytest tests/nao_core/commands/sync/test_database_provider.py` — 12 passed
- ✅ `make lint` (ty, ruff check, ruff format) — all checks passed
- ✅ End-to-end repro: hid `/lib/x86_64-linux-gnu/libmariadb.so.3` and confirmed the new message; restoring the lib makes `require_database_backend("mysql")` succeed.
- ✅ Confirmed `libmariadb3` provides `/usr/lib/x86_64-linux-gnu/libmariadb.so.3`.

Before vs. after error message:
[mysql_error_message_before_after.txt](https://cursor.com/agents/bc-019f14e7-1ff1-71b3-ab6d-8a68d90669d3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmysql_error_message_before_after.txt)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14e7-1ff1-71b3-ab6d-8a68d90669d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14e7-1ff1-71b3-ab6d-8a68d90669d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

