### PR TITLE
feat(agent): dialect-aware system prompt with Redshift rules

### DIFF
--- a/apps/backend/src/components/ai/dialect-rules.tsx
+++ b/apps/backend/src/components/ai/dialect-rules.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from 'react';
+
+import { Bold, ListItem } from '../../lib/markdown';
+
+type ConnectionLike = { type: string };
+
+/**
+ * Dialect-specific guidance injected into the system prompt for the warehouses a
+ * project is connected to. Every rule here is applied automatically whenever a
+ * matching connection is present, so users get warehouse-aware behaviour without
+ * editing their own RULES.md.
+ *
+ * This registry is meant to grow over time: when we observe the agent emitting SQL
+ * that a given warehouse rejects, add a rule with the supported alternative.
+ */
+export type DialectGuidance = {
+	/** Connection `type` values (lowercased) this guidance applies to. */
+	matches: string[];
+	/** Bold heading shown before the dialect's SQL rules, e.g. "Redshift dialect". */
+	label: string;
+	/** Rules added to the "SQL Query Rules" section. */
+	sqlRules?: string[];
+	/** Rules added to the "Tool Calls" section. */
+	toolRules?: string[];
+};
+
+export const DIALECT_GUIDANCE: DialectGuidance[] = [
+	{
+		matches: ['clickhouse'],
+		label: 'ClickHouse dialect',
+		toolRules: [
+			'When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY KEY, PARTITION BY) so you can write efficient queries.',
+		],
+	},
+	{
+		matches: ['mssql', 'fabric'],
+		label: 'T-SQL dialect (Fabric/MSSQL)',
+		sqlRules: [
+			'Use TOP N instead of LIMIT N (e.g. SELECT TOP 10 * FROM table).',
+			'Do not use GROUP BY ALL — explicitly list all non-aggregated columns in the GROUP BY clause.',
+			'Use T-SQL date functions (DATEADD, DATEDIFF, CONVERT, FORMAT) instead of PostgreSQL-style intervals or TO_CHAR.',
+			'Use ISNULL() instead of COALESCE() when there are only two arguments.',
+		],
+	},
+	{
+		matches: ['bigquery'],
+		label: 'BigQuery dialect',
+		sqlRules: [
+			'Use backtick-quoted identifiers (e.g. `project.dataset.table`).',
+			'Use SAFE_DIVIDE for division to avoid division-by-zero errors.',
+		],
+	},
+	{
+		matches: ['mysql'],
+		label: 'MySQL dialect',
+		sqlRules: [
+			'Use backtick-quoted identifiers for column and table names.',
+			'Use IFNULL() instead of COALESCE() when there are only two arguments.',
+		],
+	},
+	{
+		matches: ['redshift'],
+		label: 'Redshift dialect',
+		sqlRules: [
+			'Do not use SELECT DISTINCT ON (...) — it is not supported. Deduplicate with ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...) in a subquery and keep the rows where the row number equals 1.',
+			'Do not put multiple PERCENTILE_CONT with different ORDER BY clauses in the same query — compute each percentile in its own CTE, then join the results.',
+			'Do not combine LISTAGG(DISTINCT ...) with PERCENTILE_CONT in the same SELECT — split them into separate CTEs.',
+			"Do not call CONCAT() with literal string arguments (e.g. CONCAT(first_name, ' ', last_name)). Use the || operator instead (e.g. first_name || ' ' || last_name).",
+			"Do not use DATE_PART('year', AGE(date)). Use DATEDIFF('year', birthdate, CURRENT_DATE) instead.",
+			'Do not use COUNT(*) FILTER (WHERE ...). Use COUNT(CASE WHEN ... THEN 1 END) instead.',
+		],
+	},
+];
+
+export function getDialectSqlQueryRules(connections: ConnectionLike[]): ReactNode[] {
+	return getActiveDialectGuidance(connections).flatMap(toSqlRuleItems);
+}
+
+export function getDialectToolCallRules(connections: ConnectionLike[]): ReactNode[] {
+	return getActiveDialectGuidance(connections).flatMap(toToolRuleItems);
+}
+
+function getActiveDialectGuidance(connections: ConnectionLike[]): DialectGuidance[] {
+	const presentTypes = new Set(connections.map((connection) => connection.type.toLowerCase()));
+	return DIALECT_GUIDANCE.filter((guidance) => guidance.matches.some((match) => presentTypes.has(match)));
+}
+
+function toSqlRuleItems(guidance: DialectGuidance): ReactNode[] {
+	return (guidance.sqlRules ?? []).map((rule, index) =>
+		index === 0 ? (
+			<ListItem>
+				<Bold>{guidance.label}:</Bold> {rule}
+			</ListItem>
+		) : (
+			<ListItem>{rule}</ListItem>
+		),
+	);
+}
+
+function toToolRuleItems(guidance: DialectGuidance): ReactNode[] {
+	return (guidance.toolRules ?? []).map((rule) => <ListItem>{rule}</ListItem>);
+}

