### PR TITLE
fix: lock admin mode per chat

### DIFF
--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useRef, useCallback, useId } from 'react';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
 import { Plus, PencilRuler, Database, Image as ImageIcon, AlertTriangle, Shield, Check } from 'lucide-react';
 import { Button, ChatButton, MicButton } from './ui/button';
@@ -104,11 +104,24 @@ function ChatInputBase({
 		submitQueuedMessageNow,
 		error,
 		selectedModel,
+		messages,
 	} = useAgentContext();
+	const navigate = useNavigate();
 	const { isAdmin } = usePermissions();
 	const chatId = useChatId();
 
 	const isAdminMode = isAdmin && adminMode;
+	const adminModeLocked = messages.some((message) => message.role === 'user');
+	const handleSelectAdminMode = useCallback(() => {
+		if (!adminModeLocked) {
+			setAdminMode(!isAdminMode);
+			return;
+		}
+		if (isAdminMode) {
+			return;
+		}
+		navigate({ to: '/', search: { admin: true } });
+	}, [adminModeLocked, isAdminMode, setAdminMode, navigate]);
 	const imageUpload = useImageUpload();
 	const effectivePlaceholder = isRunning && allowQueueing ? 'Add a follow-up...' : placeholder;
 
@@ -349,7 +362,8 @@ function ChatInputBase({
 								hasSkills={hasSkills}
 								isAdmin={isAdmin}
 								isAdminMode={isAdminMode}
-								onToggleAdminMode={() => setAdminMode(!isAdminMode)}
+								adminModeLocked={adminModeLocked}
+								onSelectAdminMode={handleSelectAdminMode}
 								onAddImage={imageUpload.openFilePicker}
 								onAddStory={() => {
 									promptRef.current?.appendMention(
@@ -551,7 +565,8 @@ function ChatInputPlusMenu({
 	hasSkills,
 	isAdmin,
 	isAdminMode,
-	onToggleAdminMode,
+	adminModeLocked,
+	onSelectAdminMode,
 	onAddImage,
 	onAddStory,
 	onOpenSkills,
@@ -562,7 +577,8 @@ function ChatInputPlusMenu({
 	hasSkills: boolean;
 	isAdmin: boolean;
 	isAdminMode: boolean;
-	onToggleAdminMode: () => void;
+	adminModeLocked: boolean;
+	onSelectAdminMode: () => void;
 	onAddImage: () => void;
 	onAddStory: () => void;
 	onOpenSkills: () => void;
@@ -613,7 +629,11 @@ function ChatInputPlusMenu({
 				{isAdmin && (
 					<>
 						<DropdownMenuSeparator />
-						<DropdownMenuItem onSelect={onToggleAdminMode}>
+						<DropdownMenuItem
+							onSelect={onSelectAdminMode}
+							disabled={adminModeLocked && isAdminMode}
+							title={adminModeLocked && !isAdminMode ? 'Start a new chat in admin mode' : undefined}
+						>
 							<Shield className='size-4' />
 							<span>Admin mode</span>
 							{isAdminMode && <Check className='size-4 ml-auto' />}


### PR DESCRIPTION
## Summary
A chat is locked to the mode it started in, so admin/normal can't be switched mid-conversation. The "Admin mode" menu item now adapts once the chat has its first message:

- Admin chat: the item is disabled/grayed (still checked) — can't be turned off.
- Normal chat: the item stays clickable, but clicking it opens a new chat already in admin mode instead of switching the current one. The current chat stays saved and unchanged.
- New/empty chat: toggles freely as before.

This PR is frontend-only

Closes #1145

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

