### PR TITLE
chore: update Slack community invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,4 +120,4 @@ PRs against EE-marked files just like the rest of the codebase.
 
 ## Questions?
 
-- Ask on [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-3cgdql4up-Az9FxGkTb8Qr34z2Dxp9TQ)
+- Ask on [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-4080jlm79-nm52x5nZhG2N1ben8zwpiQ)

--- a/README-dockerhub.md
+++ b/README-dockerhub.md
@@ -2,7 +2,7 @@
 
 nao is a framework to build and deploy analytics agents. Create context for your analytics agent with the nao-core CLI, then deploy a chat UI for anyone to interact with your data.
 
-🌐 [Website](https://getnao.io) · 📚 [Documentation](https://docs.getnao.io) · 💬 [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-3cgdql4up-Az9FxGkTb8Qr34z2Dxp9TQ) · 🐙 [GitHub](https://github.com/getnao/nao)
+🌐 [Website](https://getnao.io) · 📚 [Documentation](https://docs.getnao.io) · 💬 [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-4080jlm79-nm52x5nZhG2N1ben8zwpiQ) · 🐙 [GitHub](https://github.com/getnao/nao)
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </h3>
 
 <p align="center">
-  🌐 <a href="https://getnao.io">Website</a> · 📚 <a href="https://docs.getnao.io">Documentation</a> · 💬 <a href="https://join.slack.com/t/naolabs/shared_invite/zt-3cgdql4up-Az9FxGkTb8Qr34z2Dxp9TQ">Slack</a>
+  🌐 <a href="https://getnao.io">Website</a> · 📚 <a href="https://docs.getnao.io">Documentation</a> · 💬 <a href="https://join.slack.com/t/naolabs/shared_invite/zt-4080jlm79-nm52x5nZhG2N1ben8zwpiQ">Slack</a>
 </p>
 
 <br/>
@@ -214,7 +214,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commands, and guid
 - Star the repo
 - Subscribe to releases (Watch → Custom → Releases)
 - Follow us on [LinkedIn](https://www.linkedin.com/company/getnao)
-- Join our [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-3cgdql4up-Az9FxGkTb8Qr34z2Dxp9TQ)
+- Join our [Slack](https://join.slack.com/t/naolabs/shared_invite/zt-4080jlm79-nm52x5nZhG2N1ben8zwpiQ)
 - Contribute to the repo!
 
 ## 🫰🏻 Partners

--- a/apps/frontend/src/components/sidebar-community.tsx
+++ b/apps/frontend/src/components/sidebar-community.tsx
@@ -47,7 +47,7 @@ export function SidebarCommunity({ isCollapsed }: SidebarCommunityProps) {
 					<GithubIcon className='size-3.5' />
 				</a>
 				<a
-					href='https://join.slack.com/t/naolabs/shared_invite/zt-3cgdql4up-Az9FxGkTb8Qr34z2Dxp9TQ'
+					href='https://join.slack.com/t/naolabs/shared_invite/zt-4080jlm79-nm52x5nZhG2N1ben8zwpiQ'
 					target='_blank'
 					rel='noopener noreferrer'
 					className={cn(


### PR DESCRIPTION
Updates the Slack community invite link to the current invite (`zt-4080jlm79-...`); the previous invite (`zt-3cgdql4up-...`) is expired.

Files updated:
- `README.md` (x2)
- `CONTRIBUTING.md`
- `README-dockerhub.md`
- `apps/frontend/src/components/sidebar-community.tsx`

Closes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

