### PR TITLE
Apply designer font for tables content + human readable column names

### DIFF
--- a/apps/frontend/src/components/data-table-card.tsx
+++ b/apps/frontend/src/components/data-table-card.tsx
@@ -85,6 +85,7 @@ export function DataTableCard({
 				tableContainerClassName={tableContainerClassName}
 				maxRowsBeforePagination={maxRowsBeforePagination}
 				compactFooter={true}
+				humanizeColumnLabels={true}
 			/>
 
 			<Dialog open={isFullscreen} onOpenChange={setIsFullscreen}>
@@ -117,6 +118,7 @@ export function DataTableCard({
 						tableContainerClassName='max-h-[75vh] border-t-0'
 						maxRowsBeforePagination={maxRowsBeforePagination}
 						compactFooter={true}
+						humanizeColumnLabels={true}
 					/>
 				</DialogContent>
 			</Dialog>

--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -1,4 +1,4 @@
-import { formatCellValue, isNumericColumn } from '@nao/shared/story-table-utils';
+import { formatCellValue, formatColumnLabel, isNumericColumn } from '@nao/shared/story-table-utils';
 import { useEffect, useMemo, useState } from 'react';
 import { TablePagination } from '@/components/ui/table-pagination';
 import { useDateFormat } from '@/hooks/use-date-format';
@@ -17,6 +17,7 @@ interface TableDisplayProps {
 	showRowCount?: boolean;
 	maxRowsBeforePagination?: number;
 	compactFooter?: boolean;
+	humanizeColumnLabels?: boolean;
 }
 
 export function TableDisplay({
@@ -29,6 +30,7 @@ export function TableDisplay({
 	showRowCount = true,
 	maxRowsBeforePagination = 100,
 	compactFooter = false,
+	humanizeColumnLabels = false,
 }: TableDisplayProps) {
 	const dateFormat = useDateFormat();
 	const resolvedColumns = columns && columns.length > 0 ? columns : inferColumns(data);
@@ -66,7 +68,7 @@ export function TableDisplay({
 										numericColumns.has(column) && 'text-right tabular-nums',
 									)}
 								>
-									{column}
+									{humanizeColumnLabels ? formatColumnLabel(column) : column}
 								</th>
 							))}
 						</tr>

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -187,7 +187,7 @@ code.dollar:before {
 	--font-borna:
 		'Borna', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
 		'Droid Sans', 'Helvetica Neue', sans-serif;
-	--font-mono: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+	--font-mono: 'Geist Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 :root {

--- a/apps/shared/src/story-table-utils.ts
+++ b/apps/shared/src/story-table-utils.ts
@@ -26,6 +26,16 @@ export function formatCellValue(value: unknown, dateFormat?: DateFormatSettings 
 	return String(value);
 }
 
+export function formatColumnLabel(column: string): string {
+	return column
+		.replace(/_/g, ' ')
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(' ');
+}
+
 export function isNumericColumn(rows: Record<string, unknown>[], column: string): boolean {
 	return rows
 		.filter((row) => row[column] !== null && row[column] !== undefined)


### PR DESCRIPTION
# Issue
Closes #1165

# Implemented

* Point `--font-mono` at Geist Mono (it was `source-code-pro`, which is never loaded and fell back to system Menlo/Monaco); fixes table cells and every other mono usage (code blocks, SQL, IDs)
* Humanize column names in chat/story tables (`company_name` → `Company Name`); display-only, raw keys still used for data lookup and CSV/TSV export
* Scoped to chat/story tables (`DataTableCard` / `MarkdownTable`); `execute_sql` result tables keep raw SQL identifiers

# Tests done

* Frontend + shared lint and typecheck pass
* ESLint/Prettier CI green

# Preview
<img width="1339" height="597" alt="image" src="https://github.com/user-attachments/assets/67131067-b27e-43f5-8dab-39e535fb6217" />
