### PR TITLE
[fix:chart config] display the total if no column already does so

### DIFF
--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -484,6 +484,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 			var html='<div class="nao-tooltip-label">'+(isPie?labelize(cfg.series[0]&&(cfg.series[0].label||cfg.series[0].data_key)||''):labelize(label!=null?label:''))+'</div>';
 			html+='<div class="nao-tooltip-rows">';
 			var numericValues=[];
+			var hasTotalSeries=false;
 			cfg.series.forEach(function(s, si){
 				var color;
 				if(isPie){
@@ -495,6 +496,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 				}
 				var val=row[s.data_key];
 				if(typeof val==='number')numericValues.push(val);
+				if(s.is_total)hasTotalSeries=true;
 				var rowName=isPie?labelize(label!=null?label:''):labelize(s.label||s.data_key);
 				html+='<div class="nao-tooltip-row">'
 					+'<span class="nao-tooltip-swatch" style="background:'+escHtml(color)+'"></span>'
@@ -502,7 +504,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 					+'<span class="nao-tooltip-value">'+formatVal(val)+'</span>'
 					+'</div>';
 			});
-			if(numericValues.length>1){
+			if(numericValues.length>1 && !hasTotalSeries){
 				var total=numericValues.reduce(function(a,b){return a+b},0);
 				html+='<div class="nao-tooltip-total">'
 					+'<span class="nao-tooltip-name">Total</span>'

--- a/apps/frontend/src/components/mcp-app/chart-app-view.tsx
+++ b/apps/frontend/src/components/mcp-app/chart-app-view.tsx
@@ -26,6 +26,7 @@ export const ChartAppView = memo(function ChartAppView({ config, data, naoUrl }:
 				data_key: s.data_key,
 				color: s.color ?? `var(--chart-${(i % 5) + 1})`,
 				label: s.label,
+				is_total: s.is_total,
 			})),
 		[config.series],
 	);

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -15,7 +15,7 @@ interface ChartBlock {
 	chartType: string;
 	xAxisKey: string;
 	xAxisType: string | null;
-	series: Array<{ data_key: string; color: string; label?: string }>;
+	series: Array<{ data_key: string; color: string; label?: string; is_total?: boolean }>;
 	title: string;
 	rawTag?: string;
 }
@@ -109,6 +109,7 @@ export function StoryChartEmbedShell({ chart, availableColumns, children }: Stor
 				data_key: s.data_key,
 				color: s.color || undefined,
 				label: s.label,
+				is_total: s.is_total,
 			})),
 			title: chart.title,
 		}),

--- a/apps/frontend/src/components/sidebar-community.tsx
+++ b/apps/frontend/src/components/sidebar-community.tsx
@@ -40,7 +40,7 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 					target='_blank'
 					rel='noopener noreferrer'
 					className={cn(
-						'p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
+						'p-1.5 rounded-full text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
 					)}
 					title='GitHub'
 				>
@@ -51,7 +51,7 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 					target='_blank'
 					rel='noopener noreferrer'
 					className={cn(
-						'p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
+						'p-1.5 rounded-full text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
 					)}
 					title='Join Slack'
 				>
@@ -61,7 +61,7 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 					type='button'
 					onClick={handleNewsletterClick}
 					className={cn(
-						'relative p-1.5 rounded-md text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
+						'relative p-1.5 rounded-full text-muted-foreground/40 hover:text-muted-foreground hover:bg-sidebar-accent transition-colors',
 					)}
 					title='Subscribe to newsletter'
 					aria-label='Subscribe to newsletter'

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -329,6 +329,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 			acc[s.data_key] = {
 				label: s.label || labelize(s.data_key, dateFormat),
 				color: s.color || Colors[idx % Colors.length],
+				isTotal: s.is_total,
 			};
 			return acc;
 		}, {} as ChartConfig);

--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -12,6 +12,7 @@ export type ChartConfig = {
 	[k in string]: {
 		label?: React.ReactNode;
 		icon?: React.ComponentType;
+		isTotal?: boolean;
 	} & ({ color?: string; theme?: never } | { color?: never; theme: Record<keyof typeof THEMES, string> });
 };
 
@@ -144,10 +145,14 @@ function ChartTooltipContent({
 
 	const nestLabel = payload.length === 1 && indicator !== 'dot';
 
-	// Calculate total if there are multiple numeric values that can be summed
+	// Calculate total if there are multiple numeric values that can be summed and no total column.
 	const visiblePayload = payload.filter((item) => item.type !== 'none');
 	const numericValues = visiblePayload.map((item) => item.value).filter((v): v is number => typeof v === 'number');
-	const showTotal = numericValues.length > 1;
+	const hasTotalSeries = visiblePayload.some((item) => {
+		const key = `${nameKey || item.name || item.dataKey || 'value'}`;
+		return getPayloadConfigFromPayload(config, item, key)?.isTotal === true;
+	});
+	const showTotal = numericValues.length > 1 && !hasTotalSeries;
 	const total = showTotal ? numericValues.reduce((sum, v) => sum + v, 0) : 0;
 
 	return (

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -3,7 +3,7 @@ export interface ParsedChartBlock {
 	chartType: string;
 	xAxisKey: string;
 	xAxisType: string | null;
-	series: Array<{ data_key: string; color: string; label?: string }>;
+	series: Array<{ data_key: string; color: string; label?: string; is_total?: boolean }>;
 	title: string;
 	/** The original `<chart ... />` tag this block was parsed from, when available. */
 	rawTag?: string;

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -18,6 +18,12 @@ export const SeriesConfigSchema = z.object({
 	data_key: z.string().describe('Column name from SQL result to plot.'),
 	color: z.string().describe('CSS color (defaults to theme colors).').optional(),
 	label: z.string().describe('Label to display in the legend.').optional(),
+	is_total: z
+		.boolean()
+		.describe(
+			'Set to true when this series is an already-aggregated total of the other series (e.g. a grand total, rollup, subtotal, or sum-of-parts column), so the tooltip must not sum it again. Decide this from the meaning of the column, not its name — it applies in any language.',
+		)
+		.optional(),
 });
 
 export const InputSchema = z.object({


### PR DESCRIPTION
## Description

Add an optional boolean isTotal on series config to avoid total duplication in the chart hover tooltip

### Before

<img width="735" height="443" alt="image" src="https://github.com/user-attachments/assets/ae5b7d70-8b1e-4646-b774-bcd02c94341b" />

### After

<img width="732" height="464" alt="image" src="https://github.com/user-attachments/assets/6c0be010-03fc-4340-995d-3632d616ccad" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

