### PR TITLE
fix(cli): correct httpx version pin

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "numpy>=1.26.0",
     "pandas>=2.1.0",
     "sqlglot>=26.0.0",
-    "httpx>=0.27.0",
+    "httpx>=0.28.1",
 ]
 
 [project.optional-dependencies]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -2742,7 +2742,7 @@ requires-dist = [
     { name = "glom", marker = "extra == 'aws-secrets'", specifier = ">=23.0.0" },
     { name = "google-cloud", marker = "extra == 'bigquery'", specifier = ">=0.34.0" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.61.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "ibis-framework", specifier = ">=9.0.0" },
     { name = "ibis-framework", extras = ["athena"], marker = "extra == 'athena'", specifier = ">=9.0.0" },
     { name = "ibis-framework", extras = ["bigquery"], marker = "extra == 'bigquery'", specifier = ">=9.0.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The nao CLI (`cli/pyproject.toml`) pinned `httpx>=0.27.0`. That floor permits httpx `0.27.x`, which is a **not-working version** for two of nao's LLM integrations:

- `google-genai` requires `httpx<1.0.0,>=0.28.1`
- `mistralai` requires `httpx>=0.28.1`

So installing `nao-core[gemini]` / `nao-core[mistral]` (or `nao-core[all-llms]`) with an httpx `0.27.x` already present leaves the environment on an incompatible httpx.

## Fix

Bump the httpx floor to match the ecosystem requirement:

```
- "httpx>=0.27.0",
+ "httpx>=0.28.1",
```

Regenerated `uv.lock` (still resolves to httpx `0.28.1`).

## Verification

- `uv lock --check` — resolved 190 packages, clean.
- `cd cli && make lint` — `ty`, `ruff check`, import sort, and `ruff format --check` all pass.
- Imported `httpx` + the httpx-using CLI modules (`nao_core.commands.deploy`, `nao_core.version`) against the resolved `httpx 0.28.1` — all imports OK and the used APIs (`post`, `get`, `ConnectError`, `TimeoutException`) are present.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9415-2a51-79f2-b712-63be3a614073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9415-2a51-79f2-b712-63be3a614073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

