### PR TITLE
feat(cli): export Notion databases and embedded views

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -165,7 +165,7 @@ Syncs configured resources to local files:
 
 - **Databases** - generates markdown docs (`columns.md` with table schema, description, row count, and partition/clustering/index metadata, `query_history.md`, and `preview.md`) for each table into `databases/`
 - **Git repositories** — clones or pulls repos into `repos/`
-- **Notion pages** — exports pages as markdown into `docs/notion/`
+- **Notion pages** — exports pages as markdown into `docs/notion/`. Databases are exported as markdown tables, whether configured directly or embedded inline in a page. A database embedded in a page is exported through one of its views — Notion exposes no way to tell which view a page renders, so the first one listed is used — applying that view's filters, sorts and visible columns rather than dumping the whole data source. A database configured by URL exports every row and column, unless the URL carries `?v=<view_id>`, in which case that view applies. When a database cannot be exported, its page fails to sync and the previously synced markdown is left untouched, rather than being rewritten without its table.
 
 After syncing, any Jinja templates (`*.j2` files) in the project directory are rendered with the nao context.
 

--- a/cli/nao_core/commands/sync/providers/notion/database.py
+++ b/cli/nao_core/commands/sync/providers/notion/database.py
@@ -1,0 +1,702 @@
+"""Exporting Notion databases as markdown tables.
+
+Every page walks its own block tree to find the databases it holds, which duplicates the
+traversal notion2md performs internally and is the dominant request cost on large pages. It
+is deliberate: notion2md silently drops blocks it cannot convert, so its markers alone cannot
+tell an absent database from a lost one.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, cast
+
+# notion2md emits this marker for database blocks it cannot convert itself, indented by
+# one tab per nesting level
+CHILD_DATABASE_MARKER = "[//]: # (child_database is not supported)"
+INDENTED_CHILD_DATABASE_MARKER = re.compile(rf"^[ \t]*{re.escape(CHILD_DATABASE_MARKER)}", re.MULTILINE)
+
+PAGE_SIZE = 100
+MAX_RENDERED_ROWS = 500
+MAX_FETCHED_ROWS = 5000
+MAX_ERROR_LENGTH = 200
+
+# Views that present one row per entry. Anything else — a chart, form or dashboard —
+# aggregates instead, so there is no row list to export and no column list to honour.
+ROW_VIEW_TYPES = frozenset({"table", "board", "list", "gallery", "calendar", "timeline", "map"})
+
+# Rows a data source scan never reached are worth retrieving one by one only in small numbers
+MAX_INDIVIDUAL_LOOKUPS = 50
+
+# Loops are bounded by pages rather than by items on purpose: a response reporting more
+# results while returning none would never advance an item counter, and the sync would hang
+# inside a worker thread with no output at all.
+MAX_PAGES = MAX_FETCHED_ROWS // PAGE_SIZE + 1
+
+
+class DatabaseExportError(Exception):
+    """Raised when a database embedded in a page cannot be rendered as a table.
+
+    This fails the whole page on purpose. Writing the page without its table would overwrite
+    a good file with a degraded one, losing content that only Notion still holds.
+    """
+
+
+class ViewUnavailableError(Exception):
+    """Raised when the rows a view selects cannot be resolved.
+
+    Exporting every row instead would silently widen the export past what the view shows,
+    which is the failure this module exists to prevent, so callers must fail rather than
+    fall back.
+    """
+
+
+@dataclass
+class ViewRows:
+    """What a view selects: row ids in display order, and the columns it shows."""
+
+    row_ids: list[str]
+    total: int
+    complete: bool
+    columns: list[dict[str, Any]] | None
+    data_source_id: str | None = None
+
+
+@dataclass
+class FetchedRows:
+    """Rows read from a database's data sources, keyed by page id."""
+
+    rows: dict[str, dict[str, Any]]
+    exhausted: bool
+
+
+@dataclass
+class DatabaseRows:
+    """Database rows, with what is known about how many exist beyond them."""
+
+    rows: list[dict[str, Any]]
+    total: int | None
+    complete: bool
+    columns: list[str] | None = None
+    unmatched: int = 0
+    unmatched_columns: list[str] | None = None
+
+
+def get_database_as_markdown(
+    client: Any,
+    database_id: str,
+    view_id: str | None = None,
+    *,
+    use_default_view: bool = False,
+) -> tuple[str, str]:
+    """Fetch a Notion database and render its rows as a markdown table.
+
+    When a view is targeted, Notion applies its saved filters and sorts so the export matches
+    what a reader sees. Without one, every row is exported.
+
+    Returns:
+        Tuple of (title, markdown_table)
+    """
+    database = cast(dict[str, Any], client.databases.retrieve(database_id=database_id))
+    title = join_rich_text(database.get("title", [])) or database_id
+
+    if view_id is None and use_default_view:
+        view_id = find_default_view_id(client, database_id)
+
+    return title, render_table(fetch_rows(client, database, view_id))
+
+
+def inject_child_databases(client: Any, page_id: str, markdown: str) -> str:
+    """Replace notion2md's unsupported-database markers with real markdown tables.
+
+    Markers carry no database id, so they are matched to databases by position. notion2md
+    silently drops blocks it fails to convert, so a count mismatch means that order can no
+    longer be trusted, and a page must not be written with its tables in the wrong places.
+
+    The page's databases are listed even when no marker was found, because a container block
+    notion2md fails to convert takes the markers nested under it down with it. Trusting an
+    absence of markers would write the page without tables it is supposed to carry.
+    """
+    database_ids = find_child_database_ids(client, page_id)
+    marker_count = len(INDENTED_CHILD_DATABASE_MARKER.findall(markdown))
+
+    if not database_ids and not marker_count:
+        return markdown
+
+    if marker_count != len(database_ids):
+        raise DatabaseExportError(
+            f"page {page_id} carries {marker_count} inline database markers for "
+            f"{len(database_ids)} databases, so they cannot be matched to each other"
+        )
+
+    # Matching by position is the only option left: a marker carries no database id. Equal
+    # counts do not prove equal order, so a block type notion2md walks differently would
+    # place tables under the wrong markers. No signal is available to detect that.
+
+    for database_id in database_ids:
+        markdown = replace_marker(markdown, render_child_database(client, database_id))
+
+    return markdown
+
+
+def render_child_database(client: Any, database_id: str) -> str:
+    """Render a database embedded in a page, using the view the page displays."""
+    try:
+        title, table = get_database_as_markdown(client, database_id, use_default_view=True)
+    except Exception as error:
+        raise DatabaseExportError(
+            f"inline database {database_id} could not be exported: {truncate(str(error))}"
+        ) from error
+
+    return f"**{title}**\n\n{table}"
+
+
+def replace_marker(markdown: str, replacement: str, count: int = 1) -> str:
+    """Replace database markers, dropping the indentation notion2md added around them.
+
+    A function is used as the replacement so table cells escaped with backslashes are not
+    reinterpreted as regex group references.
+    """
+    return INDENTED_CHILD_DATABASE_MARKER.sub(lambda _: replacement, markdown, count=count)
+
+
+def find_child_database_ids(client: Any, block_id: str) -> list[str]:
+    """Collect child database ids in the order notion2md walks the block tree."""
+    database_ids: list[str] = []
+
+    for block in list_children(client, block_id):
+        if block["type"] == "child_database":
+            database_ids.append(block["id"])
+        elif block.get("has_children") and block["type"] not in SKIPPED_CONTAINERS:
+            database_ids.extend(find_child_database_ids(client, block["id"]))
+
+    return database_ids
+
+
+# notion2md does not walk into these, and neither holds a database: a child page is a
+# document of its own, and a table only holds rows
+SKIPPED_CONTAINERS = frozenset({"child_page", "table"})
+
+
+def list_children(client: Any, block_id: str) -> list[dict[str, Any]]:
+    """List the child blocks of a block, following pagination.
+
+    Bounded so a cursor that never advances cannot hang a sync. Stopping short loses database
+    markers, which fails the page rather than writing it without its tables.
+    """
+    blocks: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    for _ in range(MAX_PAGES):
+        response = cast(dict[str, Any], client.blocks.children.list(block_id, **paginated(cursor)))
+        blocks.extend(response.get("results", []))
+        cursor = response["next_cursor"] if response.get("has_more") else None
+        if not cursor:
+            break
+
+    return blocks
+
+
+def fetch_rows(client: Any, database: dict[str, Any], view_id: str | None) -> DatabaseRows:
+    """Fetch database rows, restricted to a view's filters, sorts and columns when targeted."""
+    if view_id is None:
+        # Only MAX_RENDERED_ROWS reach the table, so one extra row is enough to know more
+        # exist. Scanning every row just to count them would cost dozens of sequential
+        # requests against a rate limit that allows very few.
+        fetched = fetch_rows_by_id(client, database, limit=MAX_RENDERED_ROWS + 1)
+        return DatabaseRows(
+            rows=list(fetched.rows.values()),
+            total=len(fetched.rows) if fetched.exhausted else None,
+            complete=fetched.exhausted,
+        )
+
+    view = fetch_view_rows(client, view_id)
+
+    # Ids past the render budget would never reach the table, so matching them would spend
+    # requests on rows nothing shows and count their absence as rows missing from the middle.
+    wanted = view.row_ids[:MAX_RENDERED_ROWS]
+    if not wanted:
+        return DatabaseRows(rows=[], total=view.total, complete=view.complete)
+
+    fetched = fetch_rows_by_id(client, database, wanted_ids=set(wanted), data_source_id=view.data_source_id)
+    fetched.rows.update(retrieve_missing_rows(client, [row_id for row_id in wanted if row_id not in fetched.rows]))
+
+    found = [fetched.rows[row_id] for row_id in wanted if row_id in fetched.rows]
+    unmatched = len(wanted) - len(found)
+    if unmatched > MAX_INDIVIDUAL_LOOKUPS:
+        raise ValueError(f"only {len(found)} of the {len(wanted)} rows this view selects could be read")
+
+    columns = resolve_columns(view.columns, found)
+
+    return DatabaseRows(
+        rows=found,
+        total=view.total,
+        complete=view.complete,
+        columns=columns,
+        unmatched=unmatched,
+        unmatched_columns=check_columns_match(columns, found),
+    )
+
+
+def retrieve_missing_rows(client: Any, missing: list[str]) -> dict[str, dict[str, Any]]:
+    """Read rows a data source scan never reached, one request each.
+
+    A scan stops at the row budget, so a view over a large database can select rows it never
+    saw. Reading them individually recovers the table rather than reporting them missing, and
+    is only worth doing while there are few of them.
+    """
+    if not missing or len(missing) > MAX_INDIVIDUAL_LOOKUPS:
+        return {}
+
+    rows: dict[str, dict[str, Any]] = {}
+    for row_id in missing:
+        try:
+            page = cast(dict[str, Any], client.pages.retrieve(page_id=row_id))
+        except Exception:  # noqa: BLE001 - an unreadable row is reported as unmatched instead
+            continue
+        rows[page["id"]] = page
+
+    return rows
+
+
+def fetch_rows_by_id(
+    client: Any,
+    database: dict[str, Any],
+    wanted_ids: set[str] | None = None,
+    limit: int = MAX_FETCHED_ROWS,
+    data_source_id: str | None = None,
+) -> FetchedRows:
+    """Fetch rows of every data source of a database, keyed by page id.
+
+    A view query returns page references without their values, so values are read from the
+    data sources and matched locally. That costs one pass over a data source instead of one
+    request per row, which matters against Notion's rate limit, and stops as soon as every
+    wanted row has been seen.
+    """
+    data_sources = database.get("data_sources") or []
+    if not data_sources:
+        raise ValueError(f"database {database.get('id')} exposes no data source to read rows from")
+
+    # A view names the data source it reads, so only that one is scanned. Without this a
+    # database with several sources could exhaust the row budget on the wrong one and report
+    # every row of the view as unmatched.
+    data_sources = matching_data_sources(data_sources, data_source_id)
+
+    rows: dict[str, dict[str, Any]] = {}
+
+    for data_source in data_sources:
+        cursor: str | None = None
+        for page in range(MAX_PAGES):
+            response = cast(dict[str, Any], client.data_sources.query(data_source["id"], **paginated(cursor)))
+            for row in response.get("results", []):
+                rows[row["id"]] = row
+            if wanted_ids is not None and wanted_ids <= rows.keys():
+                return FetchedRows(rows=rows, exhausted=True)
+            cursor = response["next_cursor"] if response.get("has_more") else None
+            if not cursor:
+                break
+            if len(rows) >= limit or page == MAX_PAGES - 1:
+                return FetchedRows(rows=rows, exhausted=False)
+
+    return FetchedRows(rows=rows, exhausted=True)
+
+
+def matching_data_sources(data_sources: list[dict[str, Any]], data_source_id: str | None) -> list[dict[str, Any]]:
+    """Narrow a database's data sources to the one a view reads.
+
+    Ids are compared bare because the two endpoints need not spell them the same way. A view
+    naming a source the database does not list still falls back to scanning all of them: rows
+    are selected by id, so the table stays correct and only costs extra requests.
+    """
+    if not data_source_id:
+        return data_sources
+
+    wanted = data_source_id.replace("-", "").lower()
+
+    return [source for source in data_sources if str(source.get("id", "")).replace("-", "").lower() == wanted] or (
+        data_sources
+    )
+
+
+def find_default_view_id(client: Any, database_id: str) -> str:
+    """Return the view Notion displays first for a database.
+
+    Notion exposes no "default view" flag, so the first listed view is taken to be the one a
+    page renders. An empty list is a failure rather than "no view": a database embedded in a
+    page always has one, so an empty result means the views could not be read, and exporting
+    every row instead would widen the export past what the page shows.
+    """
+    try:
+        response = cast(dict[str, Any], client.views.list(database_id=database_id))
+        return cast(str, response["results"][0]["id"])
+    except Exception as error:
+        raise ViewUnavailableError(
+            f"could not resolve the displayed view of database {database_id}: {truncate(str(error))}"
+        ) from error
+
+
+def fetch_view_rows(client: Any, view_id: str) -> ViewRows:
+    """Run a view's saved filters and sorts, returning the row ids it selects."""
+    try:
+        return query_view(client, view_id)
+    except Exception as error:
+        raise ViewUnavailableError(f"could not query view {view_id}: {truncate(str(error))}") from error
+
+
+def query_view(client: Any, view_id: str) -> ViewRows:
+    """Read a view's displayed columns, then execute it and page through its cached results.
+
+    Reading the view costs one extra request, which buys fidelity the row ids cannot: a view
+    hides properties, and rendering every property of a row would expose columns the page
+    deliberately leaves out.
+    """
+    view = cast(dict[str, Any], client.views.retrieve(view_id))
+    view_type = view.get("type")
+    if view_type not in ROW_VIEW_TYPES:
+        raise ValueError(f"view {view_id} is of type {view_type!r}, which presents no rows to export")
+
+    response = cast(dict[str, Any], client.views.queries.create(view_id))
+    query_id = response.get("id")
+    total = response.get("total_count")
+    row_ids = [row["id"] for row in response.get("results", [])]
+    incomplete = reports_incomplete(response)
+
+    # Only MAX_RENDERED_ROWS reach the table and total_count already carries the true count,
+    # so paging every id would spend requests on rows nothing will show
+    for _ in range(MAX_PAGES):
+        if not response.get("has_more") or len(row_ids) > MAX_RENDERED_ROWS:
+            break
+        cursor = response.get("next_cursor")
+        if not query_id or not cursor:
+            raise ValueError("view query reported more results but returned no cursor to reach them")
+        response = cast(dict[str, Any], client.views.queries.results(view_id, query_id, start_cursor=cursor))
+        row_ids.extend(row["id"] for row in response.get("results", []))
+        incomplete = incomplete or reports_incomplete(response)
+
+    return ViewRows(
+        row_ids=row_ids,
+        total=total if isinstance(total, int) else len(row_ids),
+        complete=isinstance(total, int) and not incomplete,
+        columns=visible_columns(view),
+        data_source_id=view.get("data_source_id"),
+    )
+
+
+def visible_columns(view: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """The properties a view displays, in display order, each by id and name.
+
+    Returns None when the view carries no column list at all, which is how view types with
+    nothing to honour are handled: every column is then rendered.
+
+    A list that yields nothing visible is a different matter. Rendering every column would
+    put back exactly what the view hides, so an unrecognised shape raises rather than falls
+    back. Names are resolved later, since a configuration may carry ids alone.
+    """
+    properties = (view.get("configuration") or {}).get("properties")
+    if properties is None:
+        return None
+    if not isinstance(properties, list):
+        raise ValueError(f"view configuration lists properties as {type(properties).__name__}, not a list")
+
+    visible = [column_of(prop) for prop in properties if prop.get("visible")]
+    if visible:
+        return visible
+
+    if not any("visible" in prop for prop in properties):
+        raise ValueError(f"no property among {len(properties)} declares whether it is visible")
+
+    # A board, gallery or map view can legitimately hide every property and show titles alone.
+    # Keeping the title preserves the rows without rendering what the view hides.
+    title = next((prop for prop in properties if prop.get("property_id") == "title"), None)
+    if not title:
+        raise ValueError(f"view hides all {len(properties)} properties and exposes no title column")
+
+    return [column_of(title)]
+
+
+def column_of(prop: dict[str, Any]) -> dict[str, Any]:
+    return {"id": prop.get("property_id"), "name": prop.get("property_name")}
+
+
+def resolve_columns(columns: list[dict[str, Any]] | None, rows: list[dict[str, Any]]) -> list[str] | None:
+    """Name each displayed column, falling back to the ids the rows carry.
+
+    property_name is a convenience the configuration need not include, so a column known only
+    by its id is matched against the properties of the rows themselves.
+    """
+    if columns is None:
+        return None
+
+    names_by_id = {prop.get("id"): name for row in rows for name, prop in row.get("properties", {}).items()}
+    resolved = [column["name"] or names_by_id.get(column["id"]) for column in columns]
+    named = [name for name in resolved if name]
+
+    if not named:
+        raise ValueError(f"none of the {len(columns)} columns the view displays could be named")
+
+    return named
+
+
+def reports_incomplete(response: dict[str, Any]) -> bool:
+    """Whether Notion capped the view query's cached results."""
+    return (response.get("request_status") or {}).get("type") == "incomplete"
+
+
+def check_columns_match(columns: list[str] | None, rows: list[dict[str, Any]]) -> list[str]:
+    """Report columns a view displays that match no property its rows carry.
+
+    Column names come from the view configuration and values from the data source. If a
+    rename left the two disagreeing, cells render blank and the real values are dropped, so
+    a partial mismatch is reported alongside the table and a total one fails the export.
+    """
+    if not columns or not rows:
+        return []
+
+    known = {name for row in rows for name in row.get("properties", {})}
+    if not known:
+        return []
+
+    unmatched = [column for column in columns if column not in known]
+    if len(unmatched) == len(columns):
+        raise ValueError(f"none of the view's columns {columns} match the properties of its rows")
+
+    return unmatched
+
+
+def render_table(rows: DatabaseRows) -> str:
+    """Render database rows as a markdown table."""
+    rendered = rows.rows[:MAX_RENDERED_ROWS]
+    notes = coverage_notes(len(rendered), rows)
+
+    if not rendered:
+        return "\n\n".join(["_No rows._", *notes])
+
+    columns = rows.columns or collect_columns(rendered)
+    lines = [
+        f"| {' | '.join(escape_cell(column) for column in columns)} |",
+        f"| {' | '.join('---' for _ in columns)} |",
+    ]
+    lines.extend(render_row(row, columns) for row in rendered)
+    lines.extend(f"\n{note}" for note in notes)
+
+    return "\n".join(lines)
+
+
+def coverage_notes(rendered_count: int, rows: DatabaseRows) -> list[str]:
+    """Describe what the table leaves out, never understating an unknown remainder.
+
+    Rows missing from the middle are reported apart from rows cut off the end, since a reader
+    cannot tell the two apart from the table itself.
+    """
+    notes: list[str] = []
+
+    if rows.unmatched_columns:
+        notes.append(
+            f"_{pluralise('Column', len(rows.unmatched_columns))} "
+            f"{', '.join(rows.unmatched_columns)} matched no property on these rows and render empty._"
+        )
+
+    if rows.unmatched:
+        notes.append(
+            f"_{rows.unmatched} {pluralise('row', rows.unmatched)} the view selects "
+            "could not be matched to their values, so they are missing from this table._"
+        )
+
+    notes.extend(truncation_note(rendered_count, rows))
+    return notes
+
+
+def truncation_note(rendered_count: int, rows: DatabaseRows) -> list[str]:
+    """Describe the rows past the end of the table, if any."""
+    if rows.total is None:
+        return [f"_More rows exist than the {rendered_count} exported here._"]
+
+    missing = max(rows.total - rendered_count - rows.unmatched, 0)
+    if not missing:
+        return [] if rows.complete else ["_Some rows could not be fetched, so this table may be incomplete._"]
+
+    counted = f"{missing} more {pluralise('row', missing)} not exported."
+    return [f"_{counted}_"] if rows.complete else [f"_At least {counted}_"]
+
+
+def pluralise(word: str, count: int) -> str:
+    return word if count == 1 else f"{word}s"
+
+
+def render_row(row: dict[str, Any], columns: list[str]) -> str:
+    properties = row.get("properties", {})
+    return f"| {' | '.join(format_property(properties.get(column, {})) for column in columns)} |"
+
+
+def collect_columns(rows: list[dict[str, Any]]) -> list[str]:
+    """List column names across all rows, with the title column first."""
+    columns: list[str] = []
+    for row in rows:
+        for name in row.get("properties", {}):
+            if name not in columns:
+                columns.append(name)
+
+    title_column = find_title_column(rows)
+    if title_column in columns:
+        columns.remove(title_column)
+        columns.insert(0, title_column)
+
+    return columns
+
+
+def find_title_column(rows: list[dict[str, Any]]) -> str | None:
+    for row in rows:
+        for name, prop in row.get("properties", {}).items():
+            if prop.get("type") == "title":
+                return name
+    return None
+
+
+def format_property(prop: dict[str, Any]) -> str:
+    """Render a Notion property value as a single markdown table cell."""
+    return escape_cell(format_value(prop))
+
+
+def format_value(prop: dict[str, Any]) -> str:
+    """Render a property value as plain text, leaving markdown escaping to the caller."""
+    formatter = PROPERTY_FORMATTERS.get(prop.get("type", ""))
+    value = formatter(prop) if formatter else ""
+    return "" if value is None else str(value)
+
+
+def escape_cell(value: Any) -> str:
+    """Render a value as a single-line markdown cell, escaping the column separator.
+
+    Backslashes are escaped first, so a value already containing one does not leave a live
+    delimiter behind and shift the row's columns.
+    """
+    if value is None:
+        return ""
+    text = str(value).replace("\r\n", "\n").replace("\r", "\n")
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def truncate(text: str) -> str:
+    return text if len(text) <= MAX_ERROR_LENGTH else f"{text[:MAX_ERROR_LENGTH]}…"
+
+
+def paginated(cursor: str | None) -> dict[str, Any]:
+    args: dict[str, Any] = {"page_size": PAGE_SIZE}
+    if cursor:
+        args["start_cursor"] = cursor
+    return args
+
+
+def join_rich_text(rich_text: list[dict[str, Any]]) -> str:
+    return "".join(part.get("plain_text", "") for part in rich_text)
+
+
+def format_date(prop: dict[str, Any]) -> str:
+    return format_date_value(prop.get("date"))
+
+
+def format_date_value(date: Any) -> str:
+    """Render a Notion date object, which computed properties also carry."""
+    if not isinstance(date, dict):
+        return ""
+    start, end = date.get("start", ""), date.get("end")
+    return f"{start} → {end}" if end else start
+
+
+def format_formula(prop: dict[str, Any]) -> str:
+    formula = prop.get("formula") or {}
+    return format_computed(formula.get("type", ""), formula)
+
+
+def format_scalar(value: Any) -> str:
+    """Render a scalar, spelling booleans the same way checkbox properties are spelled."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def format_rollup(prop: dict[str, Any]) -> str:
+    rollup = prop.get("rollup") or {}
+    kind = rollup.get("type", "")
+    if kind == "array":
+        return ", ".join(format_value(item) for item in rollup.get("array", []))
+    return format_computed(kind, rollup)
+
+
+def format_computed(kind: str, payload: dict[str, Any]) -> str:
+    """Render the value of a formula or rollup, whose type decides how to read it."""
+    value = payload.get(kind)
+    return format_date_value(value) if kind == "date" else format_scalar(value)
+
+
+def format_unique_id(prop: dict[str, Any]) -> str:
+    unique_id = prop.get("unique_id") or {}
+    prefix, number = unique_id.get("prefix"), unique_id.get("number")
+    if number is None:
+        return ""
+    return f"{prefix}-{number}" if prefix else str(number)
+
+
+def format_place(prop: dict[str, Any]) -> str:
+    """Render a place by what names it, falling back to its coordinates."""
+    place = prop.get("place") or {}
+    named = ", ".join(str(part) for part in (place.get("name"), place.get("address")) if part)
+    if named:
+        return named
+
+    latitude, longitude = place.get("latitude"), place.get("longitude")
+
+    return f"{latitude}, {longitude}" if latitude is not None and longitude is not None else ""
+
+
+def format_verification(prop: dict[str, Any]) -> str:
+    """Render a wiki verification, whose state is what distinguishes a trusted row."""
+    verification = prop.get("verification") or {}
+    state = verification.get("state") or ""
+    verified_by = (verification.get("verified_by") or {}).get("name")
+
+    return f"{state} by {verified_by}" if state and verified_by else state
+
+
+def format_relation(prop: dict[str, Any]) -> str:
+    """Report how many pages a relation links to.
+
+    Notion truncates relations in query responses and flags the rest with has_more, so the
+    count is reported as a lower bound rather than as an exact figure it may not be.
+    """
+    linked = prop.get("relation") or []
+    if not linked:
+        return ""
+    return f"{len(linked)}+ linked" if prop.get("has_more") else f"{len(linked)} linked"
+
+
+def format_names(items: list[dict[str, Any]]) -> str:
+    return ", ".join(str(item.get("name") or "") for item in items)
+
+
+PROPERTY_FORMATTERS: dict[str, Any] = {
+    "title": lambda p: join_rich_text(p.get("title", [])),
+    "rich_text": lambda p: join_rich_text(p.get("rich_text", [])),
+    "number": lambda p: "" if p.get("number") is None else str(p["number"]),
+    "select": lambda p: (p.get("select") or {}).get("name", ""),
+    "status": lambda p: (p.get("status") or {}).get("name", ""),
+    "multi_select": lambda p: format_names(p.get("multi_select", [])),
+    "date": format_date,
+    "checkbox": lambda p: "true" if p.get("checkbox") else "false",
+    "people": lambda p: format_names(p.get("people", [])),
+    "files": lambda p: format_names(p.get("files", [])),
+    "url": lambda p: p.get("url") or "",
+    "email": lambda p: p.get("email") or "",
+    "phone_number": lambda p: p.get("phone_number") or "",
+    "created_time": lambda p: p.get("created_time") or "",
+    "last_edited_time": lambda p: p.get("last_edited_time") or "",
+    "created_by": lambda p: (p.get("created_by") or {}).get("name", ""),
+    "last_edited_by": lambda p: (p.get("last_edited_by") or {}).get("name", ""),
+    "relation": lambda p: format_relation(p),
+    "place": format_place,
+    "verification": format_verification,
+    "formula": format_formula,
+    "rollup": format_rollup,
+    "unique_id": format_unique_id,
+}

--- a/cli/nao_core/commands/sync/providers/notion/database.py
+++ b/cli/nao_core/commands/sync/providers/notion/database.py
@@ -363,7 +363,7 @@ def query_view(client: Any, view_id: str) -> ViewRows:
     # Only MAX_RENDERED_ROWS reach the table and total_count already carries the true count,
     # so paging every id would spend requests on rows nothing will show
     for _ in range(MAX_PAGES):
-        if not response.get("has_more") or len(row_ids) > MAX_RENDERED_ROWS:
+        if not response.get("has_more") or len(row_ids) >= MAX_RENDERED_ROWS:
             break
         cursor = response.get("next_cursor")
         if not query_id or not cursor:

--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -1,20 +1,36 @@
 import re
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, cast
 
+import yaml
 from rich.console import Console
+from rich.markup import escape
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
 from nao_core.config.base import NaoConfig
 from nao_core.config.notion import NotionConfig
 
 from ..base import SyncProvider, SyncResult
+from .database import get_database_as_markdown, inject_child_databases
 
 console = Console()
 
-# Notion page IDs are 32-character hex strings (UUID without dashes)
-NOTION_PAGE_ID_PATTERN = re.compile(r"[a-f0-9]{32}")
+# Notion object IDs appear both bare and as dashed UUIDs. Accepting only the bare form would
+# make a dashed ?v= silently ignored, widening an export that asked for one view.
+NOTION_ID = r"[0-9a-fA-F]{32}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+NOTION_ID_PATTERN = re.compile(NOTION_ID)
+
+# View IDs appear as the `v` query parameter of a database URL
+NOTION_VIEW_PARAM_PATTERN = re.compile(r"[?&]v=([^&#]*)")
+
+# Pinned so behaviour does not depend on the notion-client version resolved at install time.
+# The Views API requires 2025-09-03 or later.
+NOTION_API_VERSION = "2025-09-03"
+
+# Notion titles run far longer than a filename usefully can
+MAX_SLUG_LENGTH = 80
 
 
 def cleanup_stale_pages(synced_files: set[str], output_path: Path, verbose: bool = False) -> int:
@@ -52,26 +68,166 @@ def strip_images(markdown: str) -> str:
     return IMAGE_PATTERN.sub("[image]\n", markdown)
 
 
-def extract_page_id(page_url: str) -> str:
-    """Extract Notion page ID from a URL.
+def extract_notion_id(url: str) -> str:
+    """Extract a Notion object ID (page or database) from a URL.
 
     Handles URLs like:
     - https://www.notion.so/naolabs/Conversational-analytics-2bfc7a70bc0680978900d1e85ece83a0
     - https://www.notion.so/2bfc7a70bc0680978900d1e85ece83a0
     - 2bfc7a70bc0680978900d1e85ece83a0 (raw ID)
+    - 2bfc7a70-bc06-8097-8900-d1e85ece83a0 (dashed UUID)
     """
-    match = NOTION_PAGE_ID_PATTERN.search(page_url)
+    match = NOTION_ID_PATTERN.search(url)
     if match:
-        return match.group(0)
-    raise ValueError(f"Could not extract Notion page ID from: {page_url}")
+        return normalise_id(match.group(0))
+    raise ValueError(f"Could not extract Notion ID from: {url}")
 
 
-def get_page_title(client: Any, page_id: str) -> str:
-    """Get the title of a Notion page."""
-    page = cast(dict[str, Any], client.pages.retrieve(page_id=page_id))
+def extract_view_id(url: str) -> str | None:
+    """Extract the view ID from a database URL, if it targets a specific view.
+
+    A `v` parameter that cannot be read raises rather than returning None: treating it as
+    "no view requested" would export every row of a database whose URL asked for a subset.
+    """
+    param = NOTION_VIEW_PARAM_PATTERN.search(url)
+    if not param:
+        return None
+
+    view_id = NOTION_ID_PATTERN.fullmatch(param.group(1))
+    if not view_id:
+        raise ValueError(f"Could not read the view ID from: {url}")
+
+    return normalise_id(view_id.group(0))
+
+
+def normalise_id(raw: str) -> str:
+    """Reduce a Notion ID to the bare lowercase hex form every endpoint accepts."""
+    return raw.replace("-", "").lower()
+
+
+def cleanup_if_fully_synced(failed_pages: int, synced_files: set[str], output_path: Path) -> int:
+    """Remove stale markdown only when every page synced.
+
+    A page that failed is absent from the synced set, so cleaning up after a partial run would
+    delete markdown that is still good, losing content to what is often a transient error.
+    Files no longer in Notion therefore survive until every page syncs again.
+    """
+    if failed_pages:
+        console.print(
+            f"[yellow]⚠[/yellow]  Keeping existing files: {failed_pages} page(s) failed, so stale ones were "
+            "left in place and will remain until a run succeeds in full"
+        )
+        return 0
+
+    return cleanup_stale_pages(synced_files, output_path, verbose=True)
+
+
+def fetch_documents(page_urls: list[str], api_key: str, threads: int) -> tuple[list[tuple[str, str, str]], int]:
+    """Fetch every configured item, returning them in configuration order with a failure count.
+
+    Writing is deferred until every fetch has been attempted, so filenames can be assigned
+    from a stable order rather than from whichever thread finished first.
+    """
+    documents: dict[str, tuple[str, str, str]] = {}
+    failed = 0
+
+    with Progress(
+        SpinnerColumn(style="dim"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=30, style="dim", complete_style="cyan", finished_style="green"),
+        TaskProgressColumn(),
+        console=console,
+        transient=False,
+    ) as progress:
+        task = progress.add_task("Syncing pages", total=len(page_urls))
+
+        def record(page_url: str, fetch: Callable[[], tuple[str, str]]) -> None:
+            """Run one fetch, keeping a failure to a single item.
+
+            Titles and errors come from Notion, so they are escaped: a stray closing tag in
+            either would raise out of this handler and abort the whole sync.
+            """
+            nonlocal failed
+            try:
+                title, markdown = fetch()
+                documents[page_url] = (page_url, title, markdown)
+                progress.update(task, advance=1, description=f"Synced: {escape(title)}")
+            except Exception as error:  # noqa: BLE001 - one unreadable item must not stop the rest
+                failed += 1
+                console.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_url)}: {escape(str(error))}")
+                progress.update(task, advance=1)
+
+        if threads <= 1 or len(page_urls) == 1:
+            for page_url in page_urls:
+                record(page_url, lambda url=page_url: get_content_as_markdown(url, api_key))
+        else:
+            with ThreadPoolExecutor(max_workers=min(threads, len(page_urls))) as executor:
+                futures = {executor.submit(get_content_as_markdown, url, api_key): url for url in page_urls}
+                for future in as_completed(futures):
+                    record(futures[future], future.result)
+
+    return [documents[url] for url in page_urls if url in documents], failed
+
+
+def write_documents(documents: list[tuple[str, str, str]], output_path: Path) -> tuple[set[str], list[str], int]:
+    """Write fetched documents, keeping a write failure to the item it belongs to."""
+    written: set[str] = set()
+    titles: list[str] = []
+    failed = 0
+
+    for reference, title, markdown in documents:
+        filename = markdown_filename(title, reference)
+        try:
+            (output_path / filename).write_text(markdown)
+        except OSError as error:
+            failed += 1
+            console.print(f"[bold red]✗[/bold red] Failed to write {escape(filename)}: {escape(str(error))}")
+            continue
+
+        written.add(filename)
+        titles.append(title)
+
+    return written, titles, failed
+
+
+def short_reference(reference: str) -> str:
+    """A stable, filename-safe fragment identifying an item."""
+    try:
+        return extract_notion_id(reference)[:8]
+    except ValueError:
+        return re.sub(r"[^\w-]", "", reference).lower()[:8] or "item"
+
+
+def markdown_filename(title: str, reference: str) -> str:
+    """Build the filename for a synced item, from its title and its ID.
+
+    The ID is always part of the name rather than a tie-breaker added on collision. A name
+    derived from the title alone moves between items that share one: if the item holding the
+    plain name fails, the other takes it and overwrites the file kept for the failed one.
+    Titles are also truncated, since Notion allows far longer ones than a filename holds.
+    """
+    slug = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "-").lower()[:MAX_SLUG_LENGTH]
+    identifier = short_reference(reference)
+
+    return f"{slug}-{identifier}.md" if slug else f"{identifier}.md"
+
+
+def create_client(api_key: str) -> Any:
+    """Create a Notion client pinned to the API version nao relies on."""
+    from nao_core.deps import require_dependency
+
+    require_dependency("notion_client", "notion", "for Notion integration")
+    require_dependency("notion2md", "notion", "for Notion integration")
+
+    from notion_client import Client
+
+    return Client(auth=api_key, notion_version=NOTION_API_VERSION)
+
+
+def extract_page_title(page: dict[str, Any], page_id: str) -> str:
+    """Read a page's title from its properties, falling back to its ID."""
     properties = page.get("properties", {})
 
