### PR TITLE
fix: The add to story button now support tabs

### DIFF
--- a/apps/frontend/src/components/settings/chats-replay-panel.tsx
+++ b/apps/frontend/src/components/settings/chats-replay-panel.tsx
@@ -116,6 +116,8 @@ export function ChatsReplayPanel({ chatInfo, onClose }: ChatsReplayPanelProps) {
 								<SidePanelProvider
 									isVisible={sidePanel.isVisible}
 									currentStorySlug={sidePanel.currentStorySlug}
+									currentStoryTabIndex={sidePanel.currentStoryTabIndex}
+									setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 									chatId={chatInfo?.chatId}
 									isReadonlyMode={!isOwner}
 									open={sidePanel.open}

--- a/apps/frontend/src/components/settings/chats-replay-panel.tsx
+++ b/apps/frontend/src/components/settings/chats-replay-panel.tsx
@@ -116,6 +116,7 @@ export function ChatsReplayPanel({ chatInfo, onClose }: ChatsReplayPanelProps) {
 								<SidePanelProvider
 									isVisible={sidePanel.isVisible}
 									currentStorySlug={sidePanel.currentStorySlug}
+									setCurrentStorySlug={sidePanel.setCurrentStorySlug}
 									currentStoryTabIndex={sidePanel.currentStoryTabIndex}
 									setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 									chatId={chatInfo?.chatId}

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -38,18 +38,25 @@ interface StoryViewerProps {
 	chatId: string;
 	storySlug: string;
 	isReadonlyMode?: boolean;
+	initialTabIndex?: number;
 }
 
-export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp }: StoryViewerProps) {
+export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, initialTabIndex }: StoryViewerProps) {
 	const tiptapEditorRef = useRef<TiptapEditor | null>(null);
 	const codeViewRef = useRef<StoryCodeViewHandle | null>(null);
 	const tabbedEditCodeRef = useRef<(() => string) | null>(null);
 	const getEditModeCode = useCallback(() => tabbedEditCodeRef.current?.() ?? null, []);
 	const [isCodeDirty, setIsCodeDirty] = useState(false);
 	const [isCodeValid, setIsCodeValid] = useState(true);
-	const [activeTabIndex, setActiveTabIndex] = useState(0);
+	const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex ?? 0);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-	const { close: closeSidePanel, isReadonlyMode: contextReadonlyMode, shareId, shareType } = useSidePanel();
+	const {
+		close: closeSidePanel,
+		isReadonlyMode: contextReadonlyMode,
+		shareId,
+		shareType,
+		setCurrentStoryTabIndex,
+	} = useSidePanel();
 	const isReadonlyMode = readonlyProp ?? contextReadonlyMode;
 	const { viewMode, setViewMode } = useStoryViewerViewMode();
 
@@ -73,6 +80,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp }:
 		isChatAgentRunning,
 	);
 	const resolvedStorySlug = draftStory?.id ?? storySlug;
+	const prevSlugRef = useRef(resolvedStorySlug);
 	const {
 		versions,
 		storyId,
@@ -160,8 +168,15 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp }:
 	}, [viewMode]);
 
 	useEffect(() => {
-		setActiveTabIndex(0);
+		if (prevSlugRef.current !== resolvedStorySlug) {
+			prevSlugRef.current = resolvedStorySlug;
+			setActiveTabIndex(0);
+		}
 	}, [resolvedStorySlug]);
+
+	useEffect(() => {
+		setCurrentStoryTabIndex(activeTab);
+	}, [activeTab, setCurrentStoryTabIndex]);
 
 	useStoryViewerStreamScroll({
 		scrollContainerRef,

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -55,6 +55,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		isReadonlyMode: contextReadonlyMode,
 		shareId,
 		shareType,
+		setCurrentStorySlug,
 		setCurrentStoryTabIndex,
 	} = useSidePanel();
 	const isReadonlyMode = readonlyProp ?? contextReadonlyMode;
@@ -173,6 +174,10 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 			setActiveTabIndex(0);
 		}
 	}, [resolvedStorySlug]);
