### PR TITLE
[fix:permissions] only admin and owner can archive/rename/move

### DIFF
--- a/apps/backend/src/trpc/story-folder.routes.ts
+++ b/apps/backend/src/trpc/story-folder.routes.ts
@@ -101,24 +101,28 @@ export const storyFolderRoutes = {
 		)
 		.mutation(async ({ input, ctx }) => {
 			const folder = await assertFolderInProject(input.id, ctx);
+			assertCanReadPrivateFolder(folder, ctx.user.id);
 			assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 			await storyFolderQueries.updateFolder(input.id, { name: input.name });
 		}),
 
 	delete: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
+		assertCanReadPrivateFolder(folder, ctx.user.id);
 		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.deleteFolderMovingContentsToParent(input.id);
 	}),
 
 	archive: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
+		assertCanReadPrivateFolder(folder, ctx.user.id);
 		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.archiveFolder(input.id);
 	}),
 
 	unarchive: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
+		assertCanReadPrivateFolder(folder, ctx.user.id);
 		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.unarchiveFolder(ctx.user.id, ctx.project.id, input.id);
 	}),

--- a/apps/backend/src/trpc/story-folder.routes.ts
+++ b/apps/backend/src/trpc/story-folder.routes.ts
@@ -1,8 +1,8 @@
+import type { UserRole } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
 import type { DBStoryFolder } from '../db/abstractSchema';
-import * as sharedStoryQueries from '../queries/shared-story.queries';
 import * as storyQueries from '../queries/story.queries';
 import * as storyFolderQueries from '../queries/story-folder.queries';
 import { canSendProcedure, projectProtectedProcedure } from './trpc';
@@ -19,9 +19,9 @@ async function assertFolderInProject(
 	return folder;
 }
 
-function assertCanModifyFolder(folder: DBStoryFolder, userId: string) {
-	if (folder.visibility !== 'public' && folder.ownerId !== userId) {
-		throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the owner can modify a private folder.' });
+function assertCanModifyFolder(folder: DBStoryFolder, userId: string, userRole: UserRole | null) {
+	if (folder.ownerId !== userId && userRole !== 'admin') {
+		throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the owner or an admin can modify this folder.' });
 	}
 }
 
@@ -46,23 +46,6 @@ function assertCanChangeFolderScope(folder: DBStoryFolder, target: DBStoryFolder
 		throw new TRPCError({
 			code: 'FORBIDDEN',
 			message: "Only the owner can change a folder's visibility.",
-		});
-	}
-}
-
-async function assertNonOwnerMovePreservesScope(storyId: string, projectId: string, target: DBStoryFolder | null) {
-	if (target && target.visibility !== 'public') {
-		throw new TRPCError({
-			code: 'FORBIDDEN',
-			message: 'Only the story owner can move it into a private folder.',
-		});
-	}
-
-	const sharing = await sharedStoryQueries.getSharedStoryInfo(storyId, projectId);
-	if (sharing?.visibility !== 'project') {
-		throw new TRPCError({
-			code: 'FORBIDDEN',
-			message: 'Only the story owner can change its sharing scope.',
 		});
 	}
 }
@@ -118,25 +101,25 @@ export const storyFolderRoutes = {
 		)
 		.mutation(async ({ input, ctx }) => {
 			const folder = await assertFolderInProject(input.id, ctx);
-			assertCanModifyFolder(folder, ctx.user.id);
+			assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 			await storyFolderQueries.updateFolder(input.id, { name: input.name });
 		}),
 
 	delete: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
-		assertCanModifyFolder(folder, ctx.user.id);
+		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.deleteFolderMovingContentsToParent(input.id);
 	}),
 
 	archive: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
-		assertCanModifyFolder(folder, ctx.user.id);
+		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.archiveFolder(input.id);
 	}),
 
 	unarchive: canSendProcedure.input(z.object({ id: z.string() })).mutation(async ({ input, ctx }) => {
 		const folder = await assertFolderInProject(input.id, ctx);
-		assertCanModifyFolder(folder, ctx.user.id);
+		assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 		await storyFolderQueries.unarchiveFolder(ctx.user.id, ctx.project.id, input.id);
 	}),
 
