### PR TITLE
fix: Change condition when aborting chat so queries remain displayed

### DIFF
--- a/apps/frontend/src/hooks/use-agent.ts
+++ b/apps/frontend/src/hooks/use-agent.ts
@@ -190,7 +190,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 					newAgent.sendMessage({ text: next.text, files: files.length > 0 ? files : undefined });
 				} else {
 					chatActivityStore.setRunning(agentId, false);
-					if (agentId !== NEW_CHAT_ID) {
+					if (agentId !== NEW_CHAT_ID && !isAbort) {
 						queryClient.invalidateQueries({ queryKey: trpc.chat.get.queryKey({ chatId: agentId }) });
 					}
 					if (chatIdRef.current !== agentId) {


### PR DESCRIPTION
This fixes #1013.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

