### PR TITLE
[fix:data-table] adapt the size of tables in expand dialog to see the max of data possible in the window

### DIFF
--- a/apps/frontend/src/components/data-table-card.tsx
+++ b/apps/frontend/src/components/data-table-card.tsx
@@ -88,7 +88,7 @@ export function DataTableCard({
 			/>
 
 			<Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
-				<DialogContent className='w-[95vw] max-w-[95vw] gap-2'>
+				<DialogContent className='flex max-h-[90vh] w-fit min-w-[32rem] max-w-[95vw] flex-col gap-2 sm:max-w-[95vw]'>
 					<DialogTitle className='sr-only'>{title ?? 'Table'}</DialogTitle>
 					<div className='flex flex-row justify-end gap-1 -my-1 px-5'>
 						<Button
@@ -113,7 +113,7 @@ export function DataTableCard({
 					<TableDisplay
 						data={data}
 						columns={resolvedColumns}
-						className='min-w-0 overflow-hidden rounded-lg border'
+						className='min-h-0 min-w-0 overflow-hidden rounded-lg border'
 						tableContainerClassName='max-h-[75vh] border-t-0'
 						maxRowsBeforePagination={maxRowsBeforePagination}
 						compactFooter={true}


### PR DESCRIPTION
## Before

<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/23c32d2b-4f83-4163-a119-0f3c2d013cd2" />
<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/bfcd050d-2dce-4b76-a0e1-1b7c1cf02b18" />

## After

<img width="1512" height="854" alt="image" src="https://github.com/user-attachments/assets/5b7c973a-5c2f-464f-a8a5-530b27b07bdc" />
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/82835897-394a-401d-9519-e914386555aa" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

