### PR TITLE
fix: Share dialog now lists everybody with access: org members and project members

### DIFF
--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -126,7 +126,7 @@ export const getUserRoleInProject = async (projectId: string, userId: string): P
 	return orgMember ? orgMember.role : null;
 };
 
-export const listAllUsersWithRoles = async (projectId: string): Promise<UserWithRole[]> => {
+export const listProjectMembersWithRoles = async (projectId: string): Promise<UserWithRole[]> => {
 	const results = await db
 		.select({
 			id: s.user.id,
@@ -143,7 +143,7 @@ export const listAllUsersWithRoles = async (projectId: string): Promise<UserWith
 	return results;
 };
 
-export const listProjectAccessibleUsersWithRoles = async (projectId: string): Promise<UserWithRole[]> => {
+export const listUsersWithProjectAccess = async (projectId: string): Promise<UserWithRole[]> => {
 	const project = await getProjectById(projectId);
 	const results = await db
 		.select({
@@ -197,7 +197,7 @@ export const getProjectByUserId = async (
 };
 
 export const checkProjectHasMoreThanOneAdmin = async (projectId: string): Promise<boolean> => {
-	const userWithRoles = await listAllUsersWithRoles(projectId);
+	const userWithRoles = await listProjectMembersWithRoles(projectId);
 	const nbAdmin = userWithRoles.filter((u) => u.role === 'admin').length;
 	return nbAdmin > 1;
 };

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_DATE_FORMAT_SETTINGS, type DisplaySettings } from '@nao/shared/date';
 import type { UpdatedAtFilter, UserRole } from '@nao/shared/types';
-import { and, asc, desc, eq, gt, gte, lte, or, type SQL, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, gte, isNotNull, lte, or, type SQL, sql } from 'drizzle-orm';
 
 import type { AgentSettings, DBProject, DBProjectMember, NewProject, NewProjectMember } from '../db/abstractSchema';
 import s from '../db/abstractSchema';
@@ -138,6 +138,25 @@ export const listAllUsersWithRoles = async (projectId: string): Promise<UserWith
 		.from(s.user)
 		.innerJoin(s.projectMember, eq(s.projectMember.userId, s.user.id))
 		.where(eq(s.projectMember.projectId, projectId))
+		.execute();
+
+	return results;
+};
+
+export const listProjectAccessibleUsersWithRoles = async (projectId: string): Promise<UserWithRole[]> => {
+	const project = await getProjectById(projectId);
+	const results = await db
+		.select({
+			id: s.user.id,
+			name: s.user.name,
+			email: s.user.email,
+			role: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role})`,
+			messagingProviderCode: s.user.messagingProviderCode,
+		})
+		.from(s.user)
+		.leftJoin(s.projectMember, and(eq(s.projectMember.userId, s.user.id), eq(s.projectMember.projectId, projectId)))
+		.leftJoin(s.orgMember, and(eq(s.orgMember.userId, s.user.id), eq(s.orgMember.orgId, project?.orgId ?? '')))
+		.where(or(isNotNull(s.projectMember.userId), isNotNull(s.orgMember.userId)))
 		.execute();
 
 	return results;

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -502,7 +502,7 @@ export const projectRoutes = {
 	regenerateMessagingProviderCode: adminProtectedProcedure
 		.input(z.object({ userId: z.string() }))
 		.mutation(async ({ ctx, input }) => {
-			const members = await projectQueries.listAllUsersWithRoles(ctx.project.id);
+			const members = await projectQueries.listProjectMembersWithRoles(ctx.project.id);
 			const isMember = members.some((m) => m.id === input.userId);
 			if (!isMember) {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'User is not a member of this project' });
@@ -627,7 +627,7 @@ export const projectRoutes = {
 		if (!ctx.project) {
 			return [];
 		}
-		return projectQueries.listAllUsersWithRoles(ctx.project.id);
+		return projectQueries.listProjectMembersWithRoles(ctx.project.id);
 	}),
 
 	getProjectMembersByChatId: protectedProcedure
@@ -641,7 +641,7 @@ export const projectRoutes = {
 			if (!role) {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this project.' });
 			}
-			return projectQueries.listProjectAccessibleUsersWithRoles(projectId);
+			return projectQueries.listUsersWithProjectAccess(projectId);
 		}),
 
 	getKnownModels: publicProcedure.query(() => {

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -641,7 +641,7 @@ export const projectRoutes = {
 			if (!role) {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not have access to this project.' });
 			}
-			return projectQueries.listAllUsersWithRoles(projectId);
+			return projectQueries.listProjectAccessibleUsersWithRoles(projectId);
 		}),
 
 	getKnownModels: publicProcedure.query(() => {

--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -134,11 +134,11 @@ export const sharedChatRoutes = {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the creator or an admin can update this.' });
 			}
 
-			const projectMembers = await projectQueries.listProjectAccessibleUsersWithRoles(ctx.resource.projectId);
-			const memberIds = new Set(projectMembers.map((m) => m.id));
-			const validUserIds = input.allowedUserIds.filter((id) => memberIds.has(id));
+			const accessibleUsers = await projectQueries.listProjectAccessibleUsersWithRoles(ctx.resource.projectId);
+			const accessibleUserIds = new Set(accessibleUsers.map((m) => m.id));
+			const validUserIds = input.allowedUserIds.filter((id) => accessibleUserIds.has(id));
 			if (input.allowedUserIds.length > 0 && validUserIds.length === 0) {
-				throw new TRPCError({ code: 'BAD_REQUEST', message: 'No valid project members in the provided list.' });
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'No valid users in the provided list.' });
 			}
 
 			await sharedChatQueries.updateSharedChatAllowedUsers(input.shareId, validUserIds);

--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -134,7 +134,7 @@ export const sharedChatRoutes = {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the creator or an admin can update this.' });
 			}
 
-			const accessibleUsers = await projectQueries.listProjectAccessibleUsersWithRoles(ctx.resource.projectId);
+			const accessibleUsers = await projectQueries.listUsersWithProjectAccess(ctx.resource.projectId);
 			const accessibleUserIds = new Set(accessibleUsers.map((m) => m.id));
 			const validUserIds = input.allowedUserIds.filter((id) => accessibleUserIds.has(id));
 			if (input.allowedUserIds.length > 0 && validUserIds.length === 0) {

--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -134,7 +134,7 @@ export const sharedChatRoutes = {
 				throw new TRPCError({ code: 'FORBIDDEN', message: 'Only the creator or an admin can update this.' });
 			}
 
-			const projectMembers = await projectQueries.listAllUsersWithRoles(ctx.resource.projectId);
+			const projectMembers = await projectQueries.listProjectAccessibleUsersWithRoles(ctx.resource.projectId);
 			const memberIds = new Set(projectMembers.map((m) => m.id));
 			const validUserIds = input.allowedUserIds.filter((id) => memberIds.has(id));
 			if (input.allowedUserIds.length > 0 && validUserIds.length === 0) {

--- a/apps/backend/src/utils/budget.ts
+++ b/apps/backend/src/utils/budget.ts
@@ -70,7 +70,7 @@ async function notifyAdminsOnBudgetLimitReached(
 		return;
 	}
 
-	const allMembers = await projectQueries.listAllUsersWithRoles(projectId);
+	const allMembers = await projectQueries.listProjectMembersWithRoles(projectId);
 	const admins = allMembers.filter((m) => m.role === 'admin');
 	if (admins.length === 0) {
 		return;

--- a/apps/backend/src/utils/email.ts
+++ b/apps/backend/src/utils/email.ts
@@ -30,7 +30,7 @@ export async function notifySharedItemRecipients({
 	allowedUserIds?: string[];
 }): Promise<void> {
 	const itemUrl = itemUrls[itemLabel](shareId);
-	const allMembers = await projectQueries.listProjectAccessibleUsersWithRoles(projectId);
+	const allMembers = await projectQueries.listUsersWithProjectAccess(projectId);
 
 	const recipients =
 		visibility === 'project'

--- a/apps/backend/src/utils/email.ts
+++ b/apps/backend/src/utils/email.ts
@@ -30,7 +30,7 @@ export async function notifySharedItemRecipients({
 	allowedUserIds?: string[];
 }): Promise<void> {
 	const itemUrl = itemUrls[itemLabel](shareId);
-	const allMembers = await projectQueries.listAllUsersWithRoles(projectId);
+	const allMembers = await projectQueries.listProjectAccessibleUsersWithRoles(projectId);
 
 	const recipients =
 		visibility === 'project'

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -6,8 +6,8 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 
 import { db as appDb } from '../src/db/db';
 import * as sqliteSchema from '../src/db/sqlite-schema';
-import { orgMember, organization, project, projectMember, user } from '../src/db/sqlite-schema';
-import { listAllUsersWithRoles, listProjectAccessibleUsersWithRoles } from '../src/queries/project.queries';
+import { organization, orgMember, project, projectMember, user } from '../src/db/sqlite-schema';
+import { listProjectMembersWithRoles, listUsersWithProjectAccess } from '../src/queries/project.queries';
 
 vi.mock('../src/db/db', async () => {
 	const { drizzle } = await import('drizzle-orm/better-sqlite3');
@@ -70,7 +70,7 @@ describe('project accessible users', () => {
 	});
 
 	it('includes org members alongside direct project members, project role wins', async () => {
-		const users = await listProjectAccessibleUsersWithRoles('pau-proj');
+		const users = await listUsersWithProjectAccess('pau-proj');
 		const rolesById = new Map(users.map(({ id, role }) => [id, role]));
 
 		expect([...rolesById.keys()].sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct', 'pau-org-only']);
@@ -81,13 +81,13 @@ describe('project accessible users', () => {
 	});
 
 	it('team listing still excludes org-only members', async () => {
-		const teamUsers = await listAllUsersWithRoles('pau-proj');
+		const teamUsers = await listProjectMembersWithRoles('pau-proj');
 
 		expect(teamUsers.map(({ id }) => id).sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct']);
 	});
 
 	it('self-hosted project without org returns only direct members', async () => {
-		const soloUsers = await listProjectAccessibleUsersWithRoles('pau-solo');
+		const soloUsers = await listUsersWithProjectAccess('pau-solo');
 
 		expect(soloUsers.map(({ id }) => id).sort()).toEqual(['pau-direct']);
 	});

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -1,0 +1,94 @@
+import '../src/env';
+
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db as appDb } from '../src/db/db';
+import * as sqliteSchema from '../src/db/sqlite-schema';
+import { orgMember, organization, project, projectMember, user } from '../src/db/sqlite-schema';
+import { listAllUsersWithRoles, listProjectAccessibleUsersWithRoles } from '../src/queries/project.queries';
+
+vi.mock('../src/db/db', async () => {
+	const { drizzle } = await import('drizzle-orm/better-sqlite3');
+	const schema = await import('../src/db/sqlite-schema');
+	return { db: drizzle('./db.sqlite', { schema }) };
+});
+
+const db = drizzle('./db.sqlite', { schema: sqliteSchema });
+
+async function cleanup() {
+	await db.delete(projectMember).where(eq(projectMember.projectId, 'pau-proj'));
+	await db.delete(projectMember).where(eq(projectMember.projectId, 'pau-solo'));
+	await db.delete(orgMember).where(eq(orgMember.orgId, 'pau-org'));
+	await db.delete(project).where(eq(project.id, 'pau-proj'));
+	await db.delete(project).where(eq(project.id, 'pau-solo'));
+	await db.delete(organization).where(eq(organization.id, 'pau-org'));
+	await db.delete(user).where(eq(user.id, 'pau-direct'));
+	await db.delete(user).where(eq(user.id, 'pau-org-only'));
+	await db.delete(user).where(eq(user.id, 'pau-both'));
+	await db.delete(user).where(eq(user.id, 'pau-ctx'));
+}
+
+describe('project accessible users', () => {
+	beforeEach(async () => {
+		await cleanup();
+		await db.insert(organization).values({ id: 'pau-org', name: 'PAU', slug: 'pau-org' });
+		await db.insert(project).values([
+			{ id: 'pau-proj', orgId: 'pau-org', name: 'PAU', type: 'local', path: '/tmp/pau' },
+			{ id: 'pau-solo', orgId: null, name: 'PAU Solo', type: 'local', path: '/tmp/pau-solo' },
+		]);
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-direct', 'PAU Direct', 'pau-direct@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-org-only', 'PAU Org Only', 'pau-org-only@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-both', 'PAU Both', 'pau-both@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-ctx', 'PAU Ctx', 'pau-ctx@example.com');
+		await db.insert(projectMember).values([
+			{ projectId: 'pau-proj', userId: 'pau-direct', role: 'admin' },
+			{ projectId: 'pau-proj', userId: 'pau-both', role: 'viewer' },
+			{ projectId: 'pau-proj', userId: 'pau-ctx', role: 'context_admin' },
+			{ projectId: 'pau-solo', userId: 'pau-direct', role: 'admin' },
+		]);
+		await db.insert(orgMember).values([
+			{ orgId: 'pau-org', userId: 'pau-org-only', role: 'user' },
+			{ orgId: 'pau-org', userId: 'pau-both', role: 'admin' },
+		]);
+	});
+
+	afterEach(cleanup);
+
+	afterAll(() => {
+		appDb.$client.close();
+		db.$client.close();
+	});
+
+	it('includes org members alongside direct project members, project role wins', async () => {
+		const users = await listProjectAccessibleUsersWithRoles('pau-proj');
+		const rolesById = new Map(users.map(({ id, role }) => [id, role]));
+
+		expect([...rolesById.keys()].sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct', 'pau-org-only']);
+		expect(rolesById.get('pau-direct')).toBe('admin');
+		expect(rolesById.get('pau-org-only')).toBe('user');
+		expect(rolesById.get('pau-both')).toBe('viewer');
+		expect(rolesById.get('pau-ctx')).toBe('context_admin');
+	});
+
+	it('team listing still excludes org-only members', async () => {
+		const teamUsers = await listAllUsersWithRoles('pau-proj');
+
+		expect(teamUsers.map(({ id }) => id).sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct']);
+	});
+
+	it('self-hosted project without org returns only direct members', async () => {
+		const soloUsers = await listProjectAccessibleUsersWithRoles('pau-solo');
+
+		expect(soloUsers.map(({ id }) => id).sort()).toEqual(['pau-direct']);
+	});
+});


### PR DESCRIPTION
## Summary
Sharing a chat or story now lets you pick anyone who can access the project, including people who have access through the organization, not just those added directly to the project (#1088).

- The share list now includes org members, so you can share a specific chat/story with them.
- Editing who a chat is shared with no longer silently drops org members.
- Team settings is unchanged -> it still shows only direct project members.
- Added a backend test covering direct, org-only, both (project role wins), project-only `context_admin`, and self-hosted (no org) cases.

Closes #1088

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

