### PR TITLE
feat: public story sharing (unauthenticated access)

### DIFF
--- a/apps/backend/src/queries/shared-story.queries.ts
+++ b/apps/backend/src/queries/shared-story.queries.ts
@@ -67,6 +67,26 @@ export async function getSharedStory(id: string): Promise<SharedStoryWithLatest 
 	return row ?? null;
 }
 
+export async function getPublicSharedStory(id: string): Promise<SharedStoryWithLatest | null> {
+	const shared = await getSharedStory(id);
+	if (!shared || shared.visibility !== 'public') {
+		return null;
+	}
+
+	const [storyRow] = await db
+		.select({ archivedAt: s.story.archivedAt })
+		.from(s.story)
+		.where(eq(s.story.id, shared.storyId))
+		.limit(1)
+		.execute();
+
+	if (!storyRow || storyRow.archivedAt) {
+		return null;
+	}
+
+	return shared;
+}
+
 export async function canUserAccessSharedStory(sharedStoryId: string, userId: string): Promise<boolean> {
 	const [row] = await db
 		.select({ sharedStoryId: s.sharedStoryAccess.sharedStoryId })
@@ -95,7 +115,12 @@ export async function listUserSharedStories(
 		and(
 			eq(s.sharedStory.projectId, projectId),
 			isNull(s.story.archivedAt),
-			or(eq(s.sharedStory.visibility, 'project'), eq(s.sharedStory.userId, userId), hasUserAccess),
+			or(
+				eq(s.sharedStory.visibility, 'project'),
+				eq(s.sharedStory.visibility, 'public'),
+				eq(s.sharedStory.userId, userId),
+				hasUserAccess,
+			),
 		)!,
 	);
 }

--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -1,3 +1,4 @@
+import { canAccessAuthenticatedSharedStory } from '@nao/shared/story-share';
 import { DOWNLOAD_FORMATS, SHARE_VISIBILITY } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
@@ -19,6 +20,7 @@ import {
 	canSendProcedure,
 	projectProtectedProcedure,
 	protectedProcedure,
+	publicSharedStoryProcedure,
 	resourceProjectProcedure,
 } from './trpc';
 
@@ -29,10 +31,14 @@ const shareAccessProcedure = resourceProjectProcedure(
 	sharedStoryQueries.getSharedStory,
 	'Shared story',
 	async (item, userId) =>
-		item.visibility !== 'specific' ||
-		item.userId === userId ||
-		sharedStoryQueries.canUserAccessSharedStory(item.id, userId),
+		canAccessAuthenticatedSharedStory({
+			visibility: item.visibility,
+			ownerUserId: item.userId,
+			viewerUserId: userId,
+			hasSpecificAccess: await sharedStoryQueries.canUserAccessSharedStory(item.id, userId),
+		}),
 );
