### PR TITLE
fix(chat): admin mode ignored after AgentProvider remount

### DIFF
--- a/apps/frontend/src/hooks/use-agent.ts
+++ b/apps/frontend/src/hooks/use-agent.ts
@@ -65,6 +65,22 @@ const agentCitationStore = new WeakMap<Agent<UIMessage>, CitationData | undefine
 /** Admin mode captured at send time, so an ack-time toggle cannot mislabel the message. */
 const agentAdminModeStore = new WeakMap<Agent<UIMessage>, boolean>();
 
+/**
+ * Live send-time refs of the hook instance currently driving each agent. Agents are
+ * cached in `agentService` across `AgentProvider` remounts (e.g. leaving the chat for
+ * settings and returning via "Chat with nao"), so a cached agent's
+ * `prepareSendMessagesRequest` closure would otherwise read stale refs from the mount
+ * that first created it — silently dropping admin mode, model and mention selections
+ * made after the remount. The active hook refreshes these on every render so requests
+ * always reflect the current UI state.
+ */
+interface AgentSendRefs {
+	adminModeRef: { current: boolean };
+	selectedModelRef: { current: LlmSelectedModel | null };
+	mentionsRef: { current: MentionOption[] };
+}
+const agentSendRefsStore = new WeakMap<Agent<UIMessage>, AgentSendRefs>();
+
 export const useAgent = ({ disableNavigation = false }: { disableNavigation?: boolean } = {}): AgentHelpers => {
 	const navigate = useNavigate();
 	const chatId = useChatId();
@@ -156,11 +172,16 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 						throw new Error('No message to send.');
 					}
 
-					const mentions = mentionsRef.current;
-					mentionsRef.current = [];
+					const liveRefs = agentSendRefsStore.get(newAgent);
+					const activeMentionsRef = liveRefs?.mentionsRef ?? mentionsRef;
+					const activeSelectedModelRef = liveRefs?.selectedModelRef ?? selectedModelRef;
+					const activeAdminModeRef = liveRefs?.adminModeRef ?? adminModeRef;
+
+					const mentions = activeMentionsRef.current;
+					activeMentionsRef.current = [];
 					const citation = agentCitationStore.get(newAgent);
 					const images = extractImagesFromMessage(messageToSend);
-					const adminModeAtSend = adminModeRef.current;
+					const adminModeAtSend = activeAdminModeRef.current;
 					agentAdminModeStore.set(newAgent, adminModeAtSend);
 					return {
 						headers: getActiveProjectId() ? { 'x-nao-project-id': getActiveProjectId()! } : undefined,
@@ -172,7 +193,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 								images: images.length > 0 ? images : undefined,
 								citation,
 							},
-							model: selectedModelRef.current ?? undefined,
+							model: activeSelectedModelRef.current ?? undefined,
 							mentions: mentions.length > 0 ? mentions : undefined,
 							timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 							adminMode: adminModeAtSend || undefined,
@@ -210,6 +231,10 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 
 		return agentService.registerAgent(agentId, newAgent);
 	}, [chatId, disableNavigation, navigate, setChat, queryClient]);
+
+	// Point the agent (which may be a cached instance from an earlier mount) at this
+	// hook's current refs so `prepareSendMessagesRequest` never reads stale send config.
+	agentSendRefsStore.set(agentInstance, { adminModeRef, selectedModelRef, mentionsRef });
 
 	const { status, error, clearError, sendMessage, setMessages, messages } = useChat({ chat: agentInstance });
 

--- a/apps/frontend/src/hooks/use-agent.ts
+++ b/apps/frontend/src/hooks/use-agent.ts
@@ -65,15 +65,6 @@ const agentCitationStore = new WeakMap<Agent<UIMessage>, CitationData | undefine
 /** Admin mode captured at send time, so an ack-time toggle cannot mislabel the message. */
 const agentAdminModeStore = new WeakMap<Agent<UIMessage>, boolean>();
 