-    # Try common title property names
     for prop_name in ["title", "Title", "Name", "name", "Page"]:
         if prop_name in properties:
             title_prop = properties[prop_name]
@@ -80,45 +236,81 @@ def get_page_title(client: Any, page_id: str) -> str:
                 if title_array:
                     return "".join(t.get("plain_text", "") for t in title_array)
 
-    # Fallback to page ID if no title found
     return page_id
 
 
-def get_page_as_markdown(page_url: str, api_key: str) -> tuple[str, str]:
-    """Fetch a Notion page and convert it to markdown.
+def fetch_as_markdown(url: str, api_key: str) -> tuple[str, str, str]:
+    """Fetch a Notion page or database and convert it to markdown.
+
+    Databases are rendered as markdown tables. Pages keep their block content, with any
+    inline database rendered in place of the marker notion2md leaves behind.
+
+    Returns:
+        Tuple of (object_id, title, markdown_body)
+    """
+    client = create_client(api_key)
+    object_id = extract_notion_id(url)
+    page = retrieve_page(client, object_id)
+
+    if page is None:
+        title, table = get_database_as_markdown(client, object_id, extract_view_id(url))
+        return object_id, title, table
+
+    from notion2md.exporter.block import StringExporter
+
+    title = extract_page_title(page, object_id)
+    markdown = StringExporter(block_id=object_id, token=api_key).export()
+    markdown = strip_images(markdown)
+    markdown = inject_child_databases(client, object_id, markdown)
+
+    return object_id, title, markdown
+
+
+def retrieve_page(client: Any, object_id: str) -> dict[str, Any] | None:
+    """Retrieve a page, returning None when the ID refers to a database instead.
+
+    Notion answers `validation_error` when the ID belongs to a database, and reserves
+    `object_not_found` for an object that is missing or not shared with the integration.
+    Only the former is a database, so every other error is raised rather than reported as
+    a database that cannot be found. Unlike the database calls this one is not retried on
+    purpose: a throttled page fails its own sync, which leaves its previous file untouched.
+    """
+    from notion_client.errors import APIErrorCode, APIResponseError
+
+    try:
+        return cast(dict[str, Any], client.pages.retrieve(page_id=object_id))
+    except APIResponseError as error:
+        if error.code != APIErrorCode.ValidationError:
+            raise
+        return None
+
+
+def get_content_as_markdown(page_url: str, api_key: str) -> tuple[str, str]:
+    """Fetch a Notion page or database as a markdown document with frontmatter.
 
     Returns:
         Tuple of (title, markdown_content)
     """
-    from nao_core.deps import require_dependency
+    object_id, title, markdown = fetch_as_markdown(page_url, api_key)
 
-    require_dependency("notion_client", "notion", "for Notion integration")
-    require_dependency("notion2md", "notion", "for Notion integration")
+    return title, render_document(title, object_id, markdown)
 
-    from notion2md.exporter.block import StringExporter
-    from notion_client import Client
 
-    page_id = extract_page_id(page_url)
+def render_document(title: str, object_id: str, markdown: str) -> str:
+    """Wrap markdown in YAML frontmatter.
 
