### PR TITLE
Add BigQuery dialect rules to system prompt

### DIFF
--- a/apps/backend/src/components/ai/dialect-rules.tsx
+++ b/apps/backend/src/components/ai/dialect-rules.tsx
@@ -68,6 +68,26 @@ export const DIALECT_GUIDANCE: DialectGuidance[] = [
 			<>
 				Use <Code>SAFE_DIVIDE</Code> for division to avoid division-by-zero errors.
 			</>,
+			<>
+				In a <Code>GROUP BY</Code> query, every column referenced inside a window <Code>ORDER BY</Code>/
+				<Code>PARTITION BY</Code> must be in the <Code>GROUP BY</Code> or wrapped in an aggregate. Wrong:{' '}
+				<Code>SUM(SUM(x)) OVER (ORDER BY DATE_TRUNC(DATE(created_at), MONTH))</Code>. Right: group by the month
+				first, e.g. <Code>SUM(SUM(x)) OVER (ORDER BY month)</Code>.
+			</>,
+			<>
+				Do not use the inline <Code>VALUES</Code> table constructor (<Code>FROM (VALUES (...)) AS t(...)</Code>)
+				— it is not supported. Build literal rows with <Code>SELECT ... UNION ALL SELECT ...</Code> or{' '}
+				<Code>UNNEST([STRUCT(...), STRUCT(...)])</Code>.
+			</>,
+			<>
+				Do not use <Code>IGNORE NULLS</Code>/<Code>RESPECT NULLS</Code> with <Code>STRING_AGG</Code> — they are
+				not supported on that function.
+			</>,
+			<>
+				Use <Code>LOGICAL_OR()</Code>/<Code>LOGICAL_AND()</Code> instead of the Postgres/DuckDB{' '}
+				<Code>BOOL_OR()</Code>/<Code>BOOL_AND()</Code>. An <Code>ORDER BY</Code> that references a column not in
+				the <Code>GROUP BY</Code> and not aggregated raises a 400 error.
+			</>,
 		],
 	},
 	{


### PR DESCRIPTION
# Issue
Closes #1099

# Implemented

* Add BigQuery-specific rules to the agent system prompt:
  * window `ORDER BY` / `PARTITION BY` columns must be grouped or aggregated
  * no inline `VALUES` table constructor
  * no `IGNORE NULLS` / `RESPECT NULLS` on `STRING_AGG`
  * use `LOGICAL_OR` / `LOGICAL_AND` instead of `BOOL_OR` / `BOOL_AND`
* Rules inject only when a BigQuery connection is present

# Tests done

* ESLint/Prettier CI green (prompt-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