+const publicShareProcedure = publicSharedStoryProcedure();
 
 export const sharedStoryRoutes = {
 	list: protectedProcedure.input(z.object({ projectId: z.string() })).query(async ({ input, ctx }) => {
@@ -65,6 +71,10 @@ export const sharedStoryRoutes = {
 		.mutation(async ({ input, ctx }) => {
 			if (input.pinAfterCreate && ctx.userRole !== 'admin') {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only admins can pin stories.' });
+			}
+
+			if (input.visibility === 'public' && input.pinAfterCreate) {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Public stories cannot be pinned.' });
 			}
 
 			const story = await storyQueries.getStoryByChatAndSlug(input.chatId, input.storySlug);
@@ -119,43 +129,16 @@ export const sharedStoryRoutes = {
 			return created;
 		}),
 
+	getPublic: publicShareProcedure.input(z.object({ shareId: z.string() })).query(async ({ ctx }) => {
+		return loadSharedStoryPayload(ctx.resource, { actorUserId: null });
+	}),
+
 	get: shareAccessProcedure.input(z.object({ shareId: z.string() })).query(async ({ ctx }) => {
 		const shared = ctx.resource;
-		const storyRow = await storyQueries.getStoryByChatAndSlug(shared.chatId!, shared.slug);
-		const isLive = storyRow?.isLive ?? false;
-		const isLiveTextDynamic = storyRow?.isLiveTextDynamic ?? false;
-		const cacheSchedule = storyRow?.cacheSchedule ?? null;
-		const cacheScheduleDescription = storyRow?.cacheScheduleDescription ?? null;
-
-		const { queryData, cachedAt } = await getStoryQueryData(
-			shared.chatId!,
-			shared.slug,
-			shared.code,
-			isLive,
-			cacheSchedule,
-		);
-
-		if (ctx.user.id !== shared.userId) {
-			logAnalyticsEvent({
-				projectId: shared.projectId,
-				type: 'page_view',
-				assetType: 'story',
-				actorUserId: ctx.user.id,
-				storyId: shared.storyId,
-				chatId: shared.chatId,
-				sharedStoryId: shared.id,
-			});
-		}
+		const payload = await loadSharedStoryPayload(shared, { actorUserId: ctx.user.id });
 
 		return {
-			...shared,
-			storyId: shared.storyId,
-			queryData,
-			isLive,
-			isLiveTextDynamic,
-			cacheSchedule,
-			cacheScheduleDescription,
-			cachedAt,
+			...payload,
 			userRole: ctx.userRole,
 		};
 	}),
@@ -232,6 +215,13 @@ export const sharedStoryRoutes = {
 		.mutation(async ({ input, ctx }) => {
 			const shared = ctx.resource;
 
+			if (shared.visibility === 'public') {
+				throw new TRPCError({
+					code: 'BAD_REQUEST',
+					message: 'Public stories cannot have member access updated. Unshare first to change visibility.',
+				});
+			}
+
 			if (shared.userId !== ctx.user.id && ctx.userRole !== 'admin') {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the creator or an admin can update this.' });
 			}
@@ -287,47 +277,103 @@ export const sharedStoryRoutes = {
 			}),
 		)
 		.query(async ({ input, ctx }) => {
-			const shared = ctx.resource;
+			return downloadSharedStory(ctx.resource, input.format, input.versionNumber, ctx.user.id);
+		}),
 
-			const version = input.versionNumber
-				? await storyQueries.getVersionByNumber(shared.chatId!, shared.slug, input.versionNumber)
-				: await storyQueries.getLatestVersionByChatAndSlug(shared.chatId!, shared.slug);
-			if (!version) {
-				throw new TRPCError({ code: 'NOT_FOUND', message: 'Story version not found.' });
-			}
-
-			const { queryData } = await getStoryQueryData(
-				shared.chatId!,
-				shared.slug,
-				version.code,
-				version.isLive,
-				version.cacheSchedule,
-			);
-
-			logAnalyticsEvent({
-				projectId: shared.projectId,
-				type: 'download',
-				assetType: 'story',
-				actorUserId: ctx.user.id,
-				storyId: shared.storyId,
-				chatId: shared.chatId,
-				sharedStoryId: shared.id,
-				metadata: {
-					type: 'download',
-					format: input.format,
-					versionNumber: version.version,
-					title: version.title,
-				},
-			});
-
-			const displaySettings = shared.projectId ? await projectQueries.getDisplaySettings(shared.projectId) : null;
-
-			return buildDownloadResponse(
-				input.format,
-				version.title,
-				version.code,
-				queryData,
-				displaySettings?.dateFormat,
-			);
+	downloadPublic: publicShareProcedure
+		.input(
+			z.object({
+				shareId: z.string(),
+				format: z.enum(DOWNLOAD_FORMATS),
+				versionNumber: z.number().int().positive().optional(),
+			}),
+		)
+		.query(async ({ input, ctx }) => {
+			return downloadSharedStory(ctx.resource, input.format, input.versionNumber, null);
 		}),
 };
+
+async function loadSharedStoryPayload(
+	shared: sharedStoryQueries.SharedStoryWithLatest,
+	options: { actorUserId: string | null },
+) {
+	const storyRow = await storyQueries.getStoryByChatAndSlug(shared.chatId!, shared.slug);
+	const isLive = storyRow?.isLive ?? false;
+	const isLiveTextDynamic = storyRow?.isLiveTextDynamic ?? false;
+	const cacheSchedule = storyRow?.cacheSchedule ?? null;
+	const cacheScheduleDescription = storyRow?.cacheScheduleDescription ?? null;
+
+	const { queryData, cachedAt } = await getStoryQueryData(
+		shared.chatId!,
+		shared.slug,
+		shared.code,
+		isLive,
+		cacheSchedule,
+	);
+
+	const shouldLogView = !options.actorUserId || options.actorUserId !== shared.userId;
+	if (shouldLogView) {
+		logAnalyticsEvent({
+			projectId: shared.projectId,
+			type: 'page_view',
+			assetType: 'story',
+			actorUserId: options.actorUserId,
+			storyId: shared.storyId,
+			chatId: shared.chatId,
+			sharedStoryId: shared.id,
+		});
+	}
+
+	return {
+		...shared,
+		storyId: shared.storyId,
+		queryData,
+		isLive,
+		isLiveTextDynamic,
+		cacheSchedule,
+		cacheScheduleDescription,
+		cachedAt,
+	};
+}
+
+async function downloadSharedStory(
+	shared: sharedStoryQueries.SharedStoryWithLatest,
+	format: (typeof DOWNLOAD_FORMATS)[number],
+	versionNumber: number | undefined,
+	actorUserId: string | null,
+) {
+	const version = versionNumber
+		? await storyQueries.getVersionByNumber(shared.chatId!, shared.slug, versionNumber)
+		: await storyQueries.getLatestVersionByChatAndSlug(shared.chatId!, shared.slug);
+	if (!version) {
+		throw new TRPCError({ code: 'NOT_FOUND', message: 'Story version not found.' });
+	}
+
+	const { queryData } = await getStoryQueryData(
+		shared.chatId!,
+		shared.slug,
+		version.code,
+		version.isLive,
+		version.cacheSchedule,
+	);
+
+	logAnalyticsEvent({
+		projectId: shared.projectId,
+		type: 'download',
+		assetType: 'story',
+		actorUserId,
+		storyId: shared.storyId,
+		chatId: shared.chatId,
+		sharedStoryId: shared.id,
+		metadata: {
+			type: 'download',
+			format,
+			versionNumber: version.version,
+			title: version.title,
+		},
+	});
+
+	const displaySettings = shared.projectId ? await projectQueries.getDisplaySettings(shared.projectId) : null;
+
+	return buildDownloadResponse(format, version.title, version.code, queryData, displaySettings?.dateFormat);
+}

--- a/apps/backend/src/trpc/trpc.ts
+++ b/apps/backend/src/trpc/trpc.ts
@@ -5,6 +5,7 @@ import superjson from 'superjson';
 
 import { getAuth } from '../auth';
 import * as projectQueries from '../queries/project.queries';
+import * as sharedStoryQueries from '../queries/shared-story.queries';
 import { HandlerError } from '../utils/error';
 import { convertHeaders } from '../utils/utils';
 
@@ -117,6 +118,23 @@ export function resourceProjectProcedure<T extends { projectId: string }>(
 		}
 
 		return next({ ctx: { resource, userRole } });
+	});
+}
+
+export function publicSharedStoryProcedure(label = 'Shared story') {
+	return publicProcedure.use(async ({ getRawInput, next }) => {
+		const rawInput = (await getRawInput()) as Record<string, unknown>;
+		const shareId = rawInput.shareId;
+		if (typeof shareId !== 'string') {
+			throw new TRPCError({ code: 'BAD_REQUEST', message: 'shareId is required.' });
+		}
+
+		const resource = await sharedStoryQueries.getPublicSharedStory(shareId);
+		if (!resource) {
+			throw new TRPCError({ code: 'NOT_FOUND', message: `${label} not found.` });
+		}
+
+		return next({ ctx: { resource } });
 	});
 }
 

--- a/apps/backend/src/utils/email.ts
+++ b/apps/backend/src/utils/email.ts
@@ -1,3 +1,4 @@
+import { buildStoryShareUrl } from '@nao/shared/story-share';
 import type { Visibility } from '@nao/shared/types';
 
 import { env } from '../env';
@@ -5,8 +6,8 @@ import * as projectQueries from '../queries/project.queries';
 import { emailService } from '../services/email';
 import { buildSharedItemEmail } from './email-builders';
 
-const itemUrls: Record<'story' | 'chat', (shareId: string) => string> = {
-	story: (shareId) => `${env.BETTER_AUTH_URL}/stories/shared/${shareId}`,
+const itemUrls: Record<'story' | 'chat', (shareId: string, visibility?: Visibility) => string> = {
+	story: (shareId, visibility = 'project') => buildStoryShareUrl(shareId, visibility, env.BETTER_AUTH_URL),
 	chat: (shareId) => `${env.BETTER_AUTH_URL}/shared-chat/${shareId}`,
 };
 
@@ -29,7 +30,11 @@ export async function notifySharedItemRecipients({
 	visibility: Visibility;
 	allowedUserIds?: string[];
 }): Promise<void> {
-	const itemUrl = itemUrls[itemLabel](shareId);
+	if (visibility === 'public') {
+		return;
+	}
+
+	const itemUrl = itemUrls[itemLabel](shareId, visibility);
 	const allMembers = await projectQueries.listAllUsersWithRoles(projectId);
 
 	const recipients =

--- a/apps/backend/tests/story-share.test.ts
+++ b/apps/backend/tests/story-share.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnv: Record<string, unknown> = {};
+
+vi.mock('../src/env', () => ({
+	get env() {
+		return mockEnv;
+	},
+}));
+
+const sendEmail = vi.fn();
+vi.mock('../src/services/email', () => ({
+	emailService: {
+		sendEmail,
+	},
+}));
+
+const listAllUsersWithRoles = vi.fn();
+vi.mock('../src/queries/project.queries', () => ({
+	listAllUsersWithRoles,
+}));
+
+describe('notifySharedItemRecipients', () => {
+	beforeEach(() => {
+		sendEmail.mockReset();
+		listAllUsersWithRoles.mockReset();
+		mockEnv.BETTER_AUTH_URL = 'https://app.example.com';
+	});
+
+	it('skips email notifications for public story shares', async () => {
+		const { notifySharedItemRecipients } = await import('../src/utils/email');
+
+		await notifySharedItemRecipients({
+			projectId: 'project-1',
+			sharerId: 'user-1',
+			sharerName: 'Alice',
+			shareId: 'share-1',
+			itemLabel: 'story',
+			itemTitle: 'Revenue',
+			visibility: 'public',
+		});
+
+		expect(listAllUsersWithRoles).not.toHaveBeenCalled();
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+});

--- a/apps/frontend/src/components/automations-feed.tsx
+++ b/apps/frontend/src/components/automations-feed.tsx
@@ -13,6 +13,7 @@ import {
 	X,
 } from 'lucide-react';
 import { Fragment, useLayoutEffect, useRef, useState } from 'react';
+import type { Visibility } from '@nao/shared/types';
 import { Streamdown } from 'streamdown';
 import type { displayChart } from '@nao/shared/tools';
 import type { ReactNode } from 'react';
@@ -69,8 +70,6 @@ export type AutomationFeedAutomationItem = {
 
 export type ActivityTrigger = 'schedule' | 'manual' | 'system';
 
-export type ShareVisibility = 'project' | 'specific';
-
 type ActivityBaseFields = {
 	id: string;
 	status: AutomationFeedRunStatus;
@@ -109,7 +108,7 @@ export type ActivityFeedStorySharedItem = {
 		title: string;
 		chatId: string | null;
 	};
-	share: { id: string; visibility: ShareVisibility };
+	share: { id: string; visibility: Visibility };
 	actorName: string | null;
 };
 
@@ -119,7 +118,7 @@ export type ActivityFeedChatSharedItem = {
 	startedAt: string | Date;
 	activity: ActivityBaseFields & { type: 'chat.shared' };
 	chat: { id: string; title: string };
-	share: { id: string; visibility: ShareVisibility };
+	share: { id: string; visibility: Visibility };
 	actorName: string | null;
 };
 
@@ -555,10 +554,11 @@ function ShareSentence({
 }: {
 	subjectLabel: 'story' | 'chat';
 	actorName: string | null;
-	visibility: ShareVisibility;
+	visibility: Visibility;
 }) {
 	const actor = actorName ?? 'Someone';
-	const target = visibility === 'project' ? 'the project' : 'you';
+	const target =
+		visibility === 'public' ? 'the public internet' : visibility === 'project' ? 'the project' : 'you';
 	return (
 		<p>
 			<span className='font-medium'>{actor}</span> shared this {subjectLabel} with{' '}
@@ -567,10 +567,11 @@ function ShareSentence({
 	);
 }
 
-function ShareScopeBadge({ visibility }: { visibility: ShareVisibility }) {
+function ShareScopeBadge({ visibility }: { visibility: Visibility }) {
+	const label = visibility === 'project' ? 'Project' : visibility === 'public' ? 'Public' : 'Direct';
 	return (
 		<Badge variant='secondary' className='shrink-0'>
-			{visibility === 'project' ? 'Project' : 'Direct'}
+			{label}
 		</Badge>
 	);
 }

--- a/apps/frontend/src/components/share-dialog.chat.tsx
+++ b/apps/frontend/src/components/share-dialog.chat.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, Link as LinkIcon, Loader2 } from 'lucide-react';
-import type { Visibility } from '@nao/shared/types';
+import type { MemberShareVisibility, Visibility } from '@nao/shared/types';
 import {
 	hasAccessChanges,
 	ManageShareFooter,
@@ -57,7 +57,7 @@ export function ShareChatDialog({ open, onOpenChange, chatId }: ShareChatDialogP
 			onOpenChange={onOpenChange}
 			chatId={chatId}
 			shareId={shareData.shareId}
-			visibility={shareData.visibility as Visibility}
+			visibility={shareData.visibility as MemberShareVisibility}
 			allowedUserIds={shareData.allowedUserIds}
 		/>
 	);
@@ -73,7 +73,7 @@ function useInvalidateShareQueries(chatId: string) {
 
 function CreateShareDialog({ open, onOpenChange, chatId }: ShareChatDialogProps) {
 	const { data: session } = useSession();
-	const [visibility, setVisibility] = useState<Visibility>('project');
+	const [visibility, setVisibility] = useState<MemberShareVisibility>('project');
 	const [notify, setNotify] = useState(false);
 	const [isCopied, setIsCopied] = useState(false);
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);

--- a/apps/frontend/src/components/share-dialog.story.tsx
+++ b/apps/frontend/src/components/share-dialog.story.tsx
@@ -2,11 +2,13 @@ import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, Link as LinkIcon, Loader2, Pin } from 'lucide-react';
 import type { Visibility } from '@nao/shared/types';
+import { buildStoryShareUrl } from '@nao/shared/story-share';
 import {
 	hasAccessChanges,
 	ManageShareFooter,
 	MemberPicker,
 	NotifyPeopleToggle,
+	PublicShareSection,
 	ShareLoadingDialog,
 	VisibilityPicker,
 	VisibilitySummary,
@@ -78,11 +80,13 @@ function useInvalidateShareQueries(chatId: string, storySlug: string) {
 function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'share' }: ShareStoryDialogProps) {
 	const { data: session } = useSession();
 	const [visibility, setVisibility] = useState<Visibility>('project');
+	const [publicConfirmed, setPublicConfirmed] = useState(false);
 	const [notify, setNotify] = useState(false);
 	const [isConfirmed, setIsConfirmed] = useState(false);
 	const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const invalidateShareQueries = useInvalidateShareQueries(chatId, storySlug);
 	const isPinIntent = intent === 'pin';
+	const isPublicShare = visibility === 'public';
 	const smtpQuery = useQuery(trpc.authConfig.smtp.isSetup.queryOptions());
 	const isSmtpEnabled = smtpQuery.data === true;
 
@@ -98,6 +102,7 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 	useEffect(() => {
 		if (open) {
 			setVisibility('project');
+			setPublicConfirmed(false);
 			setNotify(false);
 			reset();
 			setIsConfirmed(false);
@@ -114,7 +119,7 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 				visibility,
 				allowedUserIds: visibility === 'specific' ? [...selectedUserIds] : undefined,
 				pinAfterCreate: isPinIntent,
-				notify: isSmtpEnabled && notify,
+				notify: isSmtpEnabled && notify && !isPublicShare,
 			})
 			.then((data) => {
 				invalidateShareQueries();
@@ -129,7 +134,10 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 
 		if (!isPinIntent) {
 			const blobPromise = promise.then(
-				(data) => new Blob([`${window.location.origin}/stories/shared/${data.id}`], { type: 'text/plain' }),
+				(data) =>
+					new Blob([buildStoryShareUrl(data.id, data.visibility, window.location.origin)], {
+						type: 'text/plain',
+					}),
 			);
 			blobPromise.catch(() => {});
 			navigator.clipboard.write([new ClipboardItem({ 'text/plain': blobPromise })]).catch(() => {});
@@ -143,13 +151,15 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 		selectedUserIds,
 		notify,
 		isSmtpEnabled,
+		isPublicShare,
 		shareMutation,
 		invalidateShareQueries,
 		onOpenChange,
 		isPinIntent,
 	]);
 
-	const canConfirm = visibility === 'project' || selectedUserIds.size > 0;
+	const canConfirm =
+		visibility === 'public' ? publicConfirmed : visibility === 'project' || selectedUserIds.size > 0;
 
 	const title = isPinIntent ? 'Pin Story' : 'Share Story';
 	const description = isPinIntent
@@ -173,11 +183,26 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 							Once shared, this story will be pinned for the selected audience.
 						</div>
 					)}
-					<VisibilityPicker visibility={visibility} onChange={setVisibility} />
-					{isSmtpEnabled && (
+					<VisibilityPicker
+						visibility={isPublicShare ? 'project' : visibility}
+						inactive={isPublicShare}
+						onChange={(nextVisibility) => {
+							setVisibility(nextVisibility);
+							setPublicConfirmed(false);
+						}}
+					/>
+					{!isPinIntent ? (
+						<PublicShareSection
+							selected={isPublicShare}
+							onSelect={() => setVisibility('public')}
+							confirmed={publicConfirmed}
+							onConfirmedChange={setPublicConfirmed}
+						/>
+					) : null}
+					{isSmtpEnabled && !isPublicShare ? (
 						<NotifyPeopleToggle checked={notify} onCheckedChange={setNotify} itemLabel='story' />
-					)}
-					{visibility === 'specific' && (
+					) : null}
+					{visibility === 'specific' ? (
 						<MemberPicker
 							members={filteredMembers}
 							selectedUserIds={selectedUserIds}
@@ -186,7 +211,7 @@ function CreateShareDialog({ open, onOpenChange, chatId, storySlug, intent = 'sh
 							onSearchChange={setSearch}
 							onToggleUser={toggleUser}
 						/>
-					)}
+					) : null}
 				</div>
 
 				<div className='flex justify-end gap-2'>
@@ -278,8 +303,8 @@ function ManageShareDialog({
 	);
 
 	const handleCopyLink = useCallback(() => {
-		copyLink(`${window.location.origin}/stories/shared/${shareId}`);
-	}, [copyLink, shareId]);
+		copyLink(buildStoryShareUrl(shareId, visibility, window.location.origin));
+	}, [copyLink, shareId, visibility]);
 
 	const handleUnshare = useCallback(() => {
 		deleteMutation.mutate({ shareId });
@@ -303,7 +328,13 @@ function ManageShareDialog({
 
 				<div className='flex flex-col gap-4'>
 					<VisibilitySummary visibility={visibility} selectedUserIds={selectedUserIds} itemLabel='story' />
-					{visibility === 'specific' && (
+					{visibility === 'public' ? (
+						<div className='rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-muted-foreground'>
+							This story is published on the public internet. Anyone with the link can view it without signing
+							in.
+						</div>
+					) : null}
+					{visibility === 'specific' ? (
 						<MemberPicker
 							members={filteredMembers}
 							selectedUserIds={selectedUserIds}
@@ -312,7 +343,7 @@ function ManageShareDialog({
 							onSearchChange={setSearch}
 							onToggleUser={toggleUser}
 						/>
-					)}
+					) : null}
 				</div>
 
 				<ManageShareFooter

--- a/apps/frontend/src/components/share-dialog.tsx
+++ b/apps/frontend/src/components/share-dialog.tsx
@@ -1,6 +1,6 @@
-import { Check, Globe, Link as LinkIcon, Loader2, SearchIcon, Unlink, Users } from 'lucide-react';
+import { Check, Globe, Link as LinkIcon, Loader2, SearchIcon, TriangleAlert, Unlink, Users } from 'lucide-react';
 
-import type { Visibility } from '@nao/shared/types';
+import type { MemberShareVisibility, Visibility } from '@nao/shared/types';
 
 import { Avatar } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -74,26 +74,93 @@ export function ShareErrorDialog({
 export function VisibilityPicker({
 	visibility,
 	onChange,
+	inactive = false,
 }: {
-	visibility: Visibility;
-	onChange: (v: Visibility) => void;
+	visibility: Exclude<Visibility, 'public'>;
+	onChange: (v: MemberShareVisibility) => void;
+	inactive?: boolean;
 }) {
 	return (
 		<div className='flex gap-3'>
 			<VisibilityOption
-				active={visibility === 'project'}
+				active={!inactive && visibility === 'project'}
 				icon={<Globe className='size-5' />}
 				label='Entire project'
 				description='All project members'
 				onClick={() => onChange('project')}
 			/>
 			<VisibilityOption
-				active={visibility === 'specific'}
+				active={!inactive && visibility === 'specific'}
 				icon={<Users className='size-5' />}
 				label='Specific people'
 				description='Choose who can view'
 				onClick={() => onChange('specific')}
 			/>
+		</div>
+	);
+}
+
+export function PublicShareSection({
+	selected,
+	onSelect,
+	confirmed,
+	onConfirmedChange,
+}: {
+	selected: boolean;
+	onSelect: () => void;
+	confirmed: boolean;
+	onConfirmedChange: (confirmed: boolean) => void;
+}) {
+	return (
+		<div className='flex flex-col gap-3'>
+			<div className='relative flex items-center py-1'>
+				<div className='flex-grow border-t border-border' />
+				<span className='mx-3 shrink-0 text-xs text-muted-foreground'>or publish publicly</span>
+				<div className='flex-grow border-t border-border' />
+			</div>
+			<VisibilityOption
+				active={selected}
+				icon={<LinkIcon className='size-5' />}
+				label='Anyone with the link'
+				description='No nao account required'
+				onClick={onSelect}
+				className={selected ? 'border-destructive/60 bg-destructive/5' : undefined}
+			/>
+			{selected ? (
+				<PublicShareWarning confirmed={confirmed} onConfirmedChange={onConfirmedChange} />
+			) : null}
+		</div>
+	);
+}
+
+export function PublicShareWarning({
+	confirmed,
+	onConfirmedChange,
+}: {
+	confirmed: boolean;
+	onConfirmedChange: (confirmed: boolean) => void;
+}) {
+	return (
+		<div className='flex flex-col gap-3 rounded-lg border border-destructive/40 bg-destructive/5 p-3'>
+			<div className='flex gap-2 text-destructive'>
+				<TriangleAlert className='mt-0.5 size-4 shrink-0' />
+				<div className='space-y-1 text-sm'>
+					<p className='font-medium text-foreground'>This story will be on the public internet</p>
+					<p className='text-xs text-muted-foreground'>
+						Anyone with the link can view the data in this story without signing in. Only publish if you are
+						comfortable exposing this information publicly.
+					</p>
+				</div>
+			</div>
+			<label className='flex cursor-pointer items-start gap-2 text-sm'>
+				<input
+					type='checkbox'
+					checked={confirmed}
+					onChange={(event) => onConfirmedChange(event.target.checked)}
+					className='mt-0.5 size-4 rounded border-border'
+				/>
+				<span>I understand this story will be publicly accessible</span>
+			</label>
 		</div>
 	);
 }
@@ -131,7 +198,19 @@ export function VisibilitySummary({
 }) {
 	return (
 		<div className='flex items-center gap-3 rounded-lg border p-3'>
-			{visibility === 'project' ? (
+			{visibility === 'public' ? (
+				<>
+					<div className='flex size-8 items-center justify-center rounded-full'>
+						<LinkIcon className='size-4' />
+					</div>
+					<div className='flex-1 min-w-0'>
+						<p className='text-md font-medium'>Published publicly</p>
+						<p className='text-xs text-muted-foreground'>
+							Anyone with the link can view this {itemLabel} without a nao account
+						</p>
+					</div>
+				</>
+			) : visibility === 'project' ? (
 				<>
 					<div className='flex size-8 items-center justify-center rounded-full'>
 						<Globe className='size-4' />
@@ -216,12 +295,14 @@ export function VisibilityOption({
 	label,
 	description,
 	onClick,
+	className,
 }: {
 	active: boolean;
 	icon: React.ReactNode;
 	label: string;
 	description: string;
 	onClick: () => void;
+	className?: string;
 }) {
 	return (
 		<button
@@ -230,6 +311,7 @@ export function VisibilityOption({
 			className={cn(
 				'flex-1 flex flex-col items-center gap-1.5 rounded-lg border pt-3 pb-3 shadow-xs transition-colors cursor-pointer',
 				active ? 'border-primary' : 'border-border hover:border-muted-foreground/30 hover:bg-muted/50',
+				className,
 			)}
 		>
 			<div className='text-foreground'>{icon}</div>

--- a/apps/frontend/src/components/story-download.tsx
+++ b/apps/frontend/src/components/story-download.tsx
@@ -18,6 +18,7 @@ interface StoryDownloadOptions {
 	shareId?: string;
 	shareType?: 'chat' | 'story';
 	isOwner?: boolean;
+	isPublicShare?: boolean;
 	versionNumber?: number;
 }
 
@@ -28,6 +29,7 @@ function useStoryDownload({
 	shareId,
 	shareType = 'story',
 	isOwner = true,
+	isPublicShare = false,
 	versionNumber,
 }: StoryDownloadOptions) {
 	const [isDownloading, setIsDownloading] = useState(false);
@@ -58,6 +60,8 @@ function useStoryDownload({
 					format,
 					versionNumber,
 				});
+			} else if (isPublicShare) {
+				result = await trpcClient.storyShare.downloadPublic.query({ shareId: shareId!, format, versionNumber });
 			} else {
 				result = await trpcClient.storyShare.download.query({ shareId: shareId!, format, versionNumber });
 			}

--- a/apps/frontend/src/components/story-readonly-content.tsx
+++ b/apps/frontend/src/components/story-readonly-content.tsx
@@ -1,0 +1,43 @@
+import { splitCodeIntoSegments } from '@nao/shared/story-segments';
+import { useCallback, useMemo } from 'react';
+import type { ParsedChartBlock, ParsedTableBlock } from '@nao/shared/story-segments';
+
+import type { QueryDataMap } from '@/components/story-embeds';
+import { StoryChartEmbed, StoryTableEmbed } from '@/components/story-embeds';
+import { SegmentList } from '@/components/story-rendering';
+
+interface ReadonlyStoryContentProps {
+	code: string;
+	queryData: QueryDataMap | null;
+	className?: string;
+}
+
+export function ReadonlyStoryContent({ code, queryData, className }: ReadonlyStoryContentProps) {
+	const segments = useMemo(() => splitCodeIntoSegments(code), [code]);
+
+	const renderChart = useCallback(
+		(chart: ParsedChartBlock) => <StoryChartEmbed chart={chart} queryData={queryData} />,
+		[queryData],
+	);
+
+	const renderTable = useCallback(
+		(table: ParsedTableBlock) => <StoryTableEmbed table={table} queryData={queryData} />,
+		[queryData],
+	);
+
+	return (
+		<div className={className ?? 'flex-1 overflow-auto'}>
+			<div className='mx-auto flex max-w-5xl flex-col gap-4 p-4 md:p-8'>
+				<SegmentList segments={segments} renderChart={renderChart} renderTable={renderTable} />
+			</div>
+		</div>
+	);
+}
+
+export function PublicStoryBanner() {
+	return (
+		<div className='rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-muted-foreground'>
+			Public story — anyone with this link can view the data below without a nao account.
+		</div>
+	);
+}

--- a/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
+++ b/apps/frontend/src/hooks/use-session-or-navigate-to-index-page.tsx
@@ -1,3 +1,4 @@
+import { isPublicAppRoute } from '@nao/shared/story-share';
 import { useEffect } from 'react';
 import { useNavigate, useRouter, useRouterState } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
@@ -25,7 +26,9 @@ export const useSessionOrNavigateToIndexPage = () => {
 		}
 
 		const canStayUnauthenticated =
-			AUTH_ROUTES.includes(pathname) || (pathname === '/signup' && isUserSignupEnabled);
+			AUTH_ROUTES.includes(pathname) ||
+			isPublicAppRoute(pathname) ||
+			(pathname === '/signup' && isUserSignupEnabled);
 
 		if (!session.data && !canStayUnauthenticated) {
 			const redirect = getSafeRedirectPath(`${pathname}${searchStr ?? ''}`) ?? undefined;

--- a/apps/frontend/src/lib/stories-page.ts
+++ b/apps/frontend/src/lib/stories-page.ts
@@ -1,4 +1,5 @@
 import { FOLDER_SYSTEM_TYPE } from '@nao/shared/types';
+import { isPublicShareVisibility } from '@nao/shared/story-share';
 import type { inferRouterOutputs } from '@trpc/server';
 
 import type { TrpcRouter } from '@nao/backend/trpc';
@@ -55,6 +56,7 @@ export type StoryItem = {
 	link:
 		| { to: '/stories/preview/$chatId/$storySlug'; params: { chatId: string; storySlug: string } }
 		| { to: '/stories/shared/$shareId'; params: { shareId: string } }
+		| { to: '/public/stories/$shareId'; params: { shareId: string } }
 		| { to: '/stories/standalone/$storyId'; params: { storyId: string } };
 };
 
@@ -153,7 +155,9 @@ export function buildStoryItems({
 			folderId,
 			isInPrivateContext: isPrivateContext(folderId, folders),
 			link: shareId
-				? { to: '/stories/shared/$shareId', params: { shareId } }
+				? isPublicShareVisibility(sharedEntry?.visibility ?? 'project')
+					? { to: '/public/stories/$shareId', params: { shareId } }
+					: { to: '/stories/shared/$shareId', params: { shareId } }
 				: {
 						to: '/stories/preview/$chatId/$storySlug',
 						params: { chatId, storySlug: story.storySlug },
@@ -205,7 +209,9 @@ export function buildStoryItems({
 				sharedStoryId: story.id,
 				folderId,
 				isInPrivateContext: false,
-				link: { to: '/stories/shared/$shareId', params: { shareId: story.id } },
+				link: isPublicShareVisibility(story.visibility)
+					? { to: '/public/stories/$shareId', params: { shareId: story.id } }
+					: { to: '/stories/shared/$shareId', params: { shareId: story.id } },
 			};
 		});
 

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
+import { Route as PublicRouteImport } from './routes/public'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as EmbedRouteImport } from './routes/embed'
@@ -22,6 +23,7 @@ import { Route as SidebarLayoutStoriesIndexRouteImport } from './routes/_sidebar
 import { Route as SidebarLayoutSettingsIndexRouteImport } from './routes/_sidebar-layout.settings.index'
 import { Route as SidebarLayoutFeedIndexRouteImport } from './routes/_sidebar-layout.feed.index'
 import { Route as SidebarLayoutChatLayoutIndexRouteImport } from './routes/_sidebar-layout._chat-layout.index'
+import { Route as PublicStoriesShareIdRouteImport } from './routes/public.stories.$shareId'
 import { Route as EmbedStoryStoryIdRouteImport } from './routes/embed.story.$storyId'
 import { Route as EmbedChartChartEmbedIdRouteImport } from './routes/embed.chart.$chartEmbedId'
 import { Route as SidebarLayoutSharedChatShareIdRouteImport } from './routes/_sidebar-layout.shared-chat.$shareId'
@@ -62,6 +64,11 @@ const SignupRoute = SignupRouteImport.update({
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PublicRoute = PublicRouteImport.update({
+  id: '/public',
+  path: '/public',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -120,6 +127,11 @@ const SidebarLayoutChatLayoutIndexRoute =
     path: '/',
     getParentRoute: () => SidebarLayoutChatLayoutRoute,
   } as any)
+const PublicStoriesShareIdRoute = PublicStoriesShareIdRouteImport.update({
+  id: '/stories/$shareId',
+  path: '/stories/$shareId',
+  getParentRoute: () => PublicRoute,
+} as any)
 const EmbedStoryStoryIdRoute = EmbedStoryStoryIdRouteImport.update({
   id: '/story/$storyId',
   path: '/story/$storyId',
@@ -311,6 +323,7 @@ export interface FileRoutesByFullPath {
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/public': typeof PublicRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/settings': typeof SidebarLayoutSettingsRouteWithChildren
@@ -331,6 +344,7 @@ export interface FileRoutesByFullPath {
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/embed/chart/$chartEmbedId': typeof EmbedChartChartEmbedIdRoute
   '/embed/story/$storyId': typeof EmbedStoryStoryIdRoute
+  '/public/stories/$shareId': typeof PublicStoriesShareIdRoute
   '/feed/': typeof SidebarLayoutFeedIndexRoute
   '/settings/': typeof SidebarLayoutSettingsIndexRoute
   '/stories/': typeof SidebarLayoutStoriesIndexRoute
@@ -355,6 +369,7 @@ export interface FileRoutesByTo {
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/public': typeof PublicRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/$chatId': typeof SidebarLayoutChatLayoutChatIdRoute
@@ -373,6 +388,7 @@ export interface FileRoutesByTo {
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/embed/chart/$chartEmbedId': typeof EmbedChartChartEmbedIdRoute
   '/embed/story/$storyId': typeof EmbedStoryStoryIdRoute
+  '/public/stories/$shareId': typeof PublicStoriesShareIdRoute
   '/feed': typeof SidebarLayoutFeedIndexRoute
   '/settings': typeof SidebarLayoutSettingsIndexRoute
   '/stories': typeof SidebarLayoutStoriesIndexRoute
@@ -398,6 +414,7 @@ export interface FileRoutesById {
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
+  '/public': typeof PublicRouteWithChildren
   '/reset-password': typeof ResetPasswordRoute
   '/signup': typeof SignupRoute
   '/_sidebar-layout/_chat-layout': typeof SidebarLayoutChatLayoutRouteWithChildren
@@ -419,6 +436,7 @@ export interface FileRoutesById {
   '/_sidebar-layout/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/embed/chart/$chartEmbedId': typeof EmbedChartChartEmbedIdRoute
   '/embed/story/$storyId': typeof EmbedStoryStoryIdRoute
+  '/public/stories/$shareId': typeof PublicStoriesShareIdRoute
   '/_sidebar-layout/_chat-layout/': typeof SidebarLayoutChatLayoutIndexRoute
   '/_sidebar-layout/feed/': typeof SidebarLayoutFeedIndexRoute
   '/_sidebar-layout/settings/': typeof SidebarLayoutSettingsIndexRoute
@@ -446,6 +464,7 @@ export interface FileRouteTypes {
     | '/embed'
     | '/forgot-password'
     | '/login'
+    | '/public'
     | '/reset-password'
     | '/signup'
     | '/settings'
@@ -466,6 +485,7 @@ export interface FileRouteTypes {
     | '/shared-chat/$shareId'
     | '/embed/chart/$chartEmbedId'
     | '/embed/story/$storyId'
+    | '/public/stories/$shareId'
     | '/feed/'
     | '/settings/'
     | '/stories/'
@@ -490,6 +510,7 @@ export interface FileRouteTypes {
     | '/embed'
     | '/forgot-password'
     | '/login'
+    | '/public'
     | '/reset-password'
     | '/signup'
     | '/$chatId'
@@ -508,6 +529,7 @@ export interface FileRouteTypes {
     | '/shared-chat/$shareId'
     | '/embed/chart/$chartEmbedId'
     | '/embed/story/$storyId'
+    | '/public/stories/$shareId'
     | '/feed'
     | '/settings'
     | '/stories'
@@ -532,6 +554,7 @@ export interface FileRouteTypes {
     | '/embed'
     | '/forgot-password'
     | '/login'
+    | '/public'
     | '/reset-password'
     | '/signup'
     | '/_sidebar-layout/_chat-layout'
@@ -553,6 +576,7 @@ export interface FileRouteTypes {
     | '/_sidebar-layout/shared-chat/$shareId'
     | '/embed/chart/$chartEmbedId'
     | '/embed/story/$storyId'
+    | '/public/stories/$shareId'
     | '/_sidebar-layout/_chat-layout/'
     | '/_sidebar-layout/feed/'
     | '/_sidebar-layout/settings/'
@@ -579,6 +603,7 @@ export interface RootRouteChildren {
   EmbedRoute: typeof EmbedRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
+  PublicRoute: typeof PublicRouteWithChildren
   ResetPasswordRoute: typeof ResetPasswordRoute
   SignupRoute: typeof SignupRoute
 }
@@ -597,6 +622,13 @@ declare module '@tanstack/react-router' {
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/public': {
+      id: '/public'
+      path: '/public'
+      fullPath: '/public'
+      preLoaderRoute: typeof PublicRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -675,6 +707,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof SidebarLayoutChatLayoutIndexRouteImport
       parentRoute: typeof SidebarLayoutChatLayoutRoute
+    }
+    '/public/stories/$shareId': {
+      id: '/public/stories/$shareId'
+      path: '/stories/$shareId'
+      fullPath: '/public/stories/$shareId'
+      preLoaderRoute: typeof PublicStoriesShareIdRouteImport
+      parentRoute: typeof PublicRoute
     }
     '/embed/story/$storyId': {
       id: '/embed/story/$storyId'
@@ -1042,12 +1081,24 @@ const EmbedRouteChildren: EmbedRouteChildren = {
 
 const EmbedRouteWithChildren = EmbedRoute._addFileChildren(EmbedRouteChildren)
 
+interface PublicRouteChildren {
+  PublicStoriesShareIdRoute: typeof PublicStoriesShareIdRoute
+}
+
+const PublicRouteChildren: PublicRouteChildren = {
+  PublicStoriesShareIdRoute: PublicStoriesShareIdRoute,
+}
+
+const PublicRouteWithChildren =
+  PublicRoute._addFileChildren(PublicRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   SidebarLayoutRoute: SidebarLayoutRouteWithChildren,
   ConsentRoute: ConsentRoute,
   EmbedRoute: EmbedRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
+  PublicRoute: PublicRouteWithChildren,
   ResetPasswordRoute: ResetPasswordRoute,
   SignupRoute: SignupRoute,
 }

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router';
+import { isPublicAppRoute } from '@nao/shared/story-share';
 import { BrandColor } from '../components/brand-color';
 import { BrandingHead } from '../components/branding-head';
 import { ModifyPassword } from '../components/modify-password';
@@ -15,7 +16,7 @@ export const Route = createRootRoute({
 function RootComponent() {
 	const pathname = useRouterState({ select: (s) => s.location.pathname });
 
-	if (pathname.startsWith('/embed')) {
+	if (pathname.startsWith('/embed') || isPublicAppRoute(pathname)) {
 		return <Outlet />;
 	}
 

--- a/apps/frontend/src/routes/public.stories.$shareId.tsx
+++ b/apps/frontend/src/routes/public.stories.$shareId.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+
+import type { QueryDataMap } from '@/components/story-embeds';
+import { BrandingHead } from '@/components/branding-head';
+import { PublicStoryBanner, ReadonlyStoryContent } from '@/components/story-readonly-content';
+import { StoryDownload } from '@/components/story-download';
+import { Spinner } from '@/components/ui/spinner';
+import { trpc } from '@/main';
+
+export const Route = createFileRoute('/public/stories/$shareId')({
+	component: PublicStoryPage,
+});
+
+function PublicStoryPage() {
+	const { shareId } = Route.useParams();
+	const storyQuery = useQuery(trpc.storyShare.getPublic.queryOptions({ shareId }));
+	const story = storyQuery.data;
+
+	if (storyQuery.isLoading) {
+		return (
+			<div className='flex flex-1 items-center justify-center py-20'>
+				<Spinner />
+			</div>
+		);
+	}
+
+	if (storyQuery.isError || !story) {
+		return (
+			<div className='flex flex-1 items-center justify-center px-4 py-20 text-center text-sm text-muted-foreground'>
+				Story unavailable or no longer published.
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<BrandingHead />
+			<div className='flex min-h-screen flex-col'>
+				<header className='border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80'>
+					<div className='mx-auto flex w-full max-w-5xl flex-col gap-3 px-4 py-4 md:px-8'>
+						<PublicStoryBanner />
+						<div className='flex items-start justify-between gap-4'>
+							<div className='min-w-0 space-y-1'>
+								<h1 className='truncate text-xl font-semibold'>{story.title}</h1>
+								{story.authorName ? (
+									<p className='text-sm text-muted-foreground'>By {story.authorName}</p>
+								) : null}
+							</div>
+							<StoryDownload shareId={shareId} isOwner={false} isPublicShare />
+						</div>
+					</div>
+				</header>
+				<ReadonlyStoryContent code={story.code} queryData={story.queryData as QueryDataMap | null} />
+			</div>
+		</>
+	);
+}

--- a/apps/frontend/src/routes/public.tsx
+++ b/apps/frontend/src/routes/public.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/public')({
+	component: PublicLayout,
+});
+
+function PublicLayout() {
+	return (
+		<div className='flex min-h-screen min-w-0 flex-col bg-background text-foreground antialiased'>
+			<Outlet />
+		</div>
+	);
+}

--- a/apps/shared/package.json
+++ b/apps/shared/package.json
@@ -10,7 +10,8 @@
 		"./tools": "./src/tools/index.ts",
 		"./story-segments": "./src/story-segments.ts",
 		"./story-table-utils": "./src/story-table-utils.ts",
-		"./story-validation": "./src/story-validation.ts"
+		"./story-validation": "./src/story-validation.ts",
+		"./story-share": "./src/story-share.ts"
 	},
 	"scripts": {
 		"test": "vitest run",

--- a/apps/shared/src/story-share.ts
+++ b/apps/shared/src/story-share.ts
@@ -1,0 +1,40 @@
+import type { Visibility } from './types';
+
+export const AUTHENTICATED_STORY_SHARE_PATH = '/stories/shared';
+export const PUBLIC_STORY_SHARE_PATH = '/public/stories';
+export const PUBLIC_ROUTE_PREFIX = '/public';
+
+export function isPublicShareVisibility(visibility: Visibility): visibility is 'public' {
+	return visibility === 'public';
+}
+
+export function isPublicAppRoute(pathname: string): boolean {
+	return pathname === PUBLIC_ROUTE_PREFIX || pathname.startsWith(`${PUBLIC_ROUTE_PREFIX}/`);
+}
+
+export function canAccessAuthenticatedSharedStory({
+	visibility,
+	ownerUserId,
+	viewerUserId,
+	hasSpecificAccess,
+}: {
+	visibility: Visibility;
+	ownerUserId: string;
+	viewerUserId: string;
+	hasSpecificAccess: boolean;
+}): boolean {
+	if (visibility === 'public' || visibility === 'project') {
+		return true;
+	}
+
+	return ownerUserId === viewerUserId || hasSpecificAccess;
+}
+
+export function buildStorySharePath(shareId: string, visibility: Visibility): string {
+	const base = isPublicShareVisibility(visibility) ? PUBLIC_STORY_SHARE_PATH : AUTHENTICATED_STORY_SHARE_PATH;
+	return `${base}/${shareId}`;
+}
+
+export function buildStoryShareUrl(shareId: string, visibility: Visibility, origin: string): string {
+	return `${origin}${buildStorySharePath(shareId, visibility)}`;
+}

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -87,8 +87,9 @@ export const MAX_BUDGET_LIMIT_USD = 200_000;
 export const BUDGET_PERIODS = ['day', 'week', 'month'] as const;
 export type BudgetPeriod = (typeof BUDGET_PERIODS)[number];
 
-export const SHARE_VISIBILITY = ['project', 'specific'] as const;
+export const SHARE_VISIBILITY = ['project', 'specific', 'public'] as const;
 export type Visibility = (typeof SHARE_VISIBILITY)[number];
+export type MemberShareVisibility = Exclude<Visibility, 'public'>;
 
 export type StorySharingInfo = {
 	visibility: Visibility;

--- a/apps/shared/tests/story-share.test.ts
+++ b/apps/shared/tests/story-share.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	AUTHENTICATED_STORY_SHARE_PATH,
+	buildStorySharePath,
+	buildStoryShareUrl,
+	canAccessAuthenticatedSharedStory,
+	isPublicAppRoute,
+	isPublicShareVisibility,
+	PUBLIC_ROUTE_PREFIX,
+	PUBLIC_STORY_SHARE_PATH,
+} from '../src/story-share';
+
+describe('story share urls', () => {
+	it('detects public visibility', () => {
+		expect(isPublicShareVisibility('public')).toBe(true);
+		expect(isPublicShareVisibility('project')).toBe(false);
+		expect(isPublicShareVisibility('specific')).toBe(false);
+	});
+
+	it('builds authenticated share paths for project and specific visibility', () => {
+		expect(buildStorySharePath('share-1', 'project')).toBe(`${AUTHENTICATED_STORY_SHARE_PATH}/share-1`);
+		expect(buildStorySharePath('share-1', 'specific')).toBe(`${AUTHENTICATED_STORY_SHARE_PATH}/share-1`);
+	});
+
+	it('builds public share paths for public visibility', () => {
+		expect(buildStorySharePath('share-1', 'public')).toBe(`${PUBLIC_STORY_SHARE_PATH}/share-1`);
+	});
+
+	it('builds full share urls from an origin', () => {
+		expect(buildStoryShareUrl('share-1', 'public', 'https://app.example.com')).toBe(
+			'https://app.example.com/public/stories/share-1',
+		);
+		expect(buildStoryShareUrl('share-1', 'project', 'https://app.example.com')).toBe(
+			'https://app.example.com/stories/shared/share-1',
+		);
+	});
+
+	it('detects public app routes', () => {
+		expect(isPublicAppRoute(PUBLIC_ROUTE_PREFIX)).toBe(true);
+		expect(isPublicAppRoute(`${PUBLIC_STORY_SHARE_PATH}/share-1`)).toBe(true);
+		expect(isPublicAppRoute('/stories/shared/share-1')).toBe(false);
+	});
+
+	it('checks authenticated access for shared stories', () => {
+		expect(
+			canAccessAuthenticatedSharedStory({
+				visibility: 'public',
+				ownerUserId: 'owner',
+				viewerUserId: 'viewer',
+				hasSpecificAccess: false,
+			}),
+		).toBe(true);
+		expect(
+			canAccessAuthenticatedSharedStory({
+				visibility: 'specific',
+				ownerUserId: 'owner',
+				viewerUserId: 'viewer',
+				hasSpecificAccess: false,
+			}),
+		).toBe(false);
+		expect(
+			canAccessAuthenticatedSharedStory({
+				visibility: 'specific',
+				ownerUserId: 'owner',
+				viewerUserId: 'viewer',
+				hasSpecificAccess: true,
+			}),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Adds the ability to share stories with external users who don't have a nao account via a public link.

This PR lets you share a story with people who don't have a nao account, using a public link.
and to do this without breaking our current security model, I added a new public visibility option for stories so instead of building a separate table in database. This keeps the change small and reuses the existing sharing system.
to the  backend side , I added new tRPC routes that don't require login. These routes only return story data if the story's visibility is set to public. Everything else stays private, so no other project data can leak through.
On the frontend, I updated the routing so public story links skip the login redirect and load a simple, read-only view instead.
I also updated the Share Dialog to add an "Anyone with the link" option. Since this makes data public on the internet, there's a warning checkbox users have to check before turning it on.

Tested locally

closes: #1155 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