--- a/apps/backend/src/components/ai/dialect-rules.tsx
+++ b/apps/backend/src/components/ai/dialect-rules.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { Bold, ListItem } from '../../lib/markdown';
+import { Bold, Code, ListItem } from '../../lib/markdown';
 
 type ConnectionLike = { type: string };
 
@@ -11,17 +11,19 @@ type ConnectionLike = { type: string };
  * editing their own RULES.md.
  *
  * This registry is meant to grow over time: when we observe the agent emitting SQL
- * that a given warehouse rejects, add a rule with the supported alternative.
+ * that a given warehouse rejects, add a rule with the supported alternative. Rules
+ * are authored with the same markdown components as the system prompt, so SQL can
+ * be wrapped in <Code> and emphasised with <Bold>.
  */
 export type DialectGuidance = {
 	/** Connection `type` values (lowercased) this guidance applies to. */
 	matches: string[];
 	/** Bold heading shown before the dialect's SQL rules, e.g. "Redshift dialect". */
 	label: string;
-	/** Rules added to the "SQL Query Rules" section. */
-	sqlRules?: string[];
-	/** Rules added to the "Tool Calls" section. */
-	toolRules?: string[];
+	/** Rules added to the "SQL Query Rules" section, one bullet per entry. */
+	sqlRules?: ReactNode[];
+	/** Rules added to the "Tool Calls" section, one bullet per entry. */
+	toolRules?: ReactNode[];
 };
 
 export const DIALECT_GUIDANCE: DialectGuidance[] = [
@@ -29,45 +31,85 @@ export const DIALECT_GUIDANCE: DialectGuidance[] = [
 		matches: ['clickhouse'],
 		label: 'ClickHouse dialect',
 		toolRules: [
-			'When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY KEY, PARTITION BY) so you can write efficient queries.',
+			<>
+				When available, use <Code>indexes.md</Code> to see how the table is ordered and indexed (
+				<Code>ORDER BY</Code>, <Code>PRIMARY KEY</Code>, <Code>PARTITION BY</Code>) so you can write efficient
+				queries.
+			</>,
 		],
 	},
 	{
 		matches: ['mssql', 'fabric'],
 		label: 'T-SQL dialect (Fabric/MSSQL)',
 		sqlRules: [
-			'Use TOP N instead of LIMIT N (e.g. SELECT TOP 10 * FROM table).',
-			'Do not use GROUP BY ALL — explicitly list all non-aggregated columns in the GROUP BY clause.',
-			'Use T-SQL date functions (DATEADD, DATEDIFF, CONVERT, FORMAT) instead of PostgreSQL-style intervals or TO_CHAR.',
-			'Use ISNULL() instead of COALESCE() when there are only two arguments.',
+			<>
+				Use <Code>TOP N</Code> instead of <Code>LIMIT N</Code> (e.g. <Code>SELECT TOP 10 * FROM table</Code>).
+			</>,
+			<>
+				Do not use <Code>GROUP BY ALL</Code> — explicitly list all non-aggregated columns in the{' '}
+				<Code>GROUP BY</Code> clause.
+			</>,
+			<>
+				Use T-SQL date functions (<Code>DATEADD</Code>, <Code>DATEDIFF</Code>, <Code>CONVERT</Code>,{' '}
+				<Code>FORMAT</Code>) instead of PostgreSQL-style intervals or <Code>TO_CHAR</Code>.
+			</>,
+			<>
+				Use <Code>ISNULL()</Code> instead of <Code>COALESCE()</Code> when there are only two arguments.
+			</>,
 		],
 	},
 	{
 		matches: ['bigquery'],
 		label: 'BigQuery dialect',
 		sqlRules: [
-			'Use backtick-quoted identifiers (e.g. `project.dataset.table`).',
-			'Use SAFE_DIVIDE for division to avoid division-by-zero errors.',
+			<>
+				Use backtick-quoted identifiers (e.g. <Code>project.dataset.table</Code>).
+			</>,
+			<>
+				Use <Code>SAFE_DIVIDE</Code> for division to avoid division-by-zero errors.
+			</>,
 		],
 	},
 	{
 		matches: ['mysql'],
 		label: 'MySQL dialect',
 		sqlRules: [
-			'Use backtick-quoted identifiers for column and table names.',
-			'Use IFNULL() instead of COALESCE() when there are only two arguments.',
+			<>Use backtick-quoted identifiers for column and table names.</>,
+			<>
+				Use <Code>IFNULL()</Code> instead of <Code>COALESCE()</Code> when there are only two arguments.
+			</>,
 		],
 	},
 	{
 		matches: ['redshift'],
 		label: 'Redshift dialect',
 		sqlRules: [
-			'Do not use SELECT DISTINCT ON (...) — it is not supported. Deduplicate with ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...) in a subquery and keep the rows where the row number equals 1.',
-			'Do not put multiple PERCENTILE_CONT with different ORDER BY clauses in the same query — compute each percentile in its own CTE, then join the results.',
-			'Do not combine LISTAGG(DISTINCT ...) with PERCENTILE_CONT in the same SELECT — split them into separate CTEs.',
-			"Do not call CONCAT() with literal string arguments (e.g. CONCAT(first_name, ' ', last_name)). Use the || operator instead (e.g. first_name || ' ' || last_name).",
-			"Do not use DATE_PART('year', AGE(date)). Use DATEDIFF('year', birthdate, CURRENT_DATE) instead.",
-			'Do not use COUNT(*) FILTER (WHERE ...). Use COUNT(CASE WHEN ... THEN 1 END) instead.',
+			<>
+				Do not use <Code>SELECT DISTINCT ON (...)</Code> — it is not supported. Deduplicate with{' '}
+				<Code>ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)</Code> in a subquery and keep the rows where the
+				row number equals 1.
+			</>,
+			<>
+				Do not put multiple <Code>PERCENTILE_CONT</Code> with different <Code>ORDER BY</Code> clauses in the
+				same query — compute each percentile in its own CTE, then join the results.
+			</>,
+			<>
+				Do not combine <Code>LISTAGG(DISTINCT ...)</Code> with <Code>PERCENTILE_CONT</Code> in the same{' '}
+				<Code>SELECT</Code> — split them into separate CTEs.
+			</>,
+			<>
+				Do not call <Code>CONCAT()</Code> with literal string arguments (e.g.{' '}
+				<Code>CONCAT(first_name, ' ', last_name)</Code>). Use the <Code>||</Code> operator instead (e.g.{' '}
+				<Code>first_name || ' ' || last_name</Code>).
+			</>,
+			<>
+				Do not use <Code>DATE_PART('year', AGE(date))</Code>. Use{' '}
+				<Code>DATEDIFF('year', birthdate, CURRENT_DATE)</Code> instead.
+			</>,
+			<>
+				Do not use <Code>COUNT(*) FILTER (WHERE ...)</Code>. Use <Code>COUNT(CASE WHEN ... THEN 1 END)</Code>{' '}
+				instead.
+			</>,
 		],
 	},
 ];

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -5,6 +5,7 @@ import type { UserMemory } from '../../types/memory';
 import { MEMORY_CATEGORIES, MemoryCategory } from '../../types/memory';
 import { formatCurrentDate } from '../../utils/date';
 import { groupBy } from '../../utils/utils';
