### PR TITLE
Honor repo include/exclude globs for URL repos

### DIFF
--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -138,13 +138,14 @@ def _filter_repo_files(repo_dir: Path, include: list[str], exclude: list[str]) -
     if not include and not exclude:
         return
 
-    for file_path in repo_dir.rglob("*"):
-        if not file_path.is_file():
+    for entry in repo_dir.rglob("*"):
+        # Match symlinks against the link itself; never follow them.
+        if not entry.is_symlink() and not entry.is_file():
             continue
 
-        relative = PurePosixPath(file_path.relative_to(repo_dir)).as_posix()
+        relative = PurePosixPath(entry.relative_to(repo_dir)).as_posix()
         if not _matches_patterns(relative, include, exclude):
-            file_path.unlink()
+            entry.unlink()
 
     _prune_empty_dirs(repo_dir)
 
@@ -152,7 +153,7 @@ def _filter_repo_files(repo_dir: Path, include: list[str], exclude: list[str]) -
 def _prune_empty_dirs(root: Path) -> None:
     """Remove empty directories under root, deepest first, keeping root itself."""
     for dir_path in sorted(
-        (p for p in root.rglob("*") if p.is_dir()),
+        (p for p in root.rglob("*") if p.is_dir() and not p.is_symlink()),
         key=lambda p: len(p.parts),
         reverse=True,
     ):

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -58,6 +58,8 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
         if git_dir.exists():
             shutil.rmtree(git_dir)
 
+        _filter_repo_files(tmp_path, repo.include, repo.exclude)
+
         # Atomic swap: only replace existing repo after successful clone
         if repo_path.exists():
             shutil.rmtree(repo_path)
