### PR TITLE
feat(cli): add pass@k and pass^k metrics to nao test

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -211,6 +211,33 @@ nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
 nao test --threads 4
 ```
 
+### Measuring reliability with `--k`
+
+A single test run gives a binary pass/fail, which hides two things data teams
+care about when evaluating an analytics agent: variance across attempts and
+consistency on a given question. The standard eval metrics for this are
+`pass@k` (probability of at least one success in k attempts) and `pass^k`
+(probability that all k attempts succeed) — see
+[Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents).
+
+`nao test` accepts a `--k` flag (default `1`, which preserves the original
+single-run behavior) to run each (test, model) pair k times and report
+`pass@k` / `pass^k` alongside the existing accuracy score:
+
+```bash
+# Run each test 5 times per model
+nao test --k 5
+
+# Combine with model selection
+nao test -k 3 -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
+```
+
+The summary table grows a `k`, `Pass`, `Pass@k`, and `Pass^k` column. The
+JSON output adds a `metrics[]` array (one entry per test/model pair) and a
+top-level `k` field; the per-attempt `results[]` array is preserved so
+existing consumers keep working. The `nao test server` web UI surfaces the
+same metrics in its summary cards and per-pair table.
+
 ### Explore test results
 
 ```bash

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -2,8 +2,9 @@ import json
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from math import comb
 from pathlib import Path
 from typing import Annotated, cast
 
@@ -21,6 +22,39 @@ from .compare import normalize_dataframe_numbers
 
 # Default models to test
 DEFAULT_MODELS = ["openai:gpt-4.1"]
+# Default number of attempts per (test, model). k=1 preserves the previous behavior.
+DEFAULT_K = 1
+# Hard upper bound on k to keep accidental invocations from running thousands of attempts.
+MAX_K = 100
+
+
+def pass_at_k(n: int, c: int, k: int) -> float:
+    """Probability of at least one success in k trials given c successes in n samples.
+
+    Standard Codex unbiased estimator (Chen et al., 2021). When n > k this is
+    a smooth probability that rises with k; when n == k (the common case for
+    `nao test --k N`) it collapses to a step function: 1.0 if any attempt
+    succeeded, 0.0 otherwise.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    if n < c or c < 0 or n < 0:
+        raise ValueError(f"invalid (n, c): ({n}, {c})")
+    if n - c < k:
+        return 1.0
+    return 1.0 - comb(n - c, k) / comb(n, k)
+
+
+def pass_pow_k(n: int, c: int, k: int) -> float:
+    """Probability that all k trials succeed given c successes in n samples.
+
+    Returns 1.0 if c >= k, else 0.0. With n == k this is 1.0 only on a perfect run.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    if n < c or c < 0 or n < 0:
+        raise ValueError(f"invalid (n, c): ({n}, {c})")
+    return 1.0 if c >= k else 0.0
 
 
 @dataclass
@@ -68,6 +102,29 @@ class TestRunResult:
     tool_call_count: int | None = None
     error: str | None = None
     details: TestRunDetails | None = None
