### PR TITLE
feat: Improve AI summary template by giving it the database profiling

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -172,8 +172,23 @@ After syncing, any Jinja templates (`*.j2` files) in the project directory are r
 Optional `ai_summary` generation:
 
 - Add `ai_summary` to a database connection `templates` list to render `ai_summary.md`.
+- AI summaries use profiling statistics for data-quality and distribution observations. The row preview is a tiny, non-representative shape sample.
 - Use `prompt("...")` inside Jinja templates to generate `ai_summary` content.
 - `prompt(...)` requires `llm.provider`, `llm.annotation_model`, and `llm.api_key` (except for ollama).
+- Configure `profiling` and `ai_summary` refreshes independently with `refresh_policy: always`, `once`, or `interval`. Interval policies also accept `interval_days` (default: `7`):
+
+```yaml
+databases:
+  - type: duckdb
+    name: analytics
+    path: analytics.duckdb
+    templates: [columns, preview, profiling, ai_summary]
+    profiling:
+      refresh_policy: once
+    ai_summary:
+      refresh_policy: interval
+      interval_days: 7
+```
 
 ### Run tests
 

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -30,7 +30,12 @@ from nao_core.commands.sync.cleanup import (
 )
 from nao_core.commands.sync.providers.databases.query_history import TableUsageStats, compute_table_usage
 from nao_core.config import AnyDatabaseConfig, NaoConfig
-from nao_core.config.databases.base import DatabaseConfig, DatabaseTemplate, ProfilingRefreshPolicy
+from nao_core.config.databases.base import (
+    DatabaseConfig,
+    DatabaseTemplate,
+    ProfilingRefreshPolicy,
+    RefreshConfig,
+)
 from nao_core.config.llm import LLMConfig
 from nao_core.templates.context import NaoContext, create_nao_context
 from nao_core.templates.engine import get_template_engine
@@ -148,13 +153,13 @@ def _pick_query_texts(columns: list[str], rows: Any) -> list[str]:
     return [str(row[idx]) for row in rows if row[idx] is not None]
 
 
