### PR TITLE
feat(cli): show reference SQL and readable agent SQL in test server

### DIFF
--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -51,6 +51,7 @@ class TestRunDetails:
     expected_data: list[dict] | None = None
     comparison: str | None = None
     tool_calls: list[dict] | None = None
+    reference_sql: str | None = None
 
 
 @dataclass
@@ -225,6 +226,7 @@ def run_test(
                     expected_data=result.verification.expectedData,
                     comparison=comparison,
                     tool_calls=result.tool_calls,
+                    reference_sql=test_case.sql,
                 ),
             )
 
@@ -241,6 +243,7 @@ def run_test(
             details=TestRunDetails(
                 response_text=result.text,
                 tool_calls=result.tool_calls,
+                reference_sql=test_case.sql,
             ),
         )
 
@@ -252,7 +255,7 @@ def run_test(
             passed=False,
             message="error",
             error=str(e),
-            details=None,
+            details=TestRunDetails(reference_sql=test_case.sql),
         )
 
 

--- a/cli/nao_core/commands/test/server.py
+++ b/cli/nao_core/commands/test/server.py
@@ -274,6 +274,13 @@ def get_html_template() -> str:
                                 </div>
                             )}
 
+                            {details.reference_sql && (
+                                <div className="detail-section">
+                                    <h3>Reference SQL</h3>
+                                    <pre>{details.reference_sql}</pre>
+                                </div>
+                            )}
+
                             {(details.actual_data || details.expected_data) && (
                                 <div className="detail-section">
                                     <h3>Data Comparison</h3>
@@ -337,10 +344,7 @@ def get_html_template() -> str:
                             </div>
                             {expanded[i] && (
                                 <div className="tool-call-details">
-                                    <div className="tool-call-section">
-                                        <div className="tool-call-label">Arguments</div>
-                                        <pre>{JSON.stringify(tc.args, null, 2)}</pre>
-                                    </div>
+                                    <ToolCallArgs toolCall={tc} />
                                     {tc.result !== undefined && (
                                         <div className="tool-call-section">
                                             <div className="tool-call-label">Result</div>
@@ -351,6 +355,35 @@ def get_html_template() -> str:
                             )}
                         </div>
                     ))}
+                </div>
+            );
+        }
+
+        function ToolCallArgs({ toolCall }) {
+            const { toolName, args } = toolCall;
+
+            if (toolName === 'execute_sql' && args && typeof args.sql_query === 'string') {
+                const { sql_query, ...otherArgs } = args;
+                return (
+                    <>
+                        <div className="tool-call-section">
+                            <div className="tool-call-label">SQL Query</div>
+                            <pre>{sql_query}</pre>
+                        </div>
+                        {Object.keys(otherArgs).length > 0 && (
+                            <div className="tool-call-section">
+                                <div className="tool-call-label">Other Arguments</div>
+                                <pre>{JSON.stringify(otherArgs, null, 2)}</pre>
+                            </div>
+                        )}
+                    </>
+                );
+            }
+
+            return (
+                <div className="tool-call-section">
+                    <div className="tool-call-label">Arguments</div>
+                    <pre>{JSON.stringify(args, null, 2)}</pre>
                 </div>
             );
         }

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -6,13 +6,14 @@ import pytest
 
 from nao_core.commands.test.case import TestCase as NaoTestCase
 from nao_core.commands.test.client import (
-    TestResult as AgentTestResult,
-)
-from nao_core.commands.test.client import (
+    AgentClientError,
     TokenCost,
     TokenUsage,
     VerificationResult,
     serialize_model_costs,
+)
+from nao_core.commands.test.client import (
+    TestResult as AgentTestResult,
 )
 from nao_core.commands.test.runner import ModelConfig, check_dataframe, filter_test_cases, run_test
 from nao_core.config.llm import ModelCosts
@@ -165,3 +166,64 @@ def test_run_test_passes_configured_costs_to_client(monkeypatch):
 
     assert result.passed is True
     client.run_test.assert_called_once_with(test_case, provider="openai", model_id="custom-model", costs=costs)
+
+
+def test_run_test_records_reference_sql_with_verification(monkeypatch):
+    test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
+    model = ModelConfig(provider="openai", model_id="custom-model")
+    client = Mock()
+    client.run_test.return_value = AgentTestResult(
+        text="",
+        tool_calls=[],
+        usage=TokenUsage(totalTokens=0),
+        cost=TokenCost(totalCost=0),
+        finish_reason="stop",
+        duration_ms=1,
+        verification=VerificationResult(
+            data=[{"total": 1}],
+            expectedData=[{"total": 1}],
+            expectedColumns=["total"],
+        ),
+    )
+    monkeypatch.setattr(test_runner_module, "get_client", lambda **_: client)
+
+    result = run_test(test_case, model)
+
+    assert result.passed is True
+    assert result.details is not None
+    assert result.details.reference_sql == "select 1"
+
+
+def test_run_test_records_reference_sql_without_verification(monkeypatch):
+    test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
+    model = ModelConfig(provider="openai", model_id="custom-model")
+    client = Mock()
+    client.run_test.return_value = AgentTestResult(
+        text="",
+        tool_calls=[],
+        usage=TokenUsage(totalTokens=0),
+        cost=TokenCost(totalCost=0),
+        finish_reason="stop",
+        duration_ms=1,
+    )
+    monkeypatch.setattr(test_runner_module, "get_client", lambda **_: client)
+
+    result = run_test(test_case, model)
+
+    assert result.details is not None
+    assert result.details.reference_sql == "select 1"
+
+
+def test_run_test_records_reference_sql_on_client_error(monkeypatch):
+    test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
+    model = ModelConfig(provider="openai", model_id="custom-model")
+    client = Mock()
+    client.run_test.side_effect = AgentClientError("backend unreachable")
+    monkeypatch.setattr(test_runner_module, "get_client", lambda **_: client)
+
+    result = run_test(test_case, model)
+
+    assert result.passed is False
+    assert result.error == "backend unreachable"
+    assert result.details is not None
+    assert result.details.reference_sql == "select 1"


### PR DESCRIPTION
Closes #1190

- Save the test YAML query as `reference_sql` in `tests/outputs/results_*.json` (also on errored runs, where it's the only debugging context available).
- Show it in a "Reference SQL" section in the result modal.
- Render `execute_sql` tool call queries as multi-line SQL instead of escaped JSON; other tools keep the JSON rendering.

Old result files (without `reference_sql`) still render fine — the new section is conditional, same pattern as the other modal sections.

Note: `TestCase.sql` is annotated `str` but `from_yaml` can assign `None` (pre-existing); `reference_sql` is typed `str | None` to handle it. Happy to fix the annotation here or in a follow-up if you prefer.

Tested with `make lint` and pytest (3 new tests covering the field across all `run_test` branches), plus the UI checked against result files covering pass/fail/errored/legacy cases. Before/after screenshots are on the issue.

This PR was written using Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