+import { getDialectSqlQueryRules, getDialectToolCallRules } from './dialect-rules';
 import { NaoContextStructure } from './nao-context-structure';
 
 type Connection = {
@@ -32,10 +33,8 @@ export function SystemPrompt({
 	testMode,
 }: SystemPromptProps) {
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
-	const hasClickHouse = connections.some((connection) => connection.type.toLowerCase() === 'clickhouse');
-	const hasTSQL = connections.some((connection) => ['mssql', 'fabric'].includes(connection.type.toLowerCase()));
-	const hasBigQuery = connections.some((connection) => connection.type.toLowerCase() === 'bigquery');
-	const hasMySQL = connections.some((connection) => connection.type.toLowerCase() === 'mysql');
+	const dialectToolCallRules = getDialectToolCallRules(connections);
+	const dialectSqlQueryRules = getDialectSqlQueryRules(connections);
 
 	return (
 		<Block>
@@ -75,86 +74,53 @@ export function SystemPrompt({
 			</List>
 			<Title level={2}>Tool Calls</Title>
 			<List>
-				<ListItem>
-					Be efficient with tool calls and prefer calling multiple tools in parallel, especially when
-					researching.
-				</ListItem>
-				<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>
-				{!testMode && (
+				{[
 					<ListItem>
-						Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
-						proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear time
-						range, undefined metric). If you need to ask another clarifying question after the user answers,
-						call the <Bold>clarification</Bold> tool again instead of asking in plain text, bullet lists, or
-						examples.
-					</ListItem>
-				)}
-				<ListItem>
-					For display_chart x_axis_type: use "date" only when x-axis values are parseable by JavaScript Date
-					(e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods (FY25-Q1), or
-					any non-ISO-date strings.
-				</ListItem>
-				<ListItem>
-					For display_chart chart_type: use "scatter" for correlations between two numeric variables (set
-					x_axis_type to "number"). Use "radar" for comparing multiple metrics across a fixed set of
-					categories on a spider/web chart. Use "area" for time-series trends where filled area emphasis is
-					desired (similar to "line"). Use "stacked_area" to show how multiple series compose a total over
-					time (e.g. revenue by payment method, users by plan) — requires 2+ series and pivoted data.
-				</ListItem>
-				{hasClickHouse && (
+						Be efficient with tool calls and prefer calling multiple tools in parallel, especially when
+						researching.
+					</ListItem>,
+					<ListItem>If you can execute a SQL query, use the execute_sql tool for it.</ListItem>,
+					!testMode && (
+						<ListItem>
+							Use the <Bold>clarification</Bold> tool when the user's request is genuinely ambiguous and
+							proceeding would likely produce the wrong result (e.g. multiple plausible tables, unclear
+							time range, undefined metric). If you need to ask another clarifying question after the user
+							answers, call the <Bold>clarification</Bold> tool again instead of asking in plain text,
+							bullet lists, or examples.
+						</ListItem>
+					),
 					<ListItem>
-						When available, use indexes.md to see how the table is ordered and indexed (ORDER BY, PRIMARY
-						KEY, PARTITION BY) so you can write efficient queries.
-					</ListItem>
-				)}
+						For display_chart x_axis_type: use "date" only when x-axis values are parseable by JavaScript
+						Date (e.g. YYYY-MM-DD). Use "category" for quarter labels (quarter_ending), fiscal periods
+						(FY25-Q1), or any non-ISO-date strings.
+					</ListItem>,
+					<ListItem>
+						For display_chart chart_type: use "scatter" for correlations between two numeric variables (set
+						x_axis_type to "number"). Use "radar" for comparing multiple metrics across a fixed set of
+						categories on a spider/web chart. Use "area" for time-series trends where filled area emphasis
+						is desired (similar to "line"). Use "stacked_area" to show how multiple series compose a total
+						over time (e.g. revenue by payment method, users by plan) — requires 2+ series and pivoted data.
+					</ListItem>,
+					...dialectToolCallRules,
+				]}
 			</List>
 			<Title level={2}>SQL Query Rules</Title>
 			<List>
-				<ListItem>
-					If you get an error, loop until you fix the error, search for the correct name using the list or
-					search tools.
-				</ListItem>
-				<ListItem>
-					Never assume columns names, if available, use the columns.md file to get the column names.
-				</ListItem>
-				<ListItem>
-					A LIMIT/TOP clause caps how many rows are returned, not how many exist. Never state a total or an
-					"exact" count based on the number of rows a limited query returned. To count rows, run a separate
-					query using COUNT(*) (or COUNT over a subquery) without a LIMIT/TOP clause.
-				</ListItem>
-				{hasTSQL && (
-					<>
-						<ListItem>
-							<Bold>T-SQL dialect (Fabric/MSSQL):</Bold> Use TOP N instead of LIMIT N (e.g. SELECT TOP 10
-							* FROM table).
-						</ListItem>
-						<ListItem>
-							Do not use GROUP BY ALL — explicitly list all non-aggregated columns in the GROUP BY clause.
-						</ListItem>
-						<ListItem>
-							Use T-SQL date functions (DATEADD, DATEDIFF, CONVERT, FORMAT) instead of PostgreSQL-style
-							intervals or TO_CHAR.
-						</ListItem>
-						<ListItem>Use ISNULL() instead of COALESCE() when there are only two arguments.</ListItem>
-					</>
-				)}
-				{hasBigQuery && (
-					<>
-						<ListItem>
-							<Bold>BigQuery dialect:</Bold> Use backtick-quoted identifiers (e.g.{' '}
-							{`\`project.dataset.table\``}).
-						</ListItem>
-						<ListItem>Use SAFE_DIVIDE for division to avoid division-by-zero errors.</ListItem>
-					</>
-				)}
-				{hasMySQL && (
-					<>
-						<ListItem>
-							<Bold>MySQL dialect:</Bold> Use backtick-quoted identifiers for column and table names.
-						</ListItem>
-						<ListItem>Use IFNULL() instead of COALESCE() when there are only two arguments.</ListItem>
-					</>
-				)}
+				{[
+					<ListItem>
+						If you get an error, loop until you fix the error, search for the correct name using the list or
+						search tools.
+					</ListItem>,
+					<ListItem>
+						Never assume columns names, if available, use the columns.md file to get the column names.
+					</ListItem>,
+					<ListItem>
+						A LIMIT/TOP clause caps how many rows are returned, not how many exist. Never state a total or
+						an "exact" count based on the number of rows a limited query returned. To count rows, run a
+						separate query using COUNT(*) (or COUNT over a subquery) without a LIMIT/TOP clause.
+					</ListItem>,
+					...dialectSqlQueryRules,
+				]}
 			</List>
 			<Title level={2}>Citations Rules</Title>
 			<List>

--- a/apps/backend/tests/dialect-rules.test.ts
+++ b/apps/backend/tests/dialect-rules.test.ts
@@ -27,13 +27,13 @@ describe('dialect-aware system prompt', () => {
 	it('injects Redshift dialect rules when a redshift connection is present', () => {
 		const section = sqlQueryRulesSection(renderWith([{ type: 'redshift', database: 'analytics' }]));
 
-		expect(section).toContain('**Redshift dialect:** Do not use SELECT DISTINCT ON');
-		expect(section).toContain('ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)');
+		expect(section).toContain('**Redshift dialect:** Do not use `SELECT DISTINCT ON (...)`');
+		expect(section).toContain('`ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)`');
 		expect(section).toContain('compute each percentile in its own CTE');
-		expect(section).toContain('LISTAGG(DISTINCT ...) with PERCENTILE_CONT');
-		expect(section).toContain('Use the || operator instead');
-		expect(section).toContain("DATEDIFF('year', birthdate, CURRENT_DATE)");
-		expect(section).toContain('COUNT(CASE WHEN ... THEN 1 END)');
+		expect(section).toContain('`LISTAGG(DISTINCT ...)` with `PERCENTILE_CONT`');
+		expect(section).toContain('Use the `||` operator instead');
+		expect(section).toContain("`DATEDIFF('year', birthdate, CURRENT_DATE)`");
+		expect(section).toContain('`COUNT(CASE WHEN ... THEN 1 END)`');
 	});
 
 	it('matches dialects case-insensitively', () => {
@@ -51,10 +51,10 @@ describe('dialect-aware system prompt', () => {
 
 	it('keeps existing dialect guidance for T-SQL, BigQuery and MySQL', () => {
 		const tsql = sqlQueryRulesSection(renderWith([{ type: 'mssql', database: 'db' }]));
-		expect(tsql).toContain('**T-SQL dialect (Fabric/MSSQL):** Use TOP N instead of LIMIT N');
+		expect(tsql).toContain('**T-SQL dialect (Fabric/MSSQL):** Use `TOP N` instead of `LIMIT N`');
 
 		const fabric = sqlQueryRulesSection(renderWith([{ type: 'fabric', database: 'db' }]));
-		expect(fabric).toContain('**T-SQL dialect (Fabric/MSSQL):** Use TOP N instead of LIMIT N');
+		expect(fabric).toContain('**T-SQL dialect (Fabric/MSSQL):** Use `TOP N` instead of `LIMIT N`');
 
 		const bigquery = sqlQueryRulesSection(renderWith([{ type: 'bigquery', database: 'db' }]));
 		expect(bigquery).toContain('**BigQuery dialect:** Use backtick-quoted identifiers');
@@ -66,7 +66,7 @@ describe('dialect-aware system prompt', () => {
 	it('injects the ClickHouse tool-call rule under Tool Calls', () => {
 		const markdown = renderWith([{ type: 'clickhouse', database: 'events' }]);
 		const toolCalls = markdown.slice(markdown.indexOf('## Tool Calls'), markdown.indexOf('## SQL Query Rules'));
-		expect(toolCalls).toContain('use indexes.md to see how the table is ordered and indexed');
+		expect(toolCalls).toContain('use `indexes.md` to see how the table is ordered and indexed');
 	});
 });
 
@@ -87,7 +87,7 @@ describe('dialect rules end-to-end from a synced project folder', () => {
 		expect(connections).toEqual([{ type: 'redshift', database: 'analytics' }]);
 
 		const markdown = renderToMarkdown(SystemPrompt({ connections }));
-		expect(markdown).toContain('**Redshift dialect:** Do not use SELECT DISTINCT ON');
-		expect(markdown).toContain('COUNT(CASE WHEN ... THEN 1 END)');
+		expect(markdown).toContain('**Redshift dialect:** Do not use `SELECT DISTINCT ON (...)`');
+		expect(markdown).toContain('`COUNT(CASE WHEN ... THEN 1 END)`');
 	});
 });

--- a/apps/backend/tests/dialect-rules.test.ts
+++ b/apps/backend/tests/dialect-rules.test.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getConnections } from '../src/agents/user-rules';
+import { SystemPrompt } from '../src/components/ai/system-prompt';
+import { renderToMarkdown } from '../src/lib/markdown';
+
+function renderWith(connections: { type: string; database: string }[]): string {
+	return renderToMarkdown(SystemPrompt({ connections }));
+}
+
+function sqlQueryRulesSection(markdown: string): string {
+	const start = markdown.indexOf('## SQL Query Rules');
+	const end = markdown.indexOf('## Citations Rules');
+	return markdown.slice(start, end);
+}
+
+describe('dialect-aware system prompt', () => {
+	it('omits dialect rules when no matching connection is present', () => {
+		const markdown = renderWith([{ type: 'duckdb', database: 'analytics' }]);
+		expect(markdown).not.toContain('dialect:');
+		expect(markdown).not.toContain('SELECT DISTINCT ON');
+	});
+
+	it('injects Redshift dialect rules when a redshift connection is present', () => {
+		const section = sqlQueryRulesSection(renderWith([{ type: 'redshift', database: 'analytics' }]));
+
+		expect(section).toContain('**Redshift dialect:** Do not use SELECT DISTINCT ON');
+		expect(section).toContain('ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)');
+		expect(section).toContain('compute each percentile in its own CTE');
+		expect(section).toContain('LISTAGG(DISTINCT ...) with PERCENTILE_CONT');
+		expect(section).toContain('Use the || operator instead');
+		expect(section).toContain("DATEDIFF('year', birthdate, CURRENT_DATE)");
+		expect(section).toContain('COUNT(CASE WHEN ... THEN 1 END)');
+	});
+
+	it('matches dialects case-insensitively', () => {
+		const section = sqlQueryRulesSection(renderWith([{ type: 'RedShift', database: 'analytics' }]));
+		expect(section).toContain('**Redshift dialect:**');
+	});
+
+	it('renders each dialect rule as its own bullet', () => {
+		const section = sqlQueryRulesSection(renderWith([{ type: 'redshift', database: 'analytics' }]));
+		const redshiftBullets = section
+			.split('\n')
+			.filter((line) => line.startsWith('- ') && (line.includes('Redshift dialect') || line.includes('Do not')));
+		expect(redshiftBullets.length).toBe(6);
+	});
+
+	it('keeps existing dialect guidance for T-SQL, BigQuery and MySQL', () => {
+		const tsql = sqlQueryRulesSection(renderWith([{ type: 'mssql', database: 'db' }]));
+		expect(tsql).toContain('**T-SQL dialect (Fabric/MSSQL):** Use TOP N instead of LIMIT N');
+
+		const fabric = sqlQueryRulesSection(renderWith([{ type: 'fabric', database: 'db' }]));
+		expect(fabric).toContain('**T-SQL dialect (Fabric/MSSQL):** Use TOP N instead of LIMIT N');
+
+		const bigquery = sqlQueryRulesSection(renderWith([{ type: 'bigquery', database: 'db' }]));
+		expect(bigquery).toContain('**BigQuery dialect:** Use backtick-quoted identifiers');
+
+		const mysql = sqlQueryRulesSection(renderWith([{ type: 'mysql', database: 'db' }]));
+		expect(mysql).toContain('**MySQL dialect:** Use backtick-quoted identifiers');
+	});
+
+	it('injects the ClickHouse tool-call rule under Tool Calls', () => {
+		const markdown = renderWith([{ type: 'clickhouse', database: 'events' }]);
+		const toolCalls = markdown.slice(markdown.indexOf('## Tool Calls'), markdown.indexOf('## SQL Query Rules'));
+		expect(toolCalls).toContain('use indexes.md to see how the table is ordered and indexed');
+	});
+});
+
+describe('dialect rules end-to-end from a synced project folder', () => {
+	let projectFolder: string;
+
+	beforeEach(() => {
+		projectFolder = mkdtempSync(join(tmpdir(), 'nao-dialect-'));
+		mkdirSync(join(projectFolder, 'databases', 'type=redshift', 'database=analytics'), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(projectFolder, { recursive: true, force: true });
+	});
+
+	it('discovers a redshift connection and injects its dialect rules', () => {
+		const connections = getConnections(projectFolder);
+		expect(connections).toEqual([{ type: 'redshift', database: 'analytics' }]);
+
+		const markdown = renderToMarkdown(SystemPrompt({ connections }));
+		expect(markdown).toContain('**Redshift dialect:** Do not use SELECT DISTINCT ON');
+		expect(markdown).toContain('COUNT(CASE WHEN ... THEN 1 END)');
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements a **dialect-aware system injected prompt**: a single registry of warehouse-specific SQL guidance that is injected into the agent system prompt automatically based on the project's connections. This is the mechanism we can keep filling as feedback comes in from nao users, and it ships the Redshift rules requested in #981.

Closes #981.

## Why

The agent had inline, per-dialect prompt blocks (ClickHouse, T-SQL, BigQuery, MySQL) scattered in `system-prompt.tsx`, and **no Redshift guidance** — so it kept generating Redshift-incompatible SQL. The inline blocks also had a rendering bug: rules inside JSX fragments were concatenated into a single run-on line with no bullets.

## Changes

- New `apps/backend/src/components/ai/dialect-rules.tsx` — a `DIALECT_GUIDANCE` registry mapping connection types to SQL/tool rules. Designed to grow as we gather user feedback; add a rule with the supported alternative whenever a warehouse rejects something.
- Rules are authored with the **same markdown components as the system prompt** (`<Code>`, `<Bold>`, fragments) rather than plain strings, so they're friendlier to write/read and SQL snippets render as backtick-formatted code.
- Refactored `system-prompt.tsx` to consume the registry. Each dialect rule now renders as its **own bullet** (fixes the run-on-line bug) while keeping the bold dialect label on the first rule.
- Added **Redshift dialect rules** covering every pattern from #981:
  1. No `SELECT DISTINCT ON (...)` → `ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)`
  2. No multiple `PERCENTILE_CONT` with different `ORDER BY` in one query → one CTE each
  3. No `LISTAGG(DISTINCT ...)` combined with `PERCENTILE_CONT` in the same SELECT
  4. No `CONCAT(varchar, 'literal', varchar)` → `||` operator
  5. No `DATE_PART('year', AGE(date))` → `DATEDIFF('year', birthdate, CURRENT_DATE)`
  6. No `COUNT(*) FILTER (WHERE ...)` → `COUNT(CASE WHEN ... THEN 1 END)`
- Behaviour for ClickHouse / T-SQL / BigQuery / MySQL is preserved (now code-formatted); the base prompt for projects with no matching dialect is byte-identical to before.

## How it flows

`nao sync` writes `databases/type=<warehouse>/database=<name>/…` → `getConnections()` reads that layout → `SystemPrompt` matches the connection `type` (case-insensitive) against the registry → rules are injected. So every Redshift user benefits automatically, no RULES.md editing needed.

## Testing

- New `apps/backend/tests/dialect-rules.test.ts` (7 tests): Redshift injection, case-insensitive matching, one-bullet-per-rule, preserved T-SQL/BigQuery/MySQL/ClickHouse guidance, no rules when no dialect matches, and an end-to-end test that creates a real `databases/type=redshift/...` folder, runs `getConnections`, and asserts the rules appear in the rendered prompt.
- `npm run -w @nao/backend lint` (tsc + eslint) passes; prettier clean.
- Verified the rendered base prompt (no dialect) is byte-identical to `main`.

Note: pre-existing, unrelated test failures on `main` (stale `formatDate`/`resolveTimezone` imports in `system-prompt.test.ts`, plus DB/env-dependent suites) are not touched by this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f14ed-96cf-7cb5-8ace-1081c4a2a871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f14ed-96cf-7cb5-8ace-1081c4a2a871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

