### PR TITLE
[fix: stories] Move 'Create folder' action to the top of the stories list view and improved live settings button on header stories

### DIFF
--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -34,7 +34,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
+import { SwitchIndicator } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 
 export interface StoryHeaderProps {
@@ -261,7 +261,7 @@ export const StoryHeader = memo(function StoryHeader({
 					>
 						<Activity className='size-3.5 text-foreground' strokeWidth={2.25} />
 						<span className='text-xs font-medium'>Live story</span>
-						<Switch checked={isLive} disabled={isAgentRunning} className='pointer-events-none' />
+						<SwitchIndicator checked={isLive} />
 					</button>
 				</TooltipTrigger>
 				<TooltipContent>{isLive ? 'Live story settings' : 'Enable live mode'}</TooltipContent>

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -253,11 +253,16 @@ export const StoryHeader = memo(function StoryHeader({
 			)}
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<div className='flex items-center gap-2'>
+					<button
+						type='button'
+						onClick={onOpenLiveSettings}
+						disabled={isAgentRunning}
+						className='flex items-center gap-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 border hover:bg-secondary rounded-full px-2 py-0.75'
+					>
 						<Activity className='size-3.5 text-foreground' strokeWidth={2.25} />
 						<span className='text-xs font-medium'>Live story</span>
-						<Switch checked={isLive} onCheckedChange={onOpenLiveSettings} disabled={isAgentRunning} />
-					</div>
+						<Switch checked={isLive} disabled={isAgentRunning} className='pointer-events-none' />
+					</button>
 				</TooltipTrigger>
 				<TooltipContent>{isLive ? 'Live story settings' : 'Enable live mode'}</TooltipContent>
 			</Tooltip>

--- a/apps/frontend/src/components/stories-explorer.tsx
+++ b/apps/frontend/src/components/stories-explorer.tsx
@@ -1,6 +1,8 @@
+import { Fragment } from 'react';
 import { FolderPlus } from 'lucide-react';
 import type { StoryPanelDisplayMode } from '@nao/shared/types';
 import type { ExplorerEntry, FolderItem, StoryItem } from '@/lib/stories-page';
+import { isSystemFolder } from '@/lib/stories-page';
 import { FolderCard } from '@/components/stories-folder-card';
 import { StoryCard, StoriesEmptyState, StoriesNoResults } from '@/components/stories-groups';
 import { usePermissions } from '@/hooks/use-permissions';
@@ -74,41 +76,52 @@ export function StoriesExplorer({
 	const stories = entries.filter((e) => e.kind === 'story');
 
 	if (displayMode === 'lines') {
+		const lastSystemFolderIndex = entries.reduce(
+			(acc, entry, index) => (entry.kind === 'folder' && isSystemFolder(entry.folder) ? index : acc),
+			-1,
+		);
 		return (
 			<div className='flex flex-col gap-1'>
-				{entries.map((entry) => {
+				{canCreateFolder && lastSystemFolderIndex === -1 && <NewFolderRow onClick={onNewFolder} />}
+				{entries.map((entry, index) => {
+					const newFolderRow = canCreateFolder && index === lastSystemFolderIndex && (
+						<NewFolderRow onClick={onNewFolder} />
+					);
 					if (entry.kind === 'folder') {
 						return (
-							<FolderCard
-								key={`f-${entry.folder.id}`}
-								folder={entry.folder}
-								displayMode='lines'
-								currentUserName={currentUserName}
-								onModify={onModifyFolder}
-								onMove={onMoveFolder}
-								onDelete={onDeleteFolder}
-								onArchive={onArchiveFolder}
-								onRestore={onRestoreFolder}
-								selected={selectedFolderIds.has(entry.folder.id)}
-								selectionActive={selectionActive}
-								onToggleSelect={onToggleFolder}
-							/>
+							<Fragment key={`f-${entry.folder.id}`}>
+								<FolderCard
+									folder={entry.folder}
+									displayMode='lines'
+									currentUserName={currentUserName}
+									onModify={onModifyFolder}
+									onMove={onMoveFolder}
+									onDelete={onDeleteFolder}
+									onArchive={onArchiveFolder}
+									onRestore={onRestoreFolder}
+									selected={selectedFolderIds.has(entry.folder.id)}
+									selectionActive={selectionActive}
+									onToggleSelect={onToggleFolder}
+								/>
+								{newFolderRow}
+							</Fragment>
 						);
 					}
 					return (
-						<StoryCard
-							key={`s-${entry.story.id}`}
-							item={entry.story}
-							displayMode='lines'
-							showArchived={showArchived}
-							onMoveToFolder={moveToFolderHandler}
-							selected={selectedStoryIds.has(entry.story.storyId)}
-							selectionActive={selectionActive}
-							onToggleSelect={onToggleStory}
-						/>
+						<Fragment key={`s-${entry.story.id}`}>
+							<StoryCard
+								item={entry.story}
+								displayMode='lines'
+								showArchived={showArchived}
+								onMoveToFolder={moveToFolderHandler}
+								selected={selectedStoryIds.has(entry.story.storyId)}
+								selectionActive={selectionActive}
+								onToggleSelect={onToggleStory}
+							/>
+							{newFolderRow}
+						</Fragment>
 					);
 				})}
-				{canCreateFolder && <NewFolderRow onClick={onNewFolder} />}
 			</div>
 		);
 	}

--- a/apps/frontend/src/components/story-page-header.tsx
+++ b/apps/frontend/src/components/story-page-header.tsx
@@ -314,6 +314,7 @@ function LiveStoryControls({ live }: { live: LiveControls }) {
 		}
 		return (
 			<>
+				{onRefresh && <RefreshButton isRefreshing={isRefreshing} onRefresh={onRefresh} />}
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<div className='flex items-center gap-2 border rounded-full px-2 py-0.75'>
@@ -324,7 +325,6 @@ function LiveStoryControls({ live }: { live: LiveControls }) {
 					</TooltipTrigger>
 					<TooltipContent>Live story</TooltipContent>
 				</Tooltip>
-				{onRefresh && <RefreshButton isRefreshing={isRefreshing} onRefresh={onRefresh} />}
 			</>
 		);
 	}
@@ -334,11 +334,15 @@ function LiveStoryControls({ live }: { live: LiveControls }) {
 			{isLive && onRefresh && <RefreshButton isRefreshing={isRefreshing} onRefresh={onRefresh} />}
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<div className='flex items-center gap-2 border rounded-full px-2 py-0.75'>
+					<button
+						type='button'
+						onClick={onOpenSettings}
+						className='flex items-center gap-2 border rounded-full px-2 py-0.75 cursor-pointer hover:bg-secondary'
+					>
 						<Activity className='size-3.5 text-foreground' strokeWidth={2.25} />
 						<span className='text-xs font-medium'>Live story</span>
-						<Switch checked={isLive} onCheckedChange={onOpenSettings} />
-					</div>
+						<Switch checked={isLive} className='pointer-events-none' />
+					</button>
 				</TooltipTrigger>
 				<TooltipContent>{isLive ? 'Live story settings' : 'Enable live mode'}</TooltipContent>
 			</Tooltip>

--- a/apps/frontend/src/components/story-page-header.tsx
+++ b/apps/frontend/src/components/story-page-header.tsx
@@ -27,7 +27,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
+import { SwitchIndicator } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useToggleFavorite } from '@/hooks/use-toggle-favorite';
 import { cn } from '@/lib/utils';
@@ -320,7 +320,7 @@ function LiveStoryControls({ live }: { live: LiveControls }) {
 						<div className='flex items-center gap-2 border rounded-full px-2 py-0.75'>
 							<Activity className='size-3.5 text-foreground' strokeWidth={2.25} />
 							<span className='text-xs font-medium'>Live story</span>
-							<Switch checked={isLive} onCheckedChange={() => {}} disabled />
+							<SwitchIndicator checked={isLive} />
 						</div>
 					</TooltipTrigger>
 					<TooltipContent>Live story</TooltipContent>
@@ -341,7 +341,7 @@ function LiveStoryControls({ live }: { live: LiveControls }) {
 					>
 						<Activity className='size-3.5 text-foreground' strokeWidth={2.25} />
 						<span className='text-xs font-medium'>Live story</span>
-						<Switch checked={isLive} className='pointer-events-none' />
+						<SwitchIndicator checked={isLive} />
 					</button>
 				</TooltipTrigger>
 				<TooltipContent>{isLive ? 'Live story settings' : 'Enable live mode'}</TooltipContent>

--- a/apps/frontend/src/components/ui/switch.tsx
+++ b/apps/frontend/src/components/ui/switch.tsx
@@ -3,12 +3,13 @@ import { cn } from '@/lib/utils';
 
 interface SwitchProps {
 	checked: boolean;
-	onCheckedChange: (checked: boolean) => void;
+	onCheckedChange?: (checked: boolean) => void;
 	disabled?: boolean;
 	id?: string;
+	className?: string;
 }
 
-export function Switch({ checked, onCheckedChange, disabled, id }: SwitchProps) {
+export function Switch({ checked, onCheckedChange, disabled, id, className }: SwitchProps) {
 	return (
 		<button
 			id={id}
@@ -16,12 +17,13 @@ export function Switch({ checked, onCheckedChange, disabled, id }: SwitchProps) 
 			role='switch'
 			aria-checked={checked}
 			disabled={disabled}
-			onClick={() => onCheckedChange(!checked)}
+			onClick={() => onCheckedChange?.(!checked)}
 			className={cn(
 				'relative inline-flex h-5 w-8 shrink-0 cursor-pointer items-center rounded-full px-0.5 bg-muted',
 				'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
 				'shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]',
 				'disabled:cursor-not-allowed disabled:opacity-50',
+				className,
 			)}
 		>
 			<span

--- a/apps/frontend/src/components/ui/switch.tsx
+++ b/apps/frontend/src/components/ui/switch.tsx
@@ -1,6 +1,29 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
+const trackClassName =
+	'relative inline-flex h-5 w-8 shrink-0 items-center rounded-full px-0.5 bg-muted shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]';
+
+function SwitchThumb({ checked }: { checked: boolean }) {
+	return (
+		<>
+			<span
+				aria-hidden='true'
+				className={cn(
+					'pointer-events-none absolute inset-0 rounded-full bg-brand-gradient transition-opacity',
+					checked ? 'opacity-100' : 'opacity-0',
+				)}
+			/>
+			<span
+				className={cn(
+					'pointer-events-none relative block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
+					checked ? 'translate-x-3' : 'translate-x-0',
+				)}
+			/>
+		</>
+	);
+}
+
 interface SwitchProps {
 	checked: boolean;
 	onCheckedChange?: (checked: boolean) => void;
@@ -19,26 +42,22 @@ export function Switch({ checked, onCheckedChange, disabled, id, className }: Sw
 			disabled={disabled}
 			onClick={() => onCheckedChange?.(!checked)}
 			className={cn(
-				'relative inline-flex h-5 w-8 shrink-0 cursor-pointer items-center rounded-full px-0.5 bg-muted',
+				trackClassName,
+				'cursor-pointer',
 				'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-				'shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.07)]',
 				'disabled:cursor-not-allowed disabled:opacity-50',
 				className,
 			)}
 		>
-			<span
-				aria-hidden='true'
-				className={cn(
-					'pointer-events-none absolute inset-0 rounded-full bg-brand-gradient transition-opacity',
-					checked ? 'opacity-100' : 'opacity-0',
-				)}
-			/>
-			<span
-				className={cn(
-					'pointer-events-none relative block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform',
-					checked ? 'translate-x-3' : 'translate-x-0',
-				)}
-			/>
+			<SwitchThumb checked={checked} />
 		</button>
+	);
+}
+
+export function SwitchIndicator({ checked, className }: { checked: boolean; className?: string }) {
+	return (
+		<span aria-hidden='true' className={cn(trackClassName, className)}>
+			<SwitchThumb checked={checked} />
+		</span>
 	);
 }


### PR DESCRIPTION
## Summary

- Move 'Create folder' action to the top of the stories list view

<img width="1224" height="303" alt="image" src="https://github.com/user-attachments/assets/3e9b063c-95ec-480f-b5a7-5307553a4d0a" />

- Improved live settings button on header stories

<img width="815" height="80" alt="image" src="https://github.com/user-attachments/assets/6d3b4ed7-8113-4c58-a90a-4591f44ab6fa" />
<img width="199" height="66" alt="image" src="https://github.com/user-attachments/assets/1a3048aa-03bb-42f1-99a0-37ed56f42ff8" />

## Related issue

#1123 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