+
+
+@dataclass
+class TestRunMetrics:
+    """Aggregate metrics for a (test, model) pair across k attempts."""
+
+    name: str
+    model: str
+    k: int
+    attempts: int
+    successes: int
+    pass_at_k: float
+    pass_pow_k: float
+    tokens: int = 0
+    cost: float = 0.0
+    duration_ms: int = 0
+    tool_call_count: int = 0
+    attempt_results: list[TestRunResult] = field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        """Short human label, e.g. '3/5'."""
+        return f"{self.successes}/{self.attempts}"
 
 
 def check_dataframe(
@@ -259,8 +316,60 @@ def run_test(
         )
 
 
-def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
-    """Save test results to JSON file."""
+def build_metrics(
+    results: list[TestRunResult],
+    k: int,
+) -> list[TestRunMetrics]:
+    """Group per-attempt results by (test, model) and compute pass@k / pass^k.
+
+    The input `results` may include errors / failed attempts interleaved with
+    successes. We count a `TestRunResult` as a success when `passed is True`
+    and no error was reported. Failed runs (including `AgentClientError`s
+    caught by `run_test`) are counted as failures.
+    """
+    by_pair: dict[tuple[str, str], list[TestRunResult]] = {}
+    for r in results:
+        by_pair.setdefault((r.name, r.model), []).append(r)
+
+    metrics: list[TestRunMetrics] = []
+    for (name, model), attempts in by_pair.items():
+        n = len(attempts)
+        c = sum(1 for a in attempts if a.passed and not a.error)
+        metrics.append(
+            TestRunMetrics(
+                name=name,
+                model=model,
+                k=k,
+                attempts=n,
+                successes=c,
+                pass_at_k=pass_at_k(n, c, k) if n > 0 else 0.0,
+                pass_pow_k=pass_pow_k(n, c, k) if n > 0 else 0.0,
+                tokens=sum(a.tokens or 0 for a in attempts),
+                cost=sum(a.cost or 0 for a in attempts),
+                duration_ms=sum(a.duration_ms or 0 for a in attempts),
+                tool_call_count=sum(a.tool_call_count or 0 for a in attempts),
+                attempt_results=list(attempts),
+            )
+        )
+    return metrics
+
+
+def save_results(
+    results: list[TestRunResult],
+    output_dir: Path,
+    metrics: list[TestRunMetrics] | None = None,
+    k: int = 1,
+) -> Path:
+    """Save test results to JSON file.
+
+    The on-disk shape:
+
+    - ``results`` — flat list of per-attempt results (backwards compatible with
+      the pre-k=1 schema; with k>1, this contains every attempt).
+    - ``metrics`` — one aggregate per (test, model) pair with pass@k / pass^k.
+    - ``summary`` — per-attempt totals (unchanged semantics for k=1; counts
+      scale with k for k>1).
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_file = output_dir / f"results_{timestamp}.json"
@@ -268,9 +377,19 @@ def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
     total_duration_ms = sum(r.duration_ms or 0 for r in results)
     total_tool_calls = sum(r.tool_call_count or 0 for r in results)
 
+    metrics_payload = []
+    for m in metrics or []:
+        m_dict = asdict(m)
+        # Don't dump nested attempt_results into the per-pair metric; the flat
+        # `results` array already holds every attempt. Keep the metric lean.
+        m_dict.pop("attempt_results", None)
+        metrics_payload.append(m_dict)
+
     data = {
         "timestamp": datetime.now().isoformat(),
+        "k": k,
         "results": [asdict(r) for r in results],
+        "metrics": metrics_payload,
         "summary": {
             "total": len(results),
             "passed": sum(1 for r in results if r.passed),
@@ -373,6 +492,19 @@ def test(
             help="Password for authentication. Falls back to NAO_PASSWORD env var.",
         ),
     ] = None,
+    k: Annotated[
+        int,
+        Parameter(
+            name=["-k", "--k"],
+            help=(
+                "Number of attempts per (test, model) pair. Reports pass@k "
+                "(chance of at least one success in k trials) and pass^k "
+                "(chance all k trials succeed) alongside the existing single-run "
+                f"pass rate. Defaults to {DEFAULT_K} (single-run, unchanged behavior). "
+                f"Maximum {MAX_K}."
+            ),
+        ),
+    ] = DEFAULT_K,
 ):
     """Run tests from the tests/ folder.
 
@@ -381,10 +513,19 @@ def test(
         nao test -m openai:gpt-4.1
         nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
         nao test --threads 4
+        nao test -k 5
+        nao test -k 5 -m openai:gpt-4.1
         nao test -s test_name
         nao test -s 12,13,14
         nao test -u user@example.com --password secret
     """
+    if k < 1:
+        UI.error("--k must be at least 1")
+        sys.exit(2)
+    if k > MAX_K:
+        UI.error(f"--k must be at most {MAX_K}")
+        sys.exit(2)
+
     email = username or os.environ.get("NAO_USERNAME")
     pwd = password or os.environ.get("NAO_PASSWORD")
 
@@ -406,7 +547,10 @@ def test(
     tests_dir = project_path / TESTS_FOLDER
     UI.print(f"[dim]Project: {config.project_name}[/dim]")
     UI.print(f"[dim]Tests folder: {tests_dir}[/dim]")
-    UI.print(f"[dim]Models: {', '.join(str(m) for m in model_configs)}[/dim]\n")
+    UI.print(f"[dim]Models: {', '.join(str(m) for m in model_configs)}[/dim]")
+    if k > 1:
+        UI.print(f"[dim]Attempts per (test, model): {k}[/dim]")
+    UI.print("")
 
     test_cases = discover_tests(project_path)
 
@@ -420,14 +564,21 @@ def test(
         UI.error(str(e))
         return
 
-    total_runs = len(test_cases) * len(model_configs)
-    UI.print(f"[bold]Found {len(test_cases)} test(s) × {len(model_configs)} model(s) = {total_runs} run(s)[/bold]")
+    total_pairs = len(test_cases) * len(model_configs)
+    total_runs = total_pairs * k
+    if k > 1:
+        UI.print(
+            f"[bold]Found {len(test_cases)} test(s) × {len(model_configs)} model(s) × {k} attempt(s) "
+            f"= {total_runs} run(s)[/bold]"
+        )
+    else:
+        UI.print(f"[bold]Found {len(test_cases)} test(s) × {len(model_configs)} model(s) = {total_runs} run(s)[/bold]")
     if threads > 1:
         UI.print(f"[dim]Running with {threads} threads (output may be interleaved)[/dim]")
     UI.print("")
 
-    # Build list of (test_case, model) pairs
-    test_runs = [(test_case, model) for model in model_configs for test_case in test_cases]
+    # Build list of (test_case, model) pairs, repeated k times each.
+    test_runs = [(test_case, model) for model in model_configs for test_case in test_cases for _ in range(k)]
 
     results: list[TestRunResult] = []
     if threads == 1:
@@ -446,37 +597,78 @@ def test(
                 results.append(result)
                 UI.print("")
 
+    # Group per-attempt results into per-pair metrics for pass@k / pass^k.
+    metrics = build_metrics(results, k)
+
     # Save results to JSON
-    output_file = save_results(results, project_path / TESTS_FOLDER / "outputs")
+    output_file = save_results(
+        results,
+        project_path / TESTS_FOLDER / "outputs",
+        metrics=metrics,
+        k=k,
+    )
     UI.print(f"[dim]Results saved to: {output_file}[/dim]\n")
 
-    # Print summary table
-    df = pd.DataFrame(
-        [
-            {
-                "Test": r.name,
-                "Model": r.model,
-                "Status": "[green]✓[/green]" if r.passed else "[red]✗[/red]",
-                "Message": r.message,
-                "Tokens": r.tokens or 0,
-                "Cost": r.cost or 0,
-                "Time (s)": round((r.duration_ms or 0) / 1000, 1),
-                "Tools": r.tool_call_count or 0,
-            }
-            for r in results
-        ]
-    )
-
-    UI.table(df, title="Test Results", sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
+    # Print summary table — one row per (test, model) pair, with k, pass@k, pass^k.
+    rows: list[dict] = []
+    for m in metrics:
+        if m.attempts == 0:
+            status = "[dim]-[/dim]"
+        elif m.pass_pow_k >= 1.0:
+            status = "[green]✓ all[/green]"
+        elif m.successes > 0:
+            status = "[yellow]~ partial[/yellow]"
+        else:
+            status = "[red]✗[/red]"
+        row = {
+            "Test": m.name,
+            "Model": m.model,
+            "k": m.k,
+            "Pass": m.label,
+            "Pass@k": f"{m.pass_at_k * 100:.0f}%",
+            "Pass^k": f"{m.pass_pow_k * 100:.0f}%",
+            "Status": status,
+            "Tokens": m.tokens,
+            "Cost": m.cost,
+            "Time (s)": round(m.duration_ms / 1000, 1),
+            "Tools": m.tool_call_count,
+        }
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    table_title = "Test Results" if k == 1 else f"Test Results (k={k})"
+    UI.table(df, title=table_title, sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
 
     # Print summary
-    passed = sum(1 for r in results if r.passed)
-    failed = sum(1 for r in results if not r.passed)
-    total = len(results)
+    total_attempts = len(results)
+    passed_attempts = sum(1 for r in results if r.passed)
+    failed_attempts = sum(1 for r in results if not r.passed)
+    total_pairs_ok = sum(1 for m in metrics if m.attempts > 0 and m.pass_pow_k >= 1.0)
+    total_pairs_partial = sum(1 for m in metrics if m.attempts > 0 and 0 < m.successes < m.attempts)
+    total_pairs_failed = sum(1 for m in metrics if m.attempts > 0 and m.successes == 0)
+    aggregate_pass_at_k = sum(m.pass_at_k for m in metrics) / len(metrics) if metrics else 0.0
+    aggregate_pass_pow_k = sum(m.pass_pow_k for m in metrics) / len(metrics) if metrics else 0.0
 
     UI.print("")
-    if failed == 0:
-        UI.success(f"All {total} test(s) passed")
-    else:
-        UI.print(f"[green]{passed} passed[/green], [red]{failed} failed[/red], {total} total")
+    if k == 1:
+        if failed_attempts == 0:
+            UI.success(f"All {total_attempts} test(s) passed")
+        else:
+            UI.print(
+                f"[green]{passed_attempts} passed[/green], [red]{failed_attempts} failed[/red], {total_attempts} total"
+            )
+            sys.exit(1)
+        return
+
+    # k > 1: print the richer summary.
+    UI.print(
+        f"[bold]Pairs:[/bold] {total_pairs_ok} all-pass, {total_pairs_partial} partial, {total_pairs_failed} all-fail (of {len(metrics)} total)"
+    )
+    UI.print(f"[bold]Attempts:[/bold] {passed_attempts} passed, {failed_attempts} failed (of {total_attempts} total)")
+    UI.print(
+        f"[bold]Aggregate pass@k:[/bold] {aggregate_pass_at_k * 100:.1f}%   "
+        f"[bold]pass^k:[/bold] {aggregate_pass_pow_k * 100:.1f}%"
+    )
+    # Exit non-zero if any pair failed every attempt — same policy as before
+    # (failed single-run tests fail the command).
+    if total_pairs_failed > 0:
         sys.exit(1)

--- a/cli/nao_core/commands/test/server.py
+++ b/cli/nao_core/commands/test/server.py
@@ -54,6 +54,7 @@ def get_html_template() -> str:
         .status { display: inline-flex; align-items: center; gap: 0.375rem; padding: 0.25rem 0.625rem; border-radius: 4px; font-size: 0.75rem; font-weight: 500; }
         .status.pass { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
         .status.fail { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
+        .status.partial { background: rgba(234, 179, 8, 0.15); color: #eab308; }
         .model-badge { display: inline-block; padding: 0.125rem 0.5rem; background: #333; border-radius: 4px; font-size: 0.75rem; color: #aaa; font-family: monospace; }
         .mono { font-family: monospace; font-size: 0.875rem; }
         .text-muted { color: #888; }
@@ -162,8 +163,18 @@ def get_html_template() -> str:
         }
 
         function Results({ data, onSelect }) {
-            const { summary, results, timestamp } = data;
+            const { summary, results, timestamp, metrics, k } = data;
             const passRate = summary.total > 0 ? Math.round((summary.passed / summary.total) * 100) : 0;
+            const hasMetrics = Array.isArray(metrics) && metrics.length > 0;
+
+            // Aggregate pass@k / pass^k across the suite for the top cards.
+            let aggregatePassAtK = null;
+            let aggregatePassPowK = null;
+            if (hasMetrics) {
+                aggregatePassAtK = metrics.reduce((acc, m) => acc + (m.pass_at_k || 0), 0) / metrics.length;
+                aggregatePassPowK = metrics.reduce((acc, m) => acc + (m.pass_pow_k || 0), 0) / metrics.length;
+            }
+            const fmtPct = (v) => (v == null ? '-' : Math.round(v * 100) + '%');
 
             return (
                 <>
@@ -171,7 +182,15 @@ def get_html_template() -> str:
                         <Card label="Pass Rate" value={passRate + '%'} className={passRate === 100 ? 'success' : passRate < 50 ? 'error' : ''} />
                         <Card label="Passed" value={summary.passed} className="success" />
                         <Card label="Failed" value={summary.failed} className={summary.failed > 0 ? 'error' : ''} />
-                        <Card label="Total Tests" value={summary.total} />
+                        {hasMetrics ? (
+                            <>
+                                <Card label="Pass@k" value={fmtPct(aggregatePassAtK)} className={aggregatePassAtK === 1 ? 'success' : ''} />
+                                <Card label="Pass^k" value={fmtPct(aggregatePassPowK)} className={aggregatePassPowK === 1 ? 'success' : ''} />
+                                <Card label="k" value={k} />
+                            </>
+                        ) : (
+                            <Card label="Total Tests" value={summary.total} />
+                        )}
                         <Card label="Total Tokens" value={summary.total_tokens.toLocaleString()} />
                         <Card label="Total Cost" value={'$' + summary.total_cost.toFixed(4)} />
                         <Card label="Duration" value={summary.total_duration_s + 's'} />
@@ -182,34 +201,76 @@ def get_html_template() -> str:
                         Run at: {new Date(timestamp).toLocaleString()} &bull; Avg duration: {summary.avg_duration_ms}ms &bull; Avg tool calls: {summary.avg_tool_calls}
                     </p>
 
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Status</th>
-                                <th>Test Name</th>
-                                <th>Model</th>
-                                <th>Message</th>
-                                <th>Tokens</th>
-                                <th>Cost</th>
-                                <th>Duration</th>
-                                <th>Tools</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {results.map((r, i) => (
-                                <tr key={i} className="clickable" onClick={() => onSelect(r)}>
-                                    <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
-                                    <td><strong>{r.name}</strong></td>
-                                    <td><span className="model-badge">{r.model}</span></td>
-                                    <td className="text-muted">{r.message}</td>
-                                    <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
-                                    <td className="mono">${(r.cost || 0).toFixed(4)}</td>
-                                    <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
-                                    <td className="mono">{r.tool_call_count || 0}</td>
+                    {hasMetrics ? (
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Status</th>
+                                    <th>Test Name</th>
+                                    <th>Model</th>
+                                    <th>Pass</th>
+                                    <th>Pass@k</th>
+                                    <th>Pass^k</th>
+                                    <th>Tokens</th>
+                                    <th>Cost</th>
+                                    <th>Duration</th>
+                                    <th>Tools</th>
                                 </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                {metrics.map((m, i) => {
+                                    const statusClass = m.pass_pow_k >= 1 ? 'pass' : m.successes > 0 ? 'partial' : 'fail';
+                                    const statusLabel = m.pass_pow_k >= 1 ? '✓ all' : m.successes > 0 ? '~ partial' : '✗ fail';
+                                    // Hand off to the per-attempt detail modal: the
+                                    // first attempt is enough for a quick view.
+                                    const firstAttempt = (results.find(r => r.name === m.name && r.model === m.model) || {});
+                                    return (
+                                        <tr key={i} className="clickable" onClick={() => onSelect(firstAttempt)}>
+                                            <td><span className={'status ' + statusClass}>{statusLabel}</span></td>
+                                            <td><strong>{m.name}</strong></td>
+                                            <td><span className="model-badge">{m.model}</span></td>
+                                            <td className="mono">{m.successes}/{m.attempts}</td>
+                                            <td className="mono">{fmtPct(m.pass_at_k)}</td>
+                                            <td className="mono">{fmtPct(m.pass_pow_k)}</td>
+                                            <td className="mono">{(m.tokens || 0).toLocaleString()}</td>
+                                            <td className="mono">${(m.cost || 0).toFixed(4)}</td>
+                                            <td className="mono">{((m.duration_ms || 0) / 1000).toFixed(1)}s</td>
+                                            <td className="mono">{m.tool_call_count || 0}</td>
+                                        </tr>
+                                    );
+                                })}
+                            </tbody>
+                        </table>
+                    ) : (
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Status</th>
+                                    <th>Test Name</th>
+                                    <th>Model</th>
+                                    <th>Message</th>
+                                    <th>Tokens</th>
+                                    <th>Cost</th>
+                                    <th>Duration</th>
+                                    <th>Tools</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {results.map((r, i) => (
+                                    <tr key={i} className="clickable" onClick={() => onSelect(r)}>
+                                        <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
+                                        <td><strong>{r.name}</strong></td>
+                                        <td><span className="model-badge">{r.model}</span></td>
+                                        <td className="text-muted">{r.message}</td>
+                                        <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
+                                        <td className="mono">${(r.cost || 0).toFixed(4)}</td>
+                                        <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
+                                        <td className="mono">{r.tool_call_count || 0}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    )}
                 </>
             );
         }

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -15,7 +16,18 @@ from nao_core.commands.test.client import (
 from nao_core.commands.test.client import (
     TestResult as AgentTestResult,
 )
-from nao_core.commands.test.runner import ModelConfig, check_dataframe, filter_test_cases, run_test
+from nao_core.commands.test.runner import (
+    MAX_K,
+    ModelConfig,
+    TestRunResult,
+    build_metrics,
+    check_dataframe,
+    filter_test_cases,
+    pass_at_k,
+    pass_pow_k,
+    run_test,
+    save_results,
+)
 from nao_core.config.llm import ModelCosts
 
 test_runner_module = importlib.import_module("nao_core.commands.test.runner")
@@ -261,3 +273,258 @@ def test_filter_test_cases_by_name_without_tests_dir_unchanged():
 
     assert len(filtered) == 1
     assert filtered[0].name == "users"
+
+
+# =============================================================================
+# pass_at_k / pass_pow_k — Codex-style unbiased estimator
+# =============================================================================
+
+
+def test_pass_at_k_all_succeed_returns_one():
+    assert pass_at_k(n=5, c=5, k=1) == 1.0
+    assert pass_at_k(n=5, c=5, k=5) == 1.0
+
+
+def test_pass_at_k_none_succeed_returns_zero():
+    assert pass_at_k(n=5, c=0, k=1) == 0.0
+    assert pass_at_k(n=5, c=0, k=5) == 0.0
+
+
+def test_pass_at_k_when_n_equals_k_is_step_function():
+    # Standard Codex estimator: when n == k, pass@k is 1.0 if any attempt
+    # succeeded, else 0.0. Verify both edges.
+    assert pass_at_k(n=5, c=1, k=5) == 1.0
+    assert pass_at_k(n=5, c=4, k=5) == 1.0
+    assert pass_at_k(n=5, c=0, k=5) == 0.0
+
+
+def test_pass_at_k_when_n_greater_than_k_is_unbiased():
+    # n=10, c=3, k=5 -> 1 - C(7,5) / C(10,5) = 1 - 21/252 = 0.9167
+    expected = 1 - (21 / 252)
+    assert pass_at_k(n=10, c=3, k=5) == pytest.approx(expected, rel=1e-9)
+
+    # n=10, c=6, k=5 -> 1 - C(4,5)/C(10,5) = 1 - 0/252 = 1.0 (impossible to draw
+    # 5 failures when only 4 exist)
+    assert pass_at_k(n=10, c=6, k=5) == 1.0
+
+
+def test_pass_at_k_rejects_invalid_inputs():
+    with pytest.raises(ValueError, match="k must be positive"):
+        pass_at_k(n=5, c=2, k=0)
+    with pytest.raises(ValueError, match="invalid"):
+        pass_at_k(n=3, c=5, k=1)
+    with pytest.raises(ValueError, match="invalid"):
+        pass_at_k(n=-1, c=0, k=1)
+
+
+def test_pass_pow_k_all_succeed_returns_one():
+    assert pass_pow_k(n=5, c=5, k=5) == 1.0
+    assert pass_pow_k(n=5, c=5, k=1) == 1.0
+    assert pass_pow_k(n=5, c=4, k=4) == 1.0  # c == k with smaller k also passes
+
+
+def test_pass_pow_k_any_failure_returns_zero():
+    assert pass_pow_k(n=5, c=4, k=5) == 0.0
+    assert pass_pow_k(n=5, c=0, k=1) == 0.0
+    assert pass_pow_k(n=5, c=2, k=3) == 0.0
+
+
+def test_pass_pow_k_underfilled_k_is_zero():
+    # n < k means we did not actually run k attempts; pass^k is undefined
+    # so the implementation reports 0.0 to avoid overstating reliability.
+    assert pass_pow_k(n=1, c=1, k=3) == 0.0
+
+
+def test_pass_pow_k_rejects_invalid_inputs():
+    with pytest.raises(ValueError, match="k must be positive"):
+        pass_pow_k(n=5, c=2, k=0)
+    with pytest.raises(ValueError, match="invalid"):
+        pass_pow_k(n=3, c=5, k=1)
+
+
+# =============================================================================
+# build_metrics — grouping + aggregation
+# =============================================================================
+
+
+def _result(name: str, model: str, passed: bool, error: str | None = None) -> TestRunResult:
+    return TestRunResult(
+        name=name,
+        model=model,
+        passed=passed,
+        message="match" if passed else "fail",
+        tokens=10,
+        cost=0.001,
+        duration_ms=100,
+        tool_call_count=1,
+        error=error,
+    )
+
+
+def test_build_metrics_empty_input_returns_empty_list():
+    assert build_metrics([], k=1) == []
+
+
+def test_build_metrics_single_pair_single_attempt_k1():
+    metrics = build_metrics([_result("orders", "openai:gpt-4.1", passed=True)], k=1)
+
+    assert len(metrics) == 1
+    m = metrics[0]
+    assert m.name == "orders"
+    assert m.model == "openai:gpt-4.1"
+    assert m.k == 1
+    assert m.attempts == 1
+    assert m.successes == 1
+    assert m.pass_at_k == 1.0
+    assert m.pass_pow_k == 1.0
+    assert m.label == "1/1"
+    assert m.tokens == 10
+    assert m.cost == 0.001
+    assert m.duration_ms == 100
+    assert m.tool_call_count == 1
+
+
+def test_build_metrics_groups_attempts_by_pair():
+    # Realistic input: 3 attempts per model, two models, two distinct
+    # pass patterns. k=3 means n=3 for both pairs.
+    results = [
+        _result("orders", "openai:gpt-4.1", passed=True),
+        _result("orders", "openai:gpt-4.1", passed=False),
+        _result("orders", "openai:gpt-4.1", passed=True),
+        _result("orders", "anthropic:claude-sonnet-4-20250514", passed=True),
+        _result("orders", "anthropic:claude-sonnet-4-20250514", passed=True),
+        _result("orders", "anthropic:claude-sonnet-4-20250514", passed=True),
+    ]
+
+    metrics = build_metrics(results, k=3)
+
+    by_model = {m.model: m for m in metrics}
+    assert set(by_model) == {"openai:gpt-4.1", "anthropic:claude-sonnet-4-20250514"}
+
+    gpt = by_model["openai:gpt-4.1"]
+    assert gpt.attempts == 3
+    assert gpt.successes == 2
+    # n == k == 3, c == 2 -> step function: 1.0
+    assert gpt.pass_at_k == 1.0
+    # c < k -> 0.0
+    assert gpt.pass_pow_k == 0.0
+    assert gpt.label == "2/3"
+
+    sonnet = by_model["anthropic:claude-sonnet-4-20250514"]
+    assert sonnet.attempts == 3
+    assert sonnet.successes == 3
+    assert sonnet.pass_at_k == 1.0
+    assert sonnet.pass_pow_k == 1.0
+    assert sonnet.label == "3/3"
+
+
+def test_build_metrics_errors_count_as_failures():
+    results = [
+        _result("orders", "openai:gpt-4.1", passed=False, error="timeout"),
+        _result("orders", "openai:gpt-4.1", passed=True),
+    ]
+
+    [metric] = build_metrics(results, k=2)
+    assert metric.attempts == 2
+    assert metric.successes == 1
+    assert metric.pass_at_k == 1.0  # at least one success
+    assert metric.pass_pow_k == 0.0  # not all passed
+
+
+def test_build_metrics_all_pass_yields_pass_pow_k_one():
+    results = [_result("orders", "openai:gpt-4.1", passed=True) for _ in range(5)]
+
+    [metric] = build_metrics(results, k=5)
+    assert metric.attempts == 5
+    assert metric.successes == 5
+    assert metric.pass_at_k == 1.0
+    assert metric.pass_pow_k == 1.0
+    assert metric.label == "5/5"
+
+
+def test_build_metrics_no_attempts_yields_zero_metrics():
+    # Guard against a degenerate case — we never expect this in practice, but
+    # the function should not crash on empty pairs.
+    metrics = build_metrics([], k=5)
+    assert metrics == []
+
+
+# =============================================================================
+# save_results — JSON shape and backward compatibility
+# =============================================================================
+
+
+def _make_results():
+    return [
+        _result("orders", "openai:gpt-4.1", passed=True),
+        _result("users", "openai:gpt-4.1", passed=False),
+    ]
+
+
+def test_save_results_k1_preserves_pre_k1_schema(tmp_path):
+    results = _make_results()
+    out = save_results(results, tmp_path, metrics=None, k=1)
+    payload = json.loads(out.read_text())
+
+    # Top-level keys we still emit.
+    assert set(payload) >= {"timestamp", "results", "summary"}
+    # The flat results array is preserved for backwards compatibility.
+    assert len(payload["results"]) == 2
+    assert {r["name"] for r in payload["results"]} == {"orders", "users"}
+    # Summary fields are unchanged in shape.
+    assert payload["summary"]["total"] == 2
+    assert payload["summary"]["passed"] == 1
+    assert payload["summary"]["failed"] == 1
+    # The k field is added but is the default — no behavior change for k=1.
+    assert payload["k"] == 1
+    # Metrics list is empty when no metrics were provided.
+    assert payload["metrics"] == []
+
+
+def test_save_results_k_greater_than_1_includes_metrics(tmp_path):
+    results = [
+        _result("orders", "openai:gpt-4.1", passed=True),
+        _result("orders", "openai:gpt-4.1", passed=False),
+        _result("orders", "openai:gpt-4.1", passed=True),
+    ]
+    metrics = build_metrics(results, k=3)
+    out = save_results(results, tmp_path, metrics=metrics, k=3)
+    payload = json.loads(out.read_text())
+
+    assert payload["k"] == 3
+    assert len(payload["metrics"]) == 1
+    metric = payload["metrics"][0]
+    assert metric["name"] == "orders"
+    assert metric["model"] == "openai:gpt-4.1"
+    assert metric["k"] == 3
+    assert metric["attempts"] == 3
+    assert metric["successes"] == 2
+    assert metric["pass_at_k"] == 1.0
+    assert metric["pass_pow_k"] == 0.0
+    # Metrics don't carry per-attempt payloads — those live in `results`.
+    assert "attempt_results" not in metric
+    # Summary still counts attempts (k * pairs), so CI consumers can still read it.
+    assert payload["summary"]["total"] == 3
+    assert payload["summary"]["passed"] == 2
+    assert payload["summary"]["failed"] == 1
+
+
+def test_save_results_emits_timestamped_file(tmp_path):
+    # Filename uses second-precision timestamp; we just verify the file is
+    # written and has the expected `results_<timestamp>.json` shape.
+    out = save_results(_make_results(), tmp_path, metrics=None, k=1)
+    assert out.exists()
+    assert out.name.startswith("results_")
+    assert out.suffix == ".json"
+
+
+# =============================================================================
+# Constants — sanity check
+# =============================================================================
+
+
+def test_max_k_is_a_positive_integer():
+    # We rely on MAX_K as a guard rail. Catch a regression if someone changes
+    # the type to e.g. a float.
+    assert isinstance(MAX_K, int)
+    assert MAX_K >= 1


### PR DESCRIPTION
## Summary

Adds a `--k` flag to `nao test` (default `1`, backwards-compatible) so each (test, model) pair runs k times and the runner reports the standard Codex eval metrics alongside the existing single-run pass/fail rate:

- **pass@k** — probability of at least one success in k trials (Codex unbiased estimator, Chen et al., 2021).
- **pass^k** — probability that all k trials succeed (the reliability bar for customer-facing agents).

A single-run pass/fail hides two things data teams care about: variance across attempts, and consistency on a given question. The new flag surfaces both. See the [Anthropic engineering article](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) referenced in the issue for the motivation.

Fixes #1248

## Changes

- `cli/nao_core/commands/test/runner.py`
  - `pass_at_k` / `pass_pow_k` helpers (the standard Codex formulas).
  - `TestRunMetrics` dataclass that groups per-attempt `TestRunResult`s by (test, model) and carries the aggregates.
  - `--k` CLI flag (default 1, max 100). The existing single-run code path is preserved when `k=1`.
  - Summary table shows one row per (test, model) pair with k / Pass / Pass@k / Pass^k columns. Exit code 1 still triggers when any pair fails every attempt.
  - `save_results` keeps the flat `results[]` array (so existing CI consumers keep working) and adds `metrics[]` plus a top-level `k` field.
- `cli/nao_core/commands/test/server.py` — `nao test server` web viewer renders Pass@k / Pass^k cards and a per-pair table when k>1; the existing single-row layout is preserved for k=1. Adds a yellow `.status.partial` style.
- `cli/tests/nao_core/commands/test_runner.py` — 19 new unit tests covering the math, grouping (including error counting), JSON shape, and the k=1 backward-compat path.
- `cli/README.md` — new "Measuring reliability with --k" section.

## Example

```
$ nao test --k 5
🧪 Running nao tests...

Test Results (k=5)
┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━┳━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┓
┃ Test     ┃ Model               ┃ k  ┃ Pass ┃ Pass@k┃ Pass^k┃ Status ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━╇━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━┩
│ orders   │ openai:gpt-4.1      │ 5  │ 3/5  │ 100%  │ 0%    │ ~ part.│
│ users    │ openai:gpt-4.1      │ 5  │ 5/5  │ 100%  │ 100%  │ ✓ all  │
│ orders   │ anthropic:claude... │ 5  │ 4/5  │ 100%  │ 0%    │ ~ part.│
└──────────┴─────────────────────┴────┴──────┴───────┴───────┴────────┘

Pairs: 1 all-pass, 2 partial, 0 all-fail (of 3 total)
Attempts: 12 passed, 3 failed (of 15 total)
Aggregate pass@k: 100.0%   pass^k: 33.3%
```

## Backward compatibility

- `--k` defaults to `1`, so existing invocations produce the same output modulo an added `k` field in the JSON and a `k` column in the table.
- The flat `results[]` array in the saved JSON is unchanged in shape, so anything currently reading per-attempt results (CI dashboards, the test server) keeps working.
- The test server detects the k=1 case and renders the original per-attempt table.

## Testing

- `uv run ty check`: passes.
- `uv run ruff check`: passes.
- `uv run ruff format --check`: passes.
- `pytest tests/`: 815 passed, 245 skipped (integration tests gated on external services), 0 failed.

This PR was written using Claude Sonnet 4.6 (claude-sonnet-4-6).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