-def _should_refresh_profiling(
+def _should_refresh(
     output_file: Path,
-    profiling_config,
+    refresh_config: RefreshConfig,
 ) -> bool:
-    """Decide whether profiling should be recomputed based on refresh policy."""
+    """Decide whether a template should be refreshed based on its policy."""
 
-    policy = profiling_config.refresh_policy
+    policy = refresh_config.refresh_policy
     if not output_file.exists() or policy == ProfilingRefreshPolicy.ALWAYS:
         return True
     if policy == ProfilingRefreshPolicy.ONCE:
@@ -169,7 +174,7 @@ def _should_refresh_profiling(
                 if computed_at.tzinfo is None:
                     computed_at = computed_at.replace(tzinfo=timezone.utc)
                 age = datetime.now(timezone.utc) - computed_at
-                return age > timedelta(days=profiling_config.interval_days)
+                return age > timedelta(days=refresh_config.interval_days)
         except Exception:
             return True
 
@@ -296,23 +301,44 @@ def sync_database(
                 ctx = db_config.create_context(conn, schema, table)
                 ctx.set_exclude_columns(db_config.exclude_columns)
                 table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
+                has_profiling = DatabaseTemplate.PROFILING in db_config.templates
+                has_ai_summary = DatabaseTemplate.AI_SUMMARY in db_config.templates
+                profiling_due = has_profiling and _should_refresh(
+                    table_path / "profiling.md",
+                    db_config.profiling,
+                )
+                summary_due = has_ai_summary and _should_refresh(
+                    table_path / "ai_summary.md",
+                    db_config.ai_summary,
+                )
+                profiling_data = ctx.profiling() if profiling_due or summary_due else None
 
                 for template_name in templates:
                     output_filename = Path(template_name).stem
                     tpl_name = output_filename.replace(".md", "")
+                    output_file = table_path / output_filename
 
                     extra_ctx: dict[str, Any] = {}
                     if tpl_name == "how_to_use":
                         extra_ctx["usage_stats"] = table_usage
-                    output_file = table_path / output_filename
 
-                    if tpl_name == "profiling" and hasattr(db_config, "profiling"):
-                        if not _should_refresh_profiling(output_file, db_config.profiling):
+                    if tpl_name == "profiling":
+                        if not profiling_due:
                             console.print(
                                 f"    [dim]⏭ {schema}.{table} profiling skipped "
                                 f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
                             )
                             continue
+                        extra_ctx["profiling"] = profiling_data
+                    if tpl_name == "ai_summary":
+                        if not summary_due:
+                            console.print(
+                                f"    [dim]⏭ {schema}.{table} ai_summary skipped "
+                                f"(policy: {db_config.ai_summary.refresh_policy.value})[/dim]"
+                            )
+                            continue
+                        extra_ctx["profiling"] = profiling_data
+                        extra_ctx["computed_at"] = datetime.now(timezone.utc).isoformat()
 
                     t_render = time.monotonic()
                     try:

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -58,18 +58,22 @@ class ProfilingRefreshPolicy(str, Enum):
     ONCE = "once"
 
 
-class ProfilingConfig(BaseModel):
-    """Configuration for profiling refresh policy."""
+class RefreshConfig(BaseModel):
+    """Configuration for template refresh policy."""
 
     refresh_policy: ProfilingRefreshPolicy = Field(
         default=ProfilingRefreshPolicy.ALWAYS,
-        description="When to recompute profiling: always, interval, or once",
+        description="When to refresh the template: always, interval, or once",
     )
     interval_days: int = Field(
         default=7,
-        ge=1,  # strictly positive
-        description="Number of days between profiling runs (only used when refresh_policy=interval)",
+        ge=1,
+        description="Number of days between refreshes (only used when refresh_policy=interval)",
     )
+
+
+class ProfilingConfig(RefreshConfig):
+    """Configuration for profiling refresh policy."""
 
 
 class DatabaseConfig(BaseModel, ABC):
@@ -148,6 +152,10 @@ class DatabaseConfig(BaseModel, ABC):
     profiling: ProfilingConfig = Field(
         default_factory=ProfilingConfig,
         description="Profiling refresh policy configuration",
+    )
+    ai_summary: RefreshConfig = Field(
+        default_factory=RefreshConfig,
+        description="AI summary refresh policy configuration",
     )
 
     @classmethod

--- a/cli/nao_core/templates/defaults/databases/ai_summary.md.j2
+++ b/cli/nao_core/templates/defaults/databases/ai_summary.md.j2
@@ -9,7 +9,8 @@
 {% set columns = db.columns() %}
 {% set table_description = db.description() %}
 {% set profiling = profiling if profiling is defined else db.profiling() %}
-{% set computed_at = computed_at if computed_at is defined else (profiling.computed_at if profiling else "") %}
+{% set has_profiling = profiling and profiling.columns %}
+{% set computed_at = computed_at if computed_at is defined else (profiling.computed_at if has_profiling else "") %}
 {% set preview_rows = db.preview(limit=10) %}
 {% set instruction -%}
 You are generating short data documentation for analysts.
@@ -17,7 +18,7 @@ Write a concise markdown summary for table {{ dataset }}.{{ table_name }}.
 
 Include:
 1. What this table appears to represent.
-{% if profiling %}
+{% if has_profiling %}
 2. Data-quality and distribution notes grounded only in the profiling statistics.
 {% else %}
 Skip data-quality and distribution claims entirely because profiling statistics are unavailable. Do not guess.
@@ -35,7 +36,7 @@ Columns:
 Preview (a tiny, non-representative sample of up to 10 rows — do NOT infer data quality, null-rates, volume, or value distributions from these rows):
 {{ preview_rows | to_json(indent=2) }}
 
-{% if profiling %}
+{% if has_profiling %}
 Profiling statistics (JSON):
 Use these statistics for data-quality and distribution observations, including nulls, distinct counts, min/max, and top values.
 {{ profiling | to_json(indent=2) }}

--- a/cli/nao_core/templates/defaults/databases/ai_summary.md.j2
+++ b/cli/nao_core/templates/defaults/databases/ai_summary.md.j2
@@ -8,14 +8,20 @@
 #}
 {% set columns = db.columns() %}
 {% set table_description = db.description() %}
-{% set preview_rows = db.preview(limit=5) %}
+{% set profiling = profiling if profiling is defined else db.profiling() %}
+{% set computed_at = computed_at if computed_at is defined else (profiling.computed_at if profiling else "") %}
+{% set preview_rows = db.preview(limit=10) %}
 {% set instruction -%}
 You are generating short data documentation for analysts.
 Write a concise markdown summary for table {{ dataset }}.{{ table_name }}.
 
 Include:
 1. What this table appears to represent.
-2. Data quality or ambiguity risks based on the schema/preview.
+{% if profiling %}
+2. Data-quality and distribution notes grounded only in the profiling statistics.
+{% else %}
+Skip data-quality and distribution claims entirely because profiling statistics are unavailable. Do not guess.
+{% endif %}
 3. Suggested analytical use cases.
 
 Table description:
@@ -26,12 +32,20 @@ Columns:
 - {{ col.name }} ({{ col.type }}){% if col.description %}: {{ col.description }}{% endif %}
 {% endfor %}
 
-Sample rows (JSON):
+Preview (a tiny, non-representative sample of up to 10 rows — do NOT infer data quality, null-rates, volume, or value distributions from these rows):
 {{ preview_rows | to_json(indent=2) }}
+
+{% if profiling %}
+Profiling statistics (JSON):
+Use these statistics for data-quality and distribution observations, including nulls, distinct counts, min/max, and top values.
+{{ profiling | to_json(indent=2) }}
+{% endif %}
 {%- endset %}
 {% set summary = prompt(instruction) %}
 # {{ table_name }} - AI Summary
 
 **Dataset:** `{{ dataset }}`
+
+**Computed at:** `{{ computed_at }}`
 
 {{ summary }}

--- a/cli/nao_core/templates/defaults/databases/profiling.md.j2
+++ b/cli/nao_core/templates/defaults/databases/profiling.md.j2
@@ -7,11 +7,12 @@
     - dataset (str): Schema/dataset name
     - db (DatabaseContext): Database context with helper methods
 #}
-{% set result = db.profiling() %}
+{% set result = profiling if (profiling is defined and profiling is not none) else db.profiling() %}
 # {{ table_name }} - Profiling
 
 **Dataset:** `{{ dataset }}`
 
+{% if result %}
 **Computed at:** `{{ result.computed_at }}`
 
 **Columns:** {{ result.columns | length }}
@@ -26,3 +27,8 @@
 {% for col in result.columns %}
 - {{ col | to_json }}
 {% endfor %}
+{% else %}
+**Computed at:** ``
+
+Profiling data is unavailable.
+{% endif %}

--- a/cli/tests/nao_core/commands/sync/test_context.py
+++ b/cli/tests/nao_core/commands/sync/test_context.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from nao_core.commands.sync.providers.databases.context import DatabaseContext
-from nao_core.commands.sync.providers.databases.provider import _should_refresh_profiling
+from nao_core.commands.sync.providers.databases.provider import _should_refresh
 from nao_core.config.databases.base import ProfilingConfig, ProfilingRefreshPolicy
 
 
@@ -86,7 +86,7 @@ class TestDatabaseContext:
 
         config = ProfilingConfig(refresh_policy=ProfilingRefreshPolicy.INTERVAL, interval_days=1)
 
-        assert _should_refresh_profiling(profiling_file, config) is False
+        assert _should_refresh(profiling_file, config) is False
 
     def test_should_refresh_when_stale(self, tmp_path):
         profiling_file = tmp_path / "profiling.md"
@@ -95,14 +95,14 @@ class TestDatabaseContext:
 
         config = ProfilingConfig(refresh_policy=ProfilingRefreshPolicy.INTERVAL, interval_days=1)
 
-        assert _should_refresh_profiling(profiling_file, config) is True
+        assert _should_refresh(profiling_file, config) is True
 
     def test_should_refresh_when_file_missing(self, tmp_path):
         profiling_file = tmp_path / "profiling.md"
 
         config = ProfilingConfig(refresh_policy=ProfilingRefreshPolicy.ONCE, interval_days=1)
 
-        assert _should_refresh_profiling(profiling_file, config) is True
+        assert _should_refresh(profiling_file, config) is True
 
     def test_should_not_refresh_once_when_file_exists(self, tmp_path):
         profiling_file = tmp_path / "profiling.md"
@@ -110,7 +110,7 @@ class TestDatabaseContext:
 
         config = ProfilingConfig(refresh_policy=ProfilingRefreshPolicy.ONCE, interval_days=1)
 
-        assert _should_refresh_profiling(profiling_file, config) is False
+        assert _should_refresh(profiling_file, config) is False
 
     def test_interval_days_valid_with_interval_policy(self):
         config = ProfilingConfig(

--- a/cli/tests/nao_core/commands/sync/test_provider_refresh.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_refresh.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from nao_core.commands.sync.providers.databases.provider import sync_database
+from nao_core.config.databases.base import (
+    DatabaseTemplate,
+    ProfilingConfig,
+    ProfilingRefreshPolicy,
+    RefreshConfig,
+)
+
+
+def create_sync_setup(profiling_policy, summary_policy):
+    config = MagicMock()
+    config.name = "test-db"
+    config.type = "duckdb"
+    config.templates = [DatabaseTemplate.PROFILING, DatabaseTemplate.AI_SUMMARY]
+    config.exclude_columns = []
+    config.query_history_days = None
+    config.profiling = ProfilingConfig(refresh_policy=profiling_policy)
+    config.ai_summary = RefreshConfig(refresh_policy=summary_policy)
+    config.get_database_name.return_value = "analytics"
+    config.get_schemas.return_value = ["main"]
+    config.matches_pattern.return_value = True
+    config.get_semantic_views.return_value = []
+
+    connection = config.connect.return_value
+    connection.list_tables.return_value = ["orders"]
+
+    context = config.create_context.return_value
+    profiling_data = {
+        "computed_at": "2026-07-15T12:00:00+00:00",
+        "clustering_columns": [],
+        "columns": [{"name": "id", "distinct_count": 10}],
+    }
+    context.profiling.return_value = profiling_data
+
+    engine = MagicMock()
+    engine.list_templates.return_value = [
+        "databases/profiling.md.j2",
+        "databases/ai_summary.md.j2",
+    ]
+    engine.render.side_effect = lambda template_name, **_kwargs: f"rendered {Path(template_name).stem}"
+
+    return config, context, engine, profiling_data
+
+
+def table_path(tmp_path):
+    return tmp_path / "type=duckdb" / "database=analytics" / "schema=main" / "table=orders"
+
+
+def run_sync(config, engine, tmp_path):
+    progress = MagicMock()
+    progress.add_task.return_value = "task"
+    with (
+        patch(
+            "nao_core.commands.sync.providers.databases.provider.get_template_engine",
+            return_value=engine,
+        ),
+        patch("nao_core.commands.sync.providers.databases.provider.console"),
+    ):
+        sync_database(config, tmp_path, progress)
+
+
+def test_both_templates_due_compute_profiling_once(tmp_path):
+    config, context, engine, profiling_data = create_sync_setup(
+        ProfilingRefreshPolicy.ALWAYS,
+        ProfilingRefreshPolicy.ALWAYS,
+    )
+
+    run_sync(config, engine, tmp_path)
+
+    context.profiling.assert_called_once_with()
+    assert engine.render.call_count == 2
+    for call in engine.render.call_args_list:
+        assert call.kwargs["profiling"] is profiling_data
+
+
+def test_ai_summary_refresh_does_not_rewrite_frozen_profiling(tmp_path):
+    config, context, engine, profiling_data = create_sync_setup(
+        ProfilingRefreshPolicy.ONCE,
+        ProfilingRefreshPolicy.ALWAYS,
+    )
+    output_path = table_path(tmp_path)
+    output_path.mkdir(parents=True)
+    profiling_file = output_path / "profiling.md"
+    profiling_file.write_text("frozen profiling")
+
+    run_sync(config, engine, tmp_path)
+
+    context.profiling.assert_called_once_with()
+    assert profiling_file.read_text() == "frozen profiling"
+    assert (output_path / "ai_summary.md").read_text() == "rendered ai_summary.md"
+    engine.render.assert_called_once()
+    assert engine.render.call_args.kwargs["profiling"] is profiling_data
+
+
+def test_neither_template_due_skips_profiling_compute(tmp_path):
+    config, context, engine, _ = create_sync_setup(
+        ProfilingRefreshPolicy.ONCE,
+        ProfilingRefreshPolicy.ONCE,
+    )
+    output_path = table_path(tmp_path)
+    output_path.mkdir(parents=True)
+    (output_path / "profiling.md").write_text("frozen profiling")
+    (output_path / "ai_summary.md").write_text("frozen summary")
+
+    run_sync(config, engine, tmp_path)
+
+    context.profiling.assert_not_called()
+    engine.render.assert_not_called()

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from nao_core.config.base import NaoConfig
+from nao_core.config.databases.base import ProfilingRefreshPolicy
 from nao_core.config.databases.duckdb import DuckDBConfig
 from nao_core.config.llm import LLMConfig, LLMProvider
 from nao_core.config.secrets import process_secrets
@@ -190,6 +191,31 @@ def test_default_templates_exclude_profiling():
 
     db = DuckDBConfig(name="test-db", path=":memory:")
     assert DatabaseTemplate.PROFILING not in db.templates
+
+
+def test_ai_summary_refresh_config_defaults_to_always():
+    db = DuckDBConfig(name="test-db", path=":memory:")
+
+    assert db.ai_summary.refresh_policy == ProfilingRefreshPolicy.ALWAYS
+    assert db.ai_summary.interval_days == 7
+
+
+@pytest.mark.parametrize("refresh_policy", ["once", "interval"])
+def test_ai_summary_refresh_config_accepts_policy_and_interval(refresh_policy):
+    db = DuckDBConfig.model_validate(
+        {
+            "type": "duckdb",
+            "name": "test-db",
+            "path": ":memory:",
+            "ai_summary": {
+                "refresh_policy": refresh_policy,
+                "interval_days": 14,
+            },
+        }
+    )
+
+    assert db.ai_summary.refresh_policy == ProfilingRefreshPolicy(refresh_policy)
+    assert db.ai_summary.interval_days == 14
 
 
 def test_configure_profiling_templates_adds_profiling_when_enabled():

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -126,6 +126,69 @@ class TestTemplateEngine:
         assert '"id": 1' in result
         assert '"amount": 100.5' in result
 
+    def test_ai_summary_uses_profiling_and_non_representative_preview(self):
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test",
+            annotation_model="gpt-4.1-mini",
+        )
+        engine = TemplateEngine(llm_config=llm_config)
+        mock_db = MagicMock()
+        mock_db.columns.return_value = [{"name": "id", "type": "int64", "description": None}]
+        mock_db.description.return_value = "Customer records"
+        mock_db.preview.return_value = [{"id": 1}]
+        profiling = {
+            "computed_at": "2026-07-15T12:00:00+00:00",
+            "clustering_columns": [],
+            "columns": [{"name": "id", "null_count": 0, "distinct_count": 100}],
+        }
+
+        with patch.object(engine, "_generate_openai_compatible", return_value="Generated summary") as mock_generate:
+            result = engine.render(
+                "databases/ai_summary.md.j2",
+                table_name="customers",
+                dataset="main",
+                db=mock_db,
+                profiling=profiling,
+                computed_at="2026-07-15T13:00:00+00:00",
+            )
+
+        instruction = mock_generate.call_args.args[1]
+        assert "tiny, non-representative sample of up to 10 rows" in instruction
+        assert "do NOT infer data quality" in instruction
+        assert "Profiling statistics (JSON)" in instruction
+        assert '"distinct_count": 100' in instruction
+        assert "**Computed at:** `2026-07-15T13:00:00+00:00`" in result
+        mock_db.preview.assert_called_once_with(limit=10)
+        mock_db.profiling.assert_not_called()
+
+    def test_ai_summary_skips_quality_claims_without_profiling(self):
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test",
+            annotation_model="gpt-4.1-mini",
+        )
+        engine = TemplateEngine(llm_config=llm_config)
+        mock_db = MagicMock()
+        mock_db.columns.return_value = []
+        mock_db.description.return_value = None
+        mock_db.preview.return_value = []
+
+        with patch.object(engine, "_generate_openai_compatible", return_value="Generated summary") as mock_generate:
+            result = engine.render(
+                "databases/ai_summary.md.j2",
+                table_name="customers",
+                dataset="main",
+                db=mock_db,
+                profiling=None,
+            )
+
+        instruction = mock_generate.call_args.args[1]
+        assert "Skip data-quality and distribution claims entirely" in instruction
+        assert "Profiling statistics (JSON)" not in instruction
+        assert "# customers - AI Summary" in result
+        mock_db.profiling.assert_not_called()
+
     def test_user_override_takes_precedence(self, tmp_path: Path):
         """User templates override default templates."""
         templates_dir = tmp_path / "templates" / "databases"

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -189,6 +189,38 @@ class TestTemplateEngine:
         assert "# customers - AI Summary" in result
         mock_db.profiling.assert_not_called()
 
+    def test_ai_summary_skips_quality_claims_with_empty_profiling_columns(self):
+        llm_config = LLMConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test",
+            annotation_model="gpt-4.1-mini",
+        )
+        engine = TemplateEngine(llm_config=llm_config)
+        mock_db = MagicMock()
+        mock_db.columns.return_value = []
+        mock_db.description.return_value = None
+        mock_db.preview.return_value = []
+        profiling = {
+            "computed_at": "2026-07-15T12:00:00+00:00",
+            "clustering_columns": [],
+            "columns": [],
+        }
+
+        with patch.object(engine, "_generate_openai_compatible", return_value="Generated summary") as mock_generate:
+            result = engine.render(
+                "databases/ai_summary.md.j2",
+                table_name="customers",
+                dataset="main",
+                db=mock_db,
+                profiling=profiling,
+            )
+
+        instruction = mock_generate.call_args.args[1]
+        assert "Skip data-quality and distribution claims entirely" in instruction
+        assert "Profiling statistics (JSON)" not in instruction
+        assert "# customers - AI Summary" in result
+        mock_db.profiling.assert_not_called()
+
     def test_user_override_takes_precedence(self, tmp_path: Path):
         """User templates override default templates."""
         templates_dir = tmp_path / "templates" / "databases"


### PR DESCRIPTION
## Summary
- The AI table summary now bases its data-quality and distribution comments on real column statistics (empty-value counts, unique-value counts, min/max, most common values) computed over the whole table instead of guessing from only the preview. The preview is now clearly treated as a non-representative sample, and the summary stays quiet about quality when no statistics are available.
- Added a refresh setting for the AI summary so you can control how often it regenerates (`always`, `once`, or every N days), just like profiling already has. Existing setups keep regenerating every sync by default.
- Profiling is now computed only once per table and shared with the summary, so nothing is calculated twice or thrown away. Each file still refreshes on its own schedule.

## Out of scope (follow-up)
- Pulling table/column docs from dbt repos

Closes only one half of  #1010

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

