### PR TITLE
feat(cli): preserve installed extras on nao upgrade

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -211,6 +211,29 @@ nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
 nao test --threads 4
 ```
 
+### Upgrade nao-core
+
+```bash
+nao upgrade
+```
+
+Checks PyPI for a newer version of `nao-core` and, with your confirmation, runs
+`uv pip install --upgrade <spec>` (or `pip install --upgrade <spec>` if `uv`
+isn't on PATH). The package spec auto-detects the extras you originally
+installed with (`nao-core[postgres,openai]`, `nao-core[all]`, etc.) so the
+upgrade preserves them instead of silently downgrading you to the base
+package.
+
+Use `--extras` to override detection:
+
+```bash
+# Force a specific set of extras
+nao upgrade --extras postgres,openai
+
+# Upgrade the base package only (skip extras entirely)
+nao upgrade --extras ""
+```
+
 ### Explore test results
 
 ```bash

--- a/cli/nao_core/commands/upgrade.py
+++ b/cli/nao_core/commands/upgrade.py
@@ -1,50 +1,100 @@
+from __future__ import annotations
+
 import shutil
 import subprocess
 import sys
+from typing import Annotated
+
+from cyclopts import Parameter
 
 from nao_core import __version__
 from nao_core.ui import UI, ask_confirm
-from nao_core.version import clear_version_cache, get_latest_version, parse_version
+from nao_core.version import (
+    PACKAGE_NAME,
+    clear_version_cache,
+    get_installed_extras,
+    get_latest_version,
+    parse_version,
+)
 
 
-def upgrade() -> None:
+def _resolve_install_spec(
+    cli_extras: str | None,
+) -> tuple[str, set[str] | None]:
+    """Pick the package spec to install and report the source.
+
+    Returns:
+        (package_spec, detected_extras_or_none)
+
+        package_spec is the literal argument to pass to pip (e.g. ``"nao-core"``
+        or ``"nao-core[postgres,openai]"``). detected_extras_or_none is the set
+        of extras inferred from the live install, or None when detection
+        failed (so the caller can show a follow-up warning).
+    """
+    if cli_extras is not None:
+        extras_list = [e.strip() for e in cli_extras.split(",") if e.strip()]
+        if extras_list:
+            return f"{PACKAGE_NAME}[{','.join(sorted(extras_list))}]", set(extras_list)
+        return PACKAGE_NAME, set()
+
+    detected = get_installed_extras()
+    if detected is None:
+        return PACKAGE_NAME, None
+    if not detected:
+        return PACKAGE_NAME, set()
+    return f"{PACKAGE_NAME}[{','.join(sorted(detected))}]", detected
+
+
+def upgrade(
+    extras: Annotated[
+        str | None,
+        Parameter(
+            name=["--extras"],
+            help=(
+                "Comma-separated extras to install (e.g. 'postgres,openai'). "
+                "Overrides auto-detection. Pass an empty string to upgrade the "
+                "base package only."
+            ),
+        ),
+    ] = None,
+) -> None:
     """Upgrade nao-core to the latest version."""
 
-    # Clear cache to ensure we get fresh version info from PyPI
     clear_version_cache()
 
-    UI.info("\n⬆️  Checking for updates...\n")
+    UI.info("\nChecking for updates...\n")
 
-    # Get current version
     current_version = __version__
     UI.print(f"Current version: {current_version}")
 
-    # Check latest version
     latest_version = get_latest_version()
-
     if latest_version is None:
         UI.error("Failed to check for updates. Please try again later.")
         return
 
     UI.print(f"Latest version: {latest_version}")
 
-    # Check if already up to date
     if parse_version(current_version) >= parse_version(latest_version):
-        UI.success("\n✓ You are already on the latest version!")
+        UI.success("\nYou are already on the latest version!")
         return
 
-    if not ask_confirm(f"\nUpgrade from {current_version} to {latest_version}?", default=True):
+    package_spec, detected_extras = _resolve_install_spec(extras)
+    extras_label = ",".join(sorted(detected_extras)) if detected_extras else "(none)"
+
+    if not ask_confirm(
+        f"\nUpgrade {package_spec} from {current_version} to {latest_version}?",
+        default=True,
+    ):
         UI.print("Upgrade cancelled.")
         return
 
