### PR TITLE
fix(backend): scope skills per project to stop cross-project leak in cloud mode

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -549,7 +549,7 @@ class AgentManager {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
-		const skills = skillService.getSkills();
+		const skills = skillService.getSkills(this.chat.projectId);
 		const mcpServers = await mcpService.getEnabledServers(this.chat.projectId);
 		const basePrompt = renderToMarkdown(
 			SystemPrompt({
@@ -807,7 +807,9 @@ class AgentManager {
 
 	private _addSkills(messages: UIMessage[], mentions?: Mention[]): UIMessage[] {
 		const skillMention = mentions?.find((m) => m.trigger === '/');
-		const skillContent = skillMention ? skillService.getSkillContent(skillMention.id) : undefined;
+		const skillContent = skillMention
+			? skillService.getSkillContent(this.chat.projectId, skillMention.id)
+			: undefined;
 		if (!skillContent) {
 			return messages;
 		}

--- a/apps/backend/src/services/skill.ts
+++ b/apps/backend/src/services/skill.ts
@@ -12,78 +12,110 @@ export interface Skill {
 	location: string;
 }
 
-class SkillService {
-	private _projectPath: string = '';
-	private _skillsFolderPath: string;
-	private _skills: Skill[] = [];
-	private _fileWatcher: ReturnType<typeof watch> | null = null;
-	private _debouncedReload: () => void;
-	private _initialized = false;
+interface ProjectSkills {
+	projectPath: string;
+	skillsFolderPath: string;
+	skills: Skill[];
+	fileWatcher: ReturnType<typeof watch> | null;
+	debouncedReload: () => void;
+}
 
-	constructor() {
-		this._skillsFolderPath = '';
-		this._debouncedReload = debounce(() => {
-			this.loadSkills();
-		}, 2000);
-	}
+class SkillService {
+	private _projects = new Map<string, ProjectSkills>();
+	private _initPromises = new Map<string, Promise<void>>();
 
 	public async initializeSkills(projectId: string): Promise<void> {
-		if (this._initialized) {
+		if (this._projects.has(projectId)) {
 			return;
 		}
-		this._initialized = true;
 
-		const project = await projectQueries.retrieveProjectById(projectId);
-		this._projectPath = project.path || '';
-		this._skillsFolderPath = join(this._projectPath, 'agent', 'skills');
-
-		this.loadSkills();
-		this._setupFileWatcher();
-	}
-
-	public loadSkills(): void {
-		try {
-			if (!existsSync(this._skillsFolderPath)) {
-				logger.warn(`Skills folder not found: ${this._skillsFolderPath}`, { source: 'agent' });
-				this._skills = [];
-				return;
-			}
-
-			if (!statSync(this._skillsFolderPath).isDirectory()) {
-				logger.error(`Skills path is not a directory: ${this._skillsFolderPath}`, { source: 'agent' });
-				this._skills = [];
-				return;
-			}
-
-			const files = readdirSync(this._skillsFolderPath).filter((f) => f.endsWith('.md'));
-			this._readSkills(files);
-		} catch (error) {
-			logger.error(`Failed to load skills: ${String(error)}`, { source: 'agent' });
-			this._skills = [];
+		let initPromise = this._initPromises.get(projectId);
+		if (!initPromise) {
+			initPromise = this._initialize(projectId).catch((err) => {
+				this._initPromises.delete(projectId);
+				throw err;
+			});
+			this._initPromises.set(projectId, initPromise);
 		}
+
+		return initPromise;
 	}
 
-	public getSkills(): Skill[] {
-		return this._skills;
+	public getSkills(projectId: string): Skill[] {
+		return this._projects.get(projectId)?.skills ?? [];
 	}
 
-	public getSkillContent(skillName: string): string | null {
-		const skill = this._skills.find((s) => s.name === skillName);
+	public getSkillContent(projectId: string, skillName: string): string | null {
+		const entry = this._projects.get(projectId);
+		if (!entry) {
+			return null;
+		}
+
+		const skill = entry.skills.find((s) => s.name === skillName);
 		if (!skill) {
 			return null;
 		}
 
 		try {
-			return readFileSync(join(this._projectPath, skill.location), 'utf8');
+			return readFileSync(join(entry.projectPath, skill.location), 'utf8');
 		} catch (error) {
 			logger.error(`Failed to read skill content for ${skillName}: ${String(error)}`, { source: 'agent' });
 			return null;
 		}
 	}
 
-	private _readSkills(files: string[]): void {
-		this._skills = files.map((file) => {
-			const filePath = join(this._skillsFolderPath, file);
+	private async _initialize(projectId: string): Promise<void> {
+		const project = await projectQueries.retrieveProjectById(projectId);
+		const projectPath = project.path || '';
+		const skillsFolderPath = join(projectPath, 'agent', 'skills');
+
+		this._projects.set(projectId, {
+			projectPath,
+			skillsFolderPath,
+			skills: [],
+			fileWatcher: null,
+			debouncedReload: debounce(() => this._loadSkills(projectId), 2000),
+		});
+
+		this._loadSkills(projectId);
+		this._setupFileWatcher(projectId);
+	}
+
+	private _loadSkills(projectId: string): void {
+		const entry = this._projects.get(projectId);
+		if (!entry) {
+			return;
+		}
+
+		try {
+			if (!existsSync(entry.skillsFolderPath)) {
+				logger.warn(`Skills folder not found: ${entry.skillsFolderPath}`, { source: 'agent' });
+				entry.skills = [];
+				return;
+			}
+
+			if (!statSync(entry.skillsFolderPath).isDirectory()) {
+				logger.error(`Skills path is not a directory: ${entry.skillsFolderPath}`, { source: 'agent' });
+				entry.skills = [];
+				return;
+			}
+
+			const files = readdirSync(entry.skillsFolderPath).filter((f) => f.endsWith('.md'));
+			this._readSkills(projectId, files);
+		} catch (error) {
+			logger.error(`Failed to load skills: ${String(error)}`, { source: 'agent' });
+			entry.skills = [];
+		}
+	}
+
+	private _readSkills(projectId: string, files: string[]): void {
+		const entry = this._projects.get(projectId);
+		if (!entry) {
+			return;
+		}
+
+		entry.skills = files.map((file) => {
+			const filePath = join(entry.skillsFolderPath, file);
 
 			const fileContent = readFileSync(filePath, 'utf8');
 			const { data } = matter(fileContent);
@@ -91,20 +123,21 @@ class SkillService {
 			return {
 				name: data.name || file.replace('.md', ''),
 				description: data.description || '',
-				location: '/' + relative(this._projectPath, filePath),
+				location: '/' + relative(entry.projectPath, filePath),
 			};
 		});
 	}
 
-	private _setupFileWatcher(): void {
-		if (!this._skillsFolderPath || !existsSync(this._skillsFolderPath)) {
+	private _setupFileWatcher(projectId: string): void {
+		const entry = this._projects.get(projectId);
+		if (!entry || !existsSync(entry.skillsFolderPath)) {
 			return;
 		}
 
 		try {
-			this._fileWatcher = watch(this._skillsFolderPath, { recursive: true }, (eventType) => {
+			entry.fileWatcher = watch(entry.skillsFolderPath, { recursive: true }, (eventType) => {
 				if (eventType === 'change' || eventType === 'rename') {
-					this._debouncedReload();
+					entry.debouncedReload();
 				}
 			});
 		} catch (error) {

--- a/apps/backend/src/trpc/skill.routes.ts
+++ b/apps/backend/src/trpc/skill.routes.ts
@@ -3,7 +3,7 @@ import { projectProtectedProcedure, router } from './trpc';
 
 export const skillRoutes = router({
 	list: projectProtectedProcedure.query(async ({ ctx }) => {
-		await skillService.initializeSkills(ctx.project?.id);
-		return skillService.getSkills();
+		await skillService.initializeSkills(ctx.project.id);
+		return skillService.getSkills(ctx.project.id);
 	}),
 });

--- a/apps/backend/tests/skill.service.test.ts
+++ b/apps/backend/tests/skill.service.test.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const projectPaths: Record<string, string> = {};
+
+vi.mock('../src/queries/project.queries', () => ({
+	retrieveProjectById: vi.fn(async (projectId: string) => {
+		const path = projectPaths[projectId];
+		if (!path) {
+			throw new Error(`unknown project ${projectId}`);
+		}
+		return { id: projectId, path };
+	}),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('fs')>();
+	return { ...actual, watch: vi.fn(() => ({ close: vi.fn() })) };
+});
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { skillService } from '../src/services/skill';
+
+function createProjectWithSkill(prefix: string, skillName: string, body: string): string {
+	const root = mkdtempSync(join(tmpdir(), `nao-skill-${prefix}-`));
+	const skillsDir = join(root, 'agent', 'skills');
+	mkdirSync(skillsDir, { recursive: true });
+	writeFileSync(
+		join(skillsDir, `${skillName}.md`),
+		`---\nname: ${skillName}\ndescription: ${skillName} description\n---\n\n${body}\n`,
+	);
+	return root;
+}
+
+describe('skillService project isolation', () => {
+	const createdRoots: string[] = [];
+
+	afterAll(() => {
+		for (const root of createdRoots) {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it('serves each project its own skills and never leaks across projects', async () => {
+		const rootA = createProjectWithSkill('a', 'skill-a', 'Content from project A');
+		const rootB = createProjectWithSkill('b', 'skill-b', 'Content from project B');
+		createdRoots.push(rootA, rootB);
+		projectPaths['project-a'] = rootA;
+		projectPaths['project-b'] = rootB;
+
+		await skillService.initializeSkills('project-a');
+		await skillService.initializeSkills('project-b');
+
+		expect(skillService.getSkills('project-a').map((s) => s.name)).toEqual(['skill-a']);
+		expect(skillService.getSkills('project-b').map((s) => s.name)).toEqual(['skill-b']);
+
+		expect(skillService.getSkillContent('project-a', 'skill-a')).toContain('Content from project A');
+		expect(skillService.getSkillContent('project-b', 'skill-b')).toContain('Content from project B');
+
+		expect(skillService.getSkillContent('project-a', 'skill-b')).toBeNull();
+		expect(skillService.getSkillContent('project-b', 'skill-a')).toBeNull();
+	});
+
+	it('does not clobber an already-initialized project when another project initializes', async () => {
+		const rootFirst = createProjectWithSkill('first', 'first-skill', 'First body');
+		const rootSecond = createProjectWithSkill('second', 'second-skill', 'Second body');
+		createdRoots.push(rootFirst, rootSecond);
+		projectPaths['project-first'] = rootFirst;
+		projectPaths['project-second'] = rootSecond;
+
+		await skillService.initializeSkills('project-first');
+		expect(skillService.getSkills('project-first').map((s) => s.name)).toEqual(['first-skill']);
+
+		await skillService.initializeSkills('project-second');
+
+		expect(skillService.getSkills('project-first').map((s) => s.name)).toEqual(['first-skill']);
+		expect(skillService.getSkills('project-second').map((s) => s.name)).toEqual(['second-skill']);
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In cloud mode (`NAO_MODE=cloud`), a single backend process serves many projects. `SkillService` (`apps/backend/src/services/skill.ts`) was a process-wide singleton with a one-time `_initialized` guard:

```ts
public async initializeSkills(projectId: string) {
  if (this._initialized) return; // first project wins forever
  this._initialized = true;
  ...
}
```

After the first `initializeSkills(projectId)` call anywhere in the process, all later calls with a different `projectId` were no-ops. `getSkills()` / `getSkillContent()` kept serving the **first** project's skills to every other project and user — leaking skills across projects (and across users) in cloud mode. In self-hosted mode this went unnoticed because there is usually a single project.

Skills are markdown files under `{project.path}/agent/skills/*.md` (not in the DB), so this was purely a caching/state-scoping bug in the loader.

## Fix

Make `SkillService` state **per-project**, keyed by `projectId` (mirroring how `McpService` avoids stale state, but with a per-project map so concurrent access from different projects can't race):

- `_projects: Map<projectId, { projectPath, skillsFolderPath, skills, fileWatcher, debouncedReload }>`
- `_initPromises: Map<projectId, Promise>` to dedupe concurrent init of the same project
- `getSkills(projectId)` and `getSkillContent(projectId, skillName)` now require a `projectId` and read only that project's cache
- Each project gets its own file watcher/debounced reload

Updated the three read sites to pass the active project id (`skill.routes.ts`, and two in `agent.ts`). The `initializeSkills(projectId)` call sites in `handlers/agent.ts`, `handlers/automation.handler.ts`, and `mcp/tools/sub-agent.ts` already passed a project id and are unchanged.

## Testing

- Added `apps/backend/tests/skill.service.test.ts` exercising the real `SkillService` against two temp project skill folders: each project sees only its own skills, and content requests for the other project's skill return `null`.
- Verified the test **fails** when the leak is re-introduced (mutation check) and passes with the fix.
- `npm run lint` passes; full backend suite shows no new failures (the 19 failing tests are pre-existing env issues — unpushed test schema / `bun:sqlite` under vitest — present on `main`).

[skill_isolation_test.log](https://cursor.com/agents/bc-019f47ce-3f01-73e6-8f30-356968bb6c53/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskill_isolation_test.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f47ce-3f01-73e6-8f30-356968bb6c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f47ce-3f01-73e6-8f30-356968bb6c53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

