### PR TITLE
fix: disable non-current projects in switcher when NAO_DEFAULT_PROJECT_PATH is set

### DIFF
--- a/apps/backend/src/trpc/system.routes.ts
+++ b/apps/backend/src/trpc/system.routes.ts
@@ -10,6 +10,7 @@ export const systemRoutes = {
 		enableUserSignup: await isUserSignupAvailable(),
 		betaAutomationsEnabled: env.BETA_AUTOMATIONS_ENABLED,
 		betaContextRecommendationsEnabled: env.BETA_CONTEXT_RECOMMENDATIONS_ENABLED,
+		hasDefaultProjectPath: Boolean(env.NAO_DEFAULT_PROJECT_PATH),
 	})),
 
 	version: adminProtectedProcedure.query(() => ({

--- a/apps/frontend/src/components/project-selector.tsx
+++ b/apps/frontend/src/components/project-selector.tsx
@@ -22,6 +22,7 @@ export function ProjectSelector({
 	projects,
 	currentProjectId,
 	onChange,
+	disabledProjectIds,
 	className,
 	triggerClassName,
 	triggerVariant,
@@ -32,6 +33,7 @@ export function ProjectSelector({
 	projects: ProjectOption[];
 	currentProjectId: string;
 	onChange: (projectId: string) => void;
+	disabledProjectIds?: string[];
 	className?: string;
 	triggerClassName?: string;
 	triggerVariant?: 'default' | 'ghost';
@@ -50,16 +52,23 @@ export function ProjectSelector({
 				<SelectContent position='popper' align={align}>
 					<SelectGroup>
 						<SelectLabel>Projects</SelectLabel>
-						{projects.map((project) => (
-							<SelectItem key={project.id} value={project.id}>
-								<span className='flex min-w-0 items-center justify-between gap-3'>
-									<span className='truncate'>{project.name}</span>
-									<span className='shrink-0 text-xs text-muted-foreground'>
-										{USER_ROLE_LABELS[project.userRole]}
+						{projects.map((project) => {
+							const isDisabled = disabledProjectIds?.includes(project.id);
+							return (
+								<SelectItem
+									key={project.id}
+									value={project.id}
+									disabled={isDisabled}
+								>
+									<span className='flex min-w-0 items-center justify-between gap-3'>
+										<span className='truncate'>{project.name}</span>
+										<span className='shrink-0 text-xs text-muted-foreground'>
+											{USER_ROLE_LABELS[project.userRole]}
+										</span>
 									</span>
-								</span>
-							</SelectItem>
-						))}
+								</SelectItem>
+							);
+						})}
 					</SelectGroup>
 				</SelectContent>
 			</Select>

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -130,6 +130,7 @@ interface SidebarSettingsNavProps {
 	hasLicense: boolean;
 	projects: ProjectOption[];
 	currentProjectId?: string;
+	isProjectPinned?: boolean;
 	onProjectChange: (projectId: string) => void;
 }
 
@@ -153,6 +154,7 @@ export function SidebarSettingsNav({
 	hasLicense,
 	projects,
 	currentProjectId,
+	isProjectPinned,
 	onProjectChange,
 }: SidebarSettingsNavProps) {
 	const navigate = useNavigate();
@@ -378,6 +380,7 @@ export function SidebarSettingsNav({
 									<ProjectSwitcherSubItem
 										projects={projects}
 										currentProjectId={currentProjectId}
+										isProjectPinned={isProjectPinned}
 										onChange={onProjectChange}
 									/>
 								)}
@@ -393,12 +396,18 @@ export function SidebarSettingsNav({
 function ProjectSwitcherSubItem({
 	projects,
 	currentProjectId,
+	isProjectPinned,
 	onChange,
 }: {
 	projects: ProjectOption[];
 	currentProjectId: string;
+	isProjectPinned?: boolean;
 	onChange: (projectId: string) => void;
 }) {
+	const disabledProjectIds = isProjectPinned
+		? projects.filter((p) => p.id !== currentProjectId).map((p) => p.id)
+		: undefined;
+
 	return (
 		<div className='ml-3 mt-1 pl-3 border-l border-sidebar-border'>
 			<div className='px-1 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground'>Switch project</div>
@@ -406,6 +415,7 @@ function ProjectSwitcherSubItem({
 				projects={projects}
 				currentProjectId={currentProjectId}
 				onChange={onChange}
+				disabledProjectIds={disabledProjectIds}
 				triggerVariant='ghost'
 				triggerIcon={<Folder className='size-3.5 shrink-0' />}
 				triggerClassName={cn(

--- a/apps/frontend/src/components/sidebar.tsx
+++ b/apps/frontend/src/components/sidebar.tsx
@@ -47,6 +47,7 @@ export function Sidebar() {
 	const branding = useBranding();
 	const { isAdmin, isContextAdmin, isViewer } = usePermissions();
 	const isCloud = config.data?.naoMode === 'cloud';
+	const isProjectPinned = !isCloud && config.data?.hasDefaultProjectPath === true;
 	const betaAutomationsEnabled = config.data?.betaAutomationsEnabled === true;
 	const { groupBy, filters, setGroupBy, toggleFilter } = useChatViewPreferences();
 	const hasLicense = license.data?.tokenProvided === true;
@@ -246,6 +247,7 @@ export function Sidebar() {
 					hasLicense={hasLicense}
 					projects={projects.data ?? []}
 					currentProjectId={project.data?.id}
+					isProjectPinned={isProjectPinned}
 					onProjectChange={handleProjectChange}
 				/>
 			) : (


### PR DESCRIPTION
Closes: #1172

When self-hosting with `NAO_DEFAULT_PROJECT_PATH` set, the project switcher in settings silently ignored user selections — clicking a different project did nothing with no feedback.

**## Changes**
- **Backend** (`system.routes.ts`): Exposed `hasDefaultProjectPath` in the `getPublicConfig` endpoint so the frontend knows when the env var is set.
- **Frontend** (`project-selector.tsx`): Added optional `disabledProjectIds` prop to `ProjectSelector`. When provided, matching items are rendered with Radix's native `disabled` attribute (greyed out, not clickable).
- **Frontend** (`sidebar-settings-nav.tsx`): Computes `disabledProjectIds` from the `isProjectPinned` flag and passes it to `ProjectSelector`.
- **Frontend** (`sidebar.tsx`): Derives `isProjectPinned` from config (`!isCloud && hasDefaultProjectPath`) and threads it to the settings nav.

Now the dropdown remains openable so users can see all projects, but non-current entries are visibly disabled with no interaction possible — making the constraint obvious instead of silently doing nothing

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