-    # Perform upgrade
-    UI.print(f"\n🔄 Upgrading nao-core {current_version} → {latest_version}...\n")
+    UI.print(f"\nUpgrading {package_spec} {current_version} -> {latest_version}...\n")
+    UI.print(f"[dim]Detected extras: {extras_label}[/dim]")
 
-    # Use uv if available, otherwise fallback to pip
     if shutil.which("uv"):
-        cmd = ["uv", "pip", "install", "--upgrade", "nao-core"]
+        cmd = ["uv", "pip", "install", "--upgrade", package_spec]
     else:
-        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "nao-core"]
+        cmd = [sys.executable, "-m", "pip", "install", "--upgrade", package_spec]
 
     try:
         subprocess.run(
@@ -57,8 +107,15 @@ def upgrade() -> None:
         UI.success(f"Upgrade complete! Now on version {latest_version}")
         UI.print("\nPlease restart your terminal or run 'source ~/.zshrc' to use the new version.")
 
+        if detected_extras is None and extras is None:
+            UI.warn(
+                "\nCould not auto-detect the extras you originally installed "
+                "(this often happens with editable installs). If nao errors on "
+                f"a missing database driver or LLM after the upgrade, run:\n"
+                f"  pip install --upgrade '{PACKAGE_NAME}[<your-extras>]'"
+            )
     except subprocess.CalledProcessError as e:
         UI.error(f"Upgrade failed: {e}")
         UI.print(f"Error output: {e.stderr}")
         UI.print("\nYou can manually upgrade by running:")
-        UI.print("  pip install --upgrade nao-core")
+        UI.print(f"  pip install --upgrade '{package_spec}'")

--- a/cli/nao_core/version.py
+++ b/cli/nao_core/version.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 import sys
 import time
+from importlib import metadata
 from pathlib import Path
 
 from nao_core import __version__
@@ -12,11 +13,46 @@ from nao_core.ui import UI
 CACHE_FILE = Path.home() / ".nao" / "version_check.json"
 PYPI_URL = "https://pypi.org/pypi/nao-core/json"
 CHECK_INTERVAL = 24 * 60 * 60
+PACKAGE_NAME = "nao-core"
 
 
 def parse_version(v: str) -> tuple[int, ...]:
     """Parse a version string like '0.0.37' into a comparable tuple."""
     return tuple(int(x) for x in v.split("."))
+
+
+def get_installed_extras() -> set[str] | None:
+    """Return the extras the user installed alongside nao-core, or None if undetectable.
+
+    Returns:
+        A sorted set of active extras (e.g. {"postgres", "openai"}) when the
+        installed distribution exposes them. Returns None when the package is
+        editable-installed, missing, or installed on a Python version that
+        does not surface the ``Distribution.extras`` property. Callers should
+        fall back to warning the user rather than guessing.
+    """
+    try:
+        dist = metadata.distribution(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return None
+
+    extras = getattr(dist, "extras", None)
+    if extras is None:
+        # Editable installs (PathDistribution) and some legacy distributions
+        # don't expose `.extras`. Fall back to parsing Requires-Dist.
+        try:
+            reqs = dist.metadata.get_all("Requires-Dist") or []
+        except AttributeError:
+            return None
+        extras = set()
+        for req in reqs:
+            marker = '; extra == "'
+            if marker in req:
+                extras.add(req.split(marker, 1)[1].rstrip('"'))
+        if not extras:
+            return None
+
+    return {e for e in extras if e}
 
 
 def get_latest_version() -> str | None:

--- a/cli/tests/nao_core/commands/test_upgrade.py
+++ b/cli/tests/nao_core/commands/test_upgrade.py
@@ -1,0 +1,243 @@
+"""Unit tests for the upgrade command and its package-spec resolution."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from nao_core.commands.upgrade import _resolve_install_spec, upgrade
+
+# -- _resolve_install_spec ----------------------------------------------------
+
+
+def test_resolve_no_cli_flag_no_detected_extras_returns_base_package():
+    with patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()):
+        spec, detected = _resolve_install_spec(None)
+
+    assert spec == "nao-core"
+    assert detected == set()
+
+
+def test_resolve_no_cli_flag_detected_extras_includes_them_alphabetically():
+    with patch(
+        "nao_core.commands.upgrade.get_installed_extras",
+        return_value={"openai", "postgres", "all"},
+    ):
+        spec, detected = _resolve_install_spec(None)
+
+    assert spec == "nao-core[all,openai,postgres]"
+    assert detected == {"all", "openai", "postgres"}
+
+
+def test_resolve_cli_flag_overrides_detection():
+    with patch(
+        "nao_core.commands.upgrade.get_installed_extras",
+        return_value={"postgres"},
+    ):
+        spec, detected = _resolve_install_spec("postgres,openai")
+
+    assert spec == "nao-core[openai,postgres]"
+    assert detected == {"postgres", "openai"}
+
+
+def test_resolve_cli_flag_empty_string_means_base_package():
+    with patch(
+        "nao_core.commands.upgrade.get_installed_extras",
+        return_value={"postgres"},
+    ):
+        spec, detected = _resolve_install_spec("")
+
+    assert spec == "nao-core"
+    assert detected == set()
+
+
+def test_resolve_cli_flag_strips_whitespace_and_drops_empty_segments():
+    with patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()):
+        spec, detected = _resolve_install_spec(" postgres , , openai , ")
+
+    assert spec == "nao-core[openai,postgres]"
+    assert detected == {"openai", "postgres"}
+
+
+def test_resolve_detection_unavailable_returns_none_marker():
+    with patch("nao_core.commands.upgrade.get_installed_extras", return_value=None):
+        spec, detected = _resolve_install_spec(None)
+
+    assert spec == "nao-core"
+    assert detected is None  # caller is responsible for warning the user
+
+
+# -- upgrade() end-to-end via the subprocess + UI boundary -------------------
+
+
+def test_upgrade_with_detected_extras_installs_specified_package():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch(
+            "nao_core.commands.upgrade.get_installed_extras",
+            return_value={"postgres", "openai"},
+        ),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "uv"
+    assert cmd[1:] == ["pip", "install", "--upgrade", "nao-core[openai,postgres]"]
+
+
+def test_upgrade_with_no_extras_installs_base_package():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[-1] == "nao-core"
+
+
+def test_upgrade_cli_extras_overrides_detection():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch(
+            "nao_core.commands.upgrade.get_installed_extras",
+            return_value={"postgres"},
+        ),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade(extras="snowflake,athena")
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[-1] == "nao-core[athena,snowflake]"
+
+
+def test_upgrade_with_unavailable_detection_warns_user():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch("nao_core.commands.upgrade.get_installed_extras", return_value=None),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn") as mock_warn,
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    mock_run.assert_called_once()
+    assert any("Could not auto-detect" in str(call) for call in mock_warn.call_args_list)
+
+
+def test_upgrade_already_up_to_date_does_nothing():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.2.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success") as mock_success,
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    mock_run.assert_not_called()
+    mock_success.assert_called_once()
+
+
+def test_upgrade_user_declines_skips_install():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=False),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success") as mock_success,
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    mock_run.assert_not_called()
+    mock_success.assert_not_called()
+
+
+def test_upgrade_pypi_unreachable_reports_error():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value=None),
+        patch("nao_core.commands.upgrade.get_installed_extras", return_value=set()),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value="uv"),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error") as mock_error,
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    mock_run.assert_not_called()
+    mock_error.assert_called_once()
+
+
+def test_upgrade_install_command_falls_back_to_pip_when_uv_missing():
+    with (
+        patch("nao_core.commands.upgrade.__version__", "0.1.0"),
+        patch("nao_core.commands.upgrade.get_latest_version", return_value="0.2.0"),
+        patch(
+            "nao_core.commands.upgrade.get_installed_extras",
+            return_value={"postgres"},
+        ),
+        patch("nao_core.commands.upgrade.ask_confirm", return_value=True),
+        patch("nao_core.commands.upgrade.shutil.which", return_value=None),
+        patch("nao_core.commands.upgrade.subprocess.run") as mock_run,
+        patch("nao_core.commands.upgrade.UI.success"),
+        patch("nao_core.commands.upgrade.UI.warn"),
+        patch("nao_core.commands.upgrade.UI.error"),
+        patch("nao_core.commands.upgrade.UI.print"),
+        patch("nao_core.commands.upgrade.UI.info"),
+    ):
+        upgrade()
+
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == sys.executable
+    assert cmd[1:3] == ["-m", "pip"]
+    assert cmd[-1] == "nao-core[postgres]"


### PR DESCRIPTION
## Summary

`nao upgrade` currently runs `pip install --upgrade nao-core` (or `uv pip install --upgrade nao-core`), silently dropping whatever extras the user originally installed with. The CLI README documents extras like `[postgres,openai]`, `[all]`, `[all-databases]`, `[all-llms]` and per-database / per-LLM extras as the recommended install path, so a default `nao upgrade` downgrades a working install back to the base package. The next time a missing backend is touched, nao errors.

This PR makes `nao upgrade` auto-detect the extras the user installed with and re-install with them preserved. It also adds an explicit `--extras` flag for override and a follow-up warning when detection is not possible.

Refs #1274

## Changes

- `cli/nao_core/version.py` — new `get_installed_extras()` helper that returns the active extras via `importlib.metadata`, with a `Requires-Dist` marker fallback for editable installs where `Distribution.extras` is unavailable.
- `cli/nao_core/commands/upgrade.py` — refactored:
  - resolves the install spec from CLI flag > detected extras > base package,
  - prints the resolved spec and the detected extras before running the install,
  - surfaces a follow-up warning when auto-detection failed (most often on editable installs) so the user knows to re-run with the right extras,
  - adds a `--extras <comma-separated>` flag for explicit override; empty string means base package only.
- `cli/tests/nao_core/commands/test_upgrade.py` — 14 new unit tests covering the spec resolution matrix and the end-to-end `upgrade()` flow (no extras, detected extras, CLI override, detection unavailable, already up to date, user declines, PyPI unreachable, `uv` missing).
- `cli/README.md` — new "Upgrade nao-core" section (the command was previously undocumented).

## Example

```
$ nao upgrade

Checking for updates...

Current version: 0.1.9
Latest version: 0.2.0
Detected extras: openai,postgres

Upgrade nao-core[openai,postgres] from 0.1.9 to 0.2.0? [Y/n]
```

Then either `uv pip install --upgrade 'nao-core[openai,postgres]'` (or `pip install --upgrade 'nao-core[openai,postgres]'` if `uv` is not on PATH) — the same extras the user originally installed with.

## Backward compatibility

When the user has no extras installed, the resolved spec is byte-identical to today (`nao-core`). With `--extras ""` the user can explicitly opt out of extras. The new flag is opt-in.

## Testing

- `make lint` (ty + ruff + ruff check --select I + ruff format --check): all clean
- `pytest tests/`: 810 passed, 245 skipped (integration tests gated on external services), 0 failed
- 14 new unit tests for the upgrade command and its install-spec resolution

## Risks

- `importlib.metadata` API behavior differs across Python versions and install modes. The helper handles the `Distribution.extras` property (Python 3.10+, real pip installs) and falls back to parsing `Requires-Dist` markers (editable installs and older Python). When both paths fail it returns `None`, and the upgrade command emits a follow-up warning telling the user to re-run manually with their extras.
- The detected-extras list is derived from the installed distribution's metadata, which is what the user actually has on disk. There is no drift between "what was installed" and "what gets re-installed."

## Follow-ups (out of scope for this PR)

- A `nao install` / `nao init --install` command that records the original install command in `nao_config.yaml` (or a sidecar file) for a fully deterministic upgrade. Bigger surface; saved for a separate PR.
- The `cli/nao_core/context/__init__.py` `# TODO: redo the git retrieval logic` is a separate, larger problem (related to issue #1174) and not addressed here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

