### PR TITLE
feat(context-recommendations): cancel button + stale-run timeout for stuck runs

### DIFF
--- a/apps/backend/src/queries/context-recommendation.queries.ts
+++ b/apps/backend/src/queries/context-recommendation.queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, isNotNull, lt, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNotNull, lt, lte, sql } from 'drizzle-orm';
 
 import s, {
 	DBContextRecommendation,
@@ -9,6 +9,10 @@ import s, {
 } from '../db/abstractSchema';
 import { db, type DBExecutor } from '../db/db';
 import { WindowTotals } from '../types/context-recommendation';
+
+const CONTEXT_RECOMMENDATION_RUN_STALE_MS = 10 * 60 * 1_000;
+const CONTEXT_RECOMMENDATION_RUN_STALE_MESSAGE = 'Context recommendations run did not finish before the timeout.';
+const CONTEXT_RECOMMENDATION_RUN_CANCELLED_MESSAGE = 'Cancelled by user.';
 
 /**
  * Statuses the reconciler must see, i.e. everything except `dismissed` (handled
@@ -111,6 +115,32 @@ export async function failRun(runId: string, errorMessage: string): Promise<void
 		.execute();
 }
 
+/**
+ * Flips a running context recommendations run to `cancelled`. Guarded by
+ * `status = 'running'` so it's idempotent and safely no-ops on already-terminal
+ * runs (including those completed concurrently by the agent loop).
+ */
+export async function cancelRun(runId: string): Promise<boolean> {
+	const rows = await db
+		.update(s.contextRecommendationRun)
+		.set({ status: 'cancelled', completedAt: new Date(), errorMessage: CONTEXT_RECOMMENDATION_RUN_CANCELLED_MESSAGE })
+		.where(and(eq(s.contextRecommendationRun.id, runId), eq(s.contextRecommendationRun.status, 'running')))
+		.returning({ id: s.contextRecommendationRun.id })
+		.execute();
+	return rows.length > 0;
+}
+
+export async function failStaleRuns(): Promise<number> {
+	const cutoff = new Date(Date.now() - CONTEXT_RECOMMENDATION_RUN_STALE_MS);
+	const rows = await db
+		.update(s.contextRecommendationRun)
+		.set({ status: 'failed', completedAt: new Date(), errorMessage: CONTEXT_RECOMMENDATION_RUN_STALE_MESSAGE })
+		.where(and(eq(s.contextRecommendationRun.status, 'running'), lte(s.contextRecommendationRun.startedAt, cutoff)))
+		.returning({ id: s.contextRecommendationRun.id })
+		.execute();
+	return rows.length;
+}
+
 export async function getReconcilableRecommendations(projectId: string): Promise<DBContextRecommendation[]> {
 	return db
 		.select()
@@ -190,11 +220,22 @@ export async function setRecommendationPr(
 }
 
 export async function getLatestRun(projectId: string): Promise<DBContextRecommendationRun | null> {
+	await failStaleRuns();
 	const [run] = await db
 		.select()
 		.from(s.contextRecommendationRun)
 		.where(eq(s.contextRecommendationRun.projectId, projectId))
 		.orderBy(desc(s.contextRecommendationRun.startedAt))
+		.limit(1)
+		.execute();
+	return run ?? null;
+}
+
+export async function getRunById(projectId: string, runId: string): Promise<DBContextRecommendationRun | null> {
+	const [run] = await db
+		.select()
+		.from(s.contextRecommendationRun)
+		.where(and(eq(s.contextRecommendationRun.id, runId), eq(s.contextRecommendationRun.projectId, projectId)))
 		.limit(1)
 		.execute();
 	return run ?? null;

--- a/apps/backend/src/queries/context-recommendation.queries.ts
+++ b/apps/backend/src/queries/context-recommendation.queries.ts
@@ -103,7 +103,7 @@ export async function completeRun(
 	await executor
 		.update(s.contextRecommendationRun)
 		.set({ status: 'completed', completedAt: new Date(), ...patch })
-		.where(eq(s.contextRecommendationRun.id, runId))
+		.where(and(eq(s.contextRecommendationRun.id, runId), eq(s.contextRecommendationRun.status, 'running')))
 		.execute();
 }
 
@@ -111,7 +111,7 @@ export async function failRun(runId: string, errorMessage: string): Promise<void
 	await db
 		.update(s.contextRecommendationRun)
 		.set({ status: 'failed', completedAt: new Date(), errorMessage })
-		.where(eq(s.contextRecommendationRun.id, runId))
+		.where(and(eq(s.contextRecommendationRun.id, runId), eq(s.contextRecommendationRun.status, 'running')))
 		.execute();
 }
 
@@ -134,12 +134,18 @@ export async function cancelRun(runId: string): Promise<boolean> {
 	return rows.length > 0;
 }
 
-export async function failStaleRuns(): Promise<number> {
+export async function failStaleRuns(projectId: string): Promise<number> {
 	const cutoff = new Date(Date.now() - CONTEXT_RECOMMENDATION_RUN_STALE_MS);
 	const rows = await db
 		.update(s.contextRecommendationRun)
 		.set({ status: 'failed', completedAt: new Date(), errorMessage: CONTEXT_RECOMMENDATION_RUN_STALE_MESSAGE })
-		.where(and(eq(s.contextRecommendationRun.status, 'running'), lte(s.contextRecommendationRun.startedAt, cutoff)))
+		.where(
+			and(
+				eq(s.contextRecommendationRun.projectId, projectId),
+				eq(s.contextRecommendationRun.status, 'running'),
+				lte(s.contextRecommendationRun.startedAt, cutoff),
+			),
+		)
 		.returning({ id: s.contextRecommendationRun.id })
 		.execute();
 	return rows.length;
@@ -224,7 +230,7 @@ export async function setRecommendationPr(
 }
 
 export async function getLatestRun(projectId: string): Promise<DBContextRecommendationRun | null> {
-	await failStaleRuns();
+	await failStaleRuns(projectId);
 	const [run] = await db
 		.select()
 		.from(s.contextRecommendationRun)

--- a/apps/backend/src/queries/context-recommendation.queries.ts
+++ b/apps/backend/src/queries/context-recommendation.queries.ts
@@ -123,7 +123,11 @@ export async function failRun(runId: string, errorMessage: string): Promise<void
 export async function cancelRun(runId: string): Promise<boolean> {
 	const rows = await db
 		.update(s.contextRecommendationRun)
-		.set({ status: 'cancelled', completedAt: new Date(), errorMessage: CONTEXT_RECOMMENDATION_RUN_CANCELLED_MESSAGE })
+		.set({
+			status: 'cancelled',
+			completedAt: new Date(),
+			errorMessage: CONTEXT_RECOMMENDATION_RUN_CANCELLED_MESSAGE,
+		})
 		.where(and(eq(s.contextRecommendationRun.id, runId), eq(s.contextRecommendationRun.status, 'running')))
 		.returning({ id: s.contextRecommendationRun.id })
 		.execute();

--- a/apps/backend/src/trpc/context-recommendation.routes.ts
+++ b/apps/backend/src/trpc/context-recommendation.routes.ts
@@ -6,6 +6,7 @@ import { env } from '../env';
 import { ensureContextRecommendationsSchedule } from '../handlers/context-recommendations.handler';
 import * as crQueries from '../queries/context-recommendation.queries';
 import * as userQueries from '../queries/user.queries';
+import { agentService } from '../services/agent';
 import { createRecommendationPullRequest, resolveRecommendationRepo } from '../services/context-pr.service';
 import { runContextRecommendations } from '../services/context-recommendations.service';
 import * as github from '../services/github';
@@ -45,6 +46,25 @@ export const contextRecommendationRoutes = {
 			logger.error(`Manual context recommendations run failed: ${String(err)}`, { source: 'agent' });
 		});
 		return { started: true };
+	}),
+
+	cancelRun: recommendationsProcedure.input(z.object({ runId: z.string() })).mutation(async ({ ctx, input }) => {
+		const run = await crQueries.getRunById(ctx.project.id, input.runId);
+		if (!run) {
+			throw new TRPCError({ code: 'NOT_FOUND', message: `Recommendations run not found: ${input.runId}` });
+		}
+		if (run.status !== 'running') {
+			return { ...run, alreadyTerminal: true as const };
+		}
+		if (run.chatId) {
+			agentService.get(run.chatId)?.stop();
+		}
+		const cancelled = await crQueries.cancelRun(input.runId);
+		const fresh = await crQueries.getRunById(ctx.project.id, input.runId);
+		if (!fresh) {
+			throw new TRPCError({ code: 'NOT_FOUND', message: `Recommendations run not found: ${input.runId}` });
+		}
+		return { ...fresh, alreadyTerminal: !cancelled };
 	}),
 
 	listAvailableModels: recommendationsProcedure.query(async ({ ctx }) => getProjectAvailableModels(ctx.project.id)),

--- a/apps/backend/src/types/context-recommendation.ts
+++ b/apps/backend/src/types/context-recommendation.ts
@@ -1,4 +1,4 @@
-export const CONTEXT_RECOMMENDATION_RUN_STATUSES = ['running', 'completed', 'failed'] as const;
+export const CONTEXT_RECOMMENDATION_RUN_STATUSES = ['running', 'completed', 'failed', 'cancelled'] as const;
 export type ContextRecommendationRunStatus = (typeof CONTEXT_RECOMMENDATION_RUN_STATUSES)[number];
 
 export const CONTEXT_RECOMMENDATION_RUN_TRIGGERS = ['schedule', 'manual'] as const;

--- a/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { ArrowDown, ArrowUp } from 'lucide-react';
+import { ArrowDown, ArrowUp, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { LlmProvider } from '@nao/shared/types';
@@ -27,6 +27,9 @@ export const Route = createFileRoute('/_sidebar-layout/settings/recommendations'
 });
 
 const SNOOZE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** How long a run must be in progress before the cancel escape hatch appears. */
+const RUN_CANCEL_THRESHOLD_MS = 60 * 1000;
 
 const FREQUENCY_OPTIONS = [
 	{ value: 'daily', label: 'Daily' },
@@ -86,11 +89,32 @@ function RecommendationsPage() {
 	const setConfig = useMutation(trpc.contextRecommendation.setConfig.mutationOptions());
 	const setStatus = useMutation(trpc.contextRecommendation.setStatus.mutationOptions());
 	const run = useMutation(trpc.contextRecommendation.run.mutationOptions());
+	const cancelRun = useMutation(trpc.contextRecommendation.cancelRun.mutationOptions());
 
-	const isRunning = run.isPending || latestRun.data?.status === 'running';
+	const runningRun = latestRun.data?.status === 'running' ? latestRun.data : null;
+	const isRunning = run.isPending || runningRun !== null;
+
+	const [nowMs, setNowMs] = useState(() => Date.now());
+	useEffect(() => {
+		if (!runningRun) {
+			return;
+		}
+		const interval = setInterval(() => setNowMs(Date.now()), 1000);
+		return () => clearInterval(interval);
+	}, [runningRun]);
+
+	const canCancelRun = runningRun !== null && nowMs - new Date(runningRun.startedAt).getTime() >= RUN_CANCEL_THRESHOLD_MS;
 
 	const handleRun = async () => {
 		await run.mutateAsync();
+		queryClient.invalidateQueries({ queryKey: trpc.contextRecommendation.latestRun.queryKey() });
+	};
+
+	const handleCancelRun = async () => {
+		if (!runningRun) {
+			return;
+		}
+		await cancelRun.mutateAsync({ runId: runningRun.id });
 		queryClient.invalidateQueries({ queryKey: trpc.contextRecommendation.latestRun.queryKey() });
 	};
 
@@ -228,10 +252,28 @@ function RecommendationsPage() {
 						description="Diagnostic suggestions for improving this project's context, mined from real usage."
 						action={
 							<div className='flex flex-col items-end gap-1'>
-								<Button size='sm' onClick={handleRun} disabled={isRunning}>
-									{isRunning && <Spinner className='size-4' />}
-									{isRunning ? 'Running…' : 'Run now'}
-								</Button>
+								<div className='flex items-center gap-2'>
+									{canCancelRun && (
+										<Button
+											size='sm'
+											variant='ghost'
+											className='gap-1.5 text-muted-foreground hover:text-destructive'
+											onClick={handleCancelRun}
+											disabled={cancelRun.isPending}
+										>
+											{cancelRun.isPending ? (
+												<Spinner className='size-4' />
+											) : (
+												<X className='size-4' />
+											)}
+											{cancelRun.isPending ? 'Cancelling…' : 'Cancel'}
+										</Button>
+									)}
+									<Button size='sm' onClick={handleRun} disabled={isRunning}>
+										{isRunning && <Spinner className='size-4' />}
+										{isRunning ? 'Running…' : 'Run now'}
+									</Button>
+								</div>
 								{latestRun.data ? (
 									<span className='text-xs text-muted-foreground italic'>
 										Latest {new Date(latestRun.data.startedAt).toLocaleString()}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
@@ -103,7 +103,8 @@ function RecommendationsPage() {
 		return () => clearInterval(interval);
 	}, [runningRun]);
 
-	const canCancelRun = runningRun !== null && nowMs - new Date(runningRun.startedAt).getTime() >= RUN_CANCEL_THRESHOLD_MS;
+	const canCancelRun =
+		runningRun !== null && nowMs - new Date(runningRun.startedAt).getTime() >= RUN_CANCEL_THRESHOLD_MS;
 
 	const handleRun = async () => {
 		await run.mutateAsync();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes [#1070](https://github.com/getnao/nao/issues/1070). The **Run now** button on the Context Recommendations settings page could stay stuck in the `Running…` state indefinitely. The running state is driven by the run row's DB `status`, so if the run's agent hung (without throwing) or the server restarted mid-run, the row stayed `running` forever with no way to unstick it — and a stuck run also blocks new runs (`CONFLICT`).

## Fix

Mirrors the existing **Automations** cancel/stale pattern.

**Backend**
- Add a `cancelled` value to `CONTEXT_RECOMMENDATION_RUN_STATUSES` (stored as `text`, so no DB migration needed).
- Add `contextRecommendation.cancelRun` tRPC mutation: aborts the agent stream (`agentService.get(chatId)?.stop()`) when it's still alive on this process, and always force-flips the run row from `running` → `cancelled` (idempotent, guarded by `status = 'running'`).
- Add `failStaleRuns()` (10-minute cutoff) and call it on `getLatestRun`, so runs left dangling by a crash/restart auto-fail on the next read.
- Add `getRunById` for scoped run lookups.

**Frontend** (`_sidebar-layout.settings.recommendations.tsx`)
- Once a run has been in progress for over a minute, a **Cancel** button appears next to **Run now**. It calls `cancelRun` and invalidates the latest-run query.
- A 1s ticking timer re-renders while a run is in progress so the button appears at the 60s mark.

## Walkthrough

[context_reco_cancel_button_flow.mp4](https://cursor.com/agents/bc-019f2b7f-589a-705f-b988-3a28db7b5de6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontext_reco_cancel_button_flow.mp4)

Cancel button appears next to a run that's been in progress over a minute; clicking it cancels the run and re-enables **Run now**.

[Running state with Cancel button](https://cursor.com/agents/bc-019f2b7f-589a-705f-b988-3a28db7b5de6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontext_reco_running_with_cancel.webp)
[Run now re-enabled after cancel](https://cursor.com/agents/bc-019f2b7f-589a-705f-b988-3a28db7b5de6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontext_reco_after_cancel_run_now.webp)

## Testing
- ✅ `npm run lint` (backend + frontend + shared).
- ✅ Manual end-to-end: seeded a `running` run (>60s old) → Cancel button appeared → clicking it POSTed `cancelRun` and flipped the DB row to `cancelled` ("Cancelled by user.").
- ✅ Stale timeout: seeded a run started 15 min ago → a page load auto-failed it via `failStaleRuns` ("Context recommendations run did not finish before the timeout.").
- ✅ `context-recommendation-schema.test.ts` passes with the new status value.
- ⚠️ Two unrelated test files (`auth-hooks-oidc`, `system-prompt`) fail identically on the base commit (pre-existing, environment-related), not caused by this change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2b7f-589a-705f-b988-3a28db7b5de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2b7f-589a-705f-b988-3a28db7b5de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

