### PR TITLE
fix: total no longer shows up when series are unrelated, or can't be summed for any reason

### DIFF
--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -165,6 +165,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 			chartType: chart.chartType,
 			yAxisMin: chart.yAxisMin,
 			yAxisMax: chart.yAxisMax,
+			hideTotal: chart.hideTotal,
 		});
 		return (
 			<div style={{ margin: '16px 0' }}>
@@ -523,7 +524,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 					+'<span class="nao-tooltip-value">'+(isPercent?pctShare(val):formatVal(val))+'</span>'
 					+'</div>';
 			});
-			if(numericValues.length>1 && (isPercent || !hasTotalSeries)){
+			if(numericValues.length>1 && (isPercent || (!hasTotalSeries && !cfg.hideTotal))){
 				var total=numericValues.reduce(function(a,b){return a+b},0);
 				html+='<div class="nao-tooltip-total">'
 					+'<span class="nao-tooltip-name">Total</span>'

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -21,6 +21,7 @@ interface ChartBlock {
 	yAxisMax?: number;
 	title: string;
 	showDataLabels?: boolean;
+	hideTotal?: boolean;
 	rawTag?: string;
 }
 
@@ -86,6 +87,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({ chart }: { chart:
 				yAxisMin={chart.yAxisMin}
 				yAxisMax={chart.yAxisMax}
 				showDataLabels={chart.showDataLabels}
+				hideTotal={chart.hideTotal}
 			/>
 		</StoryChartEmbedShell>
 	);
@@ -122,6 +124,7 @@ export function StoryChartEmbedShell({ chart, availableColumns, children }: Stor
 			y_axis_max: chart.yAxisMax,
 			title: chart.title,
 			show_data_labels: chart.showDataLabels,
+			hide_total: chart.hideTotal,
 		}),
 		[chart],
 	);

--- a/apps/frontend/src/components/story-embeds.tsx
+++ b/apps/frontend/src/components/story-embeds.tsx
@@ -86,6 +86,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 				yAxisMin={chart.yAxisMin}
 				yAxisMax={chart.yAxisMax}
 				showDataLabels={chart.showDataLabels}
+				hideTotal={chart.hideTotal}
 			/>
 		</StoryChartEmbedShell>
 	);

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -362,6 +362,7 @@ export const DisplayChartToolCall = ({
 					yAxisMin={chartConfig.y_axis_min}
 					yAxisMax={chartConfig.y_axis_max}
 					showDataLabels={chartConfig.show_data_labels}
+					hideTotal={chartConfig.hide_total}
 				/>
 			)}
 		</div>
