### PR TITLE
Edit and add charts in story edit mode

### DIFF
--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -1,7 +1,7 @@
-import type { UIMessage } from '@nao/backend/chat';
-import type { displayChart } from '@nao/shared/tools';
 import { Pencil } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
+import type { UIMessage } from '@nao/backend/chat';
+import type { displayChart } from '@nao/shared/tools';
 
 import { ChartDisplay } from '@/components/tool-calls/display-chart';
 import { ChartConfigEditDialog } from '@/components/tool-calls/display-chart-edit-dialog';

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -138,7 +138,7 @@ export function StoryChartEmbedShell({ chart, availableColumns, children }: Stor
 					availableColumns={availableColumns}
 					isSaving={edit.isSaving}
 					onSave={(next) => edit.saveChart(chart.rawTag!, next)}
-					description='Tweak the chart parameters. Changes are saved to the story as a new version.'
+					description={edit.saveDescription}
 				/>
 			)}
 		</div>

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -1,13 +1,14 @@
-import { memo, useMemo, useState } from 'react';
-import { Pencil } from 'lucide-react';
 import type { UIMessage } from '@nao/backend/chat';
 import type { displayChart } from '@nao/shared/tools';
-import { Button } from '@/components/ui/button';
-import { useOptionalAgentContext } from '@/contexts/agent.provider';
-import { useStoryEmbedData } from '@/contexts/story-embed-data';
-import { useStoryChartEdit } from '@/contexts/story-chart-edit';
+import { Pencil } from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+
 import { ChartDisplay } from '@/components/tool-calls/display-chart';
 import { ChartConfigEditDialog } from '@/components/tool-calls/display-chart-edit-dialog';
+import { Button } from '@/components/ui/button';
+import { useOptionalAgentContext } from '@/contexts/agent.provider';
+import { useStoryChartEdit } from '@/contexts/story-chart-edit';
+import { useStoryEmbedData } from '@/contexts/story-embed-data';
 import { sortByDateKey } from '@/lib/charts.utils';
 
 interface ChartBlock {

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -15,7 +15,6 @@ import { GripVertical } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Streamdown } from 'streamdown';
 
