### PR TITLE
[fix : feed] resolve story and feed access from feed panel

### DIFF
--- a/apps/backend/src/queries/activity.queries.ts
+++ b/apps/backend/src/queries/activity.queries.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, lte, ne, or, sql } from 'drizzle-orm';
+import { aliasedTable, and, desc, eq, inArray, lte, ne, or, sql } from 'drizzle-orm';
 
 import s, {
 	type ActivityTrigger,
@@ -102,6 +102,11 @@ export const linkStoryScheduledJob = async (storyId: string, scheduledJobId: str
 	await db.update(s.story).set({ scheduledJobId }).where(eq(s.story.id, storyId)).execute();
 };
 
+export type StoryOpenLink =
+	| { to: '/stories/preview/$chatId/$storySlug'; params: { chatId: string; storySlug: string } }
+	| { to: '/stories/shared/$shareId'; params: { shareId: string } }
+	| { to: '/stories/standalone/$storyId'; params: { storyId: string } };
+
 export interface ListActivityRow {
 	activity: DBActivity;
 	actorName: string | null;
@@ -113,6 +118,7 @@ export interface ListActivityRow {
 		cacheSchedule: string | null;
 		cacheScheduleDescription: string | null;
 	} | null;
+	storyLink: StoryOpenLink | null;
 	chat: {
 		id: string;
 		title: string;
@@ -127,6 +133,29 @@ export interface ListActivityRow {
 	} | null;
 }
 
+function buildStoryOpenLink(input: {
+	storyId: string;
+	chatId: string | null;
+	storySlug: string;
+	ownerId: string | null;
+	shareId: string | null;
+	viewerId: string;
+}): StoryOpenLink | null {
+	const isOwner = input.ownerId !== null && input.ownerId === input.viewerId;
+	if (isOwner) {
+		return input.chatId
+			? {
+					to: '/stories/preview/$chatId/$storySlug',
+					params: { chatId: input.chatId, storySlug: input.storySlug },
+				}
+			: { to: '/stories/standalone/$storyId', params: { storyId: input.storyId } };
+	}
+	if (input.shareId) {
+		return { to: '/stories/shared/$shareId', params: { shareId: input.shareId } };
+	}
+	return null;
+}
+
 /**
  * Returns the most recent activities visible to `userId` inside `projectId`,
  * resolving the audience via JOINs on the share tables so a single activity
@@ -139,6 +168,10 @@ export interface ListActivityRow {
  * The story/chat/share rows are eager-loaded so the feed renderer can build
  * cards without follow-up queries.
  */
+
+const storyChat = aliasedTable(s.chat, 'story_chat');
+const storyProjectShare = aliasedTable(s.sharedStory, 'story_project_share');
+
 export const listRecentActivities = async (
 	projectId: string,
 	userId: string,
@@ -162,6 +195,9 @@ export const listRecentActivities = async (
 			storyChatId: s.story.chatId,
 			storyCacheSchedule: s.story.cacheSchedule,
 			storyCacheScheduleDescription: s.story.cacheScheduleDescription,
+			storyUserId: s.story.userId,
+			storyChatOwnerId: storyChat.userId,
+			storyProjectShareId: storyProjectShare.id,
 			chatRowId: s.chat.id,
 			chatTitle: s.chat.title,
 			storyShareId: s.sharedStory.id,
@@ -172,6 +208,11 @@ export const listRecentActivities = async (
 		.from(s.activity)
 		.leftJoin(s.user, eq(s.user.id, s.activity.userId))
 		.leftJoin(s.story, eq(s.story.id, s.activity.storyId))
+		.leftJoin(storyChat, eq(storyChat.id, s.story.chatId))
+		.leftJoin(
+			storyProjectShare,
+			and(eq(storyProjectShare.storyId, s.story.id), eq(storyProjectShare.projectId, projectId)),
+		)
 		.leftJoin(s.chat, eq(s.chat.id, s.activity.chatId))
 		.leftJoin(s.sharedStory, eq(s.sharedStory.id, s.activity.sharedStoryId))
 		.leftJoin(s.sharedChat, eq(s.sharedChat.id, s.activity.sharedChatId))
@@ -192,6 +233,16 @@ export const listRecentActivities = async (
 					cacheSchedule: row.storyCacheSchedule,
 					cacheScheduleDescription: row.storyCacheScheduleDescription,
 				}
+			: null,
+		storyLink: row.storyId
+			? buildStoryOpenLink({
+					storyId: row.storyId,
+					chatId: row.storyChatId,
+					storySlug: row.storySlug!,
+					ownerId: row.storyChatOwnerId ?? row.storyUserId,
+					shareId: row.storyShareId ?? row.storyProjectShareId,
+					viewerId: userId,
+				})
 			: null,
 		chat: row.chatRowId
 			? {

--- a/apps/backend/src/queries/automation.queries.ts
+++ b/apps/backend/src/queries/automation.queries.ts
@@ -15,7 +15,7 @@ import s, {
 } from '../db/abstractSchema';
 import { db } from '../db/db';
 import type { AutomationIntegrationResult } from '../types/automation';
-import { type ListActivityRow, listRecentActivities } from './activity.queries';
+import { type ListActivityRow, listRecentActivities, type StoryOpenLink } from './activity.queries';
 
 export const automationJobUniqueKey = (automationId: string): string => `automation:${automationId}`;
 const AUTOMATION_RUN_STALE_MS = 30 * 60 * 1_000;
@@ -375,6 +375,7 @@ export type ActivityFeedStoryRefreshItem = {
 		cacheSchedule: string | null;
 		cacheScheduleDescription: string | null;
 	};
+	link: StoryOpenLink | null;
 };
 
 export type ActivityFeedStorySharedItem = {
@@ -394,6 +395,7 @@ export type ActivityFeedStorySharedItem = {
 		id: string;
 		visibility: StoryVisibility;
 	};
+	link: StoryOpenLink | null;
 	actorName: string | null;
 };
 
@@ -497,6 +499,7 @@ function buildActivityFeedItem(row: ListActivityRow): ActivityFeedItem | null {
 				queriesRefreshed: readNumber(row.activity.payload, 'queriesRefreshed') ?? 0,
 			},
 			story: row.story,
+			link: row.storyLink,
 		};
 	}
 	if (row.activity.type === 'story.shared') {
@@ -515,6 +518,7 @@ function buildActivityFeedItem(row: ListActivityRow): ActivityFeedItem | null {
 				chatId: row.story.chatId,
 			},
 			share: row.storyShare,
+			link: row.storyLink,
 			actorName: row.actorName,
 		};
 	}

--- a/apps/frontend/src/components/automations-feed.tsx
+++ b/apps/frontend/src/components/automations-feed.tsx
@@ -80,6 +80,11 @@ type ActivityBaseFields = {
 	errorMessage?: string | null;
 };
 
+export type StoryOpenLink =
+	| { to: '/stories/preview/$chatId/$storySlug'; params: { chatId: string; storySlug: string } }
+	| { to: '/stories/shared/$shareId'; params: { shareId: string } }
+	| { to: '/stories/standalone/$storyId'; params: { storyId: string } };
+
 export type ActivityFeedStoryRefreshItem = {
 	kind: 'activity';
 	id: string;
@@ -96,6 +101,7 @@ export type ActivityFeedStoryRefreshItem = {
 		cacheSchedule: string | null;
 		cacheScheduleDescription: string | null;
 	};
+	link: StoryOpenLink | null;
 };
 
 export type ActivityFeedStorySharedItem = {
@@ -110,6 +116,7 @@ export type ActivityFeedStorySharedItem = {
 		chatId: string | null;
 	};
 	share: { id: string; visibility: ShareVisibility };
+	link: StoryOpenLink | null;
 	actorName: string | null;
 };
 
@@ -308,7 +315,7 @@ function AutomationRunCard({
 }
 
 function StoryRefreshCard({ item, isNew = false }: { item: ActivityFeedStoryRefreshItem; isNew?: boolean }) {
-	const { activity, story } = item;
+	const { activity, story, link } = item;
 	const startedAt = new Date(activity.startedAt);
 	const timeAgo = useTimeAgo(startedAt.getTime());
 	const isRunning = activity.status === 'running';
@@ -330,12 +337,8 @@ function StoryRefreshCard({ item, isNew = false }: { item: ActivityFeedStoryRefr
 						className={cn('size-3.5 shrink-0 text-muted-foreground', isRunning && 'animate-spin')}
 						aria-hidden
 					/>
-					{story.chatId ? (
-						<Link
-							to='/stories/preview/$chatId/$storySlug'
-							params={{ chatId: story.chatId, storySlug: story.slug }}
-							className='truncate text-sm font-semibold hover:underline'
-						>
+					{link ? (
+						<Link {...link} className='truncate text-sm font-semibold hover:underline'>
 							{story.title}
 						</Link>
 					) : (
@@ -365,13 +368,9 @@ function StoryRefreshCard({ item, isNew = false }: { item: ActivityFeedStoryRefr
 
 			<footer className='flex items-center justify-between gap-2 border-t px-4 py-2.5'>
 				<span className='text-xs text-muted-foreground'>Live story</span>
-				{story.chatId && (
+				{link && (
 					<Button variant='ghost' size='sm' asChild>
-						<Link
-							to='/stories/preview/$chatId/$storySlug'
-							params={{ chatId: story.chatId, storySlug: story.slug }}
-							className='gap-1.5'
-						>
+						<Link {...link} className='gap-1.5'>
 							<ExternalLink className='size-3.5' />
 							<span className='text-xs'>Open story</span>
 						</Link>
@@ -445,9 +444,10 @@ function StoryRefreshBody({
 }
 
 function StorySharedCard({ item, isNew = false }: { item: ActivityFeedStorySharedItem; isNew?: boolean }) {
-	const { activity, story, share, actorName } = item;
+	const { activity, story, share, actorName, link } = item;
 	const startedAt = new Date(activity.startedAt);
 	const timeAgo = useTimeAgo(startedAt.getTime());
+	const openLink = link ?? { to: '/stories/shared/$shareId', params: { shareId: share.id } };
 
 	return (
 		<article
@@ -460,17 +460,9 @@ function StorySharedCard({ item, isNew = false }: { item: ActivityFeedStoryShare
 			<header className='flex items-center justify-between gap-3 px-4 pt-4'>
 				<div className='flex min-w-0 items-center gap-2'>
 					<Share2 className='size-3.5 shrink-0 text-muted-foreground' aria-hidden />
-					{story.chatId ? (
-						<Link
-							to='/stories/preview/$chatId/$storySlug'
-							params={{ chatId: story.chatId, storySlug: story.slug }}
-							className='truncate text-sm font-semibold hover:underline'
-						>
-							{story.title}
-						</Link>
-					) : (
-						<span className='truncate text-sm font-semibold'>{story.title}</span>
-					)}
+					<Link {...openLink} className='truncate text-sm font-semibold hover:underline'>
+						{story.title}
+					</Link>
 					<span className='text-muted-foreground/60 text-xs' title={startedAt.toLocaleString()}>
 						· {timeAgo.humanReadable}
 					</span>
@@ -484,18 +476,12 @@ function StorySharedCard({ item, isNew = false }: { item: ActivityFeedStoryShare
 
 			<footer className='flex items-center justify-between gap-2 border-t px-4 py-2.5'>
 				<span className='text-xs text-muted-foreground'>Shared story</span>
-				{story.chatId && (
-					<Button variant='ghost' size='sm' asChild>
-						<Link
-							to='/stories/preview/$chatId/$storySlug'
-							params={{ chatId: story.chatId, storySlug: story.slug }}
-							className='gap-1.5'
-						>
-							<ExternalLink className='size-3.5' />
-							<span className='text-xs'>Open story</span>
-						</Link>
-					</Button>
-				)}
+				<Button variant='ghost' size='sm' asChild>
+					<Link {...openLink} className='gap-1.5'>
+						<ExternalLink className='size-3.5' />
+						<span className='text-xs'>Open story</span>
+					</Link>
+				</Button>
 			</footer>
 		</article>
 	);

--- a/apps/frontend/src/components/story-access-error.tsx
+++ b/apps/frontend/src/components/story-access-error.tsx
@@ -1,30 +1,69 @@
 import { Link } from '@tanstack/react-router';
-import { Lock } from 'lucide-react';
+import { Lock, SearchX, TriangleAlert } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { isForbiddenError } from '@/lib/trpc-error';
+import { isForbiddenError, isNotFoundError } from '@/lib/trpc-error';
 
-export function StoryAccessError({ error }: { error?: unknown }) {
+export function StoryAccessError({ error, onRetry }: { error?: unknown; onRetry?: () => void }) {
 	const forbidden = isForbiddenError(error);
+	const notFound = isNotFoundError(error);
+
+	if (!forbidden && !notFound) {
+		return (
+			<StoryErrorLayout
+				icon={<TriangleAlert className='size-4' aria-hidden />}
+				title='Something went wrong'
+				description="We couldn't load this story. This is likely a temporary problem, so please try again."
+			>
+				{onRetry ? <Button onClick={onRetry}>Try again</Button> : null}
+				<Button asChild variant='secondary'>
+					<Link to='/'>Go home</Link>
+				</Button>
+			</StoryErrorLayout>
+		);
+	}
+
 	const title = forbidden ? "You don't have access to this story" : 'Story not found';
 	const description = forbidden
 		? 'This story has not been shared with you. Ask the owner to share it if you need access.'
-		: 'This story may have been deleted, moved, or you may not have access to it.';
+		: 'This story may have been deleted or moved.';
 
+	return (
+		<StoryErrorLayout
+			icon={forbidden ? <Lock className='size-4' aria-hidden /> : <SearchX className='size-4' aria-hidden />}
+			title={title}
+			description={description}
+		>
+			<Button asChild variant='secondary'>
+				<Link to='/'>Go home</Link>
+			</Button>
+		</StoryErrorLayout>
+	);
+}
+
+function StoryErrorLayout({
+	icon,
+	title,
+	description,
+	children,
+}: {
+	icon: React.ReactNode;
+	title: string;
+	description: string;
+	children: React.ReactNode;
+}) {
 	return (
 		<div className='flex h-full flex-1 flex-col min-w-0 overflow-hidden justify-center bg-background'>
 			<div className='flex flex-1 items-center justify-center p-6'>
 				<div className='flex max-w-sm flex-col items-center gap-4 text-center'>
 					<div className='flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground'>
-						<Lock className='size-4' aria-hidden />
+						{icon}
 					</div>
 					<div className='space-y-2'>
 						<h1 className='text-lg font-medium tracking-tight'>{title}</h1>
 						<p className='text-sm text-muted-foreground'>{description}</p>
 					</div>
-					<Button asChild variant='secondary'>
-						<Link to='/'>Go home</Link>
-					</Button>
+					<div className='flex items-center gap-2'>{children}</div>
 				</div>
 			</div>
 		</div>

--- a/apps/frontend/src/components/story-access-error.tsx
+++ b/apps/frontend/src/components/story-access-error.tsx
@@ -1,0 +1,32 @@
+import { Link } from '@tanstack/react-router';
+import { Lock } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { isForbiddenError } from '@/lib/trpc-error';
+
+export function StoryAccessError({ error }: { error?: unknown }) {
+	const forbidden = isForbiddenError(error);
+	const title = forbidden ? "You don't have access to this story" : 'Story not found';
+	const description = forbidden
+		? 'This story has not been shared with you. Ask the owner to share it if you need access.'
+		: 'This story may have been deleted, moved, or you may not have access to it.';
+
+	return (
+		<div className='flex h-full flex-1 flex-col min-w-0 overflow-hidden justify-center bg-background'>
+			<div className='flex flex-1 items-center justify-center p-6'>
+				<div className='flex max-w-sm flex-col items-center gap-4 text-center'>
+					<div className='flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground'>
+						<Lock className='size-4' aria-hidden />
+					</div>
+					<div className='space-y-2'>
+						<h1 className='text-lg font-medium tracking-tight'>{title}</h1>
+						<p className='text-sm text-muted-foreground'>{description}</p>
+					</div>
+					<Button asChild variant='secondary'>
+						<Link to='/'>Go home</Link>
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/src/components/story-access-error.tsx
+++ b/apps/frontend/src/components/story-access-error.tsx
@@ -1,8 +1,23 @@
-import { Link } from '@tanstack/react-router';
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
+import { Link, useRouter } from '@tanstack/react-router';
 import { Lock, SearchX, TriangleAlert } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { isForbiddenError, isNotFoundError } from '@/lib/trpc-error';
+
+export function StoryRouteError({ error }: { error?: unknown }) {
+	const router = useRouter();
+	const { reset } = useQueryErrorResetBoundary();
+	return (
+		<StoryAccessError
+			error={error}
+			onRetry={() => {
+				reset();
+				router.invalidate();
+			}}
+		/>
+	);
+}
 
 export function StoryAccessError({ error, onRetry }: { error?: unknown; onRetry?: () => void }) {
 	const forbidden = isForbiddenError(error);

--- a/apps/frontend/src/lib/trpc-error.ts
+++ b/apps/frontend/src/lib/trpc-error.ts
@@ -9,3 +9,7 @@ function getTrpcErrorCode(error: unknown): string | undefined {
 export function isForbiddenError(error: unknown): boolean {
 	return getTrpcErrorCode(error) === 'FORBIDDEN';
 }
+
+export function isNotFoundError(error: unknown): boolean {
+	return getTrpcErrorCode(error) === 'NOT_FOUND';
+}

--- a/apps/frontend/src/lib/trpc-error.ts
+++ b/apps/frontend/src/lib/trpc-error.ts
@@ -1,0 +1,11 @@
+function getTrpcErrorCode(error: unknown): string | undefined {
+	if (typeof error !== 'object' || error === null || !('data' in error)) {
+		return undefined;
+	}
+	const { data } = error as { data?: { code?: string } | null };
+	return data?.code ?? undefined;
+}
+
+export function isForbiddenError(error: unknown): boolean {
+	return getTrpcErrorCode(error) === 'FORBIDDEN';
+}

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -30,6 +30,7 @@ import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useSetChatInputCallback } from '@/contexts/set-chat-input-callback';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 import { getTextOffset } from '@/lib/selection-dom.utils';
+import { isForbiddenError } from '@/lib/trpc-error';
 
 export const Route = createFileRoute('/_sidebar-layout/_chat-layout/$chatId')({
 	component: RouteComponent,
@@ -320,14 +321,6 @@ function resolveStoryCitationMeta(
 	}
 
 	return { storySlug: currentStorySlug, start, end };
-}
-
-function isForbiddenError(error: unknown): boolean {
-	if (typeof error !== 'object' || error === null || !('data' in error)) {
-		return false;
-	}
-	const { data } = error as { data?: { code?: string } | null };
-	return data?.code === 'FORBIDDEN';
 }
 
 function buildHeaderCitation(meta: ForkMetadata | undefined): { citation: string; text: string } | null {

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -1,11 +1,5 @@
-import {
-	useMutation,
-	useQuery,
-	useQueryClient,
-	useQueryErrorResetBoundary,
-	useSuspenseQuery,
-} from '@tanstack/react-query';
-import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { ArchiveRestoreIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -19,7 +13,7 @@ import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { Button } from '@/components/ui/button';
 import { trpc } from '@/main';
 import { StoryContentLoading } from '@/components/side-panel/story-content-loading';
-import { StoryAccessError } from '@/components/story-access-error';
+import { StoryRouteError } from '@/components/story-access-error';
 import { LiveStorySettingsDialog } from '@/components/side-panel/live-story-settings-dialog';
 import { useStoryViewerLiveSettings } from '@/components/side-panel/hooks/use-story-viewer-live-settings';
 import { ShareStoryDialog } from '@/components/share-dialog.story';
@@ -36,22 +30,8 @@ import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 export const Route = createFileRoute('/_sidebar-layout/stories/preview/$chatId/$storySlug')({
 	component: StoryPreviewPage,
 	pendingComponent: StoryContentLoading,
-	errorComponent: StoryPreviewError,
+	errorComponent: StoryRouteError,
 });
-
-function StoryPreviewError({ error }: { error: unknown }) {
-	const router = useRouter();
-	const { reset } = useQueryErrorResetBoundary();
-	return (
-		<StoryAccessError
-			error={error}
-			onRetry={() => {
-				reset();
-				router.invalidate();
-			}}
-		/>
-	);
-}
 
 function StoryPreviewPage() {
 	const { chatId, storySlug } = Route.useParams();

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -1,5 +1,11 @@
-import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import {
+	useMutation,
+	useQuery,
+	useQueryClient,
+	useQueryErrorResetBoundary,
+	useSuspenseQuery,
+} from '@tanstack/react-query';
+import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router';
 import { ArchiveRestoreIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -30,8 +36,22 @@ import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 export const Route = createFileRoute('/_sidebar-layout/stories/preview/$chatId/$storySlug')({
 	component: StoryPreviewPage,
 	pendingComponent: StoryContentLoading,
-	errorComponent: ({ error }) => <StoryAccessError error={error} />,
+	errorComponent: StoryPreviewError,
 });
+
+function StoryPreviewError({ error }: { error: unknown }) {
+	const router = useRouter();
+	const { reset } = useQueryErrorResetBoundary();
+	return (
+		<StoryAccessError
+			error={error}
+			onRetry={() => {
+				reset();
+				router.invalidate();
+			}}
+		/>
+	);
+}
 
 function StoryPreviewPage() {
 	const { chatId, storySlug } = Route.useParams();

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -13,6 +13,7 @@ import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { Button } from '@/components/ui/button';
 import { trpc } from '@/main';
 import { StoryContentLoading } from '@/components/side-panel/story-content-loading';
+import { StoryAccessError } from '@/components/story-access-error';
 import { LiveStorySettingsDialog } from '@/components/side-panel/live-story-settings-dialog';
 import { useStoryViewerLiveSettings } from '@/components/side-panel/hooks/use-story-viewer-live-settings';
 import { ShareStoryDialog } from '@/components/share-dialog.story';
@@ -29,6 +30,7 @@ import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 export const Route = createFileRoute('/_sidebar-layout/stories/preview/$chatId/$storySlug')({
 	component: StoryPreviewPage,
 	pendingComponent: StoryContentLoading,
+	errorComponent: ({ error }) => <StoryAccessError error={error} />,
 });
 
 function StoryPreviewPage() {

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -1,5 +1,5 @@
-import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { ParsedChartBlock, ParsedTableBlock } from '@nao/shared/story-segments';
 
@@ -14,7 +14,7 @@ import { ShareStoryDialog } from '@/components/share-dialog.story';
 import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { StoryPageBody } from '@/components/story-page-body';
 import { StoryPageHeader } from '@/components/story-page-header';
-import { StoryAccessError } from '@/components/story-access-error';
+import { StoryRouteError } from '@/components/story-access-error';
 import { StoryChartEmbed, StoryTableEmbed } from '@/components/story-embeds';
 import { StoryTabbedContent } from '@/components/story-tabbed-content';
 import { Spinner } from '@/components/ui/spinner';
@@ -28,22 +28,8 @@ import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/stories/shared/$shareId')({
 	component: SharedStoryPage,
-	errorComponent: SharedStoryError,
+	errorComponent: StoryRouteError,
 });
-
-function SharedStoryError({ error }: { error: unknown }) {
-	const router = useRouter();
-	const { reset } = useQueryErrorResetBoundary();
-	return (
-		<StoryAccessError
-			error={error}
-			onRetry={() => {
-				reset();
-				router.invalidate();
-			}}
-		/>
-	);
-}
 
 function SharedStoryPage() {
 	const { shareId } = Route.useParams();

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -14,6 +14,7 @@ import { ShareStoryDialog } from '@/components/share-dialog.story';
 import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { StoryPageBody } from '@/components/story-page-body';
 import { StoryPageHeader } from '@/components/story-page-header';
+import { StoryAccessError } from '@/components/story-access-error';
 import { StoryChartEmbed, StoryTableEmbed } from '@/components/story-embeds';
 import { StoryTabbedContent } from '@/components/story-tabbed-content';
 import { Spinner } from '@/components/ui/spinner';
@@ -27,6 +28,7 @@ import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/stories/shared/$shareId')({
 	component: SharedStoryPage,
+	errorComponent: ({ error }) => <StoryAccessError error={error} />,
 });
 
 function SharedStoryPage() {

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -1,5 +1,5 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useMutation, useQueryClient, useQueryErrorResetBoundary, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate, useRouter } from '@tanstack/react-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { ParsedChartBlock, ParsedTableBlock } from '@nao/shared/story-segments';
 
@@ -28,8 +28,22 @@ import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/stories/shared/$shareId')({
 	component: SharedStoryPage,
-	errorComponent: ({ error }) => <StoryAccessError error={error} />,
+	errorComponent: SharedStoryError,
 });
+
+function SharedStoryError({ error }: { error: unknown }) {
+	const router = useRouter();
+	const { reset } = useQueryErrorResetBoundary();
+	return (
+		<StoryAccessError
+			error={error}
+			onRetry={() => {
+				reset();
+				router.invalidate();
+			}}
+		/>
+	);
+}
 
 function SharedStoryPage() {
 	const { shareId } = Route.useParams();

--- a/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
@@ -78,7 +78,7 @@ function StandaloneStoryPage() {
 	}
 
 	if (storyQuery.isError || !story) {
-		return <StoryAccessError error={storyQuery.error} />;
+		return <StoryAccessError error={storyQuery.error} onRetry={() => storyQuery.refetch()} />;
 	}
 
 	if (story.chatId) {

--- a/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
@@ -7,6 +7,7 @@ import type { SelectionData } from '@/components/highlight-bubble';
 import type { QueryDataMap } from '@/components/story-embeds';
 import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { HighlightBubble } from '@/components/highlight-bubble';
+import { StoryAccessError } from '@/components/story-access-error';
 import { StoryChartEmbed, StoryTableEmbed } from '@/components/story-embeds';
 import { StoryTabbedContent } from '@/components/story-tabbed-content';
 import { StoryPageHeader } from '@/components/story-page-header';
@@ -76,8 +77,8 @@ function StandaloneStoryPage() {
 		);
 	}
 
-	if (!story) {
-		return <div>Not Found</div>;
+	if (storyQuery.isError || !story) {
+		return <StoryAccessError error={storyQuery.error} />;
 	}
 
 	if (story.chatId) {


### PR DESCRIPTION
## Summary

- resolve activity-feed story links per viewer access — owners open the preview/standalone route while non-owners are routed to the shared-story link, instead of always assuming the preview route
- resolve the presence of feed events for users who have no permissions (eq. issue from user who saw refresh stories that they don't have access to)
- add a StoryAccessError screen :
<img width="1508" height="853" alt="image" src="https://github.com/user-attachments/assets/357fd43e-11c7-4c45-a370-92c066b63db7" />

## Closes

#1263 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

