### PR TITLE
fix: show pointer on sortable table headers

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -106,7 +106,7 @@ export function TableDisplay({
 										<button
 											type='button'
 											onClick={() => toggleSort(column)}
-											className='group flex w-full items-center justify-between gap-3'
+											className='group flex w-full cursor-pointer items-center justify-between gap-3'
 										>
 											<span className={cn(alignRight && 'ml-auto')}>
 												{humanizeColumnLabels ? formatColumnLabel(column) : column}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- show the pointer cursor over sortable table header buttons

## Testing
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab37b7f2-273e-46a7-a71c-6df7c292f52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab37b7f2-273e-46a7-a71c-6df7c292f52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

