### PR TITLE
Use configured base_url in nao debug LLM test

### DIFF
--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -24,17 +24,25 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
     provider = llm_config.provider.value
     api_key = llm_config.api_key
 
+    base_url = llm_config.base_url
+
     if provider == "openai":
         require_dependency("openai", "openai", "for OpenAI LLM provider")
         from openai import OpenAI
 
-        client = OpenAI(api_key=api_key)
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        client = OpenAI(**kwargs)
         models = client.models.list()
     elif provider == "anthropic":
         require_dependency("anthropic", "anthropic", "for Anthropic LLM provider")
         from anthropic import Anthropic
 
-        client = Anthropic(api_key=api_key)
+        kwargs = {"api_key": api_key}
+        if base_url:
+            kwargs["base_url"] = base_url
+        client = Anthropic(**kwargs)
         models = client.models.list()
     elif provider == "gemini":
         require_dependency("google.genai", "gemini", "for Google Gemini LLM provider")
@@ -52,7 +60,7 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
         require_dependency("openai", "openai", "for OpenRouter LLM provider")
         from openai import OpenAI
 
-        client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)
+        client = OpenAI(base_url=base_url or "https://openrouter.ai/api/v1", api_key=api_key)
         models = client.models.list()
     elif provider == "ollama":
         require_dependency("ollama", "ollama", "for Ollama LLM provider")

--- a/cli/tests/nao_core/commands/test_debug.py
+++ b/cli/tests/nao_core/commands/test_debug.py
@@ -27,6 +27,24 @@ class TestLLMConnection:
             assert "3 models available" in message
             mock_openai_class.assert_called_once_with(api_key="sk-test-api-key")
 
+    def test_openai_connection_uses_configured_base_url(self):
+        """A custom base_url (e.g. a LiteLLM proxy) must reach the client, not the provider default."""
+        config = LLMConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test-api-key",
+            base_url="https://proxy.internal/v1",
+        )
+
+        with patch("openai.OpenAI") as mock_openai_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [MagicMock()]
+            mock_openai_class.return_value = mock_client
+
+            success, _ = check_llm_connection(config)
+
+            assert success is True
+            mock_openai_class.assert_called_once_with(api_key="sk-test-api-key", base_url="https://proxy.internal/v1")
+
     def test_openai_exception_returns_failure(self):
         """API exception should return False with error message."""
         config = LLMConfig(provider=LLMProvider.OPENAI, api_key="invalid")
@@ -53,6 +71,25 @@ class TestLLMConnection:
             assert "Connected successfully" in message
             assert "3 models available" in message
             mock_anthropic_class.assert_called_once_with(api_key="sk-test-api-key")
+
+    def test_anthropic_connection_uses_configured_base_url(self):
+        config = LLMConfig(
+            provider=LLMProvider.ANTHROPIC,
+            api_key="sk-test-api-key",
+            base_url="https://proxy.internal/anthropic",
+        )
+
+        with patch("anthropic.Anthropic") as mock_anthropic_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [MagicMock()]
+            mock_anthropic_class.return_value = mock_client
+
+            success, _ = check_llm_connection(config)
+
+            assert success is True
+            mock_anthropic_class.assert_called_once_with(
+                api_key="sk-test-api-key", base_url="https://proxy.internal/anthropic"
+            )
 
     def test_anthropic_exception_returns_failure(self):
         """API exception should return False with error message."""
@@ -135,6 +172,23 @@ class TestLLMConnection:
             mock_openai_class.assert_called_once_with(
                 base_url="https://openrouter.ai/api/v1", api_key="sk-test-api-key"
             )
+
+    def test_openrouter_connection_uses_configured_base_url(self):
+        """A configured base_url overrides the OpenRouter default endpoint."""
+        config = LLMConfig(
+            provider=LLMProvider.OPENROUTER,
+            api_key="sk-test-api-key",
+            base_url="https://proxy.internal/v1",
+        )
+        with patch("openai.OpenAI") as mock_openai_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [MagicMock()]
+            mock_openai_class.return_value = mock_client
+
+            success, _ = check_llm_connection(config)
+
+            assert success is True
+            mock_openai_class.assert_called_once_with(base_url="https://proxy.internal/v1", api_key="sk-test-api-key")
 
     def test_openrouter_exception_returns_failure(self):
         """API exception should return False with error message."""


### PR DESCRIPTION
# Issue
Closes #1185

# Implemented

* `nao debug`'s LLM connectivity test now builds each provider client with the configured `llm.base_url` when set, so the test hits the same endpoint the runtime uses (e.g. a LiteLLM / OpenAI-compatible proxy) instead of the provider default (`api.openai.com`), fixing the false 401.
* OpenAI and Anthropic clients now receive `base_url` when configured; falls back to the SDK default when unset (unchanged behavior).
* OpenRouter now honors a configured `base_url`, falling back to `https://openrouter.ai/api/v1` when unset.
* Mirrors the runtime's client-construction pattern in `templates/engine.py` (which wires `base_url` for the OpenAI-compatible and Anthropic paths); the runtime builds clients inline per provider inside a class, so there was no shared helper to import.

# Tests done

* `make lint` clean (ty, ruff check, import sort, format).
* Added tests asserting the configured `base_url` reaches the OpenAI, Anthropic, and OpenRouter clients; existing default-endpoint tests still pass. Full `test_debug.py` suite: 38 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

