### PR TITLE
[fix: selector story] remove the selector story from home page

### DIFF
--- a/apps/frontend/src/components/stories-groups.tsx
+++ b/apps/frontend/src/components/stories-groups.tsx
@@ -1,7 +1,7 @@
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useRouterState } from '@tanstack/react-router';
 import { ArchiveIcon, ArchiveRestoreIcon, Circle, CircleCheck, FolderInput, Pin, Star } from 'lucide-react';
 import { useState } from 'react';
 import type { MouseEvent, ReactNode } from 'react';
@@ -72,6 +72,7 @@ export function StoryCard({
 }) {
 	const { isAdmin, isViewer } = usePermissions();
 	const [pinShareDialogOpen, setPinShareDialogOpen] = useState(false);
+	const isHomePage = useRouterState({ select: (s) => s.location.pathname === '/' });
 
 	const draggableId = `drag-story-${dragIdPrefix ? `${dragIdPrefix}-` : ''}${item.storyId}`;
 	const isOwnedByUser = item.kind === 'own' || item.kind === 'own-standalone';
@@ -89,6 +90,7 @@ export function StoryCard({
 
 	const canSelect =
 		!isViewer &&
+		!isHomePage &&
 		((item.kind === 'own' && !!item.chatId && !!item.storySlug) ||
 			item.kind === 'own-standalone' ||
 			item.kind === 'shared-project');


### PR DESCRIPTION
## Before

Selector of stories was render and not clickable

<img width="370" height="282" alt="image" src="https://github.com/user-attachments/assets/16346436-5178-4b12-9146-1230eed5539b" />

## After

No more selector of stories from home page

<img width="359" height="292" alt="image" src="https://github.com/user-attachments/assets/92e61eb9-2b2f-4aa3-b8c7-8f5170c1cbda" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

