### PR TITLE
fix: stop reporting 64-bit integer columns as int32 in profiling

### DIFF
--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -459,8 +459,6 @@ class DatabaseContext:
         lowered = normalized.lower()
         if lowered.startswith("string(") and normalized.endswith(")"):
             return "string"
-        if normalized == "int64":
-            return "int32"
         return normalized
 
     @staticmethod

--- a/cli/tests/nao_core/commands/sync/integration/test_bigquery.py
+++ b/cli/tests/nao_core/commands/sync/integration/test_bigquery.py
@@ -147,7 +147,7 @@ def spec(db_config, temp_datasets):
         users_profiling_rows=[
             {
                 "column": "id",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 3,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -195,7 +195,7 @@ def spec(db_config, temp_datasets):
         orders_profiling_rows=[
             {
                 "column": "id",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -207,7 +207,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "user_id",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,

--- a/cli/tests/nao_core/commands/sync/integration/test_snowflake.py
+++ b/cli/tests/nao_core/commands/sync/integration/test_snowflake.py
@@ -219,7 +219,7 @@ def spec():
         users_profiling_rows=[
             {
                 "column": "ID",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 3,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -267,7 +267,7 @@ def spec():
         orders_profiling_rows=[
             {
                 "column": "ID",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -279,7 +279,7 @@ def spec():
             },
             {
                 "column": "USER_ID",
-                "type": "int32",
+                "type": "int64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,

--- a/cli/tests/nao_core/commands/sync/test_context.py
+++ b/cli/tests/nao_core/commands/sync/test_context.py
@@ -186,3 +186,18 @@ class TestDatabaseContext:
     def test_column_count_uses_filtered_columns(self):
         ctx, _ = self._make_context(exclude_columns=["*.name"])
         assert ctx.column_count() == 1
+
+
+class TestNormalizeType:
+    def test_strips_not_null_suffix(self):
+        assert DatabaseContext._normalize_type("int64 NOT NULL") == "int64"
+
+    def test_int64_is_reported_as_is(self):
+        assert DatabaseContext._normalize_type("int64") == "int64"
+
+    def test_parameterized_string_collapses_to_string(self):
+        assert DatabaseContext._normalize_type("String(255)") == "string"
+
+    def test_other_types_pass_through(self):
+        assert DatabaseContext._normalize_type("Int64") == "Int64"
+        assert DatabaseContext._normalize_type("timestamp('UTC')") == "timestamp('UTC')"


### PR DESCRIPTION
Closes #1104

## Problem

`_normalize_type` in `cli/nao_core/config/databases/context.py` mapped the ibis type `int64` to `int32`, so every 64-bit integer column was documented as `int32` in generated `profiling.md` files: BigQuery `INT64`, Snowflake `INTEGER` (`NUMBER(38,0)`, which ibis renders as `int64`), and any `BIGINT` column on other backends. The schema section of the same doc reports the raw type, so the two sections contradicted each other — and since the doc is read by the agent, the wrong label can influence generated SQL.

The mapping was introduced in #399 without a recorded rationale, and nothing in the codebase depends on the `int32` label (downstream checks only do substring matching on `"int"`).

## Changes

- Remove the `int64` → `int32` mapping from `_normalize_type`
- Update BigQuery and Snowflake integration expectations to `int64` (the only suites seeding 64-bit columns — all other backends seed 32-bit `INTEGER` and are unaffected)
- Add unit tests locking `_normalize_type` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