@@ -125,6 +127,37 @@ def _matches_patterns(relative_path: str, include: list[str], exclude: list[str]
             return False
 
     return True
+
+
+def _filter_repo_files(repo_dir: Path, include: list[str], exclude: list[str]) -> None:
+    """Remove files under repo_dir that do not match the include/exclude globs.
+
+    No-op when no filters are set. Empty directories left behind are pruned so
+    the synced tree mirrors the local-path filtering semantics.
+    """
+    if not include and not exclude:
+        return
+
+    for file_path in repo_dir.rglob("*"):
+        if not file_path.is_file():
+            continue
+
+        relative = PurePosixPath(file_path.relative_to(repo_dir)).as_posix()
+        if not _matches_patterns(relative, include, exclude):
+            file_path.unlink()
+
+    _prune_empty_dirs(repo_dir)
+
+
+def _prune_empty_dirs(root: Path) -> None:
+    """Remove empty directories under root, deepest first, keeping root itself."""
+    for dir_path in sorted(
+        (p for p in root.rglob("*") if p.is_dir()),
+        key=lambda p: len(p.parts),
+        reverse=True,
+    ):
+        if not any(dir_path.iterdir()):
+            dir_path.rmdir()
 
 
 def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -246,6 +246,81 @@ class TestCloneOrPullRepo:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_respects_include_patterns(self, mock_console, mock_run, tmp_path: Path):
+        """include globs must be applied to url repos, not only local_path repos."""
+        repo = RepoConfig(
+            name="filtered-repo",
+            url="https://github.com/test/filtered-repo",
+            include=["models/*.sql"],
+        )
+
+        def fake_clone(*args, **kwargs):
+            cloned = tmp_path / "filtered-repo.tmp"
+            (cloned / "models").mkdir(parents=True, exist_ok=True)
+            (cloned / "models" / "dim.sql").write_text("SELECT 1")
+            (cloned / "models" / "schema.yml").write_text("version: 2")
+            (cloned / "readme.md").write_text("docs")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_clone
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is True
+        assert (tmp_path / "filtered-repo" / "models" / "dim.sql").exists()
+        assert not (tmp_path / "filtered-repo" / "models" / "schema.yml").exists()
+        assert not (tmp_path / "filtered-repo" / "readme.md").exists()
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_respects_exclude_patterns(self, mock_console, mock_run, tmp_path: Path):
+        """exclude globs must be applied to url repos, pruning emptied directories."""
+        repo = RepoConfig(
+            name="excluded-repo",
+            url="https://github.com/test/excluded-repo",
+            exclude=["**/*.pyc", "cache/**"],
+        )
+
+        def fake_clone(*args, **kwargs):
+            cloned = tmp_path / "excluded-repo.tmp"
+            cloned.mkdir(exist_ok=True)
+            (cloned / "model.sql").write_text("SELECT 1")
+            (cloned / "build.pyc").write_text("bytecode")
+            (cloned / "cache").mkdir()
+            (cloned / "cache" / "data.bin").write_text("junk")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_clone
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is True
+        assert (tmp_path / "excluded-repo" / "model.sql").exists()
+        assert not (tmp_path / "excluded-repo" / "build.pyc").exists()
+        assert not (tmp_path / "excluded-repo" / "cache").exists()
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
+    def test_no_filters_keeps_all_files(self, mock_console, mock_run, tmp_path: Path):
+        repo = RepoConfig(name="full-repo", url="https://github.com/test/full-repo")
+
+        def fake_clone(*args, **kwargs):
+            cloned = tmp_path / "full-repo.tmp"
+            cloned.mkdir(exist_ok=True)
+            (cloned / "a.sql").write_text("SELECT 1")
+            (cloned / "b.md").write_text("docs")
+            return MagicMock(returncode=0)
+
+        mock_run.side_effect = fake_clone
+
+        result = clone_or_pull_repo(repo, tmp_path)
+
+        assert result is True
+        assert (tmp_path / "full-repo" / "a.sql").exists()
+        assert (tmp_path / "full-repo" / "b.md").exists()
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.subprocess.run")
+    @patch("nao_core.commands.sync.providers.repositories.provider.console")
     def test_rejects_path_traversal_repo_name(self, mock_console, mock_run, tmp_path: Path):
         """Security: repo.name like '../evil' must be rejected before any git call."""
         repo = RepoConfig(name="../evil", url="https://github.com/test/evil")

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -7,6 +7,7 @@ import pytest
 
 from nao_core.commands.sync.providers.repositories.provider import (
     RepositorySyncProvider,
+    _filter_repo_files,
     _matches_patterns,
     clone_or_pull_repo,
     sync_local_repo,
@@ -14,6 +15,16 @@ from nao_core.commands.sync.providers.repositories.provider import (
 )
 from nao_core.config.base import NaoConfig
 from nao_core.config.repos import RepoConfig
+
+
+def _supports_symlinks(tmp_path: Path) -> bool:
+    probe = tmp_path / ".symlink_probe"
+    try:
+        probe.symlink_to(tmp_path)
+    except (OSError, NotImplementedError):
+        return False
+    probe.unlink()
+    return True
 
 
 class TestRepoConfig:
@@ -387,6 +398,46 @@ class TestMatchesPatterns:
         assert _matches_patterns("docs/guide.md", ["docs/**"], []) is True
         assert _matches_patterns("docs/api/ref.md", ["docs/**"], []) is True
         assert _matches_patterns("src/main.py", ["docs/**"], []) is False
+
+
+class TestFilterRepoFilesSymlinks:
+    def test_removes_excluded_symlink(self, tmp_path: Path):
+        if not _supports_symlinks(tmp_path):
+            pytest.skip("platform does not support symlinks")
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / "keep.sql").write_text("SELECT 1")
+        target = tmp_path / "outside.env"
+        target.write_text("SECRET")
+        (repo_dir / "secret.env").symlink_to(target)
+
+        _filter_repo_files(repo_dir, include=[], exclude=["*.env"])
+
+        assert (repo_dir / "keep.sql").exists()
+        assert not (repo_dir / "secret.env").is_symlink()
+        assert not (repo_dir / "secret.env").exists()
+        assert target.exists()
+
+    def test_prune_does_not_crash_on_surviving_directory_symlink(self, tmp_path: Path):
+        """A directory symlink that passes the filters must not make prune raise NotADirectoryError."""
+        if not _supports_symlinks(tmp_path):
+            pytest.skip("platform does not support symlinks")
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        (repo_dir / "cache.pyc").write_text("bytecode")
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        (real_dir / "inner.txt").write_text("data")
+        (repo_dir / "linked").symlink_to(real_dir)
+
+        _filter_repo_files(repo_dir, include=[], exclude=["*.pyc"])
+
+        assert not (repo_dir / "cache.pyc").exists()
+        assert (repo_dir / "linked").is_symlink()
+        assert real_dir.exists()
+        assert (real_dir / "inner.txt").exists()
 
 
 class TestSyncLocalRepo:


### PR DESCRIPTION
# Issue
Closes #1140

# Implemented

* Apply `include`/`exclude` glob filtering to `url` repositories before the atomic swap (previously only `local_path` repos were filtered)
* Remove excluded and dangling symlinks safely; skip directory symlinks when pruning empty directories

# Tests done

* Unit tests for include/exclude on `url` repos and symlink edge cases
* `make lint` clean; CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