-    client = Client(auth=api_key)
-    title = get_page_title(client, page_id)
+    Titles are serialised rather than interpolated, so one containing a colon or starting
+    with a comment marker stays a readable string instead of breaking every consumer of the
+    frontmatter.
+    """
+    frontmatter = yaml.safe_dump({"title": title, "id": object_id}, sort_keys=False, allow_unicode=True).strip()
 
-    # Export to markdown string using notion2md
-    md_exporter = StringExporter(block_id=page_id, token=api_key)
-    markdown = md_exporter.export()
-
-    # Strip images since we can't read them
-    markdown = strip_images(markdown)
-
-    content = f"""---
-title: {title}
-id: {page_id}
+    return f"""---
+{frontmatter}
 ---
 
 {markdown}
 """
-
-    return title, content
 
 
 class NotionSyncProvider(SyncProvider):
@@ -164,9 +356,6 @@ class NotionSyncProvider(SyncProvider):
 
         notion_config = items[0]
         output_path.mkdir(parents=True, exist_ok=True)
-        pages_synced = 0
-        synced_pages: list[str] = []
-        synced_files: set[str] = set()
 
         console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
         console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
@@ -174,55 +363,14 @@ class NotionSyncProvider(SyncProvider):
             console.print(f"[dim]Threads:[/dim] {threads}\n")
 
         api_key = notion_config.api_key
