### PR TITLE
fix: document native BigQuery column types in generated docs

### DIFF
--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -108,9 +108,12 @@ class BigQueryDatabaseContext(DatabaseContext):
     def columns(self) -> list[dict[str, Any]]:
         cols = super().columns()
         try:
-            col_descs = self._fetch_column_descriptions()
+            native_types, descriptions = self._fetch_column_metadata()
             for col in cols:
-                if desc := col_descs.get(col["name"]):
+                if native_type := native_types.get(col["name"]):
+                    suffix = " NOT NULL" if col["type"].endswith(" NOT NULL") else ""
+                    col["type"] = f"{native_type}{suffix}"
+                if desc := descriptions.get(col["name"]):
                     col["description"] = desc
         except Exception:
             pass
@@ -272,15 +275,29 @@ class BigQueryDatabaseContext(DatabaseContext):
             logger.debug("_fetch_safe_partition_filter failed for %s.%s", self._schema, self._table_name)
             return None
 
-    def _fetch_column_descriptions(self) -> dict[str, str]:
+    def _fetch_column_metadata(self) -> tuple[dict[str, str], dict[str, str]]:
+        """Return native BigQuery types and descriptions per column from INFORMATION_SCHEMA.
+
+        Types come only from top-level rows (``field_path = column_name``); ibis normalises
+        BigQuery DATETIME/TIMESTAMP into a single timestamp type, so the native ``data_type``
+        is what the generated docs must show for the agent to write valid SQL.
+        """
         table_name_literal = _bq_string_literal(self._table_name)
         column_paths = _bq_path(self._project_id, self._schema, "INFORMATION_SCHEMA", "COLUMN_FIELD_PATHS")
         query = f"""
-            SELECT column_name, description
+            SELECT column_name, field_path, data_type, description
             FROM {column_paths}
-            WHERE table_name = {table_name_literal} AND description IS NOT NULL AND description != ''
+            WHERE table_name = {table_name_literal}
         """
-        return {row[0]: str(row[1]) for row in self._conn.raw_sql(query) if row[1]}  # type: ignore[union-attr]
+        native_types: dict[str, str] = {}
+        descriptions: dict[str, str] = {}
+        for row in self._conn.raw_sql(query):  # type: ignore[union-attr]
+            column_name, field_path, data_type, description = row[0], row[1], row[2], row[3]
+            if field_path == column_name and data_type:
+                native_types[column_name] = str(data_type)
+            if description:
+                descriptions[column_name] = str(description)
+        return native_types, descriptions
 
     def _quote(self, name: str) -> str:
         return f"`{name}`"

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -116,7 +116,9 @@ class BigQueryDatabaseContext(DatabaseContext):
                 if desc := descriptions.get(col["name"]):
                     col["description"] = desc
         except Exception:
-            pass
+            logger.debug(
+                "Failed to fetch column metadata for %s.%s — keeping ibis types", self._schema, self._table_name
+            )
         return cols
 
     def preview(self, limit: int = 10) -> list[dict[str, Any]]:

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -278,7 +278,7 @@ class BigQueryDatabaseContext(DatabaseContext):
     def _fetch_column_metadata(self) -> tuple[dict[str, str], dict[str, str]]:
         """Return native BigQuery types and descriptions per column from INFORMATION_SCHEMA.
 
-        Types come only from top-level rows (``field_path = column_name``); ibis normalises
+        Only top-level rows (``field_path = column_name``) are read; ibis normalises
         BigQuery DATETIME/TIMESTAMP into a single timestamp type, so the native ``data_type``
         is what the generated docs must show for the agent to write valid SQL.
         """
@@ -287,13 +287,15 @@ class BigQueryDatabaseContext(DatabaseContext):
         query = f"""
             SELECT column_name, field_path, data_type, description
             FROM {column_paths}
-            WHERE table_name = {table_name_literal}
+            WHERE table_name = {table_name_literal} AND field_path = column_name
         """
         native_types: dict[str, str] = {}
         descriptions: dict[str, str] = {}
         for row in self._conn.raw_sql(query):  # type: ignore[union-attr]
             column_name, field_path, data_type, description = row[0], row[1], row[2], row[3]
-            if field_path == column_name and data_type:
+            if field_path != column_name:
+                continue
+            if data_type:
                 native_types[column_name] = str(data_type)
             if description:
                 descriptions[column_name] = str(description)

--- a/cli/tests/nao_core/commands/sync/integration/test_bigquery.py
+++ b/cli/tests/nao_core/commands/sync/integration/test_bigquery.py
@@ -121,18 +121,18 @@ def spec(db_config, temp_datasets):
             "# users",
             f"**Dataset:** `{db_config.dataset_id}`",
             "## Columns (4)",
