### PR TITLE
Exclude "Chat with nao data" admin chats from context recommendations

### DIFF
--- a/apps/backend/src/agents/tools/query-app-db.ts
+++ b/apps/backend/src/agents/tools/query-app-db.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { ScopedViewOptions } from '../../db/app-db-views';
 import { runScopedAppDbQuery } from '../../db/readonly-app-db';
 import { ALLOWED_APP_DB_VIEWS, validateAppDbQuery } from '../../utils/app-db-allowlist';
 import { createTool } from '../../utils/tools';
@@ -16,19 +17,23 @@ export interface QueryAppDbOutput {
 	rowCount: number;
 }
 
-export async function queryAppDb(projectId: string, sql: string): Promise<QueryAppDbOutput> {
+export async function queryAppDb(
+	projectId: string,
+	sql: string,
+	options: ScopedViewOptions = {},
+): Promise<QueryAppDbOutput> {
 	const verdict = await validateAppDbQuery(sql);
 	if (!verdict.ok) {
 		throw new Error(verdict.reason ?? 'Query rejected.');
 	}
-	const { columns, rows } = await runScopedAppDbQuery(projectId, sql);
+	const { columns, rows } = await runScopedAppDbQuery(projectId, sql, options);
 	return { _version: '1', columns, rows, rowCount: rows.length };
 }
 
-export function createQueryAppDbTool(projectId: string) {
+export function createQueryAppDbTool(projectId: string, options: ScopedViewOptions = {}) {
 	return createTool<Input, QueryAppDbOutput>({
 		description: `Run a read-only SQL query over the nao app database to mine usage signal. Only SELECT/WITH over these project-scoped views is allowed: ${ALLOWED_APP_DB_VIEWS.join(', ')}.`,
 		inputSchema: InputSchema,
-		execute: async ({ sql }) => queryAppDb(projectId, sql),
+		execute: async ({ sql }) => queryAppDb(projectId, sql, options),
 	});
 }

--- a/apps/backend/src/db/app-db-views.ts
+++ b/apps/backend/src/db/app-db-views.ts
@@ -1,4 +1,4 @@
-import { asc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { pgTable, QueryBuilder as PgQueryBuilder, text as pgText } from 'drizzle-orm/pg-core';
 import { QueryBuilder as SqliteQueryBuilder, sqliteTable, text as sqliteText } from 'drizzle-orm/sqlite-core';
 
@@ -15,6 +15,18 @@ export interface ScopedView {
 	columns: string[];
 }
 
+export interface ScopedViewOptions {
+	/**
+	 * Exclude "Chat with nao data" admin-mode chats (messages sourced from `admin`)
+	 * from `v_messages`. They are internal/meta conversations, not genuine end-user
+	 * analytics questions, so the context recommendations engine leaves them out.
+	 */
+	excludeAdminChats?: boolean;
+}
+
+/** Message source used by the admin-mode "Chat with nao data" feature. */
+const ADMIN_MESSAGE_SOURCE = 'admin';
+
 type ViewSchema = typeof sqliteSchema;
 type ScopeTable = typeof sqliteScope;
 
@@ -30,15 +42,16 @@ const pgScope = pgTable('_scope', { projectId: pgText('project_id').notNull() })
  * Each view filters to the single project id held in the `_scope` temp table
  * (bound via a parameter at runtime, never interpolated into SQL).
  */
-export function getScopedViews(): ScopedView[] {
+export function getScopedViews(options: ScopedViewOptions = {}): ScopedView[] {
 	if (dbConfig.dialect === Dialect.Postgres) {
 		return buildScopedViews(
 			pgSchema as unknown as ViewSchema,
 			pgScope as unknown as ScopeTable,
 			new PgQueryBuilder() as unknown as SqliteQueryBuilder,
+			options,
 		);
 	}
-	return buildScopedViews(sqliteSchema, sqliteScope, new SqliteQueryBuilder());
+	return buildScopedViews(sqliteSchema, sqliteScope, new SqliteQueryBuilder(), options);
 }
 
 /** View name -> exposed columns. Dialect-independent; safe to use in prompts and allowlists. */
@@ -46,7 +59,12 @@ export const APP_DB_VIEW_COLUMNS: Record<string, string[]> = Object.fromEntries(
 	getScopedViews().map((view) => [view.name, view.columns]),
 );
 
-function buildScopedViews(schema: ViewSchema, scope: ScopeTable, qb: SqliteQueryBuilder): ScopedView[] {
+function buildScopedViews(
+	schema: ViewSchema,
+	scope: ScopeTable,
+	qb: SqliteQueryBuilder,
+	options: ScopedViewOptions = {},
+): ScopedView[] {
 	const {
 		chat,
 		chatMessage,
@@ -109,6 +127,15 @@ function buildScopedViews(schema: ViewSchema, scope: ScopeTable, qb: SqliteQuery
 		called_at: mcpCallLog.calledAt,
 	};
 
+	const scopedToProject = inArray(chat.projectId, scopedProjectIds());
+	// The literal is inlined (not a bound parameter) because SQLite rejects
+	// parameters inside a CREATE VIEW body.
+	const notAdminSource = or(
+		isNull(chatMessage.source),
+		sql`${chatMessage.source} <> '${sql.raw(ADMIN_MESSAGE_SOURCE)}'`,
+	);
+	const messagesWhere = options.excludeAdminChats ? and(scopedToProject, notAdminSource) : scopedToProject;
+
 	const projectSelection = { id: project.id, name: project.name };
 
 	const analyticsEventSelection = {
@@ -136,7 +163,7 @@ function buildScopedViews(schema: ViewSchema, scope: ScopeTable, qb: SqliteQuery
 				.leftJoin(chatMessage, eq(messagePart.messageId, chatMessage.id))
 				.leftJoin(chat, eq(chat.id, chatMessage.chatId))
 				.leftJoin(user, eq(user.id, chat.userId))
-				.where(inArray(chat.projectId, scopedProjectIds()))
+				.where(messagesWhere)
 				.orderBy(chatMessage.chatId, asc(messagePart.createdAt)),
 		),
 		toView(

--- a/apps/backend/src/db/readonly-app-db.ts
+++ b/apps/backend/src/db/readonly-app-db.ts
@@ -1,7 +1,7 @@
 import postgres from 'postgres';
 
 import { env } from '../env';
-import { getScopedViews } from './app-db-views';
+import { getScopedViews, ScopedViewOptions } from './app-db-views';
 import dbConfig, { Dialect } from './dbConfig';
 
 export interface AppDbQueryResult {
@@ -9,14 +9,18 @@ export interface AppDbQueryResult {
 	rows: Record<string, unknown>[];
 }
 
-export async function runScopedAppDbQuery(projectId: string, sql: string): Promise<AppDbQueryResult> {
+export async function runScopedAppDbQuery(
+	projectId: string,
+	sql: string,
+	options: ScopedViewOptions = {},
+): Promise<AppDbQueryResult> {
 	if (dbConfig.dialect === Dialect.Postgres) {
-		return runPostgres(projectId, sql);
+		return runPostgres(projectId, sql, options);
 	}
-	return runSqlite(projectId, sql);
+	return runSqlite(projectId, sql, options);
 }
 
-async function runSqlite(projectId: string, sql: string): Promise<AppDbQueryResult> {
+async function runSqlite(projectId: string, sql: string, options: ScopedViewOptions): Promise<AppDbQueryResult> {
 	// Production runs under Bun (bun:sqlite); tests run under Node (better-sqlite3).
 	// better-sqlite3's native binding does not load under Bun, so the driver is chosen by runtime.
 	if (typeof Bun !== 'undefined') {
@@ -25,7 +29,7 @@ async function runSqlite(projectId: string, sql: string): Promise<AppDbQueryResu
 		try {
 			conn.run('CREATE TEMP TABLE _scope (project_id TEXT NOT NULL)');
 			conn.query('INSERT INTO _scope (project_id) VALUES (?)').run(projectId);
-			for (const view of getScopedViews()) {
+			for (const view of getScopedViews(options)) {
 				conn.run(`CREATE TEMP VIEW ${view.name} AS ${view.body}`);
 			}
 			conn.run('PRAGMA query_only = ON');
@@ -41,7 +45,7 @@ async function runSqlite(projectId: string, sql: string): Promise<AppDbQueryResu
 	try {
 		conn.exec('CREATE TEMP TABLE _scope (project_id TEXT NOT NULL)');
 		conn.prepare('INSERT INTO _scope (project_id) VALUES (?)').run(projectId);
-		for (const view of getScopedViews()) {
+		for (const view of getScopedViews(options)) {
 			conn.exec(`CREATE TEMP VIEW ${view.name} AS ${view.body}`);
 		}
 		// Belt-and-suspenders: block any write that slipped past the validator.
@@ -53,7 +57,7 @@ async function runSqlite(projectId: string, sql: string): Promise<AppDbQueryResu
 	}
 }
 
-async function runPostgres(projectId: string, sql: string): Promise<AppDbQueryResult> {
+async function runPostgres(projectId: string, sql: string, options: ScopedViewOptions): Promise<AppDbQueryResult> {
 	const ssl = env.DB_SSL ? 'require' : undefined;
 	const client = postgres(dbConfig.dbUrl, { ssl, max: 1 });
 	try {
@@ -63,7 +67,7 @@ async function runPostgres(projectId: string, sql: string): Promise<AppDbQueryRe
 		await client.begin(async (tx) => {
 			await tx`CREATE TEMP TABLE _scope (project_id text NOT NULL)`;
 			await tx`INSERT INTO _scope (project_id) VALUES (${projectId})`;
-			for (const view of getScopedViews()) {
+			for (const view of getScopedViews(options)) {
 				await tx.unsafe(`CREATE TEMP VIEW ${view.name} AS ${view.body}`);
 			}
 		});

--- a/apps/backend/src/queries/context-recommendation.queries.ts
+++ b/apps/backend/src/queries/context-recommendation.queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, isNotNull, lt, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, ne, or, sql } from 'drizzle-orm';
 
 import s, {
 	DBContextRecommendation,
@@ -272,6 +272,9 @@ export async function setRecommendationStatus(input: {
 
 /** Total friction signals (errors, downvotes, regenerations) for a project over a window. */
 export async function getWindowTotals(projectId: string, start: Date, end: Date): Promise<WindowTotals> {
+	// "Chat with nao data" admin-mode conversations are internal/meta chats, not
+	// genuine end-user analytics questions, so they are excluded from the signal.
+	const notAdminChat = or(isNull(s.chatMessage.source), ne(s.chatMessage.source, 'admin'));
 	const [[errors], [downvotes], [regenerations]] = await Promise.all([
 		db
 			.select({ n: sql<number>`count(*)` })
@@ -284,6 +287,7 @@ export async function getWindowTotals(projectId: string, start: Date, end: Date)
 					eq(s.messagePart.toolState, 'output-error'),
 					gte(s.messagePart.createdAt, start),
 					lt(s.messagePart.createdAt, end),
+					notAdminChat,
 				),
 			)
 			.execute(),
@@ -298,6 +302,7 @@ export async function getWindowTotals(projectId: string, start: Date, end: Date)
 					eq(s.messageFeedback.vote, 'down'),
 					gte(s.messageFeedback.createdAt, start),
 					lt(s.messageFeedback.createdAt, end),
+					notAdminChat,
 				),
 			)
 			.execute(),
@@ -311,6 +316,7 @@ export async function getWindowTotals(projectId: string, start: Date, end: Date)
 					isNotNull(s.chatMessage.supersededAt),
 					gte(s.chatMessage.createdAt, start),
 					lt(s.chatMessage.createdAt, end),
+					notAdminChat,
 				),
 			)
 			.execute(),

--- a/apps/backend/src/services/context-recommendations.service.ts
+++ b/apps/backend/src/services/context-recommendations.service.ts
@@ -102,7 +102,7 @@ export async function runContextRecommendations(
 				getTools(
 					agentSettings,
 					{
-						query_app_db: createQueryAppDbTool(projectId),
+						query_app_db: createQueryAppDbTool(projectId, { excludeAdminChats: true }),
 						record_recommendation: collector.recordTool,
 						resolve_recommendation: collector.resolveTool,
 						...(fixCollector && {

--- a/apps/backend/tests/readonly-app-db.test.ts
+++ b/apps/backend/tests/readonly-app-db.test.ts
@@ -14,9 +14,9 @@ const ORG_ID = 'ro-test-org';
 const USER_ID = 'ro-test-user';
 const PROJECT_A = 'ro-test-project-a';
 const PROJECT_B = 'ro-test-project-b';
-const CHAT_IDS = ['ro-chat-a', 'ro-chat-b'];
-const MESSAGE_IDS = ['ro-msg-a', 'ro-msg-b'];
-const PART_IDS = ['ro-part-a', 'ro-part-b'];
+const CHAT_IDS = ['ro-chat-a', 'ro-chat-b', 'ro-chat-admin'];
+const MESSAGE_IDS = ['ro-msg-a', 'ro-msg-b', 'ro-msg-admin'];
+const PART_IDS = ['ro-part-a', 'ro-part-b', 'ro-part-admin'];
 
 async function cleanup() {
 	// Child -> parent so the cleanup works even without cascading FKs.
@@ -75,5 +75,31 @@ describe('runScopedAppDbQuery', () => {
 		await expect(runScopedAppDbQuery(PROJECT_A, "UPDATE chat SET title = 'hacked'")).rejects.toThrow();
 		const rows = await db.select().from(chat).where(eq(chat.id, 'ro-chat-a'));
 		expect(rows[0].title).toBe('A chat');
+	});
+
+	describe('with an admin-mode "Chat with nao data" chat', () => {
+		beforeEach(async () => {
+			await db
+				.insert(chat)
+				.values({ id: 'ro-chat-admin', userId: USER_ID, projectId: PROJECT_A, title: 'Admin analytics' });
+			await db
+				.insert(chatMessage)
+				.values({ id: 'ro-msg-admin', chatId: 'ro-chat-admin', role: 'user', source: 'admin' });
+			await db
+				.insert(messagePart)
+				.values({ id: 'ro-part-admin', messageId: 'ro-msg-admin', order: 0, type: 'text', text: 'admin' });
+		});
+
+		it('includes admin chats by default', async () => {
+			const { rows } = await runScopedAppDbQuery(PROJECT_A, 'SELECT chat_id FROM v_messages');
+			expect(new Set(rows.map((r) => r.chat_id))).toEqual(new Set(['ro-chat-a', 'ro-chat-admin']));
+		});
+
+		it('excludes admin chats when excludeAdminChats is set', async () => {
+			const { rows } = await runScopedAppDbQuery(PROJECT_A, 'SELECT chat_id FROM v_messages', {
+				excludeAdminChats: true,
+			});
+			expect(rows.map((r) => r.chat_id)).toEqual(['ro-chat-a']);
+		});
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes #1234.

The context recommendations engine analyzed **all** conversations for a project, including the internal "Chat with nao data" admin-mode chats (messages with `source = 'admin'`). These are meta/analytics chats where an admin queries nao's own usage data — not genuine end-user analytics questions — so they added noise to the surfaced recommendations.

## Change

Scopes the exclusion to the recommendations engine only (the admin "Chat with nao data" feature itself is unchanged):

- **`app-db-views.ts`** — `getScopedViews` now accepts a `ScopedViewOptions` argument. When `excludeAdminChats` is set, `v_messages` drops rows sourced from `admin` (the literal is inlined via `sql.raw`, since SQLite rejects bound parameters inside a `CREATE VIEW` body). Non-admin/`NULL` sources are preserved.
- **`readonly-app-db.ts`** / **`query-app-db.ts`** — thread the option through `runScopedAppDbQuery`, `queryAppDb`, and `createQueryAppDbTool`.
- **`context-recommendations.service.ts`** — the recommendations agent's `query_app_db` tool is created with `{ excludeAdminChats: true }`, so it can no longer see admin chats.
- **`context-recommendation.queries.ts`** — `getWindowTotals` (errors / downvotes / regenerations that feed impact scoring) now excludes admin-sourced messages too, for consistency.

The default `getScopedViews()` (used by the admin "Chat with nao data" feature and `APP_DB_VIEW_COLUMNS`) is unchanged — admin chats are only filtered when the recommendations engine opts in.

## Testing

- Added coverage in `readonly-app-db.test.ts` verifying `v_messages` includes admin chats by default and excludes them when `excludeAdminChats` is set.
- `npx tsc --noEmit` and `eslint` pass on all changed files.
- Full backend suite: all tests pass except 2 pre-existing failures in `auth-hooks-oidc.test.ts` (unrelated; they also fail on the base commit with these changes stashed).

Per the repo's Cursor Cloud testing preferences, no manual GUI verification was performed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9025-7d7b-7671-afef-f7457483ca03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9025-7d7b-7671-afef-f7457483ca03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