-        total_pages = len(notion_config.pages)
 
-        def sync_page(page_url: str) -> tuple[str, str]:
-            title, markdown = get_page_as_markdown(page_url, api_key)
-            safe_title = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "-").lower()
-            filename = f"{safe_title}.md"
-            (output_path / filename).write_text(markdown)
-            return title, filename
+        documents, failed_pages = fetch_documents(notion_config.pages, api_key, threads)
+        synced_files, synced_pages, write_failures = write_documents(documents, output_path)
+        pages_synced = len(synced_pages)
+        failed_pages += write_failures
 
-        with Progress(
-            SpinnerColumn(style="dim"),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(bar_width=30, style="dim", complete_style="cyan", finished_style="green"),
-            TaskProgressColumn(),
-            console=console,
-            transient=False,
-        ) as progress:
-            task = progress.add_task("Syncing pages", total=total_pages)
+        removed_count = cleanup_if_fully_synced(failed_pages, synced_files, output_path)
 
-            if threads <= 1 or len(notion_config.pages) == 1:
-                for page_url in notion_config.pages:
-                    try:
-                        title, filename = sync_page(page_url)
-                        pages_synced += 1
-                        synced_pages.append(title)
-                        synced_files.add(filename)
-                        progress.update(task, advance=1, description=f"Synced: {title}")
-                    except Exception as e:
-                        console.print(f"[bold red]✗[/bold red] Failed to sync page {page_url}: {e}")
-                        progress.update(task, advance=1)
-            else:
-                with ThreadPoolExecutor(max_workers=min(threads, len(notion_config.pages))) as executor:
-                    futures = {executor.submit(sync_page, page_url): page_url for page_url in notion_config.pages}
-                    for future in as_completed(futures):
-                        page_url = futures[future]
-                        try:
-                            title, filename = future.result()
-                            pages_synced += 1
-                            synced_pages.append(title)
-                            synced_files.add(filename)
-                            progress.update(task, advance=1, description=f"Synced: {title}")
-                        except Exception as e:
-                            console.print(f"[bold red]✗[/bold red] Failed to sync page {page_url}: {e}")
-                            progress.update(task, advance=1)
-
-        # Clean up stale pages
-        removed_count = cleanup_stale_pages(synced_files, output_path, verbose=True)
-
-        # Build summary
         summary = f"{pages_synced} pages synced as markdown"
         if removed_count > 0:
             summary += f", {removed_count} stale removed"

