### PR TITLE
test: account for generated marker in ai_summary refresh test

### DIFF
--- a/cli/tests/nao_core/commands/sync/test_provider_refresh.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_refresh.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from nao_core.commands.sync.markers import with_generated_marker
 from nao_core.commands.sync.providers.databases.provider import sync_database
 from nao_core.config.databases.base import (
     DatabaseTemplate,
@@ -90,7 +91,7 @@ def test_ai_summary_refresh_does_not_rewrite_frozen_profiling(tmp_path):
 
     context.profiling.assert_called_once_with()
     assert profiling_file.read_text() == "frozen profiling"
-    assert (output_path / "ai_summary.md").read_text() == "rendered ai_summary.md"
+    assert (output_path / "ai_summary.md").read_text() == with_generated_marker("rendered ai_summary.md")
     engine.render.assert_called_once()
     assert engine.render.call_args.kwargs["profiling"] is profiling_data
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