-            "- id (int64 NOT NULL)",
-            "- name (string NOT NULL)",
-            '- email (string, "User email address")',
-            "- active (boolean)",
+            "- id (INT64 NOT NULL)",
+            "- name (STRING NOT NULL)",
+            '- email (STRING, "User email address")',
+            "- active (BOOL)",
         ),
         orders_column_assertions=(
             "# orders",
             f"**Dataset:** `{db_config.dataset_id}`",
             "## Columns (3)",
-            "- id (int64 NOT NULL)",
-            "- user_id (int64 NOT NULL)",
-            "- amount (float64 NOT NULL)",
+            "- id (INT64 NOT NULL)",
+            "- user_id (INT64 NOT NULL)",
+            "- amount (FLOAT64 NOT NULL)",
         ),
         users_table_description="Registered user accounts",
         users_preview_rows=[
@@ -147,7 +147,7 @@ def spec(db_config, temp_datasets):
         users_profiling_rows=[
             {
                 "column": "id",
-                "type": "int64",
+                "type": "INT64",
                 "total_count": 3,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -159,7 +159,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "name",
-                "type": "string",
+                "type": "STRING",
                 "total_count": 3,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -172,7 +172,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "email",
-                "type": "string",
+                "type": "STRING",
                 "total_count": 3,
                 "null_count": 1,
                 "null_percentage": 33.33,
@@ -184,7 +184,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "active",
-                "type": "boolean",
+                "type": "BOOL",
                 "total_count": 3,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -195,7 +195,7 @@ def spec(db_config, temp_datasets):
         orders_profiling_rows=[
             {
                 "column": "id",
-                "type": "int64",
+                "type": "INT64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -207,7 +207,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "user_id",
-                "type": "int64",
+                "type": "INT64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,
@@ -216,7 +216,7 @@ def spec(db_config, temp_datasets):
             },
             {
                 "column": "amount",
-                "type": "float64",
+                "type": "FLOAT64",
                 "total_count": 2,
                 "null_count": 0,
                 "null_percentage": 0.0,

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -905,6 +905,106 @@ class TestClusteringColumns:
         assert ctx.clustering_columns() == []
 
 
+class TestColumnsNativeTypes:
+    """columns() must overlay native BigQuery types from INFORMATION_SCHEMA over ibis types."""
+
+    @staticmethod
+    def _dtype(rendered: str, nullable: bool = True) -> MagicMock:
+        return MagicMock(__str__=lambda s, r=rendered: r, nullable=nullable)
+
+    def _make_context_with_schema(
+        self, schema_items: list[tuple[str, MagicMock]]
+    ) -> tuple[BigQueryDatabaseContext, MagicMock]:
+        mock_conn = MagicMock()
+        mock_table = MagicMock()
+        mock_schema = MagicMock()
+        mock_schema.items.return_value = schema_items
+        mock_schema.keys.return_value = [name for name, _ in schema_items]
+        mock_table.schema.return_value = mock_schema
+        mock_conn.table.return_value = mock_table
+        ctx = BigQueryDatabaseContext(mock_conn, "my_dataset", "events", project_id="my-project")
+        return ctx, mock_conn
+
+    def test_native_types_replace_ibis_normalized_types(self):
+        """BQ DATETIME and TIMESTAMP are both rendered as timestamp variants by ibis."""
+        ctx, mock_conn = self._make_context_with_schema(
+            [
+                ("created_at", self._dtype("timestamp")),
+                ("server_received_at", self._dtype("timestamp('UTC')")),
+            ]
+        )
+        mock_conn.raw_sql.return_value = [
+            ("created_at", "created_at", "DATETIME", None),
+            ("server_received_at", "server_received_at", "TIMESTAMP", None),
+        ]
+
+        cols = {col["name"]: col for col in ctx.columns()}
+
+        assert cols["created_at"]["type"] == "DATETIME"
+        assert cols["server_received_at"]["type"] == "TIMESTAMP"
+
+    def test_not_null_suffix_is_preserved(self):
+        ctx, mock_conn = self._make_context_with_schema([("id", self._dtype("!int64", nullable=False))])
+        mock_conn.raw_sql.return_value = [("id", "id", "INT64", None)]
+
+        cols = ctx.columns()
+
+        assert cols[0]["type"] == "INT64 NOT NULL"
+
+    def test_descriptions_applied_with_a_single_query(self):
+        ctx, mock_conn = self._make_context_with_schema([("created_at", self._dtype("timestamp"))])
+        mock_conn.raw_sql.return_value = [("created_at", "created_at", "DATETIME", "Creation time")]
+
+        cols = ctx.columns()
+
+        assert cols[0]["type"] == "DATETIME"
+        assert cols[0]["description"] == "Creation time"
+        mock_conn.raw_sql.assert_called_once()
+
+    def test_information_schema_failure_keeps_ibis_types(self):
+        ctx, mock_conn = self._make_context_with_schema(
+            [
+                ("id", self._dtype("!int64", nullable=False)),
+                ("server_received_at", self._dtype("timestamp('UTC')")),
+            ]
+        )
+        mock_conn.raw_sql.side_effect = Exception("permission denied")
+
+        cols = {col["name"]: col for col in ctx.columns()}
+
+        assert cols["id"]["type"] == "int64 NOT NULL"
+        assert cols["server_received_at"]["type"] == "timestamp('UTC')"
+
+    def test_excluded_columns_are_still_filtered(self):
+        ctx, mock_conn = self._make_context_with_schema(
+            [
+                ("id", self._dtype("!int64", nullable=False)),
+                ("secret_token", self._dtype("string")),
+            ]
+        )
+        mock_conn.raw_sql.return_value = [
+            ("id", "id", "INT64", None),
+            ("secret_token", "secret_token", "STRING", None),
+        ]
+        ctx.set_exclude_columns(["my_dataset.events.secret_*"])
+
+        names = [col["name"] for col in ctx.columns()]
+
+        assert names == ["id"]
+
+    def test_nested_field_paths_are_ignored_for_types(self):
+        ctx, mock_conn = self._make_context_with_schema([("payload", self._dtype("struct<name: string>"))])
+        mock_conn.raw_sql.return_value = [
+            ("payload", "payload", "STRUCT<name STRING>", None),
+            ("payload", "payload.name", "STRING", "Nested name"),
+        ]
+
+        cols = ctx.columns()
+
+        assert cols[0]["type"] == "STRUCT<name STRING>"
+        assert cols[0]["description"] == "Nested name"
+
+
 class TestClusteredOnlyTable:
     """Regression tests for tables that are clustered but not partitioned."""
 

--- a/cli/tests/nao_core/config/test_bigquery_context.py
+++ b/cli/tests/nao_core/config/test_bigquery_context.py
@@ -992,7 +992,7 @@ class TestColumnsNativeTypes:
 
         assert names == ["id"]
 
-    def test_nested_field_paths_are_ignored_for_types(self):
+    def test_nested_field_paths_are_ignored(self):
         ctx, mock_conn = self._make_context_with_schema([("payload", self._dtype("struct<name: string>"))])
         mock_conn.raw_sql.return_value = [
             ("payload", "payload", "STRUCT<name STRING>", None),
@@ -1002,7 +1002,20 @@ class TestColumnsNativeTypes:
         cols = ctx.columns()
 
         assert cols[0]["type"] == "STRUCT<name STRING>"
-        assert cols[0]["description"] == "Nested name"
+        assert cols[0]["description"] is None
+        query = mock_conn.raw_sql.call_args[0][0]
+        assert "field_path = column_name" in query
+
+    def test_struct_column_keeps_its_own_description(self):
+        ctx, mock_conn = self._make_context_with_schema([("payload", self._dtype("struct<name: string>"))])
+        mock_conn.raw_sql.return_value = [
+            ("payload", "payload", "STRUCT<name STRING>", "Event payload"),
+            ("payload", "payload.name", "STRING", "Nested name"),
+        ]
+
+        cols = ctx.columns()
+
+        assert cols[0]["description"] == "Event payload"
 
 
 class TestClusteredOnlyTable:


### PR DESCRIPTION
Closes #1110

During sync, column types in the generated docs come from the ibis schema, which normalizes BigQuery `DATETIME` to `timestamp` and `TIMESTAMP` to `timestamp('UTC')`. The agent reads these docs before writing SQL, and the two types have different function families and timezone semantics — we hit invalid and time-shifted queries on a production BigQuery project because of this.

Fix: overlay the native `data_type` from `INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` over the ibis type in `BigQueryDatabaseContext.columns()`, following the same pattern as the ClickHouse adapter (#706, #1080). The query was already issued for column descriptions, so this adds no extra round trip. The `NOT NULL` suffix is preserved, and if the metadata query fails we fall back to today's ibis types.

Profiling follows suit: BigQuery integer columns now report `INT64` instead of `int64` (following #1106).

**Note — behavior change:** nested field rows from `COLUMN_FIELD_PATHS` are now ignored for descriptions as well as types. Struct columns whose only descriptions lived on nested fields previously inherited one of them (nondeterministically); after this PR they get no description. The inherited description was misleading, so this removes misinformation, but regenerated `columns.md` files may lose those entries on resync.

Testing: new unit tests cover the overlay — type replacement, `NOT NULL` suffix, descriptions still applied with a single query, `INFORMATION_SCHEMA` failure fallback, excluded columns, nested field paths ignored for types and descriptions. BigQuery integration expectations updated to the native types (`INT64`/`STRING`/`BOOL`/`FLOAT64`).

This PR was written using Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->