### PR TITLE
fix(auth): hide reset password for SSO-only users

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -15,6 +15,7 @@ import type { JWTPayload } from 'jose';
 import { db } from './db/db';
 import dbConfig, { Dialect } from './db/dbConfig';
 import { env, isCloud, MCP_SERVER_URL } from './env';
+import * as accountQueries from './queries/account.queries';
 import * as orgQueries from './queries/organization.queries';
 import * as userQueries from './queries/user.queries';
 import { emailService } from './services/email';
@@ -176,6 +177,12 @@ async function createAuthInstance(baseURL: string) {
 			enabled: env.ENABLE_USER_LOGIN === true,
 			disableSignUp: disableEmailSignUp,
 			sendResetPassword: async ({ user, url }) => {
+				// Users authenticated only through an identity provider (SSO) have no
+				// password account, so we never surface a reset link for them. This
+				// also prevents them from creating a local password that would bypass SSO.
+				if (!(await accountQueries.userHasPassword(user.id))) {
+					return;
+				}
 				emailService.sendEmail(user.email, buildForgotPasswordEmail(user, url));
 			},
 		},

--- a/apps/backend/src/queries/account.queries.ts
+++ b/apps/backend/src/queries/account.queries.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -13,6 +13,36 @@ export const getAccountById = async (userId: string): Promise<{ id: string; pass
 		.execute();
 
 	return account ?? null;
+};
+
+export const userHasPassword = async (userId: string): Promise<boolean> => {
+	const account = await getAccountById(userId);
+	return !!account?.password;
+};
+
+/**
+ * Returns the subset of the given user ids that own a password (credential)
+ * account. Users authenticated only through an identity provider (SSO) have no
+ * such account, so password reset does not apply to them.
+ */
+export const getUserIdsWithPassword = async (userIds: string[]): Promise<Set<string>> => {
+	if (userIds.length === 0) {
+		return new Set();
+	}
+
+	const rows = await db
+		.select({ userId: s.account.userId })
+		.from(s.account)
+		.where(
+			and(
+				inArray(s.account.userId, userIds),
+				eq(s.account.providerId, CREDENTIAL_PROVIDER_ID),
+				isNotNull(s.account.password),
+			),
+		)
+		.execute();
+
+	return new Set(rows.map((row) => row.userId));
 };
 
 export const updateAccountPassword = async (

--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -5,6 +5,7 @@ import s, { DBOrganization, DBOrgMember, NewOrganization, NewOrgMember } from '.
 import { db } from '../db/db';
 import { env } from '../env';
 import { OrgRole } from '../types/organization';
+import { getUserIdsWithPassword } from './account.queries';
 import * as projectQueries from './project.queries';
 import * as userQueries from './user.queries';
 
@@ -344,6 +345,7 @@ export interface OrgMemberWithUser {
 	name: string;
 	email: string;
 	role: OrgRole;
+	hasPassword: boolean;
 }
 
 export interface OrgProjectWithAccess {
@@ -366,7 +368,10 @@ export const listOrgMembersWithUsers = async (orgId: string): Promise<OrgMemberW
 		.innerJoin(s.user, eq(s.orgMember.userId, s.user.id))
 		.where(eq(s.orgMember.orgId, orgId))
 		.execute();
-	return rows;
+
+	const userIdsWithPassword = await getUserIdsWithPassword(rows.map((row) => row.id));
+
+	return rows.map((row) => ({ ...row, hasPassword: userIdsWithPassword.has(row.id) }));
 };
 
 export const listOrgProjectsWithAccess = async (orgId: string, userId: string): Promise<OrgProjectWithAccess[]> => {

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -9,6 +9,7 @@ import dbConfig, { Dialect } from '../db/dbConfig';
 import { env, isCloud } from '../env';
 import type { ListProjectChatsResponse, ProjectChatsFacetKey, UserWithRole } from '../types/project';
 import { HandlerError } from '../utils/error';
+import { getUserIdsWithPassword } from './account.queries';
 
 export interface UserProjectWithRole {
 	project: DBProject;
@@ -140,7 +141,9 @@ export const listAllUsersWithRoles = async (projectId: string): Promise<UserWith
 		.where(eq(s.projectMember.projectId, projectId))
 		.execute();
 
-	return results;
+	const userIdsWithPassword = await getUserIdsWithPassword(results.map((result) => result.id));
+
+	return results.map((result) => ({ ...result, hasPassword: userIdsWithPassword.has(result.id) }));
 };
 
 export const getDefaultProject = async (): Promise<DBProject | null> => {

--- a/apps/backend/src/types/project.ts
+++ b/apps/backend/src/types/project.ts
@@ -6,6 +6,7 @@ export interface UserWithRole {
 	email: string;
 	role: UserRole;
 	messagingProviderCode: string | null;
+	hasPassword: boolean;
 }
 
 export type ProjectChatsFacetKey = 'userName' | 'userRole' | 'toolState';

--- a/apps/backend/tests/account-password.test.ts
+++ b/apps/backend/tests/account-password.test.ts
@@ -1,0 +1,82 @@
+import '../src/env';
+
+import { eq, inArray } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as sqliteSchema from '../src/db/sqlite-schema';
+import { account, user } from '../src/db/sqlite-schema';
+
+const holder = vi.hoisted(() => ({ db: undefined as unknown }));
+vi.mock('../src/db/db', () => ({ db: holder.db }));
+
+const testDb = drizzle('./db.sqlite', { schema: sqliteSchema });
+holder.db = testDb;
+
+const { getUserIdsWithPassword, userHasPassword } = await import('../src/queries/account.queries');
+
+const PASSWORD_USER = 'acct-pwd-user';
+const SSO_USER = 'acct-sso-user';
+const NO_ACCOUNT_USER = 'acct-none-user';
+const ALL_USER_IDS = [PASSWORD_USER, SSO_USER, NO_ACCOUNT_USER];
+
+async function cleanup() {
+	await testDb.delete(account).where(inArray(account.userId, ALL_USER_IDS));
+	await testDb.delete(user).where(inArray(user.id, ALL_USER_IDS));
+}
+
+describe('credential account queries', () => {
+	afterEach(cleanup);
+	afterAll(() => testDb.$client.close());
+
+	async function seed() {
+		await cleanup();
+		await testDb.insert(user).values([
+			{ id: PASSWORD_USER, name: 'Pwd', email: 'pwd@example.com' },
+			{ id: SSO_USER, name: 'Sso', email: 'sso@example.com' },
+			{ id: NO_ACCOUNT_USER, name: 'None', email: 'none@example.com' },
+		]);
+		await testDb.insert(account).values([
+			{
+				id: 'acct-1',
+				accountId: PASSWORD_USER,
+				providerId: 'credential',
+				userId: PASSWORD_USER,
+				password: 'hashed',
+			},
+			{ id: 'acct-2', accountId: SSO_USER, providerId: 'google', userId: SSO_USER },
+		]);
+	}
+
+	it('returns only users that own a credential account with a password', async () => {
+		await seed();
+
+		const ids = await getUserIdsWithPassword(ALL_USER_IDS);
+
+		expect(ids.has(PASSWORD_USER)).toBe(true);
+		expect(ids.has(SSO_USER)).toBe(false);
+		expect(ids.has(NO_ACCOUNT_USER)).toBe(false);
+	});
+
+	it('ignores credential accounts without a password', async () => {
+		await seed();
+		await testDb.update(account).set({ password: null }).where(eq(account.userId, PASSWORD_USER));
+
+		const ids = await getUserIdsWithPassword(ALL_USER_IDS);
+
+		expect(ids.has(PASSWORD_USER)).toBe(false);
+	});
+
+	it('returns an empty set for no input', async () => {
+		const ids = await getUserIdsWithPassword([]);
+		expect(ids.size).toBe(0);
+	});
+
+	it('userHasPassword reflects credential account presence', async () => {
+		await seed();
+
+		expect(await userHasPassword(PASSWORD_USER)).toBe(true);
+		expect(await userHasPassword(SSO_USER)).toBe(false);
+		expect(await userHasPassword(NO_ACCOUNT_USER)).toBe(false);
+	});
+});

--- a/apps/frontend/src/components/settings/team/types.ts
+++ b/apps/frontend/src/components/settings/team/types.ts
@@ -5,4 +5,5 @@ export interface TeamMember {
 	name: string;
 	email: string;
 	role: UserRole;
+	hasPassword?: boolean;
 }

--- a/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.organization.tsx
@@ -68,6 +68,7 @@ function OrganizationPage() {
 			name: m.name,
 			email: m.email,
 			role: m.role as UserRole,
+			hasPassword: m.hasPassword,
 		})) ?? [];
 
 	const handleAdd = async (data: { email: string; name?: string }) => {
@@ -161,9 +162,11 @@ function OrganizationPage() {
 							isAdmin={isOrgAdmin}
 							onEdit={setEditMember}
 							onRemove={setRemoveMember}
-							extraActions={(member) => (
-								<ResetPasswordAction onClick={() => setResetPasswordMember(member)} />
-							)}
+							extraActions={(member) =>
+								member.hasPassword ? (
+									<ResetPasswordAction onClick={() => setResetPasswordMember(member)} />
+								) : null
+							}
 						/>
 					)}
 				</SettingsCard>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.team.tsx
@@ -43,6 +43,7 @@ function ProjectTeamTabPage() {
 			name: u.name,
 			email: u.email,
 			role: u.role,
+			hasPassword: u.hasPassword,
 		})) ?? [];
 
 	const addUser = useMutation(trpc.user.addUserToProject.mutationOptions());