-
 import { StoryChartEmbed } from './story-chart-embed';
 import { StoryTableEmbed } from './story-table-embed';
 import type { Editor, ReactNodeViewProps } from '@tiptap/react';

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -1,3 +1,4 @@
+import type { Segment } from '@nao/shared/story-segments';
 import {
 	getGridClass,
 	parseChartAttributes,
@@ -5,23 +6,23 @@ import {
 	parseTableBlock,
 	splitCodeIntoSegments,
 } from '@nao/shared/story-segments';
+import type { Editor as CoreEditor } from '@tiptap/core';
 import { Extension, mergeAttributes, Node } from '@tiptap/core';
 import { DragHandle } from '@tiptap/extension-drag-handle-react';
 import { TableKit } from '@tiptap/extension-table';
 import { Markdown } from '@tiptap/markdown';
+import type { Editor, ReactNodeViewProps } from '@tiptap/react';
 import { EditorContent, NodeViewWrapper, ReactNodeViewRenderer, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { GripVertical } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Streamdown } from 'streamdown';
 
-import { StoryChartEmbed } from './story-chart-embed';
-import { StoryTableEmbed } from './story-table-embed';
 import { EditorStoryChartEditProvider } from '@/contexts/story-chart-edit';
 import { replaceUniqueChartTag } from '@/contexts/story-chart-edit-utils';
-import type { Segment } from '@nao/shared/story-segments';
-import type { Editor as CoreEditor } from '@tiptap/core';
-import type { Editor, ReactNodeViewProps } from '@tiptap/react';
+
+import { StoryChartEmbed } from './story-chart-embed';
+import { StoryTableEmbed } from './story-table-embed';
 
 // ---------------------------------------------------------------------------
 // Encoding helpers for data-raw attributes

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -12,11 +12,13 @@ import { Markdown } from '@tiptap/markdown';
 import { EditorContent, NodeViewWrapper, ReactNodeViewRenderer, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { GripVertical } from 'lucide-react';
-import { memo, useEffect, useMemo, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Streamdown } from 'streamdown';
 
 import { StoryChartEmbed } from './story-chart-embed';
 import { StoryTableEmbed } from './story-table-embed';
+import { EditorStoryChartEditProvider } from '@/contexts/story-chart-edit';
+import { replaceUniqueChartTag } from '@/contexts/story-chart-edit-utils';
 import type { Segment } from '@nao/shared/story-segments';
 import type { Editor as CoreEditor } from '@tiptap/core';
 import type { Editor, ReactNodeViewProps } from '@tiptap/react';
@@ -60,7 +62,7 @@ export function preprocessForEditor(code: string): string {
 // ChartBlock extension – atom node rendered as an interactive chart
 // ---------------------------------------------------------------------------
 
-function ChartBlockView({ node }: ReactNodeViewProps) {
+function ChartBlockView({ node, updateAttributes }: ReactNodeViewProps) {
 	const rawTag = node.attrs.rawTag as string;
 
 	const chart = useMemo(() => {
@@ -71,6 +73,11 @@ function ChartBlockView({ node }: ReactNodeViewProps) {
 		const parsed = parseChartBlock(attrMatch[1]);
 		return parsed ? { ...parsed, rawTag } : null;
 	}, [rawTag]);
+
+	const handleReplaceTag = useCallback(
+		(_rawTag: string, nextTag: string) => updateAttributes({ rawTag: nextTag }),
+		[updateAttributes],
+	);
 
 	if (!chart) {
 		return (
@@ -85,7 +92,9 @@ function ChartBlockView({ node }: ReactNodeViewProps) {
 	return (
 		<NodeViewWrapper draggable data-type='chart-block'>
 			<div className='my-2'>
-				<StoryChartEmbed chart={chart} />
+				<EditorStoryChartEditProvider onReplaceTag={handleReplaceTag}>
+					<StoryChartEmbed chart={chart} />
+				</EditorStoryChartEditProvider>
 			</div>
 		</NodeViewWrapper>
 	);
@@ -213,7 +222,7 @@ const TableBlock = Node.create({
 // GridBlock extension – atom node rendered as a grid of charts/markdown
 // ---------------------------------------------------------------------------
 
-function GridBlockView({ node }: ReactNodeViewProps) {
+function GridBlockView({ node, updateAttributes }: ReactNodeViewProps) {
 	const rawContent = node.attrs.rawContent as string;
 
 	const { cols, segments } = useMemo(() => {
@@ -228,6 +237,16 @@ function GridBlockView({ node }: ReactNodeViewProps) {
 		};
 	}, [rawContent]);
 
+	const handleReplaceTag = useCallback(
+		(rawTag: string, nextTag: string) => {
+			const nextContent = replaceUniqueChartTag(rawContent, rawTag, nextTag);
+			if (nextContent !== rawContent) {
+				updateAttributes({ rawContent: nextContent });
+			}
+		},
+		[rawContent, updateAttributes],
+	);
+
 	const gridClass = getGridClass(cols);
 
 	return (
@@ -239,7 +258,9 @@ function GridBlockView({ node }: ReactNodeViewProps) {
 							{segment.type === 'markdown' ? (
 								<Streamdown mode='static'>{segment.content}</Streamdown>
 							) : segment.type === 'chart' ? (
-								<StoryChartEmbed chart={segment.chart} />
+								<EditorStoryChartEditProvider onReplaceTag={handleReplaceTag}>
+									<StoryChartEmbed chart={segment.chart} />
+								</EditorStoryChartEditProvider>
 							) : segment.type === 'table' ? (
 								<StoryTableEmbed table={segment.table} />
 							) : null}

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -1,4 +1,3 @@
-import type { Segment } from '@nao/shared/story-segments';
 import {
 	getGridClass,
 	parseChartAttributes,
@@ -6,23 +5,24 @@ import {
 	parseTableBlock,
 	splitCodeIntoSegments,
 } from '@nao/shared/story-segments';
-import type { Editor as CoreEditor } from '@tiptap/core';
 import { Extension, mergeAttributes, Node } from '@tiptap/core';
 import { DragHandle } from '@tiptap/extension-drag-handle-react';
 import { TableKit } from '@tiptap/extension-table';
 import { Markdown } from '@tiptap/markdown';
-import type { Editor, ReactNodeViewProps } from '@tiptap/react';
 import { EditorContent, NodeViewWrapper, ReactNodeViewRenderer, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { GripVertical } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Streamdown } from 'streamdown';
 
-import { EditorStoryChartEditProvider } from '@/contexts/story-chart-edit';
-import { replaceUniqueChartTag } from '@/contexts/story-chart-edit-utils';
 
 import { StoryChartEmbed } from './story-chart-embed';
 import { StoryTableEmbed } from './story-table-embed';
+import type { Editor, ReactNodeViewProps } from '@tiptap/react';
+import type { Editor as CoreEditor } from '@tiptap/core';
+import type { Segment } from '@nao/shared/story-segments';
+import { replaceUniqueChartTag } from '@/contexts/story-chart-edit-utils';
+import { EditorStoryChartEditProvider } from '@/contexts/story-chart-edit';
 
 // ---------------------------------------------------------------------------
 // Encoding helpers for data-raw attributes

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -1,9 +1,11 @@
-import { createContext, useCallback, useContext, useMemo } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildStoryChartBlock } from '@nao/shared';
-import { replaceUniqueChartTag } from './story-chart-edit-utils';
 import type { displayChart } from '@nao/shared/tools';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createContext, useCallback, useContext, useMemo } from 'react';
+
 import { trpc } from '@/main';
+
+import { replaceUniqueChartTag } from './story-chart-edit-utils';
 
 export interface StoryChartEditHandlers {
 	/**

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -1,11 +1,11 @@
 import { buildStoryChartBlock } from '@nao/shared';
-import type { displayChart } from '@nao/shared/tools';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createContext, useCallback, useContext, useMemo } from 'react';
 
-import { trpc } from '@/main';
 
 import { replaceUniqueChartTag } from './story-chart-edit-utils';
+import type { displayChart } from '@nao/shared/tools';
+import { trpc } from '@/main';
 
 export interface StoryChartEditHandlers {
 	/**

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -36,12 +36,6 @@ interface EditorStoryChartEditProviderProps {
 	children: React.ReactNode;
 }
 
-/**
- * Provides a `saveChart` handler for charts rendered inside the story EDIT-mode
- * editor. Unlike {@link StoryChartEditProvider}, it does not create a new story
- * version; it mutates the editor buffer in place so the change is persisted with
- * the rest of the user's edits when they save the story.
- */
 export function EditorStoryChartEditProvider({ onReplaceTag, children }: EditorStoryChartEditProviderProps) {
 	const value = useMemo<StoryChartEditHandlers>(
 		() => ({
@@ -65,10 +59,6 @@ interface StoryChartEditProviderProps {
 	children: React.ReactNode;
 }
 
-/**
- * Provides a `saveChart` handler that chart embeds inside a story can call to persist
- * edits (title/type/series/etc) back to the story via `story.createVersion`.
- */
 export function StoryChartEditProvider({
 	chatId,
 	storySlug,

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -14,11 +14,47 @@ export interface StoryChartEditHandlers {
 	saveChart: (rawTag: string, config: displayChart.Input) => Promise<void>;
 	/** Whether a save is currently in flight. */
 	isSaving: boolean;
+	/** Human-readable hint describing how the edit is persisted, shown in the edit dialog. */
+	saveDescription: string;
 }
+
+const VERSION_SAVE_DESCRIPTION = 'Tweak the chart parameters. Changes are saved to the story as a new version.';
+const EDITOR_SAVE_DESCRIPTION =
+	'Tweak the chart parameters. Changes apply to the story you are editing and are saved when you save the story.';
 
 const StoryChartEditContext = createContext<StoryChartEditHandlers | null>(null);
 
 export const useStoryChartEdit = () => useContext(StoryChartEditContext);
+
+interface EditorStoryChartEditProviderProps {
+	/**
+	 * Applies an edited chart tag to the live editor buffer, given the chart's
+	 * original `<chart ... />` tag and its replacement.
+	 */
+	onReplaceTag: (rawTag: string, nextTag: string) => void;
+	children: React.ReactNode;
+}
+
+/**
+ * Provides a `saveChart` handler for charts rendered inside the story EDIT-mode
+ * editor. Unlike {@link StoryChartEditProvider}, it does not create a new story
+ * version; it mutates the editor buffer in place so the change is persisted with
+ * the rest of the user's edits when they save the story.
+ */
+export function EditorStoryChartEditProvider({ onReplaceTag, children }: EditorStoryChartEditProviderProps) {
+	const value = useMemo<StoryChartEditHandlers>(
+		() => ({
+			saveChart: async (rawTag, config) => {
+				onReplaceTag(rawTag, buildStoryChartBlock(config));
+			},
+			isSaving: false,
+			saveDescription: EDITOR_SAVE_DESCRIPTION,
+		}),
+		[onReplaceTag],
+	);
+
+	return <StoryChartEditContext.Provider value={value}>{children}</StoryChartEditContext.Provider>;
+}
 
 interface StoryChartEditProviderProps {
 	chatId: string;
@@ -88,7 +124,7 @@ export function StoryChartEditProvider({
 	);
 
 	const value = useMemo<StoryChartEditHandlers>(
-		() => ({ saveChart, isSaving: createVersionMutation.isPending }),
+		() => ({ saveChart, isSaving: createVersionMutation.isPending, saveDescription: VERSION_SAVE_DESCRIPTION }),
 		[saveChart, createVersionMutation.isPending],
 	);
 

--- a/apps/frontend/src/contexts/story-chart-edit.tsx
+++ b/apps/frontend/src/contexts/story-chart-edit.tsx
@@ -2,7 +2,6 @@ import { buildStoryChartBlock } from '@nao/shared';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createContext, useCallback, useContext, useMemo } from 'react';
 
-
 import { replaceUniqueChartTag } from './story-chart-edit-utils';
 import type { displayChart } from '@nao/shared/tools';
 import { trpc } from '@/main';


### PR DESCRIPTION
# Issue
Closes #1063

# Implemented

* Show the edit-chart option in story edit mode

# Tests done

* Helper unit tests for chart-tag replacement
* ESLint/Prettier CI green

Preview:
<img width="643" height="541" alt="image" src="https://github.com/user-attachments/assets/71f39f1e-50ca-4d6c-a9db-29f7f110ff86" />
