### PR TITLE
[fix : tables] column sorting conserve max width

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -25,6 +25,8 @@ interface TableDisplayProps {
 	humanizeColumnLabels?: boolean;
 }
 
+type Sort = { column: string; direction: SortDirection };
+
 export function TableDisplay({
 	data,
 	columns,
@@ -49,13 +51,22 @@ export function TableDisplay({
 		[data, conditionalFormats],
 	);
 
+	const columnMinWidths = useMemo(
+		() => computeColumnMinWidths(data, resolvedColumns, dateFormat),
+		[data, resolvedColumns, dateFormat],
+	);
+
 	const [pageIndex, setPageIndex] = useState(0);
 	const [pageSize, setPageSize] = useState(maxRowsBeforePagination);
-	const [sort, setSort] = useState<{ column: string; direction: SortDirection } | null>(null);
+	const [sort, setSort] = useState<Sort | null>(null);
 
 	useEffect(() => setPageIndex(0), [data]);
 
-	const sortedData = useMemo(() => (sort ? sortTableRows(data, sort.column, sort.direction) : data), [data, sort]);
+	const activeSort = sort && resolvedColumns.includes(sort.column) ? sort : null;
+	const sortedData = useMemo(
+		() => (activeSort ? sortTableRows(data, activeSort.column, activeSort.direction) : data),
+		[data, activeSort],
+	);
 
 	const pageCount = Math.ceil(sortedData.length / pageSize);
 	const pageData = useMemo(
@@ -65,15 +76,7 @@ export function TableDisplay({
 
 	function toggleSort(column: string) {
 		setPageIndex(0);
-		setSort((current) => {
-			if (!current || current.column !== column) {
-				return { column, direction: 'asc' };
-			}
-			if (current.direction === 'asc') {
-				return { column, direction: 'desc' };
-			}
-			return null;
-		});
+		setSort(nextSort(activeSort, column));
 	}
 
 	return (
@@ -87,7 +90,7 @@ export function TableDisplay({
 							<th className='shadow-[inset_-1px_0_0_0_var(--border)] last:shadow-none px-3 py-2 text-center font-medium whitespace-nowrap text-foreground w-4' />
 							{resolvedColumns.map((column) => {
 								const alignRight = numericColumns.has(column);
-								const sortDirection = sort?.column === column ? sort.direction : null;
+								const sortDirection = activeSort?.column === column ? activeSort.direction : null;
 								return (
 									<th
 										key={column}
@@ -142,7 +145,10 @@ export function TableDisplay({
 										return (
 											<td
 												key={`${rowIndex}-${column}`}
-												style={background ? { backgroundColor: background } : undefined}
+												style={{
+													minWidth: columnMinWidths[column],
+													...(background ? { backgroundColor: background } : {}),
+												}}
 												className={cn(
 													'shadow-[inset_-1px_0_0_0_var(--border)] last:shadow-none px-3 py-1 align-top font-mono text-[11px] leading-5 whitespace-nowrap',
 													numericColumns.has(column) && 'text-right tabular-nums',
@@ -218,6 +224,35 @@ function SortIndicator({ direction }: { direction: SortDirection | null }) {
 			/>
 		</span>
 	);
+}
+
+function nextSort(current: Sort | null, column: string): Sort | null {
+	if (!current || current.column !== column) {
+		return { column, direction: 'asc' };
+	}
+	if (current.direction === 'asc') {
+		return { column, direction: 'desc' };
+	}
+	return null;
+}
+
+function computeColumnMinWidths(
+	data: TableRow[],
+	columns: string[],
+	dateFormat: ReturnType<typeof useDateFormat>,
+): Record<string, string> {
+	const widths: Record<string, string> = {};
+	for (const column of columns) {
+		let maxChars = 0;
+		for (const row of data) {
+			const chars = formatCellValue(row[column], dateFormat).length;
+			if (chars > maxChars) {
+				maxChars = chars;
+			}
+		}
+		widths[column] = `calc(${maxChars}ch + 1.5rem)`;
+	}
+	return widths;
 }
 
 function computeFormattedColumnRanges(

--- a/apps/frontend/src/components/tool-calls/display-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-table.tsx
@@ -41,7 +41,10 @@ export function TableDisplay({
 	humanizeColumnLabels = false,
 }: TableDisplayProps) {
 	const dateFormat = useDateFormat();
-	const resolvedColumns = columns && columns.length > 0 ? columns : inferColumns(data);
+	const resolvedColumns = useMemo(
+		() => (columns && columns.length > 0 ? columns : inferColumns(data)),
+		[columns, data],
+	);
 	const numericColumns = new Set(resolvedColumns.filter((column) => isNumericColumn(data, column)));
 	const hasRows = data.length > 0;
 	const showPagination = hasRows && data.length > maxRowsBeforePagination;


### PR DESCRIPTION
## Summary

- `display-table.tsx` : compute a per-column min-width from the longest formatted value across the full dataset, so column widths stay stable regardless of sort/page
- ignore the active sort when its column is no longer present in the data
The color-scale "flicker" was a visual side effect of the width jump, not a color-scale bug — cell colors depend only on value + full-column range, independent of row order

## Related issue

#1268 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

