### PR TITLE
fix: coerce string-formatted numbers in chart data to prevent Y-axis overflow

### DIFF
--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -102,6 +102,26 @@ function buildResolved(props: BuildChartProps) {
 	const colorFor = props.colorFor ?? defaultColorFor;
 	const labelFormatter = props.labelFormatter ?? ((v: string) => labelize(v));
 
+	const sanitizedData = props.data.map((item) => {
+		if (!item || typeof item !== 'object') {
+			return item;
+		}
+		const newItem = { ...item };
+		for (const s of props.series || []) {
+			if (!s || !s.data_key) {
+				continue;
+			}
+			const val = item[s.data_key];
+			if (typeof val === 'string') {
+				const num = Number(val);
+				if (!isNaN(num)) {
+					newItem[s.data_key] = num;
+				}
+			}
+		}
+		return newItem;
+	});
+
 	const titleChild = props.title ? (
 		<Customized
 			key='chart-title'
@@ -129,6 +149,7 @@ function buildResolved(props: BuildChartProps) {
 
 	const resolved: ResolvedProps = {
 		...props,
+		data: sanitizedData,
 		colorFor,
 		labelFormatter,
 		xAxisInterval,


### PR DESCRIPTION
Fixes #1103 

## Description

This PR fixes the bug where charts with string-typed numbers in their data series keys (such as `COUNT` or `SUM` query aggregates) would cause the Recharts Y-axis auto-domain calculation to fail, defaulting the range to `0 - 8` while still drawing the bar at the full coerced height. 

## Changes

This PR updates the `buildResolved` function in `apps/shared/src/chart-builder.tsx` to coerce string numbers inside series data keys to actual floats/integers before passing them to Recharts, preventing vertical overflow. This change fixes the issue for all the graph types.

## Images

Before the fix
<img width="1167" height="726" alt="image" src="https://github.com/user-attachments/assets/98210dbf-4d46-467f-892e-e38eef674935" />

After the fix
<img width="1123" height="727" alt="image" src="https://github.com/user-attachments/assets/c0d3dab2-d0d8-4679-b8ca-2d22eda387a9" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