@@ -122,9 +123,11 @@ function ProjectTeamTabPage() {
 						isAdmin={isAdmin}
 						onEdit={setEditMember}
 						onRemove={setRemoveMember}
-						extraActions={(member) => (
-							<ResetPasswordAction onClick={() => setResetPasswordMember(member)} />
-						)}
+						extraActions={(member) =>
+							member.hasPassword ? (
+								<ResetPasswordAction onClick={() => setResetPasswordMember(member)} />
+							) : null
+						}
 					/>
 				)}
 			</SettingsCard>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #1068.

When a user signs in through an identity provider (SSO) they have no local password, yet the admin UI still showed a **Reset password** action for them in `settings / project / team` and `settings / organization`. Triggering it just failed on the backend. There was also a subtler gap in the self-service flow: better-auth's `resetPassword` endpoint *creates* a `credential` account when one doesn't exist, so an SSO-only user could use the forgot-password flow to set a local password and bypass SSO.

## Approach

Rather than keying off a global "SSO enabled" flag, the decision is made **per user, based on whether that user owns a `credential` (password) account**. This is the robust signal: password-provisioned users keep the option, SSO-only users don't — regardless of cloud vs self-hosted or which providers are configured.

## Changes

- **Backend query** — `getUserIdsWithPassword()` / `userHasPassword()` in `account.queries.ts` resolve which users have a credential account with a non-null password.
- **Member lists** — `listAllUsersWithRoles` and `listOrgMembersWithUsers` now include a `hasPassword` flag.
- **Admin UI** — the `Reset password` dropdown item in the project team page and organization members page is only rendered when `member.hasPassword` is true.
- **Self-service guard** — `emailAndPassword.sendResetPassword` skips sending a reset link for users without a credential account, so SSO-only users can't create a password that bypasses SSO. Cloud users with a real password account can still reset normally.
- **Tests** — new `account-password.test.ts` covering the credential-account queries.

## Testing

- ✅ `npm run lint` (backend + frontend + shared)
- ✅ `npm run -w @nao/backend test -- tests/account-password.test.ts`
- Manual UI verification of the team page with a password user vs an SSO-only user (see walkthrough on the agent summary).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3628-5dea-7a24-be72-8f4c434020b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3628-5dea-7a24-be72-8f4c434020b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

