### PR TITLE
feat: redirect admins to chat replay for inaccessible chats

### DIFF
--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -56,8 +56,20 @@ function ChatPage() {
 	const { isLoadingMessages, isRunning } = useAgentContext();
 	const router = useRouter();
 	const { chatId } = Route.useParams();
+	const { role, canViewChatReplay } = usePermissions();
 	const chat = useChatQuery({ chatId });
 	const title = chat.data?.title;
+
+	const isForbidden = chat.isError && isForbiddenError(chat.error);
+	const shouldRedirectToReplay = isForbidden && canViewChatReplay;
+	const isResolvingReplayRedirect = isForbidden && role === undefined;
+
+	useEffect(() => {
+		if (shouldRedirectToReplay) {
+			router.navigate({ to: '/settings/chats-replay', search: { chatId } });
+		}
+	}, [shouldRedirectToReplay, chatId, router]);
+
 	const shareQuery = useQuery({
 		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
 		enabled: chat.isSuccess,
@@ -111,6 +123,9 @@ function ChatPage() {
 	}, [chat.isError, isLoadingMessages]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	if (chat.isError) {
+		if (shouldRedirectToReplay || isResolvingReplayRedirect) {
+			return null;
+		}
 		return <ChatNotFoundState />;
 	}
 
@@ -296,6 +311,14 @@ function resolveStoryCitationMeta(
 	}
 
 	return { storySlug: currentStorySlug, start, end };
+}
+
+function isForbiddenError(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null || !('data' in error)) {
+		return false;
+	}
+	const { data } = error as { data?: { code?: string } | null };
+	return data?.code === 'FORBIDDEN';
 }
 
 function buildHeaderCitation(meta: ForkMetadata | undefined): { citation: string; text: string } | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #1062.

When a user shares the URL of a chat (e.g. `/{chatId}`) with an admin/data-team member, opening that URL as an admin who is not the owner just shows a generic **"Chat not found"** screen. There was no way for the admin to actually see the shared conversation.

## Change

In the `/{chatId}` chat route, when the chat query fails with a `FORBIDDEN` error (the current user is not the chat owner) **and** the current user can view chat replay (`admin` or `context_admin`), we now redirect to the existing chats replay deep link:

```
/settings/chats-replay?chatId=<id>
```

This opens the chat directly in read-only replay mode, so an admin can see exactly what the user did.

Behavior for everyone else is unchanged:
- Regular `user`/`viewer` roles still see the "Chat not found" screen (they can't view chat replay).
- Genuinely missing chats (`NOT_FOUND`) still show "Chat not found" for all roles.
- Owners open their own chats normally.

While permissions are still loading for a forbidden chat, we render nothing (instead of briefly flashing "Chat not found") to avoid a flicker before the redirect resolves.

## Testing

- `npm run lint` (tsc + eslint across backend/frontend/shared) passes.
- Manually verified end-to-end: signed up an admin, seeded a chat owned by a different user, and confirmed that opening `/test-chat-forbidden` as the admin redirects to `/settings/chats-replay?chatId=test-chat-forbidden` and loads the replay panel ("Chat by Owner User" with the conversation messages).

[admin_forbidden_chat_redirect_to_replay.mp4](https://cursor.com/agents/bc-1cf03801-67f2-4abe-b592-bd8d47b414c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_forbidden_chat_redirect_to_replay.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cf03801-67f2-4abe-b592-bd8d47b414c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cf03801-67f2-4abe-b592-bd8d47b414c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