-/**
- * Live send-time refs of the hook instance currently driving each agent. Agents are
- * cached in `agentService` across `AgentProvider` remounts (e.g. leaving the chat for
- * settings and returning via "Chat with nao"), so a cached agent's
- * `prepareSendMessagesRequest` closure would otherwise read stale refs from the mount
- * that first created it — silently dropping admin mode, model and mention selections
- * made after the remount. The active hook refreshes these on every render so requests
- * always reflect the current UI state.
- */
 interface AgentSendRefs {
 	adminModeRef: { current: boolean };
 	selectedModelRef: { current: LlmSelectedModel | null };
@@ -232,8 +223,6 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 		return agentService.registerAgent(agentId, newAgent);
 	}, [chatId, disableNavigation, navigate, setChat, queryClient]);
 
-	// Point the agent (which may be a cached instance from an earlier mount) at this
-	// hook's current refs so `prepareSendMessagesRequest` never reads stale send config.
 	agentSendRefsStore.set(agentInstance, { adminModeRef, selectedModelRef, mentionsRef });
 
 	const { status, error, clearError, sendMessage, setMessages, messages } = useChat({ chat: agentInstance });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the admin mode PR (#989) was merged, admin mode "did not work": asking a question in admin mode used the warehouse `execute_sql` and the classical context tools (`grep`/`list`/`read`/`search`) instead of the admin tool set.

## Root cause

Agent instances are cached in a module-level singleton map (`agentService`, in `apps/frontend/src/services/agents.ts`) keyed by chat id (`NEW_CHAT_ID` for a new chat). `AgentProvider` lives under the `_chat-layout` route, so navigating to `/settings/*` **unmounts** it and returning via **"Chat with nao"** (`/?admin=true`) **remounts** it with a fresh `useAgent` hook (and fresh refs).

On remount, `agentService.getAgent(NEW_CHAT_ID)` returns the agent created by the *first* mount. That agent's `prepareSendMessagesRequest` closure keeps reading the **stale** `adminModeRef` (and `selectedModelRef`/`mentionsRef`) from the mount that first created it. So even though the UI shows the amber "Admin Mode" badge, the request goes out with `adminMode: undefined`, and the backend correctly falls back to the default warehouse + context toolset.

This is invisible in the UI (the badge is driven by the current mount's state) — only the outgoing request is wrong.

## Fix

Route the send-time refs through a per-agent `WeakMap` (`agentSendRefsStore`) that the currently-mounted hook refreshes on every render. `prepareSendMessagesRequest` now reads `adminMode`/`model`/`mentions` from that live registry instead of its closed-over refs, so a reused/cached agent always reflects the current UI state. Falls back to the closure refs defensively (e.g. the `disableNavigation` selection panel, which uses its own uncached agent).

Only `apps/frontend/src/hooks/use-agent.ts` changes.

## Verification

Reproduced end-to-end (home → settings → "Chat with nao" → send). The UI showed the Admin Mode badge in both runs; the only difference is the fix.

**Before fix**
```
route received body.adminMode=undefined isProjectAdmin=true effective=undefined
create adminMode=undefined toolContext.adminMode=false tools=[story, display_chart, execute_sql, read_query_result, grep, list, read, search, suggest_follow_ups, clarification]
```

**After fix**
```
route received body.adminMode=true isProjectAdmin=true effective=true
create adminMode=true toolContext.adminMode=true tools=[story, display_chart, execute_sql, read_query_result, suggest_follow_ups, clarification]
```

After the fix, `execute_sql` runs against nao's app-db views (`toolContext.adminMode=true`) and the `grep/list/read/search` context tools are gone. Debug logs above were temporary and are not part of the diff.

[Admin Mode badge in the chat input](https://cursor.com/agents/bc-019f2245-f6d5-7069-9c0d-fc10e6b2f081/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_mode_badge_ui.webp)

[admin_mode_toolselection_before_after.log](https://cursor.com/agents/bc-019f2245-f6d5-7069-9c0d-fc10e6b2f081/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_mode_toolselection_before_after.log)

**Testing**
- ✅ `npm run lint`
- ✅ Manual repro + fix verification in the browser (backend tool-selection logs)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2245-f6d5-7069-9c0d-fc10e6b2f081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2245-f6d5-7069-9c0d-fc10e6b2f081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

