### PR TITLE
fix(sync): guard cleanup_stale_databases against missing output dir

### DIFF
--- a/cli/nao_core/commands/sync/cleanup.py
+++ b/cli/nao_core/commands/sync/cleanup.py
@@ -136,6 +136,8 @@ def cleanup_stale_paths(state: DatabaseSyncState, verbose: bool = False) -> int:
 
 def cleanup_stale_databases(active_databases: List, base_path: Path, verbose: bool = False):
     """Remove databases that are not present in the config file."""
+    if not base_path.exists():
+        return
 
     valid_db_folders_by_type: Dict[str, set] = defaultdict(set)
     db_folders = get_database_folder_names(active_databases)

--- a/cli/tests/nao_core/commands/sync/test_cleanup.py
+++ b/cli/tests/nao_core/commands/sync/test_cleanup.py
@@ -301,6 +301,17 @@ class TestCleanupStaleDatabases:
             "database=analytics",
         ]
 
+    def test_no_cleanup_when_base_path_does_not_exist(self, tmp_path: Path):
+        missing = tmp_path / "databases"
+
+        active_dbs = [
+            DBConfig(type="duckdb", path="/tmp/test.duckdb"),
+        ]
+
+        cleanup_stale_databases(active_dbs, missing)
+
+        assert not missing.exists()
+
 
 class TestCleanupStaleRespositories:
     def test_remove_unused_repos(self, tmp_path: Path):


### PR DESCRIPTION
Fixes #1238

## What
`cleanup_stale_databases` now returns early when its output dir doesn't exist, matching the guard already in `cleanup_stale_repos`.

## Why
First `nao sync` on a fresh project crashed with `FileNotFoundError: 'databases'` — cleanup ran `base_path.iterdir()` before the dir existed, before any DB connection. `cleanup_stale_repos` and `cleanup_stale_paths` already handle the missing-path case; this aligns `cleanup_stale_databases` with them.

## Tests
Added `test_no_cleanup_when_base_path_does_not_exist` (mirrors the existing `test_no_cleanup_when_db_path_does_not_exist`). Fails with `FileNotFoundError` without the fix, passes with it. Existing cleanup tests unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