+
+	useEffect(() => {
+		setCurrentStorySlug(resolvedStorySlug);
+	}, [resolvedStorySlug, setCurrentStorySlug]);
 
 	useEffect(() => {
 		setCurrentStoryTabIndex(activeTab);

--- a/apps/frontend/src/components/tool-calls/display-chart-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-table.tsx
@@ -116,13 +116,8 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		const visibleStoryId =
-			isVisible && currentStorySlug
-				? (storyIds.find((storyId) => storyId === currentStorySlug) ??
-					storyIds.find((storyId) => storyId.startsWith(currentStorySlug)))
-				: undefined;
-		const usingVisibleStory = Boolean(visibleStoryId);
-		const targetId = visibleStoryId ?? latestStoryId;
+		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
+		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
 		if (!targetId || !chatId) {
 			return;
 		}

--- a/apps/frontend/src/components/tool-calls/display-chart-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-table.tsx
@@ -1,5 +1,6 @@
 import { sanitizeConditionalFormats } from '@nao/shared/conditional-formatting';
 import { buildStoryTableBlock } from '@nao/shared';
+import { appendBlockToStoryCode } from '@nao/shared/story-tabs';
 import { useMemo, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FilePlus, Pencil } from 'lucide-react';
@@ -30,7 +31,7 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 	const messages = agent?.messages ?? EMPTY_MESSAGES;
 	const chatId = useChatId();
 	const queryClient = useQueryClient();
-	const { open: openSidePanel, currentStorySlug, isVisible } = useSidePanel();
+	const { open: openSidePanel, currentStorySlug, currentStoryTabIndex, isVisible } = useSidePanel();
 	const [isEditOpen, setIsEditOpen] = useState(false);
 
 	const storyIds = useMemo(() => findStoryIds(messages), [messages]);
@@ -115,8 +116,8 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		const targetId =
-			isVisible && currentStorySlug && storyIds.includes(currentStorySlug) ? currentStorySlug : latestStoryId;
+		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
+		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
 		if (!targetId || !chatId) {
 			return;
 		}
@@ -131,7 +132,10 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 		}
 
 		const tableBlock = buildStoryTableBlock(config);
-		const newCode = latest.code.trimEnd() + '\n\n' + tableBlock;
+		const { code: newCode, tabIndex: openTabIndex } = appendBlockToStoryCode(latest.code, tableBlock, {
+			usingVisibleStory,
+			activeTabIndex: currentStoryTabIndex,
+		});
 
 		await addToStoryMutation.mutateAsync({
 			chatId,
@@ -142,7 +146,10 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 		});
 
 		if (!isVisible) {
-			openSidePanel(<StoryViewer chatId={chatId} storySlug={targetId} />, targetId);
+			openSidePanel(
+				<StoryViewer chatId={chatId} storySlug={targetId} initialTabIndex={openTabIndex} />,
+				targetId,
+			);
 		}
 	};
 

--- a/apps/frontend/src/components/tool-calls/display-chart-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-table.tsx
@@ -116,8 +116,13 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
-		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
+		const visibleStoryId =
+			isVisible && currentStorySlug
+				? (storyIds.find((storyId) => storyId === currentStorySlug) ??
+					storyIds.find((storyId) => storyId.startsWith(currentStorySlug)))
+				: undefined;
+		const usingVisibleStory = Boolean(visibleStoryId);
+		const targetId = visibleStoryId ?? latestStoryId;
 		if (!targetId || !chatId) {
 			return;
 		}
@@ -145,7 +150,7 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 			action: 'update',
 		});
 
