### PR TITLE
fix(stories): reset archive state when navigating from sidebar

### DIFF
--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -77,7 +77,7 @@ export function Sidebar() {
 		void queryClient.invalidateQueries({ queryKey: trpc.story.listStandaloneArchived.queryKey() });
 		void queryClient.invalidateQueries({ queryKey: trpc.storyShare.list.queryKey() });
 		void queryClient.invalidateQueries({ queryKey: trpc.favorite.list.queryKey() });
-		navigate({ to: '/stories', search: { folderId: null } });
+		navigate({ to: '/stories', search: { folderId: null, archived: false } });
 		if (isMobile) {
 			closeMobile();
 		}

--- a/apps/frontend/src/components/stories-folder-breadcrumb.tsx
+++ b/apps/frontend/src/components/stories-folder-breadcrumb.tsx
@@ -72,7 +72,7 @@ function DroppableCrumb({
 	}
 
 	return (
-		<Link to='/stories' search={{ folderId: node.id }}>
+		<Link to='/stories' search={{ folderId: node.id, archived: false }}>
 			{inner}
 		</Link>
 	);

--- a/apps/frontend/src/components/stories-folder-card.tsx
+++ b/apps/frontend/src/components/stories-folder-card.tsx
@@ -100,7 +100,7 @@ export function FolderCard({
 			>
 				<Link
 					to='/stories'
-					search={{ folderId: folder.id }}
+					search={{ folderId: folder.id, archived: false }}
 					className='flex items-center gap-3 flex-1 min-w-0'
 					onClick={(e) => e.stopPropagation()}
 				>
@@ -162,7 +162,7 @@ export function FolderCard({
 
 				<Link
 					to='/stories'
-					search={{ folderId: folder.id }}
+					search={{ folderId: folder.id, archived: false }}
 					className='absolute inset-0 flex flex-col justify-end p-2.5'
 					onClick={(e) => e.stopPropagation()}
 					aria-label={folder.name}
@@ -224,7 +224,7 @@ export function FolderCard({
 		>
 			<Link
 				to='/stories'
-				search={{ folderId: folder.id }}
+				search={{ folderId: folder.id, archived: false }}
 				className='absolute inset-0 flex items-center gap-2.5 pl-3 pr-8'
 				onClick={(e) => e.stopPropagation()}
 			>

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.index.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.index.tsx
@@ -203,7 +203,12 @@ function HomePage() {
 										{hasMoreStories && (
 											<button
 												type='button'
-												onClick={() => navigate({ to: '/stories', search: { folderId: null } })}
+												onClick={() =>
+													navigate({
+														to: '/stories',
+														search: { folderId: null, archived: false },
+													})
+												}
 												className={cn(
 													'h-9 rounded-lg border border-dashed border-muted-foreground/20 px-3',
 													'flex items-center gap-2 text-muted-foreground/50 bg-sidebar dark:bg-background',

--- a/apps/frontend/src/routes/_sidebar-layout.stories.index.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.index.tsx
@@ -47,6 +47,7 @@ import { trpc } from '@/main';
 export const Route = createFileRoute('/_sidebar-layout/stories/')({
 	validateSearch: (search: Record<string, unknown>) => ({
 		folderId: typeof search.folderId === 'string' ? search.folderId : null,
+		archived: search.archived === true || search.archived === 'true',
 	}),
 	component: StoriesPage,
 });
@@ -100,14 +101,13 @@ function StoriesPage() {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 
-	const { folderId: currentFolderId } = Route.useSearch();
+	const { folderId: currentFolderId, archived: showArchived } = Route.useSearch();
 
 	const [displayMode, setDisplayMode] = useState<StoryPanelDisplayMode>(() =>
 		getStoredSetting(STORIES_DISPLAY_KEY, ['grid', 'lines'], 'grid'),
 	);
 	const [sort, setSort] = useState<SortState>(() => readStoredSort());
 	const [searchQuery, setSearchQuery] = useState('');
-	const [showArchived, setShowArchived] = useState(false);
 	const [dialog, setDialog] = useState<DialogState>(null);
 	const [activeId, setActiveId] = useState<string | null>(null);
 
@@ -152,7 +152,7 @@ function StoriesPage() {
 			}
 			setActiveProjectId(projectId);
 			await queryClient.invalidateQueries();
-			navigate({ to: '/stories', search: { folderId: null } });
+			navigate({ to: '/stories', search: { folderId: null, archived: false } });
 		},
 		[activeProjectId, queryClient, navigate],
 	);
@@ -214,7 +214,7 @@ function StoriesPage() {
 		}
 		const exists = folders.some((f) => f.id === currentFolderId);
 		if (!exists) {
-			navigate({ to: '/stories', search: { folderId: null }, replace: true });
+			navigate({ to: '/stories', search: { folderId: null, archived: false }, replace: true });
 		}
 	}, [currentFolderId, folderTree.data, archivedFolderTree.data, folders, navigate, showArchived]);
 
@@ -284,11 +284,15 @@ function StoriesPage() {
 	}
 
 	function handleShowArchivedChange(value: boolean) {
-		setShowArchived(value);
 		setSearchQuery('');
-		if (value) {
-			navigate({ to: '/stories', search: { folderId: null } });
-		}
+
+		navigate({
+			to: '/stories',
+			search: {
+				folderId: null,
+				archived: value,
+			},
+		});
 	}
 
 	const moveStoryMutation = useMutation(


### PR DESCRIPTION
## Summary

Fixes the Stories sidebar navigation when viewing archived stories.

Previously, clicking **Stories** from the left sidebar while inside the archive view kept the archive state active instead of returning to the normal Stories view.

This change explicitly resets the `archived` search parameter when navigating from the sidebar, ensuring users always land on the active Stories page.

## Changes

- Reset `archived` to `false` when navigating to `/stories` from the sidebar.
- Added `archived` to the validated route search parameters.

Fixes #1072

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