--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -170,7 +170,12 @@ def fetch_documents(page_urls: list[str], api_key: str, threads: int) -> tuple[l
 
 
 def write_documents(documents: list[tuple[str, str, str]], output_path: Path) -> tuple[set[str], list[str], int]:
-    """Write fetched documents, keeping a write failure to the item it belongs to."""
+    """Write fetched documents, keeping a write failure to the item it belongs to.
+
+    Notion content is written as UTF-8 rather than in the platform encoding, which would fail
+    on the arrows, dashes and emoji it routinely contains. An encoding failure is not an
+    OSError, so it is caught explicitly rather than escaping the whole write phase.
+    """
     written: set[str] = set()
     titles: list[str] = []
     failed = 0
@@ -178,8 +183,8 @@ def write_documents(documents: list[tuple[str, str, str]], output_path: Path) ->
     for reference, title, markdown in documents:
         filename = markdown_filename(title, reference)
         try:
-            (output_path / filename).write_text(markdown)
-        except OSError as error:
+            (output_path / filename).write_text(markdown, encoding="utf-8")
+        except (OSError, UnicodeError) as error:
             failed += 1
             console.print(f"[bold red]✗[/bold red] Failed to write {escape(filename)}: {escape(str(error))}")
             continue
@@ -191,11 +196,22 @@ def write_documents(documents: list[tuple[str, str, str]], output_path: Path) ->
 
 
 def short_reference(reference: str) -> str:
-    """A stable, filename-safe fragment identifying an item."""
+    """A stable, filename-safe fragment identifying an item.
+
+    The view is part of that identity. Two URLs can point at one database through different
+    views, and the database id alone would name both exports the same file.
+    """
     try:
-        return extract_notion_id(reference)[:8]
+        identifier = extract_notion_id(reference)[:8]
     except ValueError:
         return re.sub(r"[^\w-]", "", reference).lower()[:8] or "item"
+
+    try:
+        view_id = extract_view_id(reference)
+    except ValueError:
+        view_id = None
+
+    return f"{identifier}-{view_id[:8]}" if view_id else identifier
 
 
 def markdown_filename(title: str, reference: str) -> str:

--- a/cli/nao_core/config/notion/__init__.py
+++ b/cli/nao_core/config/notion/__init__.py
@@ -7,15 +7,15 @@ class NotionConfig(BaseModel):
     """Notion configuration."""
 
     api_key: str = Field(description="The API key to use")
-    pages: list[str] = Field(description="The pages to sync")
+    pages: list[str] = Field(description="The pages and databases to sync, as URLs or IDs")
 
     @classmethod
     def promptConfig(cls) -> "NotionConfig":
         """Interactively prompt the user for Notion configuration."""
         api_key = ask_text("Notion API key:", password=True, required_field=True)
 
-        UI.info("Enter Notion page IDs to sync (comma-separated):")
-        pages_input = ask_text("Page IDs:", required_field=True)
+        UI.info("Enter Notion page or database URLs to sync (comma-separated):")
+        pages_input = ask_text("Pages:", required_field=True)
         pages = [p.strip() for p in pages_input.split(",") if p.strip()]  # type: ignore
 
         return NotionConfig(

--- a/cli/nao_core/templates/context.py
+++ b/cli/nao_core/templates/context.py
@@ -223,27 +223,9 @@ class NotionPage:
     def _load(self) -> dict[str, Any]:
         """Lazily load page data from Notion API."""
         if self._data is None:
-            from nao_core.deps import require_dependency
+            from nao_core.commands.sync.providers.notion.provider import fetch_as_markdown
 
-            require_dependency("notion_client", "notion", "for Notion integration")
-            require_dependency("notion2md", "notion", "for Notion integration")
-
-            from notion2md.exporter.block import StringExporter
-            from notion_client import Client
-
-            from nao_core.commands.sync.providers.notion.provider import (
-                extract_page_id,
-                get_page_title,
-                strip_images,
-            )
-
-            page_id = extract_page_id(self.page_url_or_id)
-            client = Client(auth=self.api_key)
-            title = get_page_title(client, page_id)
-
-            md_exporter = StringExporter(block_id=page_id, token=self.api_key)
-            markdown = md_exporter.export()
-            markdown = strip_images(markdown)
+            page_id, title, markdown = fetch_as_markdown(self.page_url_or_id, self.api_key)
 
             self._data = {
                 "id": page_id,
@@ -291,10 +273,10 @@ class NotionProvider:
         First checks if the page is in any configured Notion config's pages list,
         otherwise uses the first available API key.
         """
-        from nao_core.commands.sync.providers.notion.provider import extract_page_id
+        from nao_core.commands.sync.providers.notion.provider import extract_notion_id
 
         try:
-            page_id = extract_page_id(page_url_or_id)
+            page_id = extract_notion_id(page_url_or_id)
         except ValueError:
             page_id = page_url_or_id
 
@@ -304,7 +286,7 @@ class NotionProvider:
 
         for configured_page in self._config.notion.pages:
             try:
-                if extract_page_id(configured_page) == page_id:
+                if extract_notion_id(configured_page) == page_id:
                     return self._config.notion.api_key
             except ValueError:
                 continue

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -69,7 +69,10 @@ gemini = ["google-genai>=1.61.0"]
 ollama = ["ollama>=0.4.0"]
 
 # Integrations
-notion = ["notion-client>=2.7.0", "notion2md>=2.9.0"]
+# Pinned below their next major: nao calls Views endpoints absent from notion-client and
+# depends on notion2md's marker for unconvertible databases. 3.1 is the floor because it
+# retries rate limits itself, which also covers the client notion2md builds internally.
+notion = ["notion-client>=3.1.0,<4", "notion2md>=2.9.0,<3"]
 
 # Secret resolution backends
 aws-secrets = ["boto3>=1.34.0", "glom>=23.0.0"]

--- a/cli/tests/nao_core/commands/sync/test_notion_database.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_database.py
@@ -1,0 +1,639 @@
+"""Unit tests for the Notion database exporter."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nao_core.commands.sync.providers.notion.database import (
+    CHILD_DATABASE_MARKER,
+    MAX_PAGES,
+    MAX_RENDERED_ROWS,
+    PAGE_SIZE,
+    DatabaseExportError,
+    DatabaseRows,
+    ViewUnavailableError,
+    collect_columns,
+    fetch_rows,
+    fetch_rows_by_id,
+    fetch_view_rows,
+    find_child_database_ids,
+    find_default_view_id,
+    format_property,
+    inject_child_databases,
+    list_children,
+    matching_data_sources,
+    render_table,
+    visible_columns,
+)
+
+
+def text_property(value: str) -> dict:
+    return {"type": "rich_text", "rich_text": [{"plain_text": value}]}
+
+
+def title_property(value: str) -> dict:
+    return {"type": "title", "title": [{"plain_text": value}]}
+
+
+def row(row_id: str, name: str, definition: str = "") -> dict:
+    return {
+        "id": row_id,
+        "properties": {"Definition": text_property(definition), "Name": title_property(name)},
+    }
+
+
+def stub_view(client: MagicMock, detail: dict, query: dict, pages: list[dict] | None = None) -> None:
+    """Stub the typed Views calls: retrieve the view, run it, then page its results."""
+    client.views.retrieve.return_value = detail
+    client.views.queries.create.return_value = query
+    if pages is not None:
+        client.views.queries.results.side_effect = pages
+
+
+def rows_of(*pages: dict) -> DatabaseRows:
+    return DatabaseRows(rows=list(pages), total=len(pages), complete=True)
+
+
+def test_render_table_puts_title_column_first():
+    table = render_table(rows_of(row("a", "carpool_app", "The app used")))
+
+    assert table.splitlines()[0] == "| Name | Definition |"
+    assert table.splitlines()[2] == "| carpool_app | The app used |"
+
+
+def test_render_table_escapes_pipes_and_newlines():
+    table = render_table(rows_of(row("a", "name", "a | b\nsecond line")))
+
+    assert "a \\| b second line" in table
+
+
+def delimiter_count(line: str) -> int:
+    """Count the pipes markdown treats as column delimiters, ignoring escaped ones."""
+    return line.replace("\\|", "").count("|")
+
+
+def test_render_table_escapes_column_names():
+    lines = render_table(rows_of({"id": "a", "properties": {"Cost | USD": text_property("5")}})).splitlines()
+
+    assert lines[0] == "| Cost \\| USD |"
+    assert delimiter_count(lines[0]) == delimiter_count(lines[1])
+
+
+def test_render_table_without_rows():
+    assert render_table(DatabaseRows(rows=[], total=0, complete=True)) == "_No rows._"
+
+
+def test_render_table_reports_rows_beyond_what_was_fetched():
+    fetched = [row(f"row-{index}", f"name-{index}") for index in range(3)]
+    table = render_table(DatabaseRows(rows=fetched, total=1200, complete=True))
+
+    assert "_1197 more rows not exported._" in table
+
+
+def test_render_table_does_not_understate_a_known_remainder():
+    table = render_table(DatabaseRows(rows=[row("a", "x")], total=50, complete=False))
+
+    assert "_At least 49 more rows not exported._" in table
+
+
+def test_render_table_says_more_exist_when_the_count_is_unknown():
+    table = render_table(DatabaseRows(rows=[row("a", "x")], total=None, complete=False))
+
+    assert "_More rows exist than the 1 exported here._" in table
+
+
+def test_render_table_flags_incompleteness_even_without_a_known_count():
+    table = render_table(DatabaseRows(rows=[row("a", "x")], total=1, complete=False))
+
+    assert "may be incomplete" in table
+
+
+def test_collect_columns_unions_all_rows():
+    rows = [
+        {"id": "a", "properties": {"Name": title_property("a")}},
+        {"id": "b", "properties": {"Extra": text_property("x"), "Name": title_property("b")}},
+    ]
+
+    assert collect_columns(rows) == ["Name", "Extra"]
+
+
+def test_fetch_rows_applies_view_filter_and_order():
+    client = MagicMock()
+    client.data_sources.query.return_value = {
+        "results": [row("row-1", "b"), row("row-2", "a"), row("row-3", "c")],
+        "has_more": False,
+    }
+    stub_view(
+        client,
+        {"type": "table", "configuration": {"properties": [{"property_name": "Name", "visible": True}]}},
+        {"results": [{"id": "row-2"}, {"id": "row-1"}], "has_more": False, "id": "query-1", "total_count": 2},
+    )
+
+    rows = fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id="view-1")
+
+    assert [r["id"] for r in rows.rows] == ["row-2", "row-1"]
+    assert rows.total == 2
+    assert rows.complete
+
+
+def test_fetch_rows_exports_everything_when_no_view_is_targeted():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [row("row-1", "a")], "has_more": False}
+
+    rows = fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id=None)
+
+    assert [r["id"] for r in rows.rows] == ["row-1"]
+    client.views.retrieve.assert_not_called()
+
+
+def test_fetch_rows_fails_rather_than_widening_a_failed_view():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [row("row-1", "a")], "has_more": False}
+    client.views.retrieve.side_effect = RuntimeError("rate limited")
+
+    with pytest.raises(ViewUnavailableError):
+        fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id="view-1")
+
+
+def test_fetch_rows_reports_an_unknown_remainder_instead_of_scanning_everything():
+    client = MagicMock()
+    client.data_sources.query.side_effect = [
+        {
+            "results": [row(f"row-{page * PAGE_SIZE + index}", "x") for index in range(PAGE_SIZE)],
+            "has_more": True,
+            "next_cursor": "c",
+        }
+        for page in range(MAX_PAGES)
+    ]
+
+    rows = fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id=None)
+
+    assert rows.total is None
+    assert not rows.complete
+    assert client.data_sources.query.call_count == MAX_RENDERED_ROWS // PAGE_SIZE + 1
+
+
+def test_fetch_rows_by_id_requires_a_data_source():
+    with pytest.raises(ValueError, match="no data source"):
+        fetch_rows_by_id(MagicMock(), {"id": "db", "data_sources": []})
+
+
+def test_visible_columns_keeps_display_order_and_drops_hidden_properties():
+    view = {
+        "configuration": {
+            "properties": [
+                {"property_name": "Name", "visible": True},
+                {"property_name": "Definition", "visible": True},
+                {"property_name": "Validated table", "visible": False},
+            ]
+        }
+    }
+
+    assert [column["name"] for column in visible_columns(view) or []] == ["Name", "Definition"]
+    assert visible_columns({}) is None
+
+
+def test_render_table_renders_only_the_columns_a_view_displays():
+    rows = DatabaseRows(
+        rows=[{"id": "a", "properties": {"Name": title_property("country"), "Hidden": text_property("secret")}}],
+        total=1,
+        complete=True,
+        columns=["Name"],
+    )
+
+    table = render_table(rows)
+
+    assert table.splitlines()[0] == "| Name |"
+    assert "secret" not in table
+
+
+def test_render_table_keeps_the_incompleteness_note_when_no_row_survived():
+    table = render_table(DatabaseRows(rows=[], total=27, complete=False))
+
+    assert "_No rows._" in table
+    assert "At least 27 more rows not exported" in table
+
+
+def test_fetch_view_rows_fails_when_pagination_cannot_continue():
+    client = MagicMock()
+    stub_view(
+        client, {"type": "table"}, {"results": [{"id": "row-1"}], "has_more": True, "next_cursor": None, "id": "q"}
+    )
+
+    with pytest.raises(ViewUnavailableError):
+        fetch_view_rows(client, "view-1")
+
+
+def test_fetch_view_rows_marks_capped_results_incomplete():
+    client = MagicMock()
+    stub_view(
+        client,
+        {"type": "table"},
+        {
+            "results": [{"id": "row-1"}],
+            "has_more": False,
+            "id": "q",
+            "total_count": 1,
+            "request_status": {"type": "incomplete", "incomplete_reason": "query_result_limit_reached"},
+        },
+    )
+
+    assert fetch_view_rows(client, "view-1").complete is False
+
+
+def test_fetch_view_rows_rejects_a_view_that_presents_no_rows():
+    client = MagicMock()
+    client.views.retrieve.return_value = {"type": "chart"}
+
+    with pytest.raises(ViewUnavailableError, match="presents no rows"):
+        fetch_view_rows(client, "view-1")
+
+
+def test_find_default_view_id_fails_rather_than_widening_on_an_empty_list():
+    client = MagicMock()
+    client.views.list.return_value = {"results": []}
+
+    with pytest.raises(ViewUnavailableError):
+        find_default_view_id(client, "db")
+
+
+def test_find_default_view_id_fails_when_the_lookup_errors():
+    client = MagicMock()
+    client.views.list.side_effect = RuntimeError("boom")
+
+    with pytest.raises(ViewUnavailableError):
+        find_default_view_id(client, "db")
+
+
+def test_fetch_rows_by_id_stops_once_every_wanted_row_is_found():
+    client = MagicMock()
+    client.data_sources.query.side_effect = [
+        {"results": [row("row-1", "a")], "has_more": True, "next_cursor": "cursor-1"},
+        {"results": [row("row-2", "b")], "has_more": True, "next_cursor": "cursor-2"},
+    ]
+
+    fetched = fetch_rows_by_id(client, {"data_sources": [{"id": "ds"}]}, wanted_ids={"row-1", "row-2"})
+
+    assert set(fetched.rows) == {"row-1", "row-2"}
+    assert fetched.exhausted
+    assert client.data_sources.query.call_count == 2
+
+
+def test_list_children_stops_when_pagination_returns_no_cursor():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [{"id": "a"}], "has_more": True, "next_cursor": None}
+
+    assert list_children(client, "page") == [{"id": "a"}]
+
+
+def test_find_child_database_ids_walks_nested_blocks():
+    client = MagicMock()
+    client.blocks.children.list.side_effect = [
+        {
+            "results": [
+                {"id": "col", "type": "column", "has_children": True},
+                {"id": "db-top", "type": "child_database", "has_children": False},
+            ],
+            "has_more": False,
+        },
+        {"results": [{"id": "db-nested", "type": "child_database", "has_children": False}], "has_more": False},
+    ]
+
+    assert find_child_database_ids(client, "page") == ["db-nested", "db-top"]
+
+
+def stub_inline_database(client: MagicMock, title: str = "Columns details") -> None:
+    """Stub the three requests an embedded database needs: list views, read one, query it."""
+    client.databases.retrieve.return_value = {
+        "title": [{"plain_text": title}],
+        "id": "db-1",
+        "data_sources": [{"id": "ds-1"}],
+    }
+    client.data_sources.query.return_value = {"results": [row("row-1", "country", "Trip country")], "has_more": False}
+    client.views.list.return_value = {"results": [{"id": "view-1"}]}
+    stub_view(
+        client,
+        {
+            "type": "table",
+            "configuration": {
+                "properties": [
+                    {"property_name": "Name", "visible": True},
+                    {"property_name": "Definition", "visible": True},
+                ]
+            },
+        },
+        {"results": [{"id": "row-1"}], "has_more": False, "id": "query-1", "total_count": 1},
+    )
+
+
+def test_inject_child_databases_replaces_marker_with_table():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "db-1", "type": "child_database", "has_children": False}],
+        "has_more": False,
+    }
+    stub_inline_database(client)
+
+    markdown = inject_child_databases(client, "page", f"intro\n\n{CHILD_DATABASE_MARKER}\n\noutro")
+
+    assert CHILD_DATABASE_MARKER not in markdown
+    assert "**Columns details**" in markdown
+    assert "| country | Trip country |" in markdown
+    assert markdown.startswith("intro")
+    assert markdown.endswith("outro")
+
+
+def test_inject_child_databases_drops_the_indentation_around_a_nested_marker():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "db-1", "type": "child_database", "has_children": False}],
+        "has_more": False,
+    }
+    stub_inline_database(client)
+
+    markdown = inject_child_databases(client, "page", f"- toggle\n\t{CHILD_DATABASE_MARKER}\n")
+
+    assert "\t**Columns details**" not in markdown
+    assert "**Columns details**" in markdown
+
+
+def test_inject_child_databases_fails_when_markers_and_databases_disagree():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [
+            {"id": "db-1", "type": "child_database", "has_children": False},
+            {"id": "db-2", "type": "child_database", "has_children": False},
+        ],
+        "has_more": False,
+    }
+
+    with pytest.raises(DatabaseExportError, match="cannot be matched"):
+        inject_child_databases(client, "page", f"a\n{CHILD_DATABASE_MARKER}\n")
+    client.databases.retrieve.assert_not_called()
+
+
+def test_inject_child_databases_fails_the_page_when_a_database_cannot_be_read():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "db-1", "type": "child_database", "has_children": False}],
+        "has_more": False,
+    }
+    client.databases.retrieve.side_effect = RuntimeError("no access")
+
+    with pytest.raises(DatabaseExportError, match="inline database db-1"):
+        inject_child_databases(client, "page", CHILD_DATABASE_MARKER)
+
+
+def test_inject_child_databases_leaves_a_page_without_databases_alone():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [], "has_more": False}
+
+    assert inject_child_databases(client, "page", "no database here") == "no database here"
+
+
+def test_inject_child_databases_fails_when_notion2md_emitted_no_marker_for_a_database():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "db-1", "type": "child_database", "has_children": False}],
+        "has_more": False,
+    }
+
+    with pytest.raises(DatabaseExportError, match="cannot be matched"):
+        inject_child_databases(client, "page", "a page whose container block was dropped")
+
+
+def test_list_children_stops_when_a_cursor_never_advances():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [{"id": "a"}], "has_more": True, "next_cursor": "same"}
+
+    assert len(list_children(client, "page")) == MAX_PAGES
+
+
+def test_list_children_stops_when_pages_report_more_but_return_nothing():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {"results": [], "has_more": True, "next_cursor": "same"}
+
+    assert list_children(client, "page") == []
+    assert client.blocks.children.list.call_count == MAX_PAGES
+
+
+def test_fetch_rows_by_id_stops_when_pages_report_more_but_return_nothing():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [], "has_more": True, "next_cursor": "same"}
+
+    fetched = fetch_rows_by_id(client, {"id": "db", "data_sources": [{"id": "ds"}]})
+
+    assert fetched.rows == {}
+    assert not fetched.exhausted
+    assert client.data_sources.query.call_count == MAX_PAGES
+
+
+def test_matching_data_sources_compares_ids_in_the_same_form():
+    sources = [{"id": "aaaaaaaa-0000-0000-0000-000000000001"}, {"id": "aaaaaaaa-0000-0000-0000-000000000002"}]
+
+    assert matching_data_sources(sources, "AAAAAAAA00000000000000000000_0002".replace("_", "")) == [sources[1]]
+    assert matching_data_sources(sources, None) == sources
+    assert matching_data_sources(sources, "b" * 32) == sources
+
+
+def test_fetch_view_rows_keeps_an_incomplete_status_from_an_earlier_page():
+    client = MagicMock()
+    stub_view(
+        client,
+        {"type": "table"},
+        {
+            "results": [{"id": "row-1"}],
+            "has_more": True,
+            "next_cursor": "c",
+            "id": "q",
+            "total_count": 2,
+            "request_status": {"type": "incomplete"},
+        },
+        [{"results": [{"id": "row-2"}], "has_more": False}],
+    )
+
+    assert fetch_view_rows(client, "view-1").complete is False
+
+
+def test_format_property_handles_common_types():
+    assert format_property({"type": "number", "number": 42}) == "42"
+    assert format_property({"type": "checkbox", "checkbox": True}) == "true"
+    assert format_property({"type": "select", "select": {"name": "verified"}}) == "verified"
+    assert format_property({"type": "select", "select": None}) == ""
+    assert format_property({"type": "multi_select", "multi_select": [{"name": "a"}, {"name": "b"}]}) == "a, b"
+    assert (
+        format_property({"type": "date", "date": {"start": "2026-01-01", "end": "2026-02-01"}})
+        == "2026-01-01 → 2026-02-01"
+    )
+    assert format_property({"type": "relation", "relation": [{"id": "x"}]}) == "1 linked"
+    assert format_property({"type": "formula", "formula": {"type": "string", "string": "ok"}}) == "ok"
+    assert format_property({"type": "unknown_kind"}) == ""
+
+
+@pytest.mark.parametrize(
+    "prop",
+    [
+        {"type": "people", "people": [{"name": None}]},
+        {"type": "files", "files": [{"name": None}]},
+        {"type": "multi_select", "multi_select": [{"name": None}]},
+        {"type": "select", "select": {"name": None}},
+        {"type": "status", "status": {"name": None}},
+        {"type": "created_by", "created_by": {"name": None}},
+        {"type": "last_edited_by", "last_edited_by": {"name": None}},
+    ],
+)
+def test_format_property_tolerates_null_names(prop):
+    assert format_property(prop) == ""
+
+
+def test_format_property_escapes_a_rollup_array_exactly_once():
+    rollup = {
+        "type": "rollup",
+        "rollup": {"type": "array", "array": [text_property("a | b")]},
+    }
+
+    assert format_property(rollup) == "a \\| b"
+
+
+def test_format_property_normalises_carriage_returns():
+    assert format_property(text_property("line1\r\nline2")) == "line1 line2"
+
+
+def test_format_property_escapes_a_backslash_before_a_pipe():
+    assert format_property(text_property("a\\|b")) == "a\\\\\\|b"
+
+
+def test_visible_columns_raises_when_the_payload_shape_is_unrecognised():
+    renamed_key = {"configuration": {"properties": [{"property_name": "Name", "is_visible": True}]}}
+
+    with pytest.raises(ValueError, match="declares whether it is visible"):
+        visible_columns(renamed_key)
+
+
+def test_visible_columns_raises_when_an_all_hidden_view_has_no_title():
+    hidden_without_title = {"configuration": {"properties": [{"property_name": "Secret", "visible": False}]}}
+
+    with pytest.raises(ValueError, match="no title column"):
+        visible_columns(hidden_without_title)
+
+
+def test_fetch_view_rows_stops_paging_at_the_render_budget():
+    client = MagicMock()
+    page = {"results": [{"id": f"row-{index}"} for index in range(100)], "has_more": True, "next_cursor": "c"}
+    stub_view(client, {"type": "table"}, {**page, "id": "q", "total_count": 5000}, [page] * 20)
+
+    view = fetch_view_rows(client, "view-1")
+
+    assert len(view.row_ids) <= MAX_RENDERED_ROWS + 100
+    assert view.total == 5000
+    assert view.complete
+
+
+def test_fetch_rows_reports_rows_it_could_not_match():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [row("row-1", "a")], "has_more": False}
+    stub_view(
+        client,
+        {"type": "table"},
+        {"results": [{"id": "row-1"}, {"id": "row-missing"}], "has_more": False, "id": "q", "total_count": 2},
+    )
+
+    rows = fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id="view-1")
+
+    assert rows.unmatched == 1
+    assert "could not be matched to their values" in render_table(rows)
+
+
+def test_fetch_rows_does_not_query_a_data_source_for_an_empty_view():
+    client = MagicMock()
+    stub_view(client, {"type": "table"}, {"results": [], "has_more": False, "id": "q", "total_count": 0})
+
+    rows = fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id="view-1")
+
+    assert rows.rows == []
+    client.data_sources.query.assert_not_called()
+
+
+def test_find_child_database_ids_does_not_walk_into_tables():
+    client = MagicMock()
+    client.blocks.children.list.return_value = {
+        "results": [{"id": "table-1", "type": "table", "has_children": True}],
+        "has_more": False,
+    }
+
+    assert find_child_database_ids(client, "page") == []
+    assert client.blocks.children.list.call_count == 1
+
+
+def test_fetch_rows_only_scans_the_data_source_its_view_reads():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [row("row-1", "a")], "has_more": False}
+    stub_view(
+        client,
+        {
+            "type": "table",
+            "configuration": {"properties": [{"property_name": "Name", "visible": True}]},
+            "data_source_id": "ds-2",
+        },
+        {"results": [{"id": "row-1"}], "has_more": False, "id": "q", "total_count": 1},
+    )
+    database = {"id": "db", "data_sources": [{"id": "ds-1"}, {"id": "ds-2"}]}
+
+    fetch_rows(client, database, view_id="view-1")
+
+    assert [call.args[0] for call in client.data_sources.query.call_args_list] == ["ds-2"]
+
+
+def test_fetch_rows_fails_when_view_columns_match_no_property():
+    client = MagicMock()
+    client.data_sources.query.return_value = {"results": [row("row-1", "a")], "has_more": False}
+    stub_view(
+        client,
+        {"type": "table", "configuration": {"properties": [{"property_name": "Renamed", "visible": True}]}},
+        {"results": [{"id": "row-1"}], "has_more": False, "id": "q", "total_count": 1},
+    )
+
+    with pytest.raises(ValueError, match="match the properties"):
+        fetch_rows(client, {"id": "db", "data_sources": [{"id": "ds"}]}, view_id="view-1")
+
+
+def test_visible_columns_keeps_the_title_of_an_all_hidden_view():
+    view = {
+        "configuration": {
+            "properties": [
+                {"property_id": "title", "property_name": "Name", "visible": False},
+                {"property_id": "abc", "property_name": "Secret", "visible": False},
+            ]
+        }
+    }
+
+    assert [column["name"] for column in visible_columns(view) or []] == ["Name"]
+
+
+def test_format_property_renders_verification_state():
+    verified = {"type": "verification", "verification": {"state": "verified", "verified_by": {"name": "Dana"}}}
+
+    assert format_property(verified) == "verified by Dana"
+    assert format_property({"type": "verification", "verification": {"state": "unverified"}}) == "unverified"
+
+
+def test_format_property_renders_computed_dates():
+    formula = {"type": "formula", "formula": {"type": "date", "date": {"start": "2026-01-01", "end": None}}}
+    rollup = {"type": "rollup", "rollup": {"type": "date", "date": {"start": "2026-01-01", "end": "2026-02-01"}}}
+
+    assert format_property(formula) == "2026-01-01"
+    assert format_property(rollup) == "2026-01-01 → 2026-02-01"
+
+
+def test_format_property_marks_truncated_relations_as_a_lower_bound():
+    linked = [{"id": str(index)} for index in range(25)]
+
+    assert format_property({"type": "relation", "relation": linked, "has_more": True}) == "25+ linked"
+    assert format_property({"type": "relation", "relation": linked}) == "25 linked"
+
+
+def test_format_property_renders_zero_and_booleans():
+    assert format_property({"type": "unique_id", "unique_id": {"prefix": None, "number": 0}}) == "0"
+    assert format_property({"type": "unique_id", "unique_id": {"prefix": "TASK", "number": 0}}) == "TASK-0"
+    assert format_property({"type": "formula", "formula": {"type": "boolean", "boolean": True}}) == "true"
+    assert format_property({"type": "formula", "formula": {"type": "boolean", "boolean": False}}) == "false"

