### PR TITLE
[fix:ask selector] improve the selection zone

### DIFF
--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -263,7 +263,10 @@ function SuggestionCard({
 	children?: React.ReactNode;
 }) {
 	return (
-		<div className='group mb-2 flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2 animate-in fade-in slide-in-from-bottom-2 duration-200'>
+		<div
+			data-selection-ignore
+			className='group mb-2 flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2 animate-in fade-in slide-in-from-bottom-2 duration-200'
+		>
 			{icon && <div className='flex size-9 shrink-0 items-center justify-center'>{icon}</div>}
 			<p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{message}</p>
 			{children && <div className='flex shrink-0 items-center gap-1'>{children}</div>}

--- a/apps/frontend/src/components/chat-messages/chat-messages.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-messages.tsx
@@ -107,7 +107,7 @@ export const ChatMessagesContent = memo(() => {
 				))
 			)}
 
-			<div className='flex flex-col gap-4' ref={extraComponentsRef}>
+			<div className='flex flex-col gap-4' ref={extraComponentsRef} data-selection-ignore>
 				{followUpSuggestionsToolCall && <FollowUpSuggestions toolPart={followUpSuggestionsToolCall} />}
 
 				<ChatError className='mt-4' />

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -289,7 +289,7 @@ export const StoryHeader = memo(function StoryHeader({
 	);
 
 	return (
-		<div className='shrink-0'>
+		<div className='shrink-0' data-selection-ignore>
 			{isMobile ? (
 				<>
 					<div className='flex items-center gap-2 border-b px-3 py-2'>

--- a/apps/frontend/src/contexts/text-selection.tsx
+++ b/apps/frontend/src/contexts/text-selection.tsx
@@ -7,6 +7,7 @@ import {
 	getContainerLeft,
 	getSelectionBoundingRect,
 	getTextOffset,
+	isRangeInIgnoredRegion,
 	measureRangePosition,
 } from '@/lib/selection-dom.utils';
 import { trpc } from '@/main';
@@ -122,6 +123,10 @@ export const SelectionProvider = ({
 		const range = sel.getRangeAt(0);
 		const text = sel.toString().trim();
 		if (!text || !containerRef.current.contains(range.commonAncestorContainer)) {
+			return;
+		}
+
+		if (isRangeInIgnoredRegion(range)) {
 			return;
 		}
 

--- a/apps/frontend/src/lib/selection-dom.utils.ts
+++ b/apps/frontend/src/lib/selection-dom.utils.ts
@@ -27,7 +27,7 @@ export function createRangeFromOffsets(container: Element, start: number, end: n
 	while (node) {
 		const len = node.textContent?.length ?? 0;
 
-		if (!startSet && charCount + len >= start) {
+		if (!startSet && charCount + len > start) {
 			try {
 				range.setStart(node, start - charCount);
 			} catch {
@@ -127,6 +127,16 @@ export function getSelectionBoundingRect(range: Range): DOMRect | null {
 	const right = Math.max(...rects.map((r) => r.right));
 	const bottom = Math.max(...rects.map((r) => r.bottom));
 	return new DOMRect(left, top, right - left, bottom - top);
+}
+
+/** Returns true when the range lives inside `[data-selection-ignore]` (e.g. chat suggestion popups, side-panel story headers). */
+export function isRangeInIgnoredRegion(range: Range): boolean {
+	return isNodeInIgnoredRegion(range.startContainer) || isNodeInIgnoredRegion(range.endContainer);
+}
+
+function isNodeInIgnoredRegion(node: Node): boolean {
+	const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node instanceof Element ? node : null;
+	return Boolean(el?.closest('[data-selection-ignore]'));
 }
 
 /** Returns the left edge of the nearest `[data-selection-container]` ancestor of the range. */


### PR DESCRIPTION
## Description

Improvement to the boundary surrounding the selectable and searchable text area so that it does not include the header of a story in the side panel within a chat or the feedback suggestion popup

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

