### PR TITLE
fix: nao command is now consistently fast

### DIFF
--- a/cli/nao_core/version.py
+++ b/cli/nao_core/version.py
@@ -1,8 +1,8 @@
 """Check for newer nao-core versions on PyPI."""
 
-import atexit
 import json
-import threading
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -12,8 +12,6 @@ from nao_core.ui import UI
 CACHE_FILE = Path.home() / ".nao" / "version_check.json"
 PYPI_URL = "https://pypi.org/pypi/nao-core/json"
 CHECK_INTERVAL = 24 * 60 * 60
-
-_background_thread: threading.Thread | None = None
 
 
 def parse_version(v: str) -> tuple[int, ...]:
@@ -31,7 +29,6 @@ def get_latest_version() -> str | None:
 
 def check_for_updates() -> None:
     """Non-blocking version check. Shows a warning only on cache hit; refreshes cache in background."""
-    global _background_thread
     try:
         cached = _read_cache()
         if cached is not None:
@@ -39,17 +36,39 @@ def check_for_updates() -> None:
                 UI.warn(f"Update available: {__version__} → {cached}. Run: nao upgrade")
             return
 
-        _background_thread = threading.Thread(target=_fetch_and_cache, daemon=True)
-        _background_thread.start()
-        atexit.register(_wait_for_background_fetch)
+        _spawn_background_refresh()
     except Exception:
         pass
 
 
-def _wait_for_background_fetch() -> None:
-    """Wait briefly for the background fetch so the cache file is written before exit."""
-    if _background_thread is not None and _background_thread.is_alive():
-        _background_thread.join(timeout=5)
+def _spawn_background_refresh() -> None:
+    """Refresh the version cache in a detached process."""
+    command = [
+        sys.executable,
+        "-c",
+        "from nao_core.version import _fetch_and_cache; _fetch_and_cache()",
+    ]
+
+    try:
+        if sys.platform == "win32":
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "DETACHED_PROCESS", 0)
+            subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+            )
+        else:
+            subprocess.Popen(
+                command,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+    except Exception:
+        pass
 
 
 def clear_version_cache() -> None:

--- a/cli/tests/nao_core/test_version.py
+++ b/cli/tests/nao_core/test_version.py
@@ -1,0 +1,61 @@
+import subprocess
+import sys
+from unittest.mock import patch
+
+from nao_core import __version__
+from nao_core.version import check_for_updates
+
+
+def test_check_for_updates_warns_for_newer_cached_version():
+    with (
+        patch("nao_core.version._read_cache", return_value="99.0.0"),
+        patch("nao_core.version.UI.warn") as mock_warn,
+        patch("nao_core.version.subprocess.Popen") as mock_popen,
+    ):
+        check_for_updates()
+
+    mock_warn.assert_called_once_with(f"Update available: {__version__} → 99.0.0. Run: nao upgrade")
+    mock_popen.assert_not_called()
+
+
+def test_check_for_updates_does_nothing_for_current_cached_version():
+    with (
+        patch("nao_core.version._read_cache", return_value=__version__),
+        patch("nao_core.version.UI.warn") as mock_warn,
+        patch("nao_core.version.subprocess.Popen") as mock_popen,
+    ):
+        check_for_updates()
+
+    mock_warn.assert_not_called()
+    mock_popen.assert_not_called()
+
+
+def test_check_for_updates_spawns_detached_cache_refresh():
+    with (
+        patch("nao_core.version._read_cache", return_value=None),
+        patch("nao_core.version.UI.warn") as mock_warn,
+        patch("nao_core.version.subprocess.Popen") as mock_popen,
+    ):
+        check_for_updates()
+
+    expected_kwargs = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if sys.platform == "win32":
+        expected_kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS
+    else:
+        expected_kwargs["start_new_session"] = True
+
+    mock_popen.assert_called_once_with(
+        [
+            sys.executable,
+            "-c",
+            "from nao_core.version import _fetch_and_cache; _fetch_and_cache()",
+        ],
+        **expected_kwargs,
+    )
+    mock_warn.assert_not_called()
+    mock_popen.return_value.wait.assert_not_called()
+    mock_popen.return_value.communicate.assert_not_called()


### PR DESCRIPTION
## Summary
- First `nao` command of the day no longer hangs ~3s. The update check no longer blocks process exit.
- `check_for_updates()` now refreshes the cache in a detached subprocess and returns immediately
- Warm-cache "Update available…" message and `nao upgrade` behavior unchanged.
- Added `cli/tests/nao_core/test_version.py`.

Closes #1201

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

