### PR TITLE
feat(chat): smoothly hide input suggestions while typing

### DIFF
--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { MessageSquare, X, ThumbsDown, ThumbsUp, Check } from 'lucide-react';
 import { NegativeFeedbackDialog } from './chat-messages/assistant-message-actions';
@@ -12,6 +12,7 @@ import { checkAssistantMessageHasContent, NEW_CHAT_ID } from '@/lib/ai';
 import { countDisplayCharts } from '@/lib/charts.utils';
 import { createLocalStorage } from '@/lib/local-storage';
 import { findStoryIds } from '@/lib/story.utils';
+import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
 
 /** Milliseconds of inactivity before we ask the user how the conversation went. */
@@ -27,12 +28,63 @@ const storyProposalDisabledStorage = createLocalStorage<boolean>('nao-story-prop
  * A floating panel that sits above the chat input and surfaces a single
  * contextual prompt. Only one suggestion is shown at a time — the story
  * suggestion takes priority over the conversation feedback prompt.
+ *
+ * When `isHidden` is set (e.g. the user starts typing) the panel smoothly
+ * collapses and fades out instead of abruptly unmounting.
  */
-export function ChatInputSuggestions() {
+export function ChatInputSuggestions({ isHidden = false }: { isHidden?: boolean }) {
 	const { isReadonly } = useAgentContext();
 	const story = useStorySuggestion();
 	const feedback = useConversationFeedback();
 
+	const content = renderSuggestion({ isReadonly, story, feedback });
+	const isCollapsed = isHidden || !content;
+	const { ref, height } = useMeasuredHeight();
+
+	return (
+		<div
+			className='overflow-hidden'
+			style={{
+				height: isCollapsed ? 0 : height,
+				opacity: isCollapsed ? 0 : 1,
+				transition: 'height 300ms ease-out, opacity 300ms ease-out',
+			}}
+			aria-hidden={isCollapsed}
+		>
+			<div ref={ref} className={cn('pb-2', isCollapsed && 'pointer-events-none')}>
+				{content}
+			</div>
+		</div>
+	);
+}
+
+/** Measures the suggestion content height so the panel can collapse to a real, transitionable pixel value. */
+function useMeasuredHeight() {
+	const ref = useRef<HTMLDivElement>(null);
+	const [height, setHeight] = useState(0);
+
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) {
+			return;
+		}
+		const observer = new ResizeObserver(() => setHeight(element.offsetHeight));
+		observer.observe(element);
+		return () => observer.disconnect();
+	}, []);
+
+	return { ref, height };
+}
+
+function renderSuggestion({
+	isReadonly,
+	story,
+	feedback,
+}: {
+	isReadonly: boolean | undefined;
+	story: StorySuggestion;
+	feedback: ConversationFeedback;
+}) {
 	if (isReadonly) {
 		return null;
 	}
@@ -265,7 +317,7 @@ function SuggestionCard({
 	return (
 		<div
 			data-selection-ignore
-			className='group mb-2 flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2 animate-in fade-in slide-in-from-bottom-2 duration-200'
+			className='group flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2'
 		>
 			{icon && <div className='flex size-9 shrink-0 items-center justify-center'>{icon}</div>}
 			<p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{message}</p>

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -308,7 +308,7 @@ function ChatInputBase({
 			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
-			{allowQueueing && !isAdminMode && <ChatInputSuggestions />}
+			{allowQueueing && !isAdminMode && <ChatInputSuggestions isHidden={inputText.trim().length > 0} />}
 			{isAdminMode && <ChatInputAdminBadge />}
 
 			<form onSubmit={handleSubmitMessage} className='mx-auto relative'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

When the user starts typing in the chat input, the contextual suggestion card above it (e.g. "How did this conversation go?") now smoothly collapses and fades out instead of staying put. It smoothly grows and fades back in when the input is cleared.

## Why

Previously the suggestion card remained visible while typing, competing with the user's own query. Hiding it while there is input text keeps the composer focused on what the user is writing.

## How

- `chat-input.tsx`: pass `isHidden={inputText.trim().length > 0}` to `ChatInputSuggestions` so the panel hides whenever the input has text.
- `chat-input-suggestions.tsx`: wrap the suggestion content in an `overflow-hidden` container that animates `height` (measured via a `ResizeObserver`) and `opacity` with a 300ms `ease-out` transition. Collapsed state sets `height: 0; opacity: 0`.

### Implementation note

I initially used a CSS `grid-template-rows: 1fr → 0fr` collapse (the pattern used in `recommendation-card.tsx`), but found that `grid-template-rows` `fr` transitions do **not** fire when the value is updated directly via React inline styles / class toggles in this environment, whereas a plain measured `height` (length) property animates reliably. The measured-`height` approach is used instead.

## Testing

- ✅ `npm run lint -w @nao/frontend` (`tsc --noEmit && eslint`)
- Verified via in-app `requestAnimationFrame` + `getComputedStyle` instrumentation that the wrapper interpolates smoothly on a real React-driven collapse (`opacity 1 → 0.88 → 0.56 → 0.1`, `height` decreasing) — i.e. the transition genuinely animates.
- Verified the exact production wrapper element interpolates smoothly (`height 49.8 → 43.5 → 28.4 → 15.7 → 0px`, `opacity 0.989 → 0.886 → 0.614 → 0.292 → 0`):

[getComputedStyle interpolation proof](https://cursor.com/agents/bc-86b36685-bbfd-4e88-846d-716b7b6495c5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuggestion_transition_interpolation_proof.webp)

> Note: the VM's screen-recording pipeline does not capture in-progress CSS transitions (a 3s opacity fade recorded as an instant cut), so the animation is demonstrated via `getComputedStyle` sampling rather than a video. Real browsers render the fade normally.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86b36685-bbfd-4e88-846d-716b7b6495c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86b36685-bbfd-4e88-846d-716b7b6495c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

