### PR TITLE
[feat: sort table component] add sortable columns to table component

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -1,7 +1,9 @@
 import { computeColumnRange, isConditionalFormatRule, resolveCellBackground } from '@nao/shared/conditional-formatting';
-import { formatCellValue, formatColumnLabel, isNumericColumn } from '@nao/shared/story-table-utils';
+import { formatCellValue, formatColumnLabel, isNumericColumn, sortTableRows } from '@nao/shared/story-table-utils';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import type { ColumnConditionalFormats, ColumnRange, ConditionalFormatRule } from '@nao/shared/conditional-formatting';
+import type { SortDirection } from '@nao/shared/story-table-utils';
 import { TablePagination } from '@/components/ui/table-pagination';
 import { useDateFormat } from '@/hooks/use-date-format';
 import { TablePaginationCompact } from '@/components/ui/table-pagination-compact';
@@ -49,14 +51,30 @@ export function TableDisplay({
 
 	const [pageIndex, setPageIndex] = useState(0);
 	const [pageSize, setPageSize] = useState(maxRowsBeforePagination);
+	const [sort, setSort] = useState<{ column: string; direction: SortDirection } | null>(null);
 
 	useEffect(() => setPageIndex(0), [data]);
 
-	const pageCount = Math.ceil(data.length / pageSize);
+	const sortedData = useMemo(() => (sort ? sortTableRows(data, sort.column, sort.direction) : data), [data, sort]);
+
+	const pageCount = Math.ceil(sortedData.length / pageSize);
 	const pageData = useMemo(
-		() => (showPagination ? data.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize) : data),
-		[data, pageIndex, pageSize, showPagination],
+		() => (showPagination ? sortedData.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize) : sortedData),
+		[sortedData, pageIndex, pageSize, showPagination],
 	);
+
+	function toggleSort(column: string) {
+		setPageIndex(0);
+		setSort((current) => {
+			if (!current || current.column !== column) {
+				return { column, direction: 'asc' };
+			}
+			if (current.direction === 'asc') {
+				return { column, direction: 'desc' };
+			}
+			return null;
+		});
+	}
 
 	return (
 		<div className={cn('flex min-h-0 flex-col', className)}>
@@ -67,17 +85,37 @@ export function TableDisplay({
 					<thead className='sticky top-0 z-10 border-b bg-panel'>
 						<tr>
 							<th className='shadow-[inset_-1px_0_0_0_var(--border)] last:shadow-none px-3 py-2 text-center font-medium whitespace-nowrap text-foreground w-4' />
-							{resolvedColumns.map((column) => (
-								<th
-									key={column}
-									className={cn(
-										'shadow-[inset_-1px_0_0_0_var(--border)] last:shadow-none px-3 py-2 text-left font-medium whitespace-nowrap text-foreground',
-										numericColumns.has(column) && 'text-right tabular-nums',
-									)}
-								>
-									{humanizeColumnLabels ? formatColumnLabel(column) : column}
-								</th>
-							))}
+							{resolvedColumns.map((column) => {
+								const alignRight = numericColumns.has(column);
+								const sortDirection = sort?.column === column ? sort.direction : null;
+								return (
+									<th
+										key={column}
+										aria-sort={
+											sortDirection
+												? sortDirection === 'asc'
+													? 'ascending'
+													: 'descending'
+												: 'none'
+										}
+										className={cn(
+											'shadow-[inset_-1px_0_0_0_var(--border)] last:shadow-none px-3 py-2 font-medium whitespace-nowrap text-foreground',
+											alignRight && 'text-right tabular-nums',
+										)}
+									>
+										<button
+											type='button'
+											onClick={() => toggleSort(column)}
+											className='group flex w-full items-center justify-between gap-3'
+										>
+											<span className={cn(alignRight && 'ml-auto')}>
+												{humanizeColumnLabels ? formatColumnLabel(column) : column}
+											</span>
+											<SortIndicator direction={sortDirection} />
+										</button>
+									</th>
+								);
+							})}
 						</tr>
 					</thead>
 
@@ -168,6 +206,17 @@ export function TableDisplay({
 				</div>
 			) : null}
 		</div>
+	);
+}
+
+function SortIndicator({ direction }: { direction: SortDirection | null }) {
+	return (
+		<span className='inline-flex shrink-0 flex-col -space-y-1'>
+			<ChevronUp className={cn('size-3', direction === 'asc' ? 'text-foreground' : 'text-muted-foreground/50')} />
+			<ChevronDown
+				className={cn('size-3', direction === 'desc' ? 'text-foreground' : 'text-muted-foreground/50')}
+			/>
+		</span>
 	);
 }
 

--- a/apps/shared/src/story-table-utils.ts
+++ b/apps/shared/src/story-table-utils.ts
@@ -26,6 +26,48 @@ export function formatCellValue(value: unknown, dateFormat?: DateFormatSettings 
 	return String(value);
 }
 
+export type SortDirection = 'asc' | 'desc';
+
+export function sortTableRows<Row extends Record<string, unknown>>(
+	rows: Row[],
+	column: string,
+	direction: SortDirection,
+): Row[] {
+	const factor = direction === 'asc' ? 1 : -1;
+	return [...rows].sort((a, b) => {
+		const left = a[column];
+		const right = b[column];
+		const leftIsNull = left === null || left === undefined;
+		const rightIsNull = right === null || right === undefined;
+		if (leftIsNull && rightIsNull) {
+			return 0;
+		}
+		if (leftIsNull) {
+			return 1;
+		}
+		if (rightIsNull) {
+			return -1;
+		}
+		return factor * compareCellValues(left, right);
+	});
+}
+
+function compareCellValues(left: unknown, right: unknown): number {
+	if (typeof left === 'number' && typeof right === 'number') {
+		return left - right;
+	}
+	if (typeof left === 'boolean' && typeof right === 'boolean') {
+		return left === right ? 0 : left ? 1 : -1;
+	}
+	if (typeof left === 'string' && typeof right === 'string') {
+		if (isIsoDateLike(left) && isIsoDateLike(right)) {
+			return new Date(left).getTime() - new Date(right).getTime();
+		}
+		return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+	}
+	return String(left).localeCompare(String(right), undefined, { numeric: true, sensitivity: 'base' });
+}
+
 export function formatColumnLabel(column: string): string {
 	return column
 		.replace(/_/g, ' ')

--- a/apps/shared/src/story-table-utils.ts
+++ b/apps/shared/src/story-table-utils.ts
@@ -52,20 +52,42 @@ export function sortTableRows<Row extends Record<string, unknown>>(
 	});
 }
 