-		if (!isVisible) {
+		if (!usingVisibleStory) {
 			openSidePanel(
 				<StoryViewer chatId={chatId} storySlug={targetId} initialTabIndex={openTabIndex} />,
 				targetId,

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -194,8 +194,13 @@ export const DisplayChartToolCall = ({
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
-		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
+		const visibleStoryId =
+			isVisible && currentStorySlug
+				? (storyIds.find((storyId) => storyId === currentStorySlug) ??
+					storyIds.find((storyId) => storyId.startsWith(currentStorySlug)))
+				: undefined;
+		const usingVisibleStory = Boolean(visibleStoryId);
+		const targetId = visibleStoryId ?? latestStoryId;
 		if (!targetId || !chartConfig || !chatId) {
 			return;
 		}
@@ -223,7 +228,7 @@ export const DisplayChartToolCall = ({
 			action: 'update',
 		});
 
-		if (!isVisible) {
+		if (!usingVisibleStory) {
 			openSidePanel(
 				<StoryViewer chatId={chatId} storySlug={targetId} initialTabIndex={openTabIndex} />,
 				targetId,

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -1,4 +1,5 @@
 import { buildChart, bucketPieData, buildStoryChartBlock, labelize } from '@nao/shared';
+import { appendBlockToStoryCode } from '@nao/shared/story-tabs';
 import { displayChart } from '@nao/shared/tools';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChartNoAxesColumn, Code, Download, FilePlus, Pencil, Table as TableIcon } from 'lucide-react';
@@ -50,7 +51,7 @@ export const DisplayChartToolCall = ({
 	const messages = agent?.messages ?? EMPTY_MESSAGES;
 	const chatId = useChatId();
 	const queryClient = useQueryClient();
-	const { open: openSidePanel, currentStorySlug, isVisible } = useSidePanel();
+	const { open: openSidePanel, currentStorySlug, currentStoryTabIndex, isVisible } = useSidePanel();
 	const config = state !== 'input-streaming' ? input : undefined;
 	const chartConfig = config?.chart_type === 'table' ? undefined : config;
 	const tableConfig = config?.chart_type === 'table' ? config : undefined;
@@ -193,13 +194,8 @@ export const DisplayChartToolCall = ({
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		// Prefer the currently-visible story slug, but only if it's a real story
-		// from this chat — the side panel's currentStorySlug can lag behind (e.g.
-		// it was set from a partial streamed slug during the story tool's
-		// input-streaming phase) and would otherwise point to a non-existent
-		// story.
-		const targetId =
-			isVisible && currentStorySlug && storyIds.includes(currentStorySlug) ? currentStorySlug : latestStoryId;
+		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
+		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
 		if (!targetId || !chartConfig || !chatId) {
 			return;
 		}
@@ -214,7 +210,10 @@ export const DisplayChartToolCall = ({
 		}
 
 		const chartBlock = buildStoryChartBlock(chartConfig);
-		const newCode = latest.code.trimEnd() + '\n\n' + chartBlock;
+		const { code: newCode, tabIndex: openTabIndex } = appendBlockToStoryCode(latest.code, chartBlock, {
+			usingVisibleStory,
+			activeTabIndex: currentStoryTabIndex,
+		});
 
 		addToStoryMutation.mutate({
 			chatId,
@@ -225,7 +224,10 @@ export const DisplayChartToolCall = ({
 		});
 
 		if (!isVisible) {
-			openSidePanel(<StoryViewer chatId={chatId} storySlug={targetId} />, targetId);
+			openSidePanel(
+				<StoryViewer chatId={chatId} storySlug={targetId} initialTabIndex={openTabIndex} />,
+				targetId,
+			);
 		}
 	};
 

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -194,13 +194,8 @@ export const DisplayChartToolCall = ({
 
 	const handleAddToStory = async () => {
 		const latestStoryId = storyIds[storyIds.length - 1];
-		const visibleStoryId =
-			isVisible && currentStorySlug
-				? (storyIds.find((storyId) => storyId === currentStorySlug) ??
-					storyIds.find((storyId) => storyId.startsWith(currentStorySlug)))
-				: undefined;
-		const usingVisibleStory = Boolean(visibleStoryId);
-		const targetId = visibleStoryId ?? latestStoryId;
+		const usingVisibleStory = Boolean(isVisible && currentStorySlug && storyIds.includes(currentStorySlug));
+		const targetId = usingVisibleStory ? currentStorySlug! : latestStoryId;
 		if (!targetId || !chartConfig || !chatId) {
 			return;
 		}

--- a/apps/frontend/src/contexts/side-panel.tsx
+++ b/apps/frontend/src/contexts/side-panel.tsx
@@ -5,6 +5,7 @@ type ShareType = 'chat' | 'story';
 interface SidePanelContext {
 	isVisible: boolean;
 	currentStorySlug: string | null;
+	setCurrentStorySlug: (slug: string | null) => void;
 	currentStoryTabIndex: number;
 	setCurrentStoryTabIndex: (index: number) => void;
 	chatId: string | null;
@@ -20,6 +21,7 @@ const SidePanelContext = createContext<SidePanelContext | null>(null);
 const noopSidePanel: SidePanelContext = {
 	isVisible: false,
 	currentStorySlug: null,
+	setCurrentStorySlug: () => {},
 	currentStoryTabIndex: 0,
 	setCurrentStoryTabIndex: () => {},
 	chatId: null,
@@ -38,6 +40,7 @@ export const SidePanelProvider = ({
 	children,
 	isVisible,
 	currentStorySlug,
+	setCurrentStorySlug,
 	currentStoryTabIndex,
 	setCurrentStoryTabIndex,
 	chatId,
@@ -50,6 +53,7 @@ export const SidePanelProvider = ({
 	children: React.ReactNode;
 	isVisible: boolean;
 	currentStorySlug: string | null;
+	setCurrentStorySlug: (slug: string | null) => void;
 	currentStoryTabIndex: number;
 	setCurrentStoryTabIndex: (index: number) => void;
 	chatId: string | null;
@@ -63,6 +67,7 @@ export const SidePanelProvider = ({
 		() => ({
 			isVisible,
 			currentStorySlug,
+			setCurrentStorySlug,
 			currentStoryTabIndex,
 			setCurrentStoryTabIndex,
 			chatId,
@@ -75,6 +80,7 @@ export const SidePanelProvider = ({
 		[
 			isVisible,
 			currentStorySlug,
+			setCurrentStorySlug,
 			currentStoryTabIndex,
 			setCurrentStoryTabIndex,
 			chatId,

--- a/apps/frontend/src/contexts/side-panel.tsx
+++ b/apps/frontend/src/contexts/side-panel.tsx
@@ -5,6 +5,8 @@ type ShareType = 'chat' | 'story';
 interface SidePanelContext {
 	isVisible: boolean;
 	currentStorySlug: string | null;
+	currentStoryTabIndex: number;
+	setCurrentStoryTabIndex: (index: number) => void;
 	chatId: string | null;
 	shareId: string | null;
 	shareType: ShareType | null;
@@ -18,6 +20,8 @@ const SidePanelContext = createContext<SidePanelContext | null>(null);
 const noopSidePanel: SidePanelContext = {
 	isVisible: false,
 	currentStorySlug: null,
+	currentStoryTabIndex: 0,
+	setCurrentStoryTabIndex: () => {},
 	chatId: null,
 	shareId: null,
 	shareType: null,
@@ -34,6 +38,8 @@ export const SidePanelProvider = ({
 	children,
 	isVisible,
 	currentStorySlug,
+	currentStoryTabIndex,
+	setCurrentStoryTabIndex,
 	chatId,
 	shareId = null,
 	shareType = null,
@@ -44,6 +50,8 @@ export const SidePanelProvider = ({
 	children: React.ReactNode;
 	isVisible: boolean;
 	currentStorySlug: string | null;
+	currentStoryTabIndex: number;
+	setCurrentStoryTabIndex: (index: number) => void;
 	chatId: string | null;
 	shareId?: string | null;
 	shareType?: ShareType | null;
@@ -52,8 +60,30 @@ export const SidePanelProvider = ({
 	close: () => void;
 }) => {
 	const value = useMemo(
-		() => ({ isVisible, currentStorySlug, chatId, shareId, shareType, isReadonlyMode, open, close }),
-		[isVisible, currentStorySlug, chatId, shareId, shareType, isReadonlyMode, open, close],
+		() => ({
+			isVisible,
+			currentStorySlug,
+			currentStoryTabIndex,
+			setCurrentStoryTabIndex,
+			chatId,
+			shareId,
+			shareType,
+			isReadonlyMode,
+			open,
+			close,
+		}),
+		[
+			isVisible,
+			currentStorySlug,
+			currentStoryTabIndex,
+			setCurrentStoryTabIndex,
+			chatId,
+			shareId,
+			shareType,
+			isReadonlyMode,
+			open,
+			close,
+		],
 	);
 	return <SidePanelContext.Provider value={value}>{children}</SidePanelContext.Provider>;
 };

--- a/apps/frontend/src/hooks/use-side-panel.ts
+++ b/apps/frontend/src/hooks/use-side-panel.ts
@@ -26,6 +26,7 @@ export const useSidePanel = ({
 
 	const [content, setContent] = useState<React.ReactNode>(null);
 	const [currentStorySlug, setCurrentStorySlug] = useState<string | null>(null);
+	const [currentStoryTabIndex, setCurrentStoryTabIndex] = useState(0);
 
 	const [isVisible, setIsVisible] = useState(false);
 	const [isAnimating, setIsAnimating] = useState(false);
@@ -114,6 +115,7 @@ export const useSidePanel = ({
 			setIsVisible(true);
 			setContent(newContent);
 			setCurrentStorySlug(storySlug ?? null);
+			setCurrentStoryTabIndex(0);
 			if (!isMobile && shouldCollapseSidebar) {
 				didCollapseSidebarRef.current = !isSidebarCollapsed;
 				collapseSidebar({ persist: false });
@@ -132,6 +134,7 @@ export const useSidePanel = ({
 	const close = useCallback(() => {
 		setIsVisible(false);
 		setCurrentStorySlug(null);
+		setCurrentStoryTabIndex(0);
 		if (isMobile) {
 			setContent(null);
 		} else {
@@ -149,6 +152,7 @@ export const useSidePanel = ({
 		setIsVisible(false);
 		setContent(null);
 		setCurrentStorySlug(null);
+		setCurrentStoryTabIndex(0);
 	}, [routeKey, expandSidebarIfWasCollapsed]);
 
 	return {
@@ -157,6 +161,8 @@ export const useSidePanel = ({
 		isAnimating,
 		content,
 		currentStorySlug,
+		currentStoryTabIndex,
+		setCurrentStoryTabIndex,
 		open,
 		close,
 	};

--- a/apps/frontend/src/hooks/use-side-panel.ts
+++ b/apps/frontend/src/hooks/use-side-panel.ts
@@ -161,6 +161,7 @@ export const useSidePanel = ({
 		isAnimating,
 		content,
 		currentStorySlug,
+		setCurrentStorySlug,
 		currentStoryTabIndex,
 		setCurrentStoryTabIndex,
 		open,

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -133,6 +133,8 @@ function ChatPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
+			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={chatId}
 			open={sidePanel.open}
 			close={sidePanel.close}

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -133,6 +133,7 @@ function ChatPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			setCurrentStorySlug={sidePanel.setCurrentStorySlug}
 			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
 			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={chatId}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
@@ -241,6 +241,7 @@ function RecommendationsPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			setCurrentStorySlug={sidePanel.setCurrentStorySlug}
 			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
 			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={null}

--- a/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.recommendations.tsx
@@ -241,6 +241,8 @@ function RecommendationsPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
+			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={null}
 			open={sidePanel.open}
 			close={sidePanel.close}

--- a/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
@@ -69,6 +69,7 @@ function SharedChatPage() {
 			<SidePanelProvider
 				isVisible={sidePanel.isVisible}
 				currentStorySlug={sidePanel.currentStorySlug}
+				setCurrentStorySlug={sidePanel.setCurrentStorySlug}
 				currentStoryTabIndex={sidePanel.currentStoryTabIndex}
 				setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 				chatId={share.chatId}

--- a/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.shared-chat.$shareId.tsx
@@ -69,6 +69,8 @@ function SharedChatPage() {
 			<SidePanelProvider
 				isVisible={sidePanel.isVisible}
 				currentStorySlug={sidePanel.currentStorySlug}
+				currentStoryTabIndex={sidePanel.currentStoryTabIndex}
+				setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 				chatId={share.chatId}
 				shareId={shareId}
 				shareType='chat'

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -144,6 +144,7 @@ function SharedStoryPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			setCurrentStorySlug={sidePanel.setCurrentStorySlug}
 			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
 			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={story.chatId}

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -144,6 +144,8 @@ function SharedStoryPage() {
 		<SidePanelProvider
 			isVisible={sidePanel.isVisible}
 			currentStorySlug={sidePanel.currentStorySlug}
+			currentStoryTabIndex={sidePanel.currentStoryTabIndex}
+			setCurrentStoryTabIndex={sidePanel.setCurrentStoryTabIndex}
 			chatId={story.chatId}
 			shareId={shareId}
 			shareType='story'

--- a/apps/shared/src/story-tabs.ts
+++ b/apps/shared/src/story-tabs.ts
@@ -18,6 +18,23 @@ export function parseStoryTabs(code: string): StoryTab[] | null {
 	return findStoryTabBlocks(code).map(({ title, innerCode }) => ({ title, innerCode }));
 }
 
+export function appendBlockToStoryCode(
+	code: string,
+	block: string,
+	options: { usingVisibleStory: boolean; activeTabIndex: number },
+): { code: string; tabIndex: number } {
+	const tabs = parseStoryTabs(code);
+	if (!tabs || tabs.length === 0) {
+		return { code: code.trimEnd() + '\n\n' + block, tabIndex: 0 };
+	}
+	const tabIndex = options.usingVisibleStory
+		? Math.min(Math.max(options.activeTabIndex, 0), tabs.length - 1)
+		: tabs.length - 1;
+	const existingInner = tabs[tabIndex].innerCode.trimEnd();
+	const newInner = existingInner ? existingInner + '\n\n' + block : block;
+	return { code: replaceStoryTabInner(code, tabIndex, newInner), tabIndex };
+}
+
 export function flattenStoryTabs(code: string): string {
 	const tabs = parseStoryTabs(code);
 	if (!tabs?.length) {

--- a/apps/shared/tests/story-tabs.test.ts
+++ b/apps/shared/tests/story-tabs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	addStoryTab,
+	appendBlockToStoryCode,
 	deleteStoryTab,
 	flattenStoryTabs,
 	moveStoryTab,
@@ -73,6 +74,74 @@ describe('story tabs', () => {
 		expect(tabs?.[1].innerCode.trim()).toBe(replacement.trim());
 		expect(tabs?.[2].innerCode).toBe(parseStoryTabs(storyCode)?.[2].innerCode);
 		expect(replaced).toContain('<tab title="Details">');
+	});
+
+	describe('appendBlockToStoryCode', () => {
+		const block = '<table query_id="appended" />';
+
+		it('appends to non-tabbed code', () => {
+			const result = appendBlockToStoryCode('# Story\n\nContent', '<chart query_id="q" />', {
+				usingVisibleStory: true,
+				activeTabIndex: 0,
+			});
+
+			expect(result).toEqual({
+				code: '# Story\n\nContent\n\n<chart query_id="q" />',
+				tabIndex: 0,
+			});
+		});
+
+		it('appends to the active visible tab only', () => {
+			const originalTabs = parseStoryTabs(storyCode);
+			const result = appendBlockToStoryCode(storyCode, block, {
+				usingVisibleStory: true,
+				activeTabIndex: 1,
+			});
+			const tabs = parseStoryTabs(result.code);
+
+			expect(result.tabIndex).toBe(1);
+			expect(tabs?.[0].innerCode).toBe(originalTabs?.[0].innerCode);
+			expect(tabs?.[1].innerCode.trim()).toBe(`${originalTabs?.[1].innerCode.trim()}\n\n${block}`);
+			expect(tabs?.[2].innerCode).toBe(originalTabs?.[2].innerCode);
+			expect(validateStoryCode(result.code)).toEqual([]);
+		});
+
+		it('clamps an out-of-range visible tab index to the last tab', () => {
+			const result = appendBlockToStoryCode(storyCode, block, {
+				usingVisibleStory: true,
+				activeTabIndex: 99,
+			});
+			const tabs = parseStoryTabs(result.code);
+
+			expect(result.tabIndex).toBe(2);
+			expect(tabs?.[2].innerCode).toContain(block);
+			expect(validateStoryCode(result.code)).toEqual([]);
+		});
+
+		it('targets the last tab when the story is not visible', () => {
+			const result = appendBlockToStoryCode(storyCode, block, {
+				usingVisibleStory: false,
+				activeTabIndex: 0,
+			});
+			const tabs = parseStoryTabs(result.code);
+
+			expect(result.tabIndex).toBe(2);
+			expect(tabs?.[2].innerCode).toContain(block);
+			expect(validateStoryCode(result.code)).toEqual([]);
+		});
+
+		it('appends to an empty tab without a leading blank line', () => {
+			const emptyTabCode = '<tab title="A">\n\n</tab>';
+			const result = appendBlockToStoryCode(emptyTabCode, block, {
+				usingVisibleStory: true,
+				activeTabIndex: 0,
+			});
+			const tabs = parseStoryTabs(result.code);
+
+			expect(result.tabIndex).toBe(0);
+			expect(tabs?.[0].innerCode.trim()).toBe(block);
+			expect(validateStoryCode(result.code)).toEqual([]);
+		});
 	});
 
 	it('deletes the selected tab', () => {


### PR DESCRIPTION
## Summary
- Fix the "Add to story" button on in-chat charts and tables for tabbed stories. It now adds the chart to the end of the tab you're currently viewing, instead of dropping it after the last tab which wouldn't compile.
- Stories without tabs are unchanged.
- If the story isn't open on screen, the chart goes to the last tab and the story opens on that tab so you see it right away.
- Moved the insertion logic into one shared helper (`appendBlockToStoryCode`) used by both charts and tables, with unit tests for every case.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

