### PR TITLE
Add MiniMax provider support

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -339,6 +339,22 @@ export const PROVIDER_META: ProviderMetaMap = {
 		summaryModelId: '',
 		models: [],
 	},
+	minimax: {
+		auth: { apiKey: 'required' },
+		envVar: 'MINIMAX_API_KEY',
+		baseUrlEnvVar: 'MINIMAX_BASE_URL',
+		extractorModelId: 'MiniMax-M3',
+		summaryModelId: 'MiniMax-M3',
+		models: [
+			{
+				id: 'MiniMax-M3',
+				name: 'MiniMax M3',
+				default: true,
+				contextWindow: 1_000_000,
+				costPerM: { inputNoCache: 0.6, inputCacheRead: 0.12, inputCacheWrite: 0, output: 2.4 },
+			},
+		],
+	},
 };
 
 export function getDefaultModelId(provider: LlmProvider): string {

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -150,6 +150,15 @@ export const LLM_PROVIDERS: LlmProvidersType = {
 		},
 		defaultOptions: { store: false, reasoningSummary: 'auto' },
 	},
+	minimax: {
+		...PROVIDER_META.minimax,
+		create: (settings, modelId) =>
+			createOpenAI({
+				...settings,
+				baseURL: settings.baseURL || 'https://api.minimax.io/v1',
+			}).responses(modelId),
+		defaultOptions: { store: false, reasoningSummary: 'auto' },
+	},
 };
 
 export type ProviderModelResult = {

--- a/apps/backend/src/types/llm.ts
+++ b/apps/backend/src/types/llm.ts
@@ -62,6 +62,7 @@ export type ProviderConfigMap = {
 	bedrock: AmazonBedrockLanguageModelOptions;
 	vertex: GoogleGenerativeAIProviderOptions;
 	azure: AzureOpenAIResponsesProviderOptions;
+	minimax: OpenAIResponsesProviderOptions;
 };
 
 /** Model definition with provider-specific config type */

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -35,6 +35,7 @@ export const LLM_PROVIDERS = [
 	'bedrock',
 	'vertex',
 	'azure',
+	'minimax',
 ] as const;
 
 export const providerLabels: Record<LlmProvider, string> = {
@@ -47,6 +48,7 @@ export const providerLabels: Record<LlmProvider, string> = {
 	bedrock: 'Amazon Bedrock',
 	vertex: 'Vertex AI',
 	azure: 'Azure Foundry',
+	minimax: 'MiniMax',
 };
 
 export type LlmProvider = (typeof LLM_PROVIDERS)[number];


### PR DESCRIPTION
Reason: provider-add | 2026-07-06 | 有清晰 provider registry:shared/src/types.ts 的 LLM_PROVIDERS enum(9家)+ agents/provider-meta.ts 静态模型目录 + agents/providers.ts 的 create 映射(全走 @ai-sdk/*)...

## Summary
- Add MiniMax to the shared LLM provider registry and UI labels.
- Register MiniMax M3 metadata with context window and pricing.
- Wire MiniMax through the existing OpenAI-compatible provider path with a default base URL.

## Checks
- Secret scan: `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"` (passed)
- `npm install` (failed: @vscode/ripgrep postinstall GitHub release download returned 403)
- `npm run lint -w @nao/backend` (failed: dependencies unavailable, `tsc` not found)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