@@ -380,6 +381,7 @@ export interface ChartDisplayProps {
 	yAxisMin?: number;
 	yAxisMax?: number;
 	showDataLabels?: boolean;
+	hideTotal?: boolean;
 }
 
 export const ChartDisplay = memo(function ChartDisplay({
@@ -394,6 +396,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 	yAxisMin,
 	yAxisMax,
 	showDataLabels,
+	hideTotal,
 }: ChartDisplayProps) {
 	const dateFormat = useDateFormat();
 
@@ -505,7 +508,11 @@ export const ChartDisplay = memo(function ChartDisplay({
 						animationEasing='linear'
 						allowEscapeViewBox={{ y: true, x: false }}
 						content={
-							<ChartTooltipContent percent={isPercentStacked} labelFormatter={tooltipLabelFormatter} />
+							<ChartTooltipContent
+								percent={isPercentStacked}
+								hideTotal={hideTotal}
+								labelFormatter={tooltipLabelFormatter}
+							/>
 						}
 					/>,
 					chartType !== 'kpi_card' && (
@@ -541,6 +548,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 			yAxisMin,
 			yAxisMax,
 			showDataLabels,
+			hideTotal,
 			legendPayload,
 			handleToggleSeriesVisibility,
 			title,

--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -109,6 +109,7 @@ function ChartTooltipContent({
 	nameKey,
 	labelKey,
 	percent = false,
+	hideTotal = false,
 }: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
 	React.ComponentProps<'div'> & {
 		hideLabel?: boolean;
@@ -117,6 +118,7 @@ function ChartTooltipContent({
 		nameKey?: string;
 		labelKey?: string;
 		percent?: boolean;
+		hideTotal?: boolean;
 	}) {
 	const { config } = useChart();
 
@@ -163,7 +165,7 @@ function ChartTooltipContent({
 			.map((item) => ({ value: item.value as number, isTotal: isTotalItem(item) })),
 	);
 	// In 100% stacked mode every category totals 100%, so ignore already-aggregated total series.
-	const showTotal = numericValues.length > 1 && (percent || !hasTotalSeries);
+	const showTotal = numericValues.length > 1 && (percent || (!hasTotalSeries && !hideTotal));
 	const formatValue = (value: number) =>
 		percent ? formatPercentShare(value, shareBase) : formatCompactNumber(value);
 

--- a/apps/shared/src/chart-block.ts
+++ b/apps/shared/src/chart-block.ts
@@ -20,6 +20,7 @@ export type StoryChartBlockInput = Pick<
 	| 'y_axis_min'
 	| 'y_axis_max'
 	| 'show_data_labels'
+	| 'hide_total'
 > & {
 	title?: displayChart.ChartInput['title'];
 };
@@ -33,7 +34,8 @@ export function buildStoryChartBlock(input: StoryChartBlockInput): string {
 	const titleAttr =
 		input.title != null && input.title !== '' ? ` title="${escapeDoubleQuotedStoryAttr(input.title)}"` : '';
 	const dataLabelsAttr = input.show_data_labels ? ' show_data_labels="true"' : '';
-	return `<chart query_id="${escapeDoubleQuotedStoryAttr(input.query_id)}" chart_type="${escapeDoubleQuotedStoryAttr(input.chart_type)}" x_axis_key="${escapeDoubleQuotedStoryAttr(input.x_axis_key)}"${xAxisTypeAttr}${yMinAttr}${yMaxAttr} series='${seriesJson}'${titleAttr}${dataLabelsAttr} />`;
+	const hideTotalAttr = input.hide_total ? ' hide_total="true"' : '';
+	return `<chart query_id="${escapeDoubleQuotedStoryAttr(input.query_id)}" chart_type="${escapeDoubleQuotedStoryAttr(input.chart_type)}" x_axis_key="${escapeDoubleQuotedStoryAttr(input.x_axis_key)}"${xAxisTypeAttr}${yMinAttr}${yMaxAttr} series='${seriesJson}'${titleAttr}${dataLabelsAttr}${hideTotalAttr} />`;
 }
 
 export type StoryTableBlockInput = Pick<displayChart.TableInput, 'query_id' | 'title' | 'conditional_formats'>;

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -11,6 +11,7 @@ export interface ParsedChartBlock {
 	yAxisMax?: number;
 	title: string;
 	showDataLabels?: boolean;
+	hideTotal?: boolean;
 	/** The original `<chart ... />` tag this block was parsed from, when available. */
 	rawTag?: string;
 }
@@ -93,6 +94,7 @@ export function parseChartBlock(attrString: string): ParsedChartBlock | null {
 		yAxisMax,
 		title: attrs.title || '',
 		showDataLabels: attrs.show_data_labels === 'true',
+		hideTotal: attrs.hide_total === 'true',
 	};
 }
 

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -111,6 +111,12 @@ export const ChartInputSchema = z
 				'Show the numeric value of each data point directly on the chart. Set to true when the user asks to display values/data labels on the chart.',
 			)
 			.optional(),
+		hide_total: z
+			.boolean()
+			.describe(
+				'Set to true when the chart\'s series must NOT be added together into a single grand total — e.g. they are unrelated metrics, in different units, or different currencies, so a combined total would be meaningless. When true, the hover tooltip omits the "Total" row. Leave unset when the series are additive parts of the same measure (a total then makes sense). This is a chart-wide setting; for a single series that is itself an aggregated total of the others, use the per-series is_total flag instead.',
+			)
+			.optional(),
 		title: z
 			.string()
 			.describe(
@@ -151,6 +157,12 @@ const BaseInputSchema = z.object({
 		.array(SeriesConfigSchema)
 		.min(1)
 		.describe('Columns to plot as data series. Required for charts and omitted for tables.')
+		.optional(),
+	hide_total: z
+		.boolean()
+		.describe(
+			'Set to true when the chart\'s series must NOT be added together into a single grand total — e.g. they are unrelated metrics, in different units, or different currencies, so a combined total would be meaningless. When true, the hover tooltip omits the "Total" row. Leave unset when the series are additive parts of the same measure (a total then makes sense). This is a chart-wide setting; for a single series that is itself an aggregated total of the others, use the per-series is_total flag instead.',
+		)
 		.optional(),
 	title: z.string().describe('A concise, descriptive title for the visualization. Required for charts.').optional(),
 	conditional_formats: ColumnConditionalFormatsSchema.describe(

--- a/apps/shared/tests/story-segments.test.ts
+++ b/apps/shared/tests/story-segments.test.ts
@@ -66,6 +66,31 @@ describe('splitCodeIntoSegments chart series', () => {
 	});
 });
 
+describe('splitCodeIntoSegments chart total visibility', () => {
+	it('parses hide_total and defaults it to false when omitted', () => {
+		const hidden =
+			'<chart query_id="q1" chart_type="bar" x_axis_key="month" series=\'[{"data_key":"rev"}]\' hide_total="true" />';
+		const visible = '<chart query_id="q1" chart_type="bar" x_axis_key="month" series=\'[{"data_key":"rev"}]\' />';
+
+		expect(chartOf(hidden)?.hideTotal).toBe(true);
+		expect(chartOf(visible)?.hideTotal).toBe(false);
+	});
+
+	it('round-trips hide_total through buildStoryChartBlock', () => {
+		const code = buildStoryChartBlock({
+			query_id: 'q1',
+			chart_type: 'bar',
+			x_axis_key: 'month',
+			series: [{ data_key: 'rev' }],
+			title: 'Revenue',
+			hide_total: true,
+		});
+
+		expect(code).toContain('hide_total="true"');
+		expect(chartOf(code)?.hideTotal).toBe(true);
+	});
+});
+
 describe('splitCodeIntoSegments slash-in-attribute handling', () => {
 	it('parses a chart whose title contains a slash', () => {
 		const code =

--- a/apps/shared/tests/story-table-block.test.ts
+++ b/apps/shared/tests/story-table-block.test.ts
@@ -150,6 +150,20 @@ describe('displayChart.InputSchema table variant', () => {
 		expect(result.success).toBe(true);
 	});
 
+	it('retains hide_total in a valid chart config', () => {
+		const result = displayChart.InputSchema.safeParse({
+			query_id: 'q',
+			chart_type: 'line',
+			x_axis_key: 'month',
+			x_axis_type: 'date',
+			series: [{ data_key: 'a' }, { data_key: 'b' }],
+			title: 't',
+			hide_total: true,
+		});
+		expect(result.success).toBe(true);
+		expect(result.success && result.data.chart_type !== 'table' && result.data.hide_total).toBe(true);
+	});
+
 	it('rejects a chart config missing chart fields', () => {
 		const result = displayChart.InputSchema.safeParse({
 			query_id: 'query_1',


### PR DESCRIPTION
## Summary
- Add a chart-wide `hide_total` option so the assistant can turn off the tooltip's "Total" row when a chart's series can't be meaningfully added up (unrelated metrics, different units or currencies). Additive charts still show the total; percentage charts still show 100%.
- The flag is part of the schema the model actually sees, so the agent can set it itself
- The per-series `is_total` behavior is unchanged

Closes #1116

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

