### PR TITLE
[fix:chart] charts and tables no longer show "data unavailable" after editing a story

### DIFF
--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-versions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-versions.ts
@@ -31,10 +31,13 @@ export const useStoryViewerVersions = ({
 		if (previousRunningRef.current && !isAgentRunning) {
 			void refetch();
 			void queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+			void queryClient.invalidateQueries({
+				queryKey: trpc.story.getLatest.queryKey({ chatId, storySlug }),
+			});
 		}
 
 		previousRunningRef.current = isAgentRunning;
-	}, [isAgentRunning, queryClient, refetch]);
+	}, [isAgentRunning, queryClient, refetch, chatId, storySlug]);
 
 	useEffect(() => {
 		setSelectedVersionIndex(versions.length - 1);


### PR DESCRIPTION
## Summary

When you edited a chart or table in a story (e.g. changing the X-axis granularity or refreshing the data), it would sometimes show a "Chart data unavailable" / "Table data unavailable" placeholder instead of the updated visualization.
The story now refreshes its data right after an edit — by invalidating the stale query cache so the new data is fetched — so charts and tables render correctly without needing a page reload.

## Related issue

#869 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