@@ -145,6 +128,7 @@ export const storyFolderRoutes = {
 		.mutation(async ({ input, ctx }) => {
 			const folder = await assertFolderInProject(input.id, ctx);
 			assertCanReadPrivateFolder(folder, ctx.user.id);
+			assertCanModifyFolder(folder, ctx.user.id, ctx.userRole);
 
 			let target: DBStoryFolder | null = null;
 			if (input.newParentId) {
@@ -180,12 +164,8 @@ export const storyFolderRoutes = {
 				throw new TRPCError({ code: 'NOT_FOUND', message: 'Story not found.' });
 			}
 
-			const isStoryOwner = storyOwnerId === ctx.user.id;
-			if (!isStoryOwner) {
-				const canAccess = await storyQueries.canUserAccessStory(input.storyId, ctx.user.id);
-				if (!canAccess) {
-					throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this story.' });
-				}
+			if (storyOwnerId !== ctx.user.id && ctx.userRole !== 'admin') {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the owner or an admin can move this story.' });
 			}
 
 			let target: DBStoryFolder | null = null;
@@ -194,11 +174,7 @@ export const storyFolderRoutes = {
 				assertCanReadPrivateFolder(target, ctx.user.id);
 			}
 
-			if (isStoryOwner) {
-				assertCanPlaceInDestination(target, ctx.user.id);
-			} else {
-				await assertNonOwnerMovePreservesScope(input.storyId, ctx.project.id, target);
-			}
+			assertCanPlaceInDestination(target, ctx.user.id);
 
 			await storyFolderQueries.moveStoryToFolder(input.storyId, input.folderId, {
 				storyOwnerId,

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -25,10 +25,14 @@ const storyOwnerProcedure = ownedResourceProcedure(storyQueries.getStoryOwnerId,
 
 async function assertCanArchiveSharedStory(
 	storyId: string,
-	ctx: { user: { id: string }; userRole: UserRole | null },
+	ctx: { user: { id: string }; userRole: UserRole | null; project: { id: string } },
 ): Promise<void> {
 	const ownerId = await storyQueries.getStoryOwnerId(storyId);
 	if (!ownerId) {
+		throw new TRPCError({ code: 'NOT_FOUND', message: 'Story not found.' });
+	}
+	const storyProjectId = await storyQueries.getStoryProjectId(storyId);
+	if (storyProjectId !== ctx.project.id) {
 		throw new TRPCError({ code: 'NOT_FOUND', message: 'Story not found.' });
 	}
 	if (ownerId !== ctx.user.id && ctx.userRole !== 'admin') {

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -1,4 +1,5 @@
 import { NO_CACHE_SCHEDULE } from '@nao/shared';
+import type { UserRole } from '@nao/shared/types';
 import { DOWNLOAD_FORMATS } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
@@ -22,12 +23,18 @@ import { canSendProcedure, ownedResourceProcedure, projectProtectedProcedure, pr
 const chatOwnerProcedure = ownedResourceProcedure(chatQueries.getChatOwnerId, 'chat');
 const storyOwnerProcedure = ownedResourceProcedure(storyQueries.getStoryOwnerId, 'story');
 
-async function assertStoryPublicInProject(storyId: string, projectId: string): Promise<void> {
-	const share = await sharedStoryQueries.getSharedStoryInfo(storyId, projectId);
-	if (!share || share.visibility !== 'project') {
+async function assertCanArchiveSharedStory(
+	storyId: string,
+	ctx: { user: { id: string }; userRole: UserRole | null },
+): Promise<void> {
+	const ownerId = await storyQueries.getStoryOwnerId(storyId);
+	if (!ownerId) {
+		throw new TRPCError({ code: 'NOT_FOUND', message: 'Story not found.' });
+	}
+	if (ownerId !== ctx.user.id && ctx.userRole !== 'admin') {
 		throw new TRPCError({
 			code: 'FORBIDDEN',
-			message: 'Only public stories can be archived by other members.',
+			message: 'Only the owner or an admin can archive this story.',
 		});
 	}
 }
@@ -320,13 +327,13 @@ export const storyRoutes = {
 	}),
 
 	archiveShared: canSendProcedure.input(z.object({ storyId: z.string() })).mutation(async ({ input, ctx }) => {
-		await assertStoryPublicInProject(input.storyId, ctx.project.id);
+		await assertCanArchiveSharedStory(input.storyId, ctx);
 		await storyQueries.archiveByStoryId(input.storyId);
 		await unscheduleStoryRefreshJob(input.storyId);
 	}),
 
 	unarchiveShared: canSendProcedure.input(z.object({ storyId: z.string() })).mutation(async ({ input, ctx }) => {
-		await assertStoryPublicInProject(input.storyId, ctx.project.id);
+		await assertCanArchiveSharedStory(input.storyId, ctx);
 		await storyQueries.unarchiveByStoryId(input.storyId);
 		await storyFolderQueries.rehomeUnarchivedStory(ctx.user.id, ctx.project.id, input.storyId);
 	}),

--- a/apps/frontend/src/components/stories-folder-card.tsx
+++ b/apps/frontend/src/components/stories-folder-card.tsx
@@ -28,6 +28,7 @@ import {
 import { SimpleTooltip } from '@/components/ui/tooltip';
 import { useToggleFavorite } from '@/hooks/use-toggle-favorite';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useSession } from '@/lib/auth-client';
 import { formatRelativeDate } from '@/lib/time-ago';
 import { cn } from '@/lib/utils';
 
@@ -52,7 +53,9 @@ export function FolderCard({
 	onArchive: (folder: FolderItem) => void;
 	onRestore: (folder: FolderItem) => void;
 }) {
-	const { isViewer } = usePermissions();
+	const { isViewer, isAdmin } = usePermissions();
+	const { data: session } = useSession();
+	const canManage = isAdmin || folder.ownerId === session?.user?.id;
 	const isVirtual = folder.id === '__shared_with_me__';
 	const draggableId = `drag-folder-${displayMode}-${folder.id}`;
 	const droppableId = `drop-folder-${displayMode}-${folder.id}`;
@@ -70,7 +73,7 @@ export function FolderCard({
 		isDragging,
 	} = useDraggable({
 		id: draggableId,
-		disabled: isVirtual || isSystemFolder(folder) || isViewer,
+		disabled: isVirtual || isSystemFolder(folder) || isViewer || !canManage,
 	});
 	const { setNodeRef: setDropRef, isOver } = useDroppable({
 		id: droppableId,
@@ -122,6 +125,7 @@ export function FolderCard({
 								<div className='absolute top-1/2 right-0 -translate-y-1/2'>
 									<FolderKebab
 										folder={folder}
+										canManage={canManage}
 										onModify={onModify}
 										onMove={onMove}
 										onDelete={onDelete}
@@ -134,6 +138,7 @@ export function FolderCard({
 								className={cn(
 									'absolute top-1/2 right-0 -translate-y-1/2 z-10 transition-transform duration-150',
 									!isViewer &&
+										canManage &&
 										'group-hover:-translate-x-5 group-has-data-[state=open]:-translate-x-5',
 								)}
 								onPointerDown={(e) => e.stopPropagation()}
@@ -196,6 +201,7 @@ export function FolderCard({
 							>
 								<FolderKebab
 									folder={folder}
+									canManage={canManage}
 									onModify={onModify}
 									onMove={onMove}
 									onDelete={onDelete}
@@ -237,6 +243,7 @@ export function FolderCard({
 						<div className='absolute top-1/2 right-1.5 -translate-y-1/2 z-10'>
 							<FolderKebab
 								folder={folder}
+								canManage={canManage}
 								onModify={onModify}
 								onMove={onMove}
 								onDelete={onDelete}
@@ -248,7 +255,9 @@ export function FolderCard({
 					<div
 						className={cn(
 							'absolute top-1/2 right-1.5 -translate-y-1/2 z-20 transition-transform duration-150',
-							!isViewer && 'group-hover:-translate-x-5 group-has-data-[state=open]:-translate-x-5',
+							!isViewer &&
+								canManage &&
+								'group-hover:-translate-x-5 group-has-data-[state=open]:-translate-x-5',
 						)}
 						onPointerDown={(e) => e.stopPropagation()}
 					>
@@ -301,6 +310,7 @@ function FolderIcon({ folder }: { folder: FolderItem }) {
 
 function FolderKebab({
 	folder,
+	canManage,
 	onModify,
 	onMove,
 	onDelete,
@@ -308,6 +318,7 @@ function FolderKebab({
 	onRestore,
 }: {
 	folder: FolderItem;
+	canManage: boolean;
 	onModify: (folder: FolderItem) => void;
 	onMove: (folder: FolderItem) => void;
 	onDelete: (folder: FolderItem) => void;
@@ -315,6 +326,10 @@ function FolderKebab({
 	onRestore: (folder: FolderItem) => void;
 }) {
 	const isArchived = folder.archivedAt !== null;
+
+	if (!canManage) {
+		return null;
+	}
 
 	function stop(e: MouseEvent) {
 		e.preventDefault();

--- a/apps/frontend/src/components/stories-groups.tsx
+++ b/apps/frontend/src/components/stories-groups.tsx
@@ -69,12 +69,14 @@ export function StoryCard({
 
 	const draggableId = `drag-story-${dragIdPrefix ? `${dragIdPrefix}-` : ''}${item.storyId}`;
 	const isOwnedByUser = item.kind === 'own' || item.kind === 'own-standalone';
+	const canMove = isOwnedByUser || isAdmin;
 	const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
 		id: draggableId,
-		disabled: isViewer,
+		disabled: isViewer || !canMove,
 		data: { type: 'story', isOwnedByUser },
 	});
 	const style = transform ? { transform: CSS.Translate.toString(transform) } : undefined;
+	const moveHandler = canMove ? onMoveToFolder : undefined;
 
 	const canOpenPinShareDialog =
 		isAdmin && !item.sharedStoryId && item.kind === 'own' && !!item.chatId && !!item.storySlug;
@@ -115,8 +117,8 @@ export function StoryCard({
 					>
 						<StoryQuickActions item={item} onRequestPinShare={() => setPinShareDialogOpen(true)} />
 						<div className='flex items-center max-w-0 overflow-hidden group-hover:max-w-[60px] transition-[max-width] duration-200 ease-out'>
-							{!showArchived && onMoveToFolder && (
-								<StoryMoveToFolderButton item={item} onMoveToFolder={onMoveToFolder} />
+							{!showArchived && moveHandler && (
+								<StoryMoveToFolderButton item={item} onMoveToFolder={moveHandler} />
 							)}
 							<StoryArchiveButton item={item} showArchived={showArchived} />
 						</div>
@@ -167,7 +169,7 @@ export function StoryCard({
 						item={item}
 						showArchived={showArchived}
 						onRequestPinShare={() => setPinShareDialogOpen(true)}
-						onMoveToFolder={onMoveToFolder}
+						onMoveToFolder={moveHandler}
 					/>
 				</div>
 			</div>
@@ -353,7 +355,7 @@ function QuickActionButton({
 
 function StoryArchiveButton({ item, showArchived }: { item: StoryItem; showArchived: boolean }) {
 	const queryClient = useQueryClient();
-	const { isViewer } = usePermissions();
+	const { isViewer, isAdmin } = usePermissions();
 
 	function invalidateAfterArchive() {
 		queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
@@ -387,7 +389,7 @@ function StoryArchiveButton({ item, showArchived }: { item: StoryItem; showArchi
 	const canArchive =
 		(item.kind === 'own' && item.chatId && item.storySlug) ||
 		item.kind === 'own-standalone' ||
-		item.kind === 'shared-project';
+		(item.kind === 'shared-project' && isAdmin);
 
 	if (!canArchive || isViewer) {
 		return null;


### PR DESCRIPTION
## Description

Only admin and owner can archive/rename/move stories and folder on the public story explorer

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