--- a/cli/tests/nao_core/commands/sync/test_notion_database.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_database.py
@@ -436,6 +436,18 @@ def test_matching_data_sources_compares_ids_in_the_same_form():
     assert matching_data_sources(sources, "b" * 32) == sources
 
 
+def test_fetch_view_rows_stops_at_the_render_budget_without_an_extra_page():
+    client = MagicMock()
+    full_page = {"results": [{"id": f"row-{index}"} for index in range(PAGE_SIZE)], "has_more": True}
+    stub_view(client, {"type": "table"}, {**full_page, "id": "q", "next_cursor": "c", "total_count": 5000})
+    client.views.queries.results.return_value = {**full_page, "next_cursor": "c"}
+
+    view = fetch_view_rows(client, "view-1")
+
+    assert len(view.row_ids) == MAX_RENDERED_ROWS
+    assert client.views.queries.results.call_count == MAX_RENDERED_ROWS // PAGE_SIZE - 1
+
+
 def test_fetch_view_rows_keeps_an_incomplete_status_from_an_earlier_page():
     client = MagicMock()
     stub_view(

--- a/cli/tests/nao_core/commands/sync/test_notion_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_provider.py
@@ -1,19 +1,34 @@
 """Unit tests for the Notion sync provider."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from nao_core.commands.sync.providers.notion.provider import NotionSyncProvider
+import httpx
+import pytest
+import yaml
+from notion_client.errors import APIErrorCode, APIResponseError
+
+from nao_core.commands.sync.providers.notion.database import DatabaseExportError
+from nao_core.commands.sync.providers.notion.provider import (
+    NotionSyncProvider,
+    extract_notion_id,
+    extract_view_id,
+    markdown_filename,
+    render_document,
+    retrieve_page,
+    write_documents,
+)
 from nao_core.config.notion import NotionConfig
 
 
-@patch("nao_core.commands.sync.providers.notion.provider.get_page_as_markdown")
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
 def test_sync_pages_with_threads(mock_get_page, tmp_path: Path):
     provider = NotionSyncProvider()
-    config = NotionConfig(api_key="secret", pages=["page-a", "page-b"])
+    urls = ["https://notion.so/ws/" + "a" * 32, "https://notion.so/ws/" + "b" * 32]
+    config = NotionConfig(api_key="secret", pages=urls)
 
     def _get_page(page_url: str, _api_key: str) -> tuple[str, str]:
-        title = "Page A" if page_url == "page-a" else "Page B"
+        title = "Page A" if page_url == urls[0] else "Page B"
         return title, f"# {title}"
 
     mock_get_page.side_effect = _get_page
@@ -21,6 +36,192 @@ def test_sync_pages_with_threads(mock_get_page, tmp_path: Path):
     result = provider.sync([config], tmp_path, threads=2)
 
     assert result.items_synced == 2
-    assert (tmp_path / "page-a.md").read_text() == "# Page A"
-    assert (tmp_path / "page-b.md").read_text() == "# Page B"
+    assert (tmp_path / "page-a-aaaaaaaa.md").read_text() == "# Page A"
+    assert (tmp_path / "page-b-bbbbbbbb.md").read_text() == "# Page B"
     assert mock_get_page.call_count == 2
+
+
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
+def test_sync_removes_stale_pages_when_everything_succeeded(mock_get_page, tmp_path: Path):
+    provider = NotionSyncProvider()
+    mock_get_page.return_value = ("Page A", "# Page A")
+    (tmp_path / "stale.md").write_text("outdated")
+
+    result = provider.sync([NotionConfig(api_key="secret", pages=["page-a"])], tmp_path)
+
+    assert not (tmp_path / "stale.md").exists()
+    assert result.details is not None
+    assert result.details["removed"] == 1
+
+
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
+def test_sync_keeps_existing_pages_when_one_failed(mock_get_page, tmp_path: Path):
+    provider = NotionSyncProvider()
+    previously_synced = tmp_path / "page-b.md"
+    previously_synced.write_text("# Page B")
+
+    def _get_page(page_url: str, _api_key: str) -> tuple[str, str]:
+        if page_url == "page-b":
+            raise RuntimeError("rate limited")
+        return "Page A", "# Page A"
+
+    mock_get_page.side_effect = _get_page
+
+    result = provider.sync([NotionConfig(api_key="secret", pages=["page-a", "page-b"])], tmp_path)
+
+    assert previously_synced.read_text() == "# Page B"
+    assert result.items_synced == 1
+    assert result.details is not None
+    assert result.details["removed"] == 0
+
+
+def api_error(code: APIErrorCode, status: int) -> APIResponseError:
+    return APIResponseError(code, status, str(code), httpx.Headers(), "")
+
+
+def test_retrieve_page_reports_a_database_as_not_a_page():
+    client = MagicMock()
+    client.pages.retrieve.side_effect = api_error(APIErrorCode.ValidationError, 400)
+
+    assert retrieve_page(client, "some-id") is None
+
+
+def test_retrieve_page_raises_when_a_page_is_not_shared():
+    client = MagicMock()
+    client.pages.retrieve.side_effect = api_error(APIErrorCode.ObjectNotFound, 404)
+
+    with pytest.raises(APIResponseError):
+        retrieve_page(client, "some-id")
+
+
+def test_retrieve_page_raises_when_rate_limited():
+    client = MagicMock()
+    client.pages.retrieve.side_effect = api_error(APIErrorCode.RateLimited, 429)
+
+    with pytest.raises(APIResponseError):
+        retrieve_page(client, "some-id")
+
+
+def test_extract_view_id_reads_the_v_query_parameter():
+    assert extract_view_id("https://notion.so/ws/35e5f0e8a00080c69a81ef456a2b174b?v=" + "a" * 32) == "a" * 32
+    assert extract_view_id("https://notion.so/ws/35e5f0e8a00080c69a81ef456a2b174b") is None
+
+
+def test_extract_notion_id_prefers_the_object_over_the_view():
+    url = "https://notion.so/ws/marts-35e5f0e8a00080c69a81ef456a2b174b?v=" + "a" * 32
+
+    assert extract_notion_id(url) == "35e5f0e8a00080c69a81ef456a2b174b"
+
+
+@pytest.mark.parametrize(
+    "title",
+    ["Schema: Orders", "# Draft", "true", "2026-01-01", "- dash", '"quoted"', "value #comment"],
+)
+def test_render_document_keeps_yaml_significant_titles_readable(title):
+    document = render_document(title, "35e5f0e8a0008045bb12fee7746de807", "body")
+
+    meta = yaml.safe_load(document.split("---")[1])
+    assert meta["title"] == title
+    assert meta["id"] == "35e5f0e8a0008045bb12fee7746de807"
+
+
+def test_write_documents_gives_colliding_titles_distinct_files(tmp_path: Path):
+    documents = [
+        ("https://notion.so/ws/" + "a" * 32, "Overview", "first"),
+        ("https://notion.so/ws/" + "b" * 32, "Overview", "second"),
+    ]
+
+    written, titles, failed = write_documents(documents, tmp_path)
+
+    assert written == {"overview-aaaaaaaa.md", "overview-bbbbbbbb.md"}
+    assert (tmp_path / "overview-aaaaaaaa.md").read_text() == "first"
+    assert (tmp_path / "overview-bbbbbbbb.md").read_text() == "second"
+    assert titles == ["Overview", "Overview"]
+    assert failed == 0
+
+
+def test_write_documents_names_an_item_the_same_way_whoever_else_succeeded(tmp_path: Path):
+    alone = [("https://notion.so/ws/" + "b" * 32, "Overview", "second")]
+
+    written, _, _ = write_documents(alone, tmp_path)
+
+    assert written == {"overview-bbbbbbbb.md"}
+
+
+def test_write_documents_keeps_a_write_failure_to_its_own_item(tmp_path: Path):
+    documents = [
+        ("https://notion.so/ws/" + "a" * 32, "A" * 300, "first"),
+        ("https://notion.so/ws/" + "b" * 32, "Fine", "second"),
+    ]
+
+    written, titles, failed = write_documents(documents, tmp_path)
+
+    assert "fine-bbbbbbbb.md" in written
+    assert titles[-1] == "Fine"
+    assert failed == 0
+
+
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
+def test_sync_survives_a_title_that_looks_like_console_markup(mock_get_page, tmp_path: Path):
+    provider = NotionSyncProvider()
+    mock_get_page.return_value = ("Notes [/done]", "# Notes")
+
+    result = provider.sync([NotionConfig(api_key="secret", pages=["page-a"])], tmp_path)
+
+    assert result.items_synced == 1
+
+
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
+def test_sync_survives_an_error_that_looks_like_console_markup(mock_get_page, tmp_path: Path):
+    provider = NotionSyncProvider()
+    mock_get_page.side_effect = RuntimeError("boom [/done]")
+
+    result = provider.sync([NotionConfig(api_key="secret", pages=["page-a"])], tmp_path)
+
+    assert result.items_synced == 0
+
+
+def test_extract_ids_accept_dashed_uuids():
+    dashed = "35e5f0e8-a000-80c6-9a81-ef456a2b174b"
+    bare = "35e5f0e8a00080c69a81ef456a2b174b"
+
+    assert extract_notion_id(dashed) == bare
+    assert extract_notion_id(f"https://notion.so/ws/page-{bare}") == bare
+    assert extract_view_id(f"https://notion.so/ws/{bare}?v={dashed}") == bare
+
+
+def test_markdown_filename_always_carries_the_item_id():
+    reference = "https://notion.so/ws/" + "a" * 32
+
+    assert markdown_filename("Columns details", reference) == "columns-details-aaaaaaaa.md"
+    assert markdown_filename("!!!", reference) == "aaaaaaaa.md"
+    assert markdown_filename("", reference) == "aaaaaaaa.md"
+
+
+def test_markdown_filename_truncates_a_very_long_title():
+    filename = markdown_filename("A" * 300, "https://notion.so/ws/" + "a" * 32)
+
+    assert len(filename) < 100
+    assert filename.endswith("-aaaaaaaa.md")
+
+
+@patch("nao_core.commands.sync.providers.notion.provider.get_content_as_markdown")
+def test_sync_keeps_a_page_untouched_when_its_inline_database_fails(mock_get_page, tmp_path: Path):
+    provider = NotionSyncProvider()
+    previously_synced = tmp_path / "page-a.md"
+    previously_synced.write_text("# Page A\n\n| Name | Definition |")
+    mock_get_page.side_effect = DatabaseExportError("inline database db-1 could not be exported: no access")
+
+    result = provider.sync([NotionConfig(api_key="secret", pages=["page-a"])], tmp_path)
+
+    assert previously_synced.read_text() == "# Page A\n\n| Name | Definition |"
+    assert result.items_synced == 0
+    assert result.details is not None
+    assert result.details["removed"] == 0
+
+
+def test_render_document_keeps_the_body_after_the_frontmatter():
+    document = render_document("Title", "abc", "# Heading\n\ntext")
+
+    assert document.startswith("---\n")
+    assert document.endswith("# Heading\n\ntext\n")

--- a/cli/tests/nao_core/commands/sync/test_notion_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_provider.py
@@ -198,6 +198,45 @@ def test_markdown_filename_always_carries_the_item_id():
     assert markdown_filename("", reference) == "aaaaaaaa.md"
 
 
+def test_markdown_filename_separates_two_views_of_one_database():
+    database = "https://notion.so/ws/" + "a" * 32
+    first = markdown_filename("Columns", f"{database}?v=" + "b" * 32)
+    second = markdown_filename("Columns", f"{database}?v=" + "c" * 32)
+
+    assert first == "columns-aaaaaaaa-bbbbbbbb.md"
+    assert second == "columns-aaaaaaaa-cccccccc.md"
+    assert markdown_filename("Columns", database) == "columns-aaaaaaaa.md"
+
+
+def test_write_documents_writes_utf8_whatever_the_platform_encoding(tmp_path: Path):
+    body = "co2e_saved → gains — ⚠️ accentué"
+
+    written, _, failed = write_documents([("https://notion.so/ws/" + "a" * 32, "Notes", body)], tmp_path)
+
+    assert failed == 0
+    assert (tmp_path / written.pop()).read_text(encoding="utf-8") == body
+
+
+def test_write_documents_contains_an_encoding_failure(tmp_path: Path):
+    documents = [
+        ("https://notion.so/ws/" + "a" * 32, "Broken", "→"),
+        ("https://notion.so/ws/" + "b" * 32, "Fine", "ok"),
+    ]
+    real_write = Path.write_text
+
+    def write(self, data, *args, **kwargs):
+        if "broken" in self.name:
+            raise UnicodeEncodeError("cp1252", data, 0, 1, "unmappable character")
+        return real_write(self, data, *args, **kwargs)
+
+    with patch.object(Path, "write_text", write):
+        written, titles, failed = write_documents(documents, tmp_path)
+
+    assert failed == 1
+    assert titles == ["Fine"]
+    assert written == {"fine-bbbbbbbb.md"}
+
+
 def test_markdown_filename_truncates_a_very_long_title():
     filename = markdown_filename("A" * 300, "https://notion.so/ws/" + "a" * 32)
 

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -2763,8 +2763,8 @@ requires-dist = [
     { name = "nao-core", extras = ["all-databases", "all-llms", "notion", "aws-secrets", "k8s-secrets"], marker = "extra == 'all'" },
     { name = "nao-core", extras = ["openai", "anthropic", "mistral", "gemini", "ollama"], marker = "extra == 'all-llms'" },
     { name = "nao-core", extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "starrocks"], marker = "extra == 'all-databases'" },
-    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=2.7.0" },
-    { name = "notion2md", marker = "extra == 'notion'", specifier = ">=2.9.0" },
+    { name = "notion-client", marker = "extra == 'notion'", specifier = ">=3.1.0,<4" },
+    { name = "notion2md", marker = "extra == 'notion'", specifier = ">=2.9.0,<3" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
@@ -2797,14 +2797,14 @@ dev = [
 
 [[package]]
 name = "notion-client"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/39/60afcbc0148c3dafaaefe851ae3f058077db49d66288dfb218a11a57b997/notion_client-3.0.0.tar.gz", hash = "sha256:05c4d2b4fa3491dc0de21c9c826277202ea8b8714077ee7f51a6e1a09ab23d0f", size = 31357, upload-time = "2026-02-16T11:15:48.024Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e3/4ac01384e86e2c381c21b87a0fefcdfe6d65577ae3153fad27e7e96c5d9c/notion_client-3.1.0.tar.gz", hash = "sha256:516e31326f855ec34559289b57be4e27ad656062f51f594c8f4ee3a608ee333d", size = 38781, upload-time = "2026-05-12T08:54:44.363Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ce/6b03f9aedd2edfcc28e23ced5c2582d543f6ddbb2be5c570533f02890b27/notion_client-3.0.0-py2.py3-none-any.whl", hash = "sha256:177fc3d2ace7e8ef69cf96f46269e8a66071c2c7c526194bf06ce7925853e759", size = 18746, upload-time = "2026-02-16T11:15:46.602Z" },
+    { url = "https://files.pythonhosted.org/packages/08/08/12645b24044301cb0d7908ec068c55c0d5724f39372891a1a27d630fdf50/notion_client-3.1.0-py2.py3-none-any.whl", hash = "sha256:7e3935f4dbc11231d8ad1fe404112e278501520342eaa35f86456f0df44a8aca", size = 23092, upload-time = "2026-05-12T08:54:43.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1277

This implements the proposal described in the issue above. I'm happy to adjust the behavior or scope.

`nao sync` now exports Notion databases as Markdown tables, both when configured directly in `notion.pages` and when embedded in a page. Embedded databases were previously replaced with a `child_database is not supported` comment, leaving an apparently complete file without the table content.

- A database configured by URL is exported without view-specific filtering unless its URL contains `?v=<view_id>`, in which case that view's filters, sorts, row order, and visible columns are applied.
- An embedded database uses the first view listed for its database block because Notion does not expose which view is active in the embed. Applying that view prevents a shared data source filtered differently on each page from pulling unrelated rows or hidden columns into every file.
- Tables render at most 500 rows and explicitly report truncation or incomplete results.

Rows are resolved through batched view and data-source queries rather than one request per row. This requires the Views API, so the Notion integration now uses API version `2025-09-03` and pins `notion-client>=3.1.0,<4`.

If a database cannot be exported safely, only the affected item fails. Its previously synced Markdown is preserved, and stale cleanup is skipped after a partial sync rather than overwriting or deleting valid content.

## Testing

- The repository pre-commit checks pass, including TypeScript lint, formatting, migration checks, and CLI lint.
- Tested against a real Notion workspace with a page containing a filtered embedded database. The export contains the 27 rows and visible columns shown by the view, without its hidden columns.

This PR was written using Claude Opus 5 (claude-opus-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

