### PR TITLE
fix: always show gutter drag handle so lone charts/tables are movable

### DIFF
--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -21,7 +21,6 @@ export const StoryEditor = memo(function StoryEditor({ code, editorRef, onSave }
 		gridDragSourceRef,
 		storyBlockDragContext,
 		handleDragHandleNodeChange,
-		handleNodeType,
 		storyEditorRef,
 		onElementDragStart,
 		onElementDragEnd,
@@ -39,11 +38,9 @@ export const StoryEditor = memo(function StoryEditor({ code, editorRef, onSave }
 							onElementDragStart={onElementDragStart}
 							onElementDragEnd={onElementDragEnd}
 						>
-							{handleNodeType === 'chartBlock' || handleNodeType === 'tableBlock' ? null : (
-								<div className='drag-handle-button'>
-									<GripVertical className='size-4' />
-								</div>
-							)}
+							<div className='drag-handle-button'>
+								<GripVertical className='size-4' />
+							</div>
 						</DragHandle>
 					)}
 					<EditorContent editor={editor} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Lone chart/table blocks can't be dragged (and can't be moved as part of a multi-select) because the gutter drag handle is hidden whenever the hovered node is a `chartBlock` or `tableBlock`.

## Cause

`story-editor.tsx` renders `null` instead of the drag-handle button for those node types:

```tsx
{handleNodeType === 'chartBlock' || handleNodeType === 'tableBlock' ? null : (
	<div className='drag-handle-button'><GripVertical /></div>
)}
```

This regressed via the flexible-chart-grids work (#1224); an earlier fix that removed this conditional never reached `main`.

## Fix

Always render the drag-handle button and drop the now-unused `handleNodeType` from the destructuring. One-file, minimal change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-109e2374-a270-41ea-91e7-af0e9c8f5333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-109e2374-a270-41ea-91e7-af0e9c8f5333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

