### PR TITLE
fix(slack): render result tables as monospace instead of Block Kit table blocks

### DIFF
--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -4,7 +4,7 @@ import { createSlackAdapter } from '@chat-adapter/slack';
 import { createMemoryState } from '@chat-adapter/state-memory';
 import { CITATION_TAG_REGEX } from '@nao/shared';
 import type { LlmSelectedModel } from '@nao/shared/types';
-import { type ChatPostMessageArguments, WebClient } from '@slack/web-api';
+import { type ChatPostMessageArguments, type ChatPostMessageResponse, WebClient } from '@slack/web-api';
 import { InferUIMessageChunk, readUIMessageStream } from 'ai';
 import { Card, Chat, deriveChannelId, Message, SentMessage, Thread, ThreadImpl } from 'chat';
 
@@ -162,7 +162,20 @@ class ProjectSlackBot {
 		if (blocks) {
 			(args as { blocks?: unknown }).blocks = blocks;
 		}
-		const result = await this._slackClient.chat.postMessage(args);
+
+		let result: ChatPostMessageResponse;
+		try {
+			result = await this._slackClient.chat.postMessage(args);
+		} catch (error) {
+			if (!blocks) {
+				throw error;
+			}
+			// Block Kit payload was rejected (e.g. an invalid/oversized block); never drop the
+			// answer. Retry with just the text field, which already carries the full content.
+			logger.warn(`Slack rejected block payload, retrying as text-only: ${String(error)}`, { channelId });
+			delete (args as { blocks?: unknown }).blocks;
+			result = await this._slackClient.chat.postMessage(args);
+		}
 
 		if (!result.ok) {
 			throw new Error(result.error ?? 'Failed to post Slack message.');

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -1,7 +1,7 @@
 import { cardToBlockKit } from '@chat-adapter/slack';
 import { CITATION_TAG_REGEX, pluralize, TOOL_LABELS } from '@nao/shared';
 import type { CardChild, CardElement, ModalElement } from 'chat';
-import { Actions, Button, Card, CardText, Image, LinkButton, Table } from 'chat';
+import { Actions, Button, Card, CardText, Image, LinkButton } from 'chat';
 
 import { ToolCallEntry } from '../types/messaging-provider';
 import { BudgetExceededError } from './error';
@@ -106,11 +106,60 @@ export const createTextBlock = (text: string): CardChild => {
 	return CardText(rendered || text);
 };
 
+// Slack rejects section text over 3000 chars; leave headroom for the ``` fences.
+const SLACK_SECTION_TEXT_LIMIT = 2900;
+const FENCE_OVERHEAD = '```\n'.length + '\n```'.length;
+// A single cell longer than this is truncated so it can never blow the section limit.
+const MAX_CELL_CHARS = 200;
+// Keep answers bounded; overflow points the user at the full result in nao.
+const MAX_TABLE_ROWS = 100;
+
+const clampCell = (value: string): string => {
+	const cell = value ?? '';
+	return cell.length > MAX_CELL_CHARS ? `${cell.slice(0, MAX_CELL_CHARS - 1)}…` : cell;
+};
+
+// Render a parsed markdown table as fixed-width monospace text, split into chunks
+// that each stay under Slack's section limit. The header row repeats per chunk.
+const buildMonospaceTable = (
+	headers: string[],
+	allRows: string[][],
+): { chunks: string[]; hiddenRows: number } => {
+	const rows = allRows.slice(0, MAX_TABLE_ROWS).map((row) => row.map(clampCell));
+	const head = headers.map(clampCell);
+	const widths = head.map((cell, col) => Math.max(cell.length, ...rows.map((row) => (row[col] ?? '').length)));
+	const formatRow = (cells: string[]): string =>
+		widths.map((width, col) => (cells[col] ?? '').padEnd(width)).join('  ');
+	const heading = `${formatRow(head)}\n${widths.map((width) => '-'.repeat(width)).join('  ')}`;
+
+	const chunks: string[] = [];
+	let current = heading;
+	for (const row of rows) {
+		const line = formatRow(row);
+		if (current.length + 1 + line.length + FENCE_OVERHEAD > SLACK_SECTION_TEXT_LIMIT) {
+			chunks.push(current);
+			current = `${heading}\n${line}`;
+		} else {
+			current = `${current}\n${line}`;
+		}
+	}
+	chunks.push(current);
+	return { chunks, hiddenRows: allRows.length - rows.length };
+};
+
+const fenceMonospace = (chunk: string): string => `\`\`\`\n${chunk}\n\`\`\``;
+
 export const createTextBlocks = (text: string): CardChild[] => {
 	const blocks: CardChild[] = [];
 	for (const segment of splitMarkdownSegments(text)) {
 		if (segment.type === 'table') {
-			blocks.push(Table({ headers: segment.headers, rows: segment.rows }));
+			const { chunks, hiddenRows } = buildMonospaceTable(segment.headers, segment.rows);
+			for (const chunk of chunks) {
+				blocks.push(CardText(fenceMonospace(chunk)));
+			}
+			if (hiddenRows > 0) {
+				blocks.push(CardText(`_…${hiddenRows} more ${pluralize('row', hiddenRows)} (open in nao)_`, { style: 'muted' }));
+			}
 			continue;
 		}
 		const rendered = mdToMrkdwn(segment.text).trim();
@@ -121,17 +170,29 @@ export const createTextBlocks = (text: string): CardChild[] => {
 	return blocks;
 };
 
+// Inline monospace version for the plain-text `text` field / notification fallback.
+const renderMarkdownTablesInline = (text: string): string =>
+	splitMarkdownSegments(text)
+		.map((segment) =>
+			segment.type === 'table'
+				? buildMonospaceTable(segment.headers, segment.rows)
+						.chunks.map(fenceMonospace)
+						.join('\n\n')
+				: segment.text,
+		)
+		.join('\n');
+
 export function buildSlackTableBlocks(text: string): ReturnType<typeof cardToBlockKit> | null {
 	const sanitized = text.replace(CITATION_TAG_REGEX, '');
-	const children = createTextBlocks(sanitized);
-	if (!children.some((child) => child.type === 'table')) {
+	const hasTable = splitMarkdownSegments(sanitized).some((segment) => segment.type === 'table');
+	if (!hasTable) {
 		return null;
 	}
-	return cardToBlockKit(Card({ children }));
+	return cardToBlockKit(Card({ children: createTextBlocks(sanitized) }));
 }
 
 export function formatSlackMessageText(text: string): string {
-	const sanitized = text.replace(CITATION_TAG_REGEX, '');
+	const sanitized = renderMarkdownTablesInline(text.replace(CITATION_TAG_REGEX, ''));
 	return mdToMrkdwn(sanitized) || sanitized;
 }
 

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { buildSlackTableBlocks, createTextBlocks } from '../src/utils/messaging-provider';
 
 type AnyBlock = { type: string; [key: string]: unknown };
+type TextChild = { type: string; content: string };
 
-function tableChild(blocks: ReturnType<typeof createTextBlocks>) {
-	return blocks.find((block) => block.type === 'table') as
-		| { type: 'table'; headers: string[]; rows: string[][] }
-		| undefined;
-}
+const contents = (blocks: ReturnType<typeof createTextBlocks>): string[] =>
+	blocks.map((block) => (block as TextChild).content);
+
+const tableChunks = (blocks: ReturnType<typeof createTextBlocks>): string[] =>
+	contents(blocks).filter((content) => content.startsWith('```'));
 
 describe('createTextBlocks', () => {
 	it('returns a single text block when there is no table', () => {
@@ -17,7 +18,7 @@ describe('createTextBlocks', () => {
 		expect(blocks[0]).toMatchObject({ type: 'text', content: 'Just a plain answer with *bold*.' });
 	});
 
-	it('splits a markdown table into a Table element with text around it', () => {
+	it('renders a markdown table as a monospace text block, never a Slack table block', () => {
 		const text = [
 			'Here is your table:',
 			'',
@@ -31,66 +32,59 @@ describe('createTextBlocks', () => {
 
 		const blocks = createTextBlocks(text);
 
-		expect(blocks.map((block) => block.type)).toEqual(['text', 'table', 'text']);
-		expect(tableChild(blocks)).toEqual({
-			type: 'table',
-			headers: ['Column A', 'Column B'],
-			rows: [
-				['Hello', 'World'],
-				['Foo', 'Bar'],
-			],
-		});
-		expect(blocks[0]).toMatchObject({ content: 'Here is your table:' });
-		expect(blocks[2]).toMatchObject({ content: 'Let me know!' });
+		expect(blocks.every((block) => block.type === 'text')).toBe(true);
+		expect(blocks.some((block) => (block as AnyBlock).type === 'table')).toBe(false);
+
+		const table = tableChunks(blocks)[0];
+		expect(table).toBeDefined();
+		expect(table).toContain('Column A  Column B');
+		expect(table).toContain('Hello     World');
+		expect(table).toContain('Foo       Bar');
+		expect(contents(blocks)[0]).toBe('Here is your table:');
+		expect(contents(blocks).at(-1)).toBe('Let me know!');
 	});
 
-	it('handles tables without outer pipes and alignment markers', () => {
-		const text = ['Revenue | Region', ':---|---:', 'Hello | World'].join('\n');
-		const table = tableChild(createTextBlocks(text));
-		expect(table).toEqual({
-			type: 'table',
-			headers: ['Revenue', 'Region'],
-			rows: [['Hello', 'World']],
-		});
+	it('renders empty and missing cells as blank padding rather than invalid blocks', () => {
+		// ENG-6842: an empty cell produced an empty `raw_text` element that Slack rejected.
+		const text = ['| A | B | C |', '|---|---|---|', '| 1 |  | 3 |', '| 4 | 5 |'].join('\n');
+		const blocks = createTextBlocks(text);
+		expect(blocks.every((block) => block.type === 'text')).toBe(true);
+		const table = tableChunks(blocks)[0];
+		expect(table).toContain('1');
+		expect(table).toContain('4  5');
 	});
 
-	it('strips inline markdown and links inside table cells', () => {
-		const text = ['| Name | Link |', '|------|------|', '| **Bob** | [docs](https://x.dev) |'].join('\n');
-		const table = tableChild(createTextBlocks(text));
-		expect(table?.rows).toEqual([['Bob', 'docs']]);
+	it('truncates an oversized cell so a chunk can never exceed the Slack section limit', () => {
+		// ENG-6842: a very long cell tripped Slack's "failed to match any allowed schemas".
+		const huge = 'x'.repeat(5000);
+		const text = ['| A | B |', '|---|---|', `| ${huge} | ok |`].join('\n');
+		const table = tableChunks(createTextBlocks(text))[0];
+		expect(table.length).toBeLessThan(3000);
+		expect(table).toContain('…');
 	});
 
-	it('pads and truncates rows to match the header column count', () => {
-		const text = ['| A | B | C |', '|---|---|---|', '| 1 | 2 |', '| 1 | 2 | 3 | 4 |'].join('\n');
-		const table = tableChild(createTextBlocks(text));
-		expect(table?.rows).toEqual([
-			['1', '2', ''],
-			['1', '2', '3'],
-		]);
+	it('splits a wide table into multiple monospace blocks each under the section limit', () => {
+		const rows = Array.from({ length: 60 }, (_, i) => `| row-${i} | ${'v'.repeat(80)} |`);
+		const text = ['| A | B |', '|---|---|', ...rows].join('\n');
+		const chunks = tableChunks(createTextBlocks(text));
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(2900);
+		}
+	});
+
+	it('caps very long tables and points overflow at nao', () => {
+		const rows = Array.from({ length: 250 }, (_, i) => `| ${i} | v${i} |`);
+		const text = ['| A | B |', '|---|---|', ...rows].join('\n');
+		const overflow = contents(createTextBlocks(text)).find((c) => c.includes('more row'));
+		expect(overflow).toBeDefined();
+		expect(overflow).toContain('open in nao');
 	});
 
 	it('does not treat pipe tables inside fenced code blocks as tables', () => {
 		const text = ['```', '| A | B |', '|---|---|', '| 1 | 2 |', '```'].join('\n');
 		const blocks = createTextBlocks(text);
 		expect(blocks.map((block) => block.type)).toEqual(['text']);
-		expect(tableChild(blocks)).toBeUndefined();
-	});
-
-	it('keeps a mismatched fence marker as literal content inside a code block', () => {
-		const text = ['```', '~~~', '| A | B |', '|---|---|', '| 1 | 2 |', '```'].join('\n');
-		const blocks = createTextBlocks(text);
-		expect(blocks.map((block) => block.type)).toEqual(['text']);
-		expect(tableChild(blocks)).toBeUndefined();
-	});
-
-	it('parses a real table that follows a closed code block', () => {
-		const text = ['```', 'code', '```', '', '| A | B |', '|---|---|', '| 1 | 2 |'].join('\n');
-		const table = tableChild(createTextBlocks(text));
-		expect(table).toEqual({
-			type: 'table',
-			headers: ['A', 'B'],
-			rows: [['1', '2']],
-		});
 	});
 });
 
@@ -99,31 +93,14 @@ describe('buildSlackTableBlocks', () => {
 		expect(buildSlackTableBlocks('No tables here, just text.')).toBeNull();
 	});
 
-	it('builds an official Slack table block from a markdown table', () => {
+	it('builds only valid section blocks (no fragile Slack table block) from a markdown table', () => {
 		const text = ['| Column A | Column B |', '|----------|----------|', '| Hello | World |', '| Foo | Bar |'].join(
 			'\n',
 		);
 
 		const blocks = buildSlackTableBlocks(text) as AnyBlock[] | null;
 		expect(blocks).not.toBeNull();
-
-		const tableBlock = blocks!.find((block) => block.type === 'table') as
-			| { type: 'table'; rows: { type: string; text: string }[][] }
-			| undefined;
-		expect(tableBlock).toBeDefined();
-		expect(tableBlock!.rows).toEqual([
-			[
-				{ type: 'raw_text', text: 'Column A' },
-				{ type: 'raw_text', text: 'Column B' },
-			],
-			[
-				{ type: 'raw_text', text: 'Hello' },
-				{ type: 'raw_text', text: 'World' },
-			],
-			[
-				{ type: 'raw_text', text: 'Foo' },
-				{ type: 'raw_text', text: 'Bar' },
-			],
-		]);
+		expect(blocks!.length).toBeGreaterThan(0);
+		expect(blocks!.some((block) => block.type === 'table')).toBe(false);
 	});
 });


### PR DESCRIPTION
## Problem

When an answer contains a markdown table, the Slack integration renders it as a Block Kit `table` block. Real query output breaks that block's schema, so `@slack/web-api` rejects the whole message and the user gets no answer:

- empty cells omit a required cell value
- long cell text exceeds the allowed length
- some values map to an invalid element type

`ProjectSlackBot.postMessage` attaches the blocks with no fallback, so a rejected payload drops the entire answer. Observed as repeated `WebClient` validation errors (`missing required field ... /blocks/N/rows/N`, `must be more than N characters`, `failed to match any allowed schemas`).

## Fix

- Render markdown tables as fixed-width monospace text inside a code block (a `section`/mrkdwn block), which is not subject to the `table` block schema. Tables are chunked to stay under the 3000-char section limit, cells are clamped, and very long tables are capped with an overflow hint.
- Apply the same monospace rendering to the plain-text `text` field so the notification fallback is readable.
- As defense in depth, retry `postMessage` without blocks if a block payload is ever rejected, so an answer is never silently dropped.

Both the direct post path and the streaming edit path go through `createTextBlocks`, so both are covered.

## Testing

Updated `slack-message-blocks.test.ts` to the new contract and added cases for the exact triggers: empty cells, missing/NULL cells, an oversized cell, a wide table that chunks, and the row cap.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