+const enum ValueRank {
+	Number = 0,
+	Boolean = 1,
+	Date = 2,
+	Text = 3,
+}
+
 function compareCellValues(left: unknown, right: unknown): number {
-	if (typeof left === 'number' && typeof right === 'number') {
-		return left - right;
+	const leftRank = valueRank(left);
+	const rightRank = valueRank(right);
+	if (leftRank !== rightRank) {
+		return leftRank - rightRank;
 	}
-	if (typeof left === 'boolean' && typeof right === 'boolean') {
-		return left === right ? 0 : left ? 1 : -1;
+	switch (leftRank) {
+		case ValueRank.Number:
+			return (left as number) - (right as number);
+		case ValueRank.Boolean:
+			return left === right ? 0 : left ? 1 : -1;
+		case ValueRank.Date:
+			return new Date(left as string).getTime() - new Date(right as string).getTime();
+		default:
+			return String(left).localeCompare(String(right), undefined, { numeric: true, sensitivity: 'base' });
 	}
-	if (typeof left === 'string' && typeof right === 'string') {
-		if (isIsoDateLike(left) && isIsoDateLike(right)) {
-			return new Date(left).getTime() - new Date(right).getTime();
-		}
-		return left.localeCompare(right, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function valueRank(value: unknown): ValueRank {
+	if (typeof value === 'number') {
+		return ValueRank.Number;
 	}
-	return String(left).localeCompare(String(right), undefined, { numeric: true, sensitivity: 'base' });
+	if (typeof value === 'boolean') {
+		return ValueRank.Boolean;
+	}
+	if (typeof value === 'string' && isIsoDateLike(value)) {
+		return ValueRank.Date;
+	}
+	return ValueRank.Text;
 }
 
 export function formatColumnLabel(column: string): string {


### PR DESCRIPTION
## Summary

Add chevron on the right side of column name in each table component (`execute_sql` tool, ui component form chat OR story) => `1st click = sort asc`, `2nd = sort desc`, `3rd = none`, etc

<img width="1473" height="659" alt="image" src="https://github.com/user-attachments/assets/7405835f-4eb8-4a94-b577-b6dd6cd2c05f" />

## Related issue

#717 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

