### PR TITLE
Improve LLMConfig in `nao_config.yaml`

### DIFF
--- a/apps/backend/src/queries/usage.queries.ts
+++ b/apps/backend/src/queries/usage.queries.ts
@@ -5,9 +5,10 @@ import { LLM_PROVIDERS } from '../agents/providers';
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
 import dbConfig, { Dialect } from '../db/dbConfig';
+import type { ModelCosts } from '../types/llm';
 import type { Granularity, TotalUsageRecord, UsageFilter, UsageRecord, UsageSource } from '../types/usage';
 import { fillMissingDates, getLookbackTimestamp } from '../utils/date';
-import * as projectLlmConfigQueries from './project-llm-config.queries';
+import { getProjectDeclaredModels } from '../utils/llm';
 
 const COST_COLS = [
 	'provider',
@@ -258,36 +259,32 @@ async function buildCostValuesTable(projectId: string): Promise<SQL> {
 }
 
 async function getCostLookupTuples(projectId: string): Promise<CostLookupTuple[]> {
-	const knownModelTuples = Object.entries(LLM_PROVIDERS).flatMap(([provider, config]) =>
-		config.models.map((model) => {
-			const cost = model.costPerM ?? {};
-			return [
-				provider,
-				model.id,
-				cost.inputNoCache ?? 0,
-				cost.inputCacheRead ?? 0,
-				cost.inputCacheWrite ?? 0,
-				cost.output ?? 0,
-			] satisfies CostLookupTuple;
-		}),
-	);
+	const costs = new Map<string, ModelCosts>();
 
-	const configs = await projectLlmConfigQueries.getProjectLlmConfigs(projectId);
-	const customModelTuples = configs.flatMap((config) =>
-		(config.customModels ?? []).map((model) => {
-			const cost = model.costPerM ?? {};
-			return [
-				config.provider,
-				model.id,
-				cost.inputNoCache ?? 0,
-				cost.inputCacheRead ?? 0,
-				cost.inputCacheWrite ?? 0,
-				cost.output ?? 0,
-			] satisfies CostLookupTuple;
-		}),
-	);
+	for (const [provider, config] of Object.entries(LLM_PROVIDERS)) {
+		for (const model of config.models) {
+			costs.set(`${provider}\u0000${model.id}`, { ...model.costPerM });
+		}
+	}
 
-	return [...knownModelTuples, ...customModelTuples];
+	for (const { provider, models } of await getProjectDeclaredModels(projectId)) {
+		for (const model of models) {
+			const key = `${provider}\u0000${model.id}`;
+			costs.set(key, { ...costs.get(key), ...model.costPerM });
+		}
+	}
+
+	return [...costs].map(([key, cost]) => {
+		const [provider, modelId] = key.split('\u0000');
+		return [
+			provider,
+			modelId,
+			cost.inputNoCache ?? 0,
+			cost.inputCacheRead ?? 0,
+			cost.inputCacheWrite ?? 0,
+			cost.output ?? 0,
+		] satisfies CostLookupTuple;
+	});
 }
 
 function tupleToValuesRow(tuple: CostLookupTuple): SQL {

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -32,7 +32,6 @@ import { renderToMarkdown } from '../lib/markdown';
 import * as chatQueries from '../queries/chat.queries';
 import * as imageQueries from '../queries/image.queries';
 import * as projectQueries from '../queries/project.queries';
-import * as llmConfigQueries from '../queries/project-llm-config.queries';
 import * as storyQueries from '../queries/story.queries';
 import { AgentSettings } from '../types/agent-settings';
 import {
@@ -58,8 +57,8 @@ import {
 import { assertBudgetNotExceeded } from '../utils/budget';
 import { HandlerError } from '../utils/error';
 import {
-	getDefaultModelId,
-	getEnvModelSelections,
+	getProjectAvailableModels,
+	getProjectDeclaredModels,
 	resolveAnnotationModelId,
 	resolveProviderModel,
 	resolveProviderSettings,
@@ -289,20 +288,11 @@ export class AgentService {
 			return modelSelection;
 		}
 
-		// Get the first available provider config
-		const configs = await llmConfigQueries.getProjectLlmConfigs(projectId);
-		const config = configs.at(0);
-		if (config) {
-			return {
-				provider: config.provider,
-				modelId: getDefaultModelId(config.provider),
-			};
-		}
-
-		// Fallback to env-based provider
-		const envSelection = getEnvModelSelections().at(0);
-		if (envSelection) {
-			return envSelection;
+		// Same order the model picker offers, across the database, nao_config.yaml and the environment.
+		const available = await getProjectAvailableModels(projectId);
+		const first = available.at(0);
+		if (first) {
+			return { provider: first.provider, modelId: first.modelId };
 		}
 
 		throw new HandlerError('BAD_REQUEST', 'No model config found');
@@ -810,9 +800,11 @@ class AgentManager {
 			const durationMs = Math.round(performance.now() - startTime);
 
 			const usage = convertToTokenUsage(result.totalUsage);
-			const customModels = await llmConfigQueries
-				.getProjectLlmConfigByProvider(this.chat.projectId, this._modelSelection.provider)
-				.then((c) => c?.customModels ?? [])
+			const customModels = await getProjectDeclaredModels(this.chat.projectId)
+				.then(
+					(sources) =>
+						sources.find((source) => source.provider === this._modelSelection.provider)?.models ?? [],
+				)
 				.catch(() => []);
 			const cost = convertToCost(
 				usage,

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -24,11 +24,23 @@ import { posthog, PostHogEvent } from '../services/posthog';
 import { slackService } from '../services/slack';
 import { listAvailableTranscribeModels as getAvailableTranscribeModels } from '../services/transcribe.service';
 import { AgentSettings } from '../types/agent-settings';
-import { customModelMetadataSchema, llmConfigSchema, llmProviderSchema, modelSettingsMapSchema } from '../types/llm';
+import {
+	configLlmProviderSchema,
+	customModelMetadataSchema,
+	llmConfigSchema,
+	llmProviderSchema,
+	modelSettingsMapSchema,
+} from '../types/llm';
 import { isValidIsoDateString } from '../utils/date';
-import { getEnvApiKey, getEnvBaseUrls, getEnvProviders, getProjectAvailableModels } from '../utils/llm';
+import {
+	getEnvApiKey,
+	getEnvBaseUrls,
+	getEnvProviders,
+	getProjectAvailableModels,
+	getProjectConfigLlm,
+} from '../utils/llm';
 import { extractRequiredEnvVars } from '../utils/nao-config';
-import { buildCredentialPreviews } from '../utils/utils';
+import { buildCredentialPreviews, previewApiKey } from '../utils/utils';
 import {
 	adminProtectedProcedure,
 	contextAdminProtectedProcedure,
@@ -88,13 +100,14 @@ export const projectRoutes = {
 		.output(
 			z.object({
 				projectConfigs: z.array(llmConfigSchema),
+				configProviders: z.array(configLlmProviderSchema),
 				envProviders: z.array(llmProviderSchema),
 				envBaseUrls: z.record(z.string(), z.string()),
 			}),
 		)
 		.query(async ({ ctx }) => {
 			if (!ctx.project) {
-				return { projectConfigs: [], envProviders: [], envBaseUrls: {} };
+				return { projectConfigs: [], configProviders: [], envProviders: [], envBaseUrls: {} };
 			}
 
 			const configs = await llmConfigQueries.getProjectLlmConfigs(ctx.project.id);
@@ -102,7 +115,7 @@ export const projectRoutes = {
 			const projectConfigs = configs.map((c) => ({
 				id: c.id,
 				provider: c.provider as LlmProvider,
-				apiKeyPreview: c.apiKey ? c.apiKey.slice(0, 8) + '...' + c.apiKey.slice(-4) : null,
+				apiKeyPreview: previewApiKey(c.apiKey),
 				credentialPreviews: buildCredentialPreviews(c.credentials),
 				enabledModels: c.enabledModels ?? [],
 				customModels: c.customModels ?? [],
@@ -112,10 +125,23 @@ export const projectRoutes = {
 				updatedAt: c.updatedAt,
 			}));
 
-			const envProviders = getEnvProviders();
-			const envBaseUrls = getEnvBaseUrls();
+			const configLlm = await getProjectConfigLlm(ctx.project.id);
+			const configProviders = (configLlm?.providers ?? []).map((p) => ({
+				provider: p.provider,
+				apiKeyPreview: previewApiKey(p.apiKey),
+				credentialPreviews: buildCredentialPreviews(p.credentials),
+				enabledModels: p.enabledModels,
+				customModels: p.customModels,
+				modelSettings: p.modelSettings,
+				baseUrl: p.baseUrl,
+			}));
 
-			return { projectConfigs, envProviders, envBaseUrls };
+			// nao chat also exports config credentials to the environment; show each provider once.
+			const envProviders = getEnvProviders().filter(
+				(provider) => !configProviders.some((p) => p.provider === provider),
+			);
+
+			return { projectConfigs, configProviders, envProviders, envBaseUrls: getEnvBaseUrls() };
 		}),
 
 	/** Get all available models for the current project (for user model selection) */
@@ -196,7 +222,7 @@ export const projectRoutes = {
 			return {
 				id: config.id,
 				provider: config.provider as LlmProvider,
-				apiKeyPreview: config.apiKey ? config.apiKey.slice(0, 8) + '...' + config.apiKey.slice(-4) : null,
+				apiKeyPreview: previewApiKey(config.apiKey),
 				credentialPreviews: buildCredentialPreviews(config.credentials),
 				enabledModels: config.enabledModels ?? [],
 				customModels: config.customModels ?? [],

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -40,6 +40,7 @@ import {
 	getProjectConfigLlm,
 } from '../utils/llm';
 import { extractRequiredEnvVars } from '../utils/nao-config';
+import { findConfigLlmProvider } from '../utils/nao-config-llm';
 import { buildCredentialPreviews, previewApiKey } from '../utils/utils';
 import {
 	adminProtectedProcedure,
@@ -177,19 +178,29 @@ export const projectRoutes = {
 		.output(llmConfigSchema.omit({ createdAt: true, updatedAt: true }))
 		.mutation(async ({ ctx, input }) => {
 			const existingConfig = await llmConfigQueries.getProjectLlmConfigByProvider(ctx.project.id, input.provider);
+			const inheritedConfig = existingConfig
+				? null
+				: findConfigLlmProvider(await getProjectConfigLlm(ctx.project.id), input.provider);
 			const envApiKey = getEnvApiKey(input.provider);
 
-			const hasNewCredentials =
-				input.credentials && Object.keys(input.credentials).some((k) => input.credentials![k]);
+			const hasNewCredentials = Object.values(input.credentials ?? {}).some(Boolean);
+			const credentials = hasNewCredentials
+				? {
+						...(existingConfig?.credentials ?? inheritedConfig?.credentials),
+						...input.credentials,
+					}
+				: (inheritedConfig?.credentials ?? undefined);
 
 			let apiKey: string | null;
 
 			if (input.apiKey) {
 				apiKey = input.apiKey;
-			} else if (hasNewCredentials && !input.apiKey) {
+			} else if (hasNewCredentials) {
 				apiKey = '';
 			} else if (existingConfig) {
 				apiKey = null;
+			} else if (inheritedConfig?.apiKey) {
+				apiKey = inheritedConfig.apiKey;
 			} else if (envApiKey) {
 				apiKey = envApiKey;
 			} else if (getProviderAuth(input.provider).apiKey !== 'required') {
@@ -212,7 +223,7 @@ export const projectRoutes = {
 				projectId: ctx.project.id,
 				provider: input.provider,
 				apiKey,
-				credentials: hasNewCredentials ? input.credentials! : undefined,
+				credentials,
 				enabledModels,
 				customModels,
 				modelSettings,

--- a/apps/backend/src/types/llm.ts
+++ b/apps/backend/src/types/llm.ts
@@ -167,6 +167,17 @@ export const llmConfigSchema = z.object({
 	updatedAt: z.date(),
 });
 
+/** A provider declared in nao_config.yaml rather than saved from the settings UI. */
+export const configLlmProviderSchema = z.object({
+	provider: llmProviderSchema,
+	apiKeyPreview: z.string().nullable(),
+	credentialPreviews: z.record(z.string(), z.string()).nullable(),
+	enabledModels: z.array(z.string()),
+	customModels: z.array(customModelMetadataSchema),
+	modelSettings: modelSettingsMapSchema,
+	baseUrl: z.string().nullable(),
+});
+
 /** Flatten an interface into a plain type so it gains an implicit index signature. */
 type Flatten<T> = { [K in keyof T]: T[K] };
 

--- a/apps/backend/src/utils/ai.ts
+++ b/apps/backend/src/utils/ai.ts
@@ -29,10 +29,11 @@ export const convertToCost = (
 	customModels: CustomModelMetadata[] = [],
 	costs?: ModelCosts,
 ): TokenCost => {
-	const costPerM =
-		LLM_PROVIDERS[provider].models.find((model) => model.id === modelId)?.costPerM ??
-		customModels.find((m) => m.id === modelId)?.costPerM ??
-		costs;
+	const builtInCosts = LLM_PROVIDERS[provider].models.find((model) => model.id === modelId)?.costPerM;
+	const declaredCosts = customModels.find((m) => m.id === modelId)?.costPerM;
+
+	// Prices declared for a model win over nao's built-in table, token type by token type.
+	const costPerM = builtInCosts || declaredCosts ? { ...builtInCosts, ...declaredCosts } : costs;
 
 	if (!costPerM) {
 		return {

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -1,8 +1,10 @@
 import type { LlmProvider, LlmSelectedModel } from '@nao/shared/types';
 
 import { createProviderModel, getDefaultModelId, LLM_PROVIDERS, type ProviderModelResult } from '../agents/providers';
+import * as projectQueries from '../queries/project.queries';
 import * as projectLlmConfigQueries from '../queries/project-llm-config.queries';
-import type { ProviderSettings } from '../types/llm';
+import type { CustomModelMetadata, ProviderSettings } from '../types/llm';
+import { type ConfigLlm, type ConfigLlmProvider, findConfigLlmProvider, readProjectConfigLlm } from './nao-config-llm';
 
 export { getDefaultModelId };
 
@@ -76,7 +78,7 @@ export function getEnvModelSelections(): LlmSelectedModel[] {
 	}));
 }
 
-/** Resolve API key + base URL for a provider from DB config or env vars. */
+/** Resolve API key + base URL for a provider from DB config, nao_config.yaml or env vars. */
 export async function resolveProviderSettings(
 	projectId: string,
 	provider: LlmProvider,
@@ -88,6 +90,11 @@ export async function resolveProviderSettings(
 			...(config.baseUrl && { baseURL: config.baseUrl }),
 			...(config.credentials && { credentials: config.credentials }),
 		};
+	}
+
+	const configured = findConfigLlmProvider(await getProjectConfigLlm(projectId), provider);
+	if (configured) {
+		return toProviderSettings(configured);
 	}
 
 	const envApiKey = getEnvApiKey(provider);
@@ -104,8 +111,8 @@ export async function resolveProviderSettings(
 }
 
 /**
- * Resolve a provider model from DB config, falling back to env vars.
- * Returns null when neither source has credentials for the provider.
+ * Resolve a provider model from DB config, falling back to nao_config.yaml then env vars.
+ * Returns null when no source has credentials for the provider.
  */
 export async function resolveProviderModel(
 	projectId: string,
@@ -127,6 +134,16 @@ export async function resolveProviderModel(
 		);
 	}
 
+	const configured = findConfigLlmProvider(await getProjectConfigLlm(projectId), provider);
+	if (configured) {
+		return createProviderModel(
+			provider,
+			toProviderSettings(configured),
+			modelId,
+			applyUserSettings ? configured.modelSettings[modelId] : undefined,
+		);
+	}
+
 	const envApiKey = getEnvApiKey(provider);
 	if (envApiKey) {
 		const envBaseUrl = getEnvBaseUrl(provider);
@@ -144,9 +161,31 @@ export async function resolveProviderModel(
 	return null;
 }
 
+/** Read the `llm` block of the project's nao_config.yaml, if the project has one on disk. */
+export async function getProjectConfigLlm(projectId: string): Promise<ConfigLlm | null> {
+	const project = await projectQueries.getProjectById(projectId).catch(() => null);
+	if (!project?.path) {
+		return null;
+	}
+	return readProjectConfigLlm(project.path, (project.envVars as Record<string, string>) ?? {});
+}
+
+/** Credentials from nao_config.yaml, topped up from the environment for whatever it leaves out. */
+function toProviderSettings(configured: ConfigLlmProvider): ProviderSettings {
+	const apiKey = configured.apiKey ?? getEnvApiKey(configured.provider) ?? '';
+	const baseURL = configured.baseUrl ?? getEnvBaseUrl(configured.provider);
+
+	return {
+		apiKey,
+		...(baseURL && { baseURL }),
+		...(configured.credentials && { credentials: configured.credentials }),
+	};
+}
+
 /**
  * Resolve the model to use for background tasks (memory extraction, compaction, title generation).
- * Priority: NAO_ANNOTATION_MODEL env var > first enabled model in project config > provider default.
+ * Priority: NAO_ANNOTATION_MODEL env var > first model enabled for the provider in the database >
+ * `llm.annotation_model` of nao_config.yaml > first model the file enables > provider default.
  */
 export async function resolveAnnotationModelId(
 	projectId: string,
@@ -164,44 +203,97 @@ export async function resolveAnnotationModelId(
 		return enabledModels[0];
 	}
 
+	const configLlm = await getProjectConfigLlm(projectId);
+	const annotationTarget = resolveConfigAnnotationTarget(configLlm);
+	if (annotationTarget?.provider === provider) {
+		return annotationTarget.modelId;
+	}
+
+	const configured = findConfigLlmProvider(configLlm, provider);
+	if (configured?.enabledModels.length) {
+		return configured.enabledModels[0];
+	}
+
 	return fallbackModelId;
+}
+
+/** The provider and model that `llm.annotation_model` points at, mirroring the CLI resolution. */
+function resolveConfigAnnotationTarget(configLlm: ConfigLlm | null): { provider: LlmProvider; modelId: string } | null {
+	const modelId = configLlm?.annotationModel;
+	if (!configLlm || !modelId) {
+		return null;
+	}
+
+	const owner = configLlm.providers.find((candidate) => candidate.enabledModels.includes(modelId));
+	return { provider: (owner ?? configLlm.providers[0]).provider, modelId };
 }
 
 export const getProjectAvailableModels = async (
 	projectId: string,
 ): Promise<Array<{ provider: LlmProvider; modelId: string; name: string }>> => {
-	const configs = await projectLlmConfigQueries.getProjectLlmConfigs(projectId);
-	const models: Array<{ provider: LlmProvider; modelId: string; name: string }> = [];
+	const sources = await getProjectModelSources(projectId);
 
-	for (const config of configs) {
-		const provider = config.provider as LlmProvider;
-		const enabledModels = config.enabledModels ?? [];
-		const customModels = config.customModels ?? [];
-
+	return sources.flatMap(({ provider, enabledModels, customModels }) => {
 		if (enabledModels.length === 0) {
-			// If no models explicitly enabled, add the default
-			const defaultModelId = getDefaultModelId(provider);
-			models.push({ provider, modelId: defaultModelId, name: getModelName(provider, defaultModelId) });
-		} else {
-			for (const modelId of enabledModels) {
-				const customModel = customModels.find((m) => m.id === modelId);
-				models.push({
-					provider,
-					modelId,
-					name: customModel?.displayName?.trim() || getModelName(provider, modelId),
-				});
-			}
+			const modelId = getDefaultModelId(provider);
+			return [{ provider, modelId, name: getModelName(provider, modelId) }];
+		}
+
+		return enabledModels.map((modelId) => ({
+			provider,
+			modelId,
+			name: customModels.find((m) => m.id === modelId)?.displayName?.trim() || getModelName(provider, modelId),
+		}));
+	});
+};
+
+/** The models declared for each provider, used to price usage on top of nao's built-in table. */
+export const getProjectDeclaredModels = async (
+	projectId: string,
+): Promise<Array<{ provider: LlmProvider; models: CustomModelMetadata[] }>> => {
+	const sources = await getProjectModelSources(projectId);
+	return sources.map(({ provider, customModels }) => ({ provider, models: customModels }));
+};
+
+type ProviderModelSource = {
+	provider: LlmProvider;
+	enabledModels: string[];
+	customModels: CustomModelMetadata[];
+};
+
+/**
+ * The model list of every provider available to a project, taking each provider from the first
+ * source that declares it: the database, then nao_config.yaml, then the environment.
+ */
+async function getProjectModelSources(projectId: string): Promise<ProviderModelSource[]> {
+	const configs = await projectLlmConfigQueries.getProjectLlmConfigs(projectId);
+	const sources: ProviderModelSource[] = configs.map((config) => ({
+		provider: config.provider as LlmProvider,
+		enabledModels: config.enabledModels ?? [],
+		customModels: config.customModels ?? [],
+	}));
+
+	const declares = (provider: LlmProvider) => sources.some((source) => source.provider === provider);
+
+	const configLlm = await getProjectConfigLlm(projectId);
+	for (const configured of configLlm?.providers ?? []) {
+		if (!declares(configured.provider)) {
+			sources.push({
+				provider: configured.provider,
+				enabledModels: configured.enabledModels,
+				customModels: configured.customModels,
+			});
 		}
 	}
 
-	// Also add env-configured providers with their defaults
-	const envSelections = getEnvModelSelections()
-		.filter((s) => !configs.some((c) => c.provider === s.provider))
-		.map((s) => ({ ...s, name: getModelName(s.provider, s.modelId) }));
-	models.push(...envSelections);
+	for (const provider of getEnvProviders()) {
+		if (!declares(provider)) {
+			sources.push({ provider, enabledModels: [], customModels: [] });
+		}
+	}
 
-	return models;
-};
+	return sources;
+}
 
 const getModelName = (provider: LlmProvider, modelId: string): string =>
 	LLM_PROVIDERS[provider].models.find((m) => m.id === modelId)?.name ?? modelId;

--- a/apps/backend/src/utils/nao-config-llm.ts
+++ b/apps/backend/src/utils/nao-config-llm.ts
@@ -1,0 +1,277 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { LLM_PROVIDERS as LLM_PROVIDER_NAMES, type LlmProvider } from '@nao/shared/types';
+import yaml from 'js-yaml';
+import { z } from 'zod/v4';
+
+import {
+	type CustomModelMetadata,
+	type ModelInferenceSettings,
+	modelInferenceSettingsSchema,
+	type ModelSettingsMap,
+} from '../types/llm';
+import { logger } from './logger';
+
+/** An `llm` provider entry of nao_config.yaml, shaped like the rows of `project_llm_config`. */
+export type ConfigLlmProvider = {
+	provider: LlmProvider;
+	apiKey: string | null;
+	baseUrl: string | null;
+	credentials: Record<string, string> | null;
+	enabledModels: string[];
+	customModels: CustomModelMetadata[];
+	modelSettings: ModelSettingsMap;
+};
+
+export type ConfigLlm = {
+	providers: ConfigLlmProvider[];
+	annotationModel: string | null;
+};
+
+/** nao_config.yaml keeps the `gemini` spelling that the provider SDK calls `google`. */
+const PROVIDER_ALIASES: Record<string, LlmProvider> = { gemini: 'google' };
+
+/** Maps the credential keys of nao_config.yaml onto the `credentials` names each provider expects. */
+const CREDENTIAL_KEYS: Partial<Record<LlmProvider, Record<string, string>>> = {
+	bedrock: { aws_region: 'region', access_key: 'accessKeyId', secret_key: 'secretAccessKey' },
+	vertex: {
+		gcp_project: 'project',
+		gcp_location: 'location',
+		service_account_json: 'serviceAccountJson',
+		key_file: 'keyFile',
+	},
+	azure: { resource_name: 'resourceName', api_version: 'apiVersion' },
+};
+
+const SECRET_PATTERN = /\$?\{\{\s*(env|aws|k8s)\(['"]([^'"]+)['"]\)\s*\}\}/g;
+
+const costsSchema = z.object({
+	input_no_cache: z.number().min(0).optional(),
+	input_cache_read: z.number().min(0).optional(),
+	input_cache_write: z.number().min(0).optional(),
+	output: z.number().min(0).optional(),
+});
+
+const modelSchema = z.object({
+	id: z.string().min(1),
+	name: z.string().optional(),
+	default: z.boolean().optional(),
+	costs: costsSchema.optional(),
+	settings: z.record(z.string(), z.unknown()).optional(),
+});
+
+const providerSchema = z.looseObject({
+	provider: z.string(),
+	api_key: z.string().nullish(),
+	base_url: z.string().nullish(),
+	models: z.array(modelSchema).nullish(),
+});
+
+const llmSchema = z.looseObject({
+	providers: z.array(providerSchema).nullish(),
+	annotation_model: z.string().nullish(),
+});
+
+type RawProvider = z.infer<typeof providerSchema>;
+
+/**
+ * Read the `llm` block of a project's nao_config.yaml.
+ *
+ * Returns null when the project has no config file, no `llm` block, or one nao cannot make
+ * sense of, so that callers fall back to the database and the environment.
+ */
+export function readProjectConfigLlm(projectPath: string, extraEnv: Record<string, string> = {}): ConfigLlm | null {
+	const raw = loadLlmBlock(projectPath);
+	if (!raw) {
+		return null;
+	}
+
+	const parsed = llmSchema.safeParse(raw);
+	if (!parsed.success) {
+		logger.warn(`Ignoring the \`llm\` block of ${configPath(projectPath)}: ${parsed.error.message}`, {
+			source: 'system',
+		});
+		return null;
+	}
+
+	const providers = (parsed.data.providers ?? [normalizeLegacyShape(parsed.data)])
+		.map((provider) => toConfigProvider(provider, extraEnv))
+		.filter((provider): provider is ConfigLlmProvider => provider !== null);
+
+	if (providers.length === 0) {
+		return null;
+	}
+
+	return { providers, annotationModel: parsed.data.annotation_model ?? null };
+}
+
+export function findConfigLlmProvider(config: ConfigLlm | null, provider: LlmProvider): ConfigLlmProvider | null {
+	return config?.providers.find((candidate) => candidate.provider === provider) ?? null;
+}
+
+const rawCache = new Map<string, { mtimeMs: number; llm: unknown }>();
+
+/** Parse the config file, caching by modification time so hot paths only pay a stat. */
+function loadLlmBlock(projectPath: string): unknown {
+	const filePath = configPath(projectPath);
+
+	let mtimeMs: number;
+	try {
+		mtimeMs = fs.statSync(filePath).mtimeMs;
+	} catch {
+		rawCache.delete(filePath);
+		return null;
+	}
+
+	const cached = rawCache.get(filePath);
+	if (cached?.mtimeMs === mtimeMs) {
+		return cached.llm;
+	}
+
+	let llm: unknown = null;
+	try {
+		const config = yaml.load(fs.readFileSync(filePath, 'utf-8'));
+		llm = isRecord(config) ? (config.llm ?? null) : null;
+	} catch (err) {
+		logger.warn(`Failed to parse ${filePath}: ${err instanceof Error ? err.message : String(err)}`, {
+			source: 'system',
+		});
+	}
+
+	rawCache.set(filePath, { mtimeMs, llm });
+	return llm;
+}
+
+/** Treat a single inline provider as the one entry of `providers`. */
+function normalizeLegacyShape(llm: Record<string, unknown>): RawProvider {
+	const { providers: _providers, annotation_model: _annotationModel, meta: _meta, ...provider } = llm;
+	return provider as RawProvider;
+}
+
+function toConfigProvider(raw: RawProvider, extraEnv: Record<string, string>): ConfigLlmProvider | null {
+	const provider = resolveProviderName(raw.provider);
+	if (!provider) {
+		logger.warn(`Ignoring unknown LLM provider '${raw.provider}' in nao_config.yaml`, { source: 'system' });
+		return null;
+	}
+
+	const models = (raw.models ?? []).filter((model) => model.id);
+	const ordered = [...models].sort((a, b) => Number(b.default ?? false) - Number(a.default ?? false));
+
+	return {
+		provider,
+		apiKey: resolveSecrets(raw.api_key, extraEnv),
+		baseUrl: resolveSecrets(raw.base_url, extraEnv),
+		credentials: toCredentials(provider, raw, extraEnv),
+		enabledModels: ordered.map((model) => model.id),
+		customModels: ordered.flatMap((model) => toCustomModel(model)),
+		modelSettings: toModelSettings(ordered),
+	};
+}
+
+function toCredentials(
+	provider: LlmProvider,
+	raw: RawProvider,
+	extraEnv: Record<string, string>,
+): Record<string, string> | null {
+	const credentials: Record<string, string> = {};
+
+	for (const [configKey, credentialKey] of Object.entries(CREDENTIAL_KEYS[provider] ?? {})) {
+		const value = resolveSecrets(raw[configKey], extraEnv);
+		if (value) {
+			credentials[credentialKey] = value;
+		}
+	}
+
+	return Object.keys(credentials).length > 0 ? credentials : null;
+}
+
+function toCustomModel(model: z.infer<typeof modelSchema>): CustomModelMetadata[] {
+	const costPerM = model.costs && {
+		...(model.costs.input_no_cache !== undefined && { inputNoCache: model.costs.input_no_cache }),
+		...(model.costs.input_cache_read !== undefined && { inputCacheRead: model.costs.input_cache_read }),
+		...(model.costs.input_cache_write !== undefined && { inputCacheWrite: model.costs.input_cache_write }),
+		...(model.costs.output !== undefined && { output: model.costs.output }),
+	};
+
+	if (!model.name && !costPerM) {
+		return [];
+	}
+
+	return [
+		{
+			id: model.id,
+			...(model.name && { displayName: model.name }),
+			...(costPerM && Object.keys(costPerM).length > 0 && { costPerM }),
+		},
+	];
+}
+
+function toModelSettings(models: z.infer<typeof modelSchema>[]): ModelSettingsMap {
+	const settings: ModelSettingsMap = {};
+
+	for (const model of models) {
+		if (!model.settings) {
+			continue;
+		}
+
+		const parsed = modelInferenceSettingsSchema.safeParse(camelCaseKeys(model.settings));
+		if (!parsed.success || Object.keys(parsed.data).length === 0) {
+			logger.warn(`Ignoring unsupported settings for model '${model.id}' in nao_config.yaml`, {
+				source: 'system',
+			});
+			continue;
+		}
+		settings[model.id] = parsed.data as ModelInferenceSettings;
+	}
+
+	return settings;
+}
+
+/**
+ * Substitute `{{ env('NAME') }}` references, which nao_config.yaml uses to keep secrets out of
+ * the file. `aws(...)` and `k8s(...)` are resolved by the CLI only, so a value that still needs
+ * them is dropped in favour of the environment.
+ */
+function resolveSecrets(value: unknown, extraEnv: Record<string, string>): string | null {
+	if (typeof value !== 'string') {
+		return null;
+	}
+
+	let resolvable = true;
+	const resolved = value.replace(SECRET_PATTERN, (_match, protocol: string, identifier: string) => {
+		if (protocol !== 'env') {
+			resolvable = false;
+			return '';
+		}
+		return extraEnv[identifier] || process.env[identifier] || '';
+	});
+
+	return resolvable && resolved.trim() ? resolved : null;
+}
+
+function resolveProviderName(name: string): LlmProvider | null {
+	const normalized = name?.trim().toLowerCase();
+	if (PROVIDER_ALIASES[normalized]) {
+		return PROVIDER_ALIASES[normalized];
+	}
+	return (LLM_PROVIDER_NAMES as readonly string[]).includes(normalized) ? (normalized as LlmProvider) : null;
+}
+
+function camelCaseKeys(record: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(record).map(([key, value]) => [
+			key.replace(/_([a-z0-9])/g, (_match, char: string) => char.toUpperCase()),
+			value,
+		]),
+	);
+}
+
+function configPath(projectPath: string): string {
+	return path.join(projectPath, 'nao_config.yaml');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/backend/src/utils/utils.ts
+++ b/apps/backend/src/utils/utils.ts
@@ -160,6 +160,9 @@ export function groupBy<T, K extends string>(
 	);
 }
 
+export const previewApiKey = (apiKey: string | null | undefined): string | null =>
+	apiKey ? apiKey.slice(0, 8) + '...' + apiKey.slice(-4) : null;
+
 export const buildCredentialPreviews = (
 	credentials: Record<string, string> | null | undefined,
 ): Record<string, string> | null => {

--- a/apps/backend/tests/nao-config-llm.test.ts
+++ b/apps/backend/tests/nao-config-llm.test.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { findConfigLlmProvider, readProjectConfigLlm } from '../src/utils/nao-config-llm';
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const dirs: string[] = [];
+
+function writeConfig(lines: string[]): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-llm-'));
+	dirs.push(dir);
+	fs.writeFileSync(path.join(dir, 'nao_config.yaml'), lines.join('\n'));
+	return dir;
+}
+
+afterEach(() => {
+	while (dirs.length > 0) {
+		fs.rmSync(dirs.pop() as string, { force: true, recursive: true });
+	}
+	delete process.env.TEST_OPENAI_KEY;
+});
+
+describe('readProjectConfigLlm', () => {
+	it('reads providers with their models, display names, costs and settings', () => {
+		const dir = writeConfig([
+			'project_name: demo',
+			'llm:',
+			'  annotation_model: gpt-4.1-mini',
+			'  providers:',
+			'  - provider: openai',
+			'    api_key: sk-openai',
+			'    base_url: http://localhost:4000',
+			'    models:',
+			'    - id: gpt-4.1-mini',
+			'      name: GPT-4.1 mini',
+			'      costs:',
+			'        input_no_cache: 0.4',
+			'        output: 1.6',
+			'    - id: gpt-4.1',
+			'      default: true',
+			'      settings:',
+			'        reasoning_effort: high',
+		]);
+
+		expect(readProjectConfigLlm(dir)).toEqual({
+			annotationModel: 'gpt-4.1-mini',
+			providers: [
+				{
+					provider: 'openai',
+					apiKey: 'sk-openai',
+					baseUrl: 'http://localhost:4000',
+					credentials: null,
+					enabledModels: ['gpt-4.1', 'gpt-4.1-mini'],
+					customModels: [
+						{
+							id: 'gpt-4.1-mini',
+							displayName: 'GPT-4.1 mini',
+							costPerM: { inputNoCache: 0.4, output: 1.6 },
+						},
+					],
+					modelSettings: { 'gpt-4.1': { reasoningEffort: 'high' } },
+				},
+			],
+		});
+	});
+
+	it('nests a legacy single provider block under providers', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  provider: anthropic',
+			'  api_key: sk-ant',
+			'  meta:',
+			'    costs:',
+			'      output: 15',
+		]);
+
+		const config = readProjectConfigLlm(dir);
+
+		expect(config?.providers).toEqual([
+			{
+				provider: 'anthropic',
+				apiKey: 'sk-ant',
+				baseUrl: null,
+				credentials: null,
+				enabledModels: [],
+				customModels: [],
+				modelSettings: {},
+			},
+		]);
+	});
+
+	it('resolves env placeholders from the project env vars then the process env', () => {
+		process.env.TEST_OPENAI_KEY = 'sk-from-process';
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: openai',
+			'    api_key: "{{ env(\'TEST_OPENAI_KEY\') }}"',
+		]);
+
+		expect(readProjectConfigLlm(dir)?.providers[0].apiKey).toBe('sk-from-process');
+		expect(readProjectConfigLlm(dir, { TEST_OPENAI_KEY: 'sk-from-project' })?.providers[0].apiKey).toBe(
+			'sk-from-project',
+		);
+	});
+
+	it('drops values that only the CLI can resolve so the environment is used instead', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: openai',
+			'    api_key: "{{ aws(\'openai/api_key\') }}"',
+		]);
+
+		expect(readProjectConfigLlm(dir)?.providers[0].apiKey).toBeNull();
+	});
+
+	it('maps provider credentials onto the names each provider expects', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: bedrock',
+			'    access_key: AKIA',
+			'    secret_key: secret',
+			'    aws_region: us-east-1',
+			'  - provider: gemini',
+			'    api_key: gm-key',
+		]);
+
+		const config = readProjectConfigLlm(dir);
+
+		expect(findConfigLlmProvider(config, 'bedrock')?.credentials).toEqual({
+			accessKeyId: 'AKIA',
+			secretAccessKey: 'secret',
+			region: 'us-east-1',
+		});
+		expect(findConfigLlmProvider(config, 'google')?.apiKey).toBe('gm-key');
+	});
+
+	it('skips unknown providers and unsupported model settings', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: not-a-provider',
+			'    api_key: nope',
+			'  - provider: openai',
+			'    api_key: sk-openai',
+			'    models:',
+			'    - id: gpt-4.1',
+			'      settings:',
+			'        made_up_setting: 3',
+		]);
+
+		const config = readProjectConfigLlm(dir);
+
+		expect(config?.providers.map((p) => p.provider)).toEqual(['openai']);
+		expect(config?.providers[0].modelSettings).toEqual({});
+	});
+
+	it('returns null when the project has no config, no llm block or an unusable one', () => {
+		expect(readProjectConfigLlm(path.join(os.tmpdir(), 'nao-missing-project'))).toBeNull();
+		expect(readProjectConfigLlm(writeConfig(['project_name: demo']))).toBeNull();
+		expect(readProjectConfigLlm(writeConfig(['llm:', '  providers: []']))).toBeNull();
+		expect(readProjectConfigLlm(writeConfig(['llm:', '  providers: not-a-list']))).toBeNull();
+	});
+
+	it('picks up edits to the config file', () => {
+		const dir = writeConfig(['llm:', '  providers:', '  - provider: openai', '    api_key: sk-first']);
+		expect(readProjectConfigLlm(dir)?.providers[0].apiKey).toBe('sk-first');
+
+		const filePath = path.join(dir, 'nao_config.yaml');
+		fs.writeFileSync(
+			filePath,
+			['llm:', '  providers:', '  - provider: openai', '    api_key: sk-second'].join('\n'),
+		);
+		fs.utimesSync(filePath, new Date(), new Date(Date.now() + 1000));
+
+		expect(readProjectConfigLlm(dir)?.providers[0].apiKey).toBe('sk-second');
+	});
+});

--- a/apps/backend/tests/project-llm-config-override.test.ts
+++ b/apps/backend/tests/project-llm-config-override.test.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+	projectPath: '',
+	upsertProjectLlmConfig: vi.fn(),
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getProjectById: vi.fn(async () => project()),
+	getProjectByUserId: vi.fn(async () => project()),
+	getUserRoleInProject: vi.fn(async () => 'admin'),
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigByProvider: vi.fn(() => null),
+	upsertProjectLlmConfig: testState.upsertProjectLlmConfig,
+}));
+
+vi.mock('../src/queries/chat.queries', () => ({}));
+vi.mock('../src/queries/project-saved-prompt.queries', () => ({}));
+vi.mock('../src/queries/project-slack-config.queries', () => ({}));
+vi.mock('../src/queries/project-teams-config.queries', () => ({}));
+vi.mock('../src/queries/project-telegram-config.queries', () => ({}));
+vi.mock('../src/queries/project-whatsapp-config.queries', () => ({}));
+vi.mock('../src/queries/project-whatsapp-link.queries', () => ({}));
+vi.mock('../src/queries/user.queries', () => ({}));
+vi.mock('../src/agents/user-rules', () => ({ getDatabaseObjects: vi.fn() }));
+vi.mock('../src/auth', () => ({ getAuth: vi.fn() }));
+vi.mock('../src/services/posthog', () => ({ posthog: {}, PostHogEvent: {} }));
+vi.mock('../src/services/slack', () => ({ slackService: {} }));
+vi.mock('../src/services/transcribe.service', () => ({ listAvailableTranscribeModels: vi.fn() }));
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { projectRoutes } from '../src/trpc/project.routes';
+import { router } from '../src/trpc/trpc';
+
+const testRouter = router(projectRoutes);
+const directories: string[] = [];
+
+describe('project LLM config overrides', () => {
+	beforeEach(() => {
+		testState.upsertProjectLlmConfig.mockReset();
+		testState.upsertProjectLlmConfig.mockImplementation((config) => ({
+			id: 'config-id',
+			...config,
+			credentials: config.credentials ?? null,
+			modelSettings: config.modelSettings ?? {},
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		}));
+		delete process.env.OPENAI_API_KEY;
+		delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+		delete process.env.AWS_ACCESS_KEY_ID;
+		delete process.env.AWS_SECRET_ACCESS_KEY;
+	});
+
+	afterAll(() => {
+		for (const directory of directories) {
+			fs.rmSync(directory, { force: true, recursive: true });
+		}
+	});
+
+	it('preserves a required API key inherited from nao_config.yaml', async () => {
+		writeConfig(['llm:', '  providers:', '  - provider: openai', '    api_key: sk-from-config']);
+
+		await callUpsert('openai');
+
+		expect(testState.upsertProjectLlmConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: 'openai',
+				apiKey: 'sk-from-config',
+			}),
+		);
+	});
+
+	it('preserves structured credentials inherited from nao_config.yaml', async () => {
+		writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: bedrock',
+			'    access_key: AKIA_FROM_CONFIG',
+			'    secret_key: secret-from-config',
+			'    aws_region: us-east-1',
+		]);
+
+		await callUpsert('bedrock');
+
+		expect(testState.upsertProjectLlmConfig).toHaveBeenCalledWith(
+			expect.objectContaining({
+				provider: 'bedrock',
+				apiKey: '',
+				credentials: {
+					accessKeyId: 'AKIA_FROM_CONFIG',
+					secretAccessKey: 'secret-from-config',
+					region: 'us-east-1',
+				},
+			}),
+		);
+	});
+});
+
+function project() {
+	return {
+		id: 'project-id',
+		name: 'Test project',
+		path: testState.projectPath,
+		envVars: {},
+	};
+}
+
+function writeConfig(lines: string[]): void {
+	const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-project-llm-override-'));
+	directories.push(directory);
+	fs.writeFileSync(path.join(directory, 'nao_config.yaml'), lines.join('\n'));
+	testState.projectPath = directory;
+}
+
+async function callUpsert(provider: 'openai' | 'bedrock'): Promise<void> {
+	const caller = testRouter.createCaller({
+		session: { user: { id: 'user-id' } },
+		selectedProjectId: 'project-id',
+	} as never);
+
+	await caller.upsertLlmConfig({
+		provider,
+		enabledModels: [],
+		customModels: [],
+		modelSettings: {},
+	});
+}

--- a/apps/frontend/src/components/settings/llm-provider-card.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-card.tsx
@@ -11,7 +11,8 @@ interface ProviderCardProps {
 	baseUrl?: string | null;
 	envBaseUrl?: string;
 	enabledModels?: string[] | null;
-	isEnvProvider: boolean;
+	/** Where this provider comes from, e.g. `ENV` or `nao_config.yaml`. */
+	badges?: string[];
 	isAdmin: boolean;
 	isFormActive: boolean;
 	onEdit: () => void;
@@ -27,7 +28,7 @@ export function ProviderCard({
 	baseUrl,
 	envBaseUrl,
 	enabledModels,
-	isEnvProvider,
+	badges = [],
 	isAdmin,
 	isFormActive,
 	onEdit,
@@ -42,11 +43,14 @@ export function ProviderCard({
 					<div className='flex items-center gap-2'>
 						<LlmProviderIcon provider={provider} className='size-3.5' />
 						<span className='text-sm font-medium text-foreground capitalize'>{provider}</span>
-						{isEnvProvider && (
-							<span className='px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground'>
-								ENV
+						{badges.map((badge) => (
+							<span
+								key={badge}
+								className='px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground'
+							>
+								{badge}
 							</span>
-						)}
+						))}
 					</div>
 					{apiKeyPreview || credentialPreviews ? (
 						<div className='flex items-center gap-2 text-xs text-muted-foreground flex-wrap'>

--- a/apps/frontend/src/components/settings/llm-provider-form.test.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-form.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LlmProviderForm } from './llm-provider-form';
+
+describe('LlmProviderForm', () => {
+	afterEach(cleanup);
+
+	it('describes inherited config credentials for optional-auth providers', () => {
+		render(
+			<LlmProviderForm
+				provider='bedrock'
+				isEditing={true}
+				inheritedKeySource='config'
+				currentModels={[]}
+				onSubmit={vi.fn()}
+				onCancel={vi.fn()}
+				isPending={false}
+				error={null}
+				title='Override bedrock'
+			/>,
+		);
+
+		expect(screen.getByText('(optional - leave empty to use nao_config.yaml)')).toBeTruthy();
+		expect(screen.getByPlaceholderText('Enter bearer token to override nao_config.yaml')).toBeTruthy();
+		expect(screen.queryByText(/leave empty to use AWS credentials from environment/)).toBeNull();
+	});
+});

--- a/apps/frontend/src/components/settings/llm-provider-form.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-form.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useForm } from '@tanstack/react-form';
-import { Check, ChevronDown, MoreHorizontal, Plus, X } from 'lucide-react';
+import { Check, ChevronDown, MoreHorizontal, Plus, TriangleAlert, X } from 'lucide-react';
 import { getDefaultModelId, getModelParameterSpec, getProviderAuth } from '@nao/backend/provider-meta';
 import { CustomModelDialog } from './custom-model-dialog';
 import { ModelParametersDialog } from './model-parameters-dialog';
@@ -12,10 +12,18 @@ import { Input } from '@/components/ui/input';
 import { capitalize } from '@/lib/utils';
 import { PasswordField, TextField, TextareaField, FormError } from '@/components/ui/form-fields';
 
+/** Where credentials already come from when the UI is only layering settings on top. */
+export type InheritedKeySource = 'env' | 'config';
+
+const INHERITED_KEY_LABELS: Record<InheritedKeySource, string> = {
+	env: 'env',
+	config: 'nao_config.yaml',
+};
+
 export interface LlmProviderFormProps {
 	provider: LlmProvider;
 	isEditing: boolean;
-	usesEnvKey: boolean;
+	inheritedKeySource: InheritedKeySource | null;
 	initialValues?: {
 		enabledModels: string[];
 		customModels: CustomModelMetadata[];
@@ -42,7 +50,7 @@ export interface LlmProviderFormProps {
 export function LlmProviderForm({
 	provider,
 	isEditing,
-	usesEnvKey,
+	inheritedKeySource,
 	initialValues,
 	currentModels,
 	onSubmit,
@@ -63,6 +71,7 @@ export function LlmProviderForm({
 	const extraFields = providerAuth.extraFields ?? [];
 
 	const defaultCredentials = Object.fromEntries(extraFields.map((f) => [f.name, '']));
+	const inheritedKeyLabel = inheritedKeySource ? INHERITED_KEY_LABELS[inheritedKeySource] : null;
 
 	const form = useForm({
 		defaultValues: {
@@ -91,8 +100,8 @@ export function LlmProviderForm({
 		if (providerAuth.apiKey === 'optional') {
 			return providerAuth.hint ? `(${providerAuth.hint})` : '(optional)';
 		}
-		if (usesEnvKey) {
-			return '(optional - leave empty to use env)';
+		if (inheritedKeyLabel) {
+			return `(optional - leave empty to use ${inheritedKeyLabel})`;
 		}
 		if (isEditing) {
 			return '(leave empty to keep current)';
@@ -104,8 +113,8 @@ export function LlmProviderForm({
 		if (providerAuth.apiKey === 'optional') {
 			return 'Enter bearer token or leave empty for env credentials';
 		}
-		if (usesEnvKey) {
-			return 'Enter API key to override env variable';
+		if (inheritedKeyLabel) {
+			return `Enter API key to override ${inheritedKeyLabel}`;
 		}
 		if (isEditing) {
 			return 'Enter new API key to update';
@@ -127,12 +136,28 @@ export function LlmProviderForm({
 			<div className='flex items-center justify-between'>
 				<span className='text-sm font-medium text-foreground capitalize'>
 					{title}
-					{usesEnvKey && <span className='text-muted-foreground font-normal ml-1'>(using env API key)</span>}
+					{inheritedKeyLabel && (
+						<span className='text-muted-foreground font-normal ml-1'>
+							(using {inheritedKeyLabel} API key)
+						</span>
+					)}
 				</span>
 				<Button variant='ghost' size='icon-sm' onClick={onCancel} type='button'>
 					<X className='size-4' />
 				</Button>
 			</div>
+
+			{inheritedKeySource === 'config' && (
+				<div className='flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20'>
+					<TriangleAlert className='size-4 shrink-0 mt-0.5 text-amber-500' />
+					<p className='text-xs text-amber-700 dark:text-amber-400'>
+						This provider is defined in <span className='font-mono'>nao_config.yaml</span>. Settings saved
+						here are stored in the project and take precedence over the file, so later edits to{' '}
+						<span className='font-mono'>nao_config.yaml</span> are ignored until you delete this provider
+						here.
+					</p>
+				</div>
+			)}
 
 			{showApiKey && (
 				<PasswordField
@@ -141,7 +166,7 @@ export function LlmProviderForm({
 					label='API Key'
 					hint={getApiKeyHint()}
 					placeholder={getApiKeyPlaceholder()}
-					required={providerAuth.apiKey === 'required' && !isEditing && !usesEnvKey}
+					required={providerAuth.apiKey === 'required' && !isEditing && !inheritedKeySource}
 				/>
 			)}
 

--- a/apps/frontend/src/components/settings/llm-provider-form.tsx
+++ b/apps/frontend/src/components/settings/llm-provider-form.tsx
@@ -97,11 +97,11 @@ export function LlmProviderForm({
 	});
 
 	const getApiKeyHint = () => {
-		if (providerAuth.apiKey === 'optional') {
-			return providerAuth.hint ? `(${providerAuth.hint})` : '(optional)';
-		}
 		if (inheritedKeyLabel) {
 			return `(optional - leave empty to use ${inheritedKeyLabel})`;
+		}
+		if (providerAuth.apiKey === 'optional') {
+			return providerAuth.hint ? `(${providerAuth.hint})` : '(optional)';
 		}
 		if (isEditing) {
 			return '(leave empty to keep current)';
@@ -110,11 +110,12 @@ export function LlmProviderForm({
 	};
 
 	const getApiKeyPlaceholder = () => {
+		if (inheritedKeyLabel) {
+			const credentialLabel = providerAuth.apiKey === 'optional' ? 'bearer token' : 'API key';
+			return `Enter ${credentialLabel} to override ${inheritedKeyLabel}`;
+		}
 		if (providerAuth.apiKey === 'optional') {
 			return 'Enter bearer token or leave empty for env credentials';
-		}
-		if (inheritedKeyLabel) {
-			return `Enter API key to override ${inheritedKeyLabel}`;
 		}
 		if (isEditing) {
 			return 'Enter new API key to update';

--- a/apps/frontend/src/components/settings/llm-providers-section.tsx
+++ b/apps/frontend/src/components/settings/llm-providers-section.tsx
@@ -1,6 +1,5 @@
 import { ProviderCard } from './llm-provider-card';
 import { LlmProviderForm } from './llm-provider-form';
-import type { LlmProvider } from '@nao/shared/types';
 import { useLlmProviders } from '@/hooks/use-llm-providers';
 
 interface LlmProvidersSectionProps {
@@ -31,13 +30,14 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 		getModelDisplayName,
 	} = useLlmProviders();
 
-	const providerBadges = (provider: LlmProvider) => {
+	const projectConfigBadges = (config: (typeof projectConfigs)[number]) => {
 		const badges: string[] = [];
-		if (envProviders.includes(provider)) {
-			badges.push('ENV');
+		const hasOwnCredentials = !!(config.apiKeyPreview || config.credentialPreviews);
+		if (envProviders.includes(config.provider)) {
+			badges.push(hasOwnCredentials ? 'ENV (overridden)' : 'ENV');
 		}
-		if (configProviders.some((c) => c.provider === provider)) {
-			badges.push('nao_config.yaml');
+		if (configProviders.some((c) => c.provider === config.provider)) {
+			badges.push('nao_config.yaml (overridden)');
 		}
 		return badges;
 	};
@@ -103,7 +103,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 						credentialPreviews={configProvider.credentialPreviews}
 						baseUrl={configProvider.baseUrl}
 						enabledModels={configProvider.enabledModels}
-						badges={providerBadges(configProvider.provider)}
+						badges={['nao_config.yaml']}
 						isAdmin={isAdmin}
 						isFormActive={!!editingState}
 						onEdit={() => handleOverrideConfigProvider(configProvider)}
@@ -140,7 +140,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 						baseUrl={config.baseUrl}
 						envBaseUrl={envBaseUrls[config.provider]}
 						enabledModels={config.enabledModels}
-						badges={providerBadges(config.provider)}
+						badges={projectConfigBadges(config)}
 						isAdmin={isAdmin}
 						isFormActive={!!editingState}
 						onEdit={() => handleEditConfig(config)}

--- a/apps/frontend/src/components/settings/llm-providers-section.tsx
+++ b/apps/frontend/src/components/settings/llm-providers-section.tsx
@@ -1,5 +1,6 @@
 import { ProviderCard } from './llm-provider-card';
 import { LlmProviderForm } from './llm-provider-form';
+import type { LlmProvider } from '@nao/shared/types';
 import { useLlmProviders } from '@/hooks/use-llm-providers';
 
 interface LlmProvidersSectionProps {
@@ -9,10 +10,12 @@ interface LlmProvidersSectionProps {
 export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 	const {
 		projectConfigs,
+		configProviders,
 		envProviders,
 		envBaseUrls,
 		availableProvidersToAdd,
 		unconfiguredEnvProviders,
+		unconfiguredConfigProviders,
 		currentModels,
 		editingState,
 		upsertPending,
@@ -21,11 +24,23 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 		handleSubmit,
 		handleCancel,
 		handleEditConfig,
+		handleOverrideConfigProvider,
 		handleDeleteConfig,
 		handleSelectProvider,
 		handleConfigureEnvProvider,
 		getModelDisplayName,
 	} = useLlmProviders();
+
+	const providerBadges = (provider: LlmProvider) => {
+		const badges: string[] = [];
+		if (envProviders.includes(provider)) {
+			badges.push('ENV');
+		}
+		if (configProviders.some((c) => c.provider === provider)) {
+			badges.push('nao_config.yaml');
+		}
+		return badges;
+	};
 
 	return (
 		<div className='grid gap-4'>
@@ -37,7 +52,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 							key={`env-${provider}`}
 							provider={provider}
 							isEditing={true}
-							usesEnvKey={true}
+							inheritedKeySource='env'
 							currentModels={currentModels}
 							onSubmit={handleSubmit}
 							onCancel={handleCancel}
@@ -51,11 +66,47 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 					<ProviderCard
 						key={`env-${provider}`}
 						provider={provider}
-						isEnvProvider
+						badges={['ENV']}
 						envBaseUrl={envBaseUrls[provider]}
 						isAdmin={isAdmin}
 						isFormActive={!!editingState}
 						onEdit={() => handleConfigureEnvProvider(provider)}
+						getModelDisplayName={getModelDisplayName}
+					/>
+				);
+			})}
+
+			{/* Providers declared in nao_config.yaml */}
+			{unconfiguredConfigProviders.map((configProvider) => {
+				if (editingState?.isEditing && editingState.provider === configProvider.provider) {
+					return (
+						<LlmProviderForm
+							key={`config-${configProvider.provider}`}
+							provider={configProvider.provider}
+							isEditing={true}
+							inheritedKeySource='config'
+							initialValues={editingState.initialValues}
+							currentModels={currentModels}
+							onSubmit={handleSubmit}
+							onCancel={handleCancel}
+							isPending={upsertPending}
+							error={upsertError}
+							title={`Override ${configProvider.provider}`}
+						/>
+					);
+				}
+				return (
+					<ProviderCard
+						key={`config-${configProvider.provider}`}
+						provider={configProvider.provider}
+						apiKeyPreview={configProvider.apiKeyPreview}
+						credentialPreviews={configProvider.credentialPreviews}
+						baseUrl={configProvider.baseUrl}
+						enabledModels={configProvider.enabledModels}
+						badges={providerBadges(configProvider.provider)}
+						isAdmin={isAdmin}
+						isFormActive={!!editingState}
+						onEdit={() => handleOverrideConfigProvider(configProvider)}
 						getModelDisplayName={getModelDisplayName}
 					/>
 				);
@@ -69,7 +120,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 							key={config.id}
 							provider={config.provider}
 							isEditing={true}
-							usesEnvKey={envProviders.includes(config.provider)}
+							inheritedKeySource={editingState.inheritedKeySource}
 							initialValues={editingState.initialValues}
 							currentModels={currentModels}
 							onSubmit={handleSubmit}
@@ -89,7 +140,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 						baseUrl={config.baseUrl}
 						envBaseUrl={envBaseUrls[config.provider]}
 						enabledModels={config.enabledModels}
-						isEnvProvider={envProviders.includes(config.provider)}
+						badges={providerBadges(config.provider)}
 						isAdmin={isAdmin}
 						isFormActive={!!editingState}
 						onEdit={() => handleEditConfig(config)}
@@ -125,7 +176,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 						<LlmProviderForm
 							provider={editingState.provider}
 							isEditing={false}
-							usesEnvKey={editingState.usesEnvKey}
+							inheritedKeySource={editingState.inheritedKeySource}
 							currentModels={currentModels}
 							onSubmit={handleSubmit}
 							onCancel={handleCancel}
@@ -141,6 +192,7 @@ export function LlmProvidersSection({ isAdmin }: LlmProvidersSectionProps) {
 
 			{projectConfigs.length === 0 &&
 				unconfiguredEnvProviders.length === 0 &&
+				unconfiguredConfigProviders.length === 0 &&
 				availableProvidersToAdd.length === 0 && (
 					<p className='text-sm text-muted-foreground'>
 						{isAdmin

--- a/apps/frontend/src/hooks/use-llm-providers.ts
+++ b/apps/frontend/src/hooks/use-llm-providers.ts
@@ -3,12 +3,13 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { llmProviderSchema } from '@nao/backend/llm';
 import type { CustomModelMetadata, ModelSettingsMap } from '@nao/backend/llm';
 import type { LlmProvider } from '@nao/shared/types';
+import type { InheritedKeySource } from '@/components/settings/llm-provider-form';
 import { trpc } from '@/main';
 
 export interface EditingState {
 	provider: LlmProvider;
 	isEditing: boolean;
-	usesEnvKey: boolean;
+	inheritedKeySource: InheritedKeySource | null;
 	initialValues?: {
 		enabledModels: string[];
 		customModels: CustomModelMetadata[];
@@ -33,17 +34,33 @@ export function useLlmProviders() {
 
 	// Derived data
 	const projectConfigs = llmConfigs.data?.projectConfigs ?? [];
+	const configProviders = llmConfigs.data?.configProviders ?? [];
 	const envProviders = llmConfigs.data?.envProviders ?? [];
 	const envBaseUrls = llmConfigs.data?.envBaseUrls ?? {};
 	const projectConfiguredProviders = projectConfigs.map((c) => c.provider);
 
 	const availableProvidersToAdd: LlmProvider[] = llmProviderSchema.options.filter(
-		(p) => !projectConfiguredProviders.includes(p) && !envProviders.includes(p),
+		(p) =>
+			!projectConfiguredProviders.includes(p) &&
+			!envProviders.includes(p) &&
+			!configProviders.some((c) => c.provider === p),
 	);
 
 	const unconfiguredEnvProviders = envProviders.filter((p) => !projectConfiguredProviders.includes(p));
 
+	const unconfiguredConfigProviders = configProviders.filter((c) => !projectConfiguredProviders.includes(c.provider));
+
 	const currentModels = editingState?.provider && knownModels.data ? knownModels.data[editingState.provider] : [];
+
+	const resolveInheritedKeySource = (provider: LlmProvider): InheritedKeySource | null => {
+		if (configProviders.some((c) => c.provider === provider)) {
+			return 'config';
+		}
+		if (envProviders.includes(provider)) {
+			return 'env';
+		}
+		return null;
+	};
 
 	// Handlers
 	const invalidateQueries = async () => {
@@ -91,12 +108,27 @@ export function useLlmProviders() {
 		setEditingState({
 			provider: config.provider,
 			isEditing: true,
-			usesEnvKey: envProviders.includes(config.provider),
+			inheritedKeySource: resolveInheritedKeySource(config.provider),
 			initialValues: {
 				enabledModels: config.enabledModels ?? [],
 				customModels: config.customModels ?? [],
 				modelSettings: config.modelSettings ?? {},
 				baseUrl: config.baseUrl ?? '',
+			},
+		});
+	};
+
+	/** Seed the form with the nao_config.yaml values so saving creates an override of them. */
+	const handleOverrideConfigProvider = (configProvider: (typeof configProviders)[0]) => {
+		setEditingState({
+			provider: configProvider.provider,
+			isEditing: true,
+			inheritedKeySource: 'config',
+			initialValues: {
+				enabledModels: configProvider.enabledModels,
+				customModels: configProvider.customModels,
+				modelSettings: configProvider.modelSettings,
+				baseUrl: configProvider.baseUrl ?? '',
 			},
 		});
 	};
@@ -110,7 +142,7 @@ export function useLlmProviders() {
 		setEditingState({
 			provider,
 			isEditing: false,
-			usesEnvKey: envProviders.includes(provider),
+			inheritedKeySource: resolveInheritedKeySource(provider),
 		});
 	};
 
@@ -118,7 +150,7 @@ export function useLlmProviders() {
 		setEditingState({
 			provider,
 			isEditing: true,
-			usesEnvKey: true,
+			inheritedKeySource: 'env',
 		});
 	};
 
@@ -128,19 +160,29 @@ export function useLlmProviders() {
 		if (knownName) {
 			return knownName;
 		}
-		const customModel = projectConfigs
+		const customModel = findCustomModel(provider, modelId);
+		return customModel?.displayName?.trim() || modelId;
+	};
+
+	const findCustomModel = (provider: LlmProvider, modelId: string) => {
+		const fromProjectConfig = projectConfigs
 			.find((c) => c.provider === provider)
 			?.customModels?.find((m) => m.id === modelId);
-		return customModel?.displayName?.trim() || modelId;
+		if (fromProjectConfig) {
+			return fromProjectConfig;
+		}
+		return configProviders.find((c) => c.provider === provider)?.customModels.find((m) => m.id === modelId);
 	};
 
 	return {
 		// Data
 		projectConfigs,
+		configProviders,
 		envProviders,
 		envBaseUrls,
 		availableProvidersToAdd,
 		unconfiguredEnvProviders,
+		unconfiguredConfigProviders,
 		currentModels,
 
 		// State
@@ -155,6 +197,7 @@ export function useLlmProviders() {
 		handleSubmit,
 		handleCancel,
 		handleEditConfig,
+		handleOverrideConfigProvider,
 		handleDeleteConfig,
 		handleSelectProvider,
 		handleConfigureEnvProvider,

--- a/cli/README.md
+++ b/cli/README.md
@@ -174,7 +174,7 @@ Optional `ai_summary` generation:
 - Add `ai_summary` to a database connection `templates` list to render `ai_summary.md`.
 - AI summaries use profiling statistics for data-quality and distribution observations. The row preview is a tiny, non-representative shape sample.
 - Use `prompt("...")` inside Jinja templates to generate `ai_summary` content.
-- `prompt(...)` requires `llm.provider`, `llm.annotation_model`, and `llm.api_key` (except for ollama).
+- `prompt(...)` requires an `llm.providers` entry with an `api_key` (except for ollama), plus `llm.annotation_model`.
 - Configure `profiling` and `ai_summary` refreshes independently with `refresh_policy: always`, `once`, or `interval`. Interval policies also accept `interval_days` (default: `7`):
 
 ```yaml
@@ -202,6 +202,8 @@ Options:
 
 - `--model` / `-m`: Models to test against (default: `openai:gpt-4.1`). Can be specified multiple times.
 - `--threads` / `-t`: Number of parallel threads (default: `1`)
+- `--select` / `-s`: Run only selected tests by name, yaml stem, or subfolder. Comma-separated.
+- `--username` / `-u`, `--password`: Credentials for the nao backend. Fall back to `NAO_USERNAME` / `NAO_PASSWORD`.
 
 Examples:
 
@@ -209,6 +211,20 @@ Examples:
 nao test -m openai:gpt-4.1
 nao test -m openai:gpt-4.1 -m anthropic:claude-sonnet-4-20250514
 nao test --threads 4
+```
+
+Defaults for every run live in the `test` block of `nao_config.yaml`, and the `--model` / `--threads` flags override them:
+
+```yaml
+test:
+  models:
+    - openai:gpt-4.1
+    - anthropic:claude-sonnet-4-5
+  threads: 4
+  comparison:
+    rtol: 0.00001
+    atol: 0.00000001
+    decimals: 2
 ```
 
 ### Explore test results

--- a/cli/nao_core/commands/__init__.py
+++ b/cli/nao_core/commands/__init__.py
@@ -3,10 +3,23 @@ from nao_core.commands.debug import debug
 from nao_core.commands.deploy import deploy
 from nao_core.commands.docs import docs
 from nao_core.commands.init import init
+from nao_core.commands.migrate import migrate
 from nao_core.commands.reset_password import reset_password
 from nao_core.commands.skills import skills
 from nao_core.commands.sync import sync
 from nao_core.commands.test import test
 from nao_core.commands.upgrade import upgrade
 
-__all__ = ["chat", "debug", "deploy", "docs", "init", "reset_password", "skills", "sync", "test", "upgrade"]
+__all__ = [
+    "chat",
+    "debug",
+    "deploy",
+    "docs",
+    "init",
+    "migrate",
+    "reset_password",
+    "skills",
+    "sync",
+    "test",
+    "upgrade",
+]

--- a/cli/nao_core/commands/chat.py
+++ b/cli/nao_core/commands/chat.py
@@ -12,7 +12,7 @@ from cyclopts import Parameter
 from nao_core import __version__
 from nao_core.branding import should_show_banner
 from nao_core.config import NaoConfig, resolve_project_path
-from nao_core.config.llm import PROVIDER_AUTH, LLMProvider
+from nao_core.config.llm import PROVIDER_AUTH, LLMConfig, LLMProvider, ProviderConfig
 from nao_core.mode import MODE
 from nao_core.tracking import track_command
 from nao_core.ui import UI, console
@@ -121,6 +121,55 @@ def ensure_auth_secret(bin_dir: Path) -> str | None:
         return new_secret
 
 
+def build_llm_env(llm: LLMConfig) -> dict[str, str]:
+    """Map every configured provider onto the env vars its SDK credential chain reads.
+
+    The chat server reads models, prices and the annotation model straight from nao_config.yaml;
+    these variables only cover the credential lookups performed by the provider SDKs themselves.
+    """
+    env: dict[str, str] = {}
+
+    for provider_config in llm.providers:
+        auth = PROVIDER_AUTH[provider_config.provider]
+        if provider_config.api_key is not None and auth.api_key != "none":
+            env[auth.env_var] = provider_config.api_key
+        if provider_config.base_url and auth.base_url_env_var:
+            env[auth.base_url_env_var] = provider_config.base_url
+
+        if provider_config.provider == LLMProvider.BEDROCK:
+            env.update(_bedrock_env(provider_config))
+        elif provider_config.provider == LLMProvider.VERTEX:
+            env.update(_vertex_env(provider_config))
+
+    return env
+
+
+def _bedrock_env(provider_config: ProviderConfig) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if provider_config.access_key:
+        env["AWS_ACCESS_KEY_ID"] = provider_config.access_key
+    if provider_config.secret_key:
+        env["AWS_SECRET_ACCESS_KEY"] = provider_config.secret_key
+    if provider_config.aws_profile:
+        env["AWS_PROFILE"] = provider_config.aws_profile
+    if provider_config.aws_region:
+        env["AWS_REGION"] = provider_config.aws_region
+    return env
+
+
+def _vertex_env(provider_config: ProviderConfig) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if provider_config.gcp_project:
+        env["GOOGLE_VERTEX_PROJECT"] = provider_config.gcp_project
+    if provider_config.gcp_location:
+        env["GOOGLE_VERTEX_LOCATION"] = provider_config.gcp_location
+    if provider_config.service_account_json:
+        env["VERTEX_GOOGLE_SERVICE_ACCOUNT_JSON"] = provider_config.service_account_json
+    if provider_config.key_file:
+        env["VERTEX_GOOGLE_APPLICATION_CREDENTIALS"] = str(Path(provider_config.key_file).resolve())
+    return env
+
+
 def start_ngrok_tunnel(port: int) -> str:
     """Start an ngrok tunnel and return the public HTTPS URL."""
     try:
@@ -215,52 +264,12 @@ def chat(
             env["BETTER_AUTH_SECRET"] = auth_secret
 
         if config and config.llm:
-            auth = PROVIDER_AUTH[config.llm.provider]
-            if config.llm.api_key is not None and auth.api_key != "none":
-                env[auth.env_var] = config.llm.api_key
-                console.print(f"[bold green]✓[/bold green] Set {auth.env_var} from config")
-            if config.llm.base_url and auth.base_url_env_var:
-                env[auth.base_url_env_var] = config.llm.base_url
-                console.print(f"[bold green]✓[/bold green] Set {auth.base_url_env_var} from config")
-
-            if config.llm.provider == LLMProvider.BEDROCK:
-                if config.llm.access_key:
-                    env["AWS_ACCESS_KEY_ID"] = config.llm.access_key
-                    console.print("[bold green]✓[/bold green] Set AWS_ACCESS_KEY_ID from config")
-                if config.llm.secret_key:
-                    env["AWS_SECRET_ACCESS_KEY"] = config.llm.secret_key
-                    console.print("[bold green]✓[/bold green] Set AWS_SECRET_ACCESS_KEY from config")
-                aws_profile = config.llm.aws_profile or os.environ.get("AWS_PROFILE")
-                if aws_profile:
-                    env["AWS_PROFILE"] = aws_profile
-                    console.print("[bold green]✓[/bold green] Set AWS_PROFILE from config")
-                session_token = os.environ.get("AWS_SESSION_TOKEN")
-                if session_token:
-                    env["AWS_SESSION_TOKEN"] = session_token
-                    console.print("[bold green]✓[/bold green] Set AWS_SESSION_TOKEN from environment")
-                if config.llm.aws_region:
-                    env["AWS_REGION"] = config.llm.aws_region
-                    console.print("[bold green]✓[/bold green] Set AWS_REGION from config")
-
-            if config.llm.provider == LLMProvider.VERTEX:
-                if config.llm.gcp_project:
-                    env["GOOGLE_VERTEX_PROJECT"] = config.llm.gcp_project
-                    console.print("[bold green]✓[/bold green] Set GOOGLE_VERTEX_PROJECT from config")
-                if config.llm.gcp_location:
-                    env["GOOGLE_VERTEX_LOCATION"] = config.llm.gcp_location
-                    console.print("[bold green]✓[/bold green] Set GOOGLE_VERTEX_LOCATION from config")
-                if config.llm.service_account_json:
-                    env["VERTEX_GOOGLE_SERVICE_ACCOUNT_JSON"] = config.llm.service_account_json
-                    console.print("[bold green]✓[/bold green] Set VERTEX_GOOGLE_SERVICE_ACCOUNT_JSON from config")
-                if config.llm.key_file:
-                    env["VERTEX_GOOGLE_APPLICATION_CREDENTIALS"] = str(Path(config.llm.key_file).resolve())
-                    console.print("[bold green]✓[/bold green] Set VERTEX_GOOGLE_APPLICATION_CREDENTIALS from config")
+            llm_env = build_llm_env(config.llm)
+            env.update(llm_env)
+            for name in llm_env:
+                console.print(f"[bold green]✓[/bold green] Set {name} from config")
 
         env["NAO_DEFAULT_PROJECT_PATH"] = str(Path.cwd())
-
-        if config and config.llm and config.llm.annotation_model:
-            env["NAO_ANNOTATION_MODEL"] = config.llm.annotation_model
-            console.print("[bold green]✓[/bold green] Set NAO_ANNOTATION_MODEL from config")
 
         if ngrok:
             ngrok_url = start_ngrok_tunnel(port)

--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -1,10 +1,11 @@
 import os
-from typing import Tuple
+from typing import Any, Tuple
 
 from rich.console import Console
 from rich.table import Table
 
 from nao_core.config import NaoConfig, resolve_project_path
+from nao_core.config.llm import ProviderConfig
 from nao_core.tracking import track_command
 
 console = Console()
@@ -18,7 +19,54 @@ def _count(models) -> int:
         return sum(1 for _ in models)
 
 
-def _check_available_models(llm_config) -> Tuple[bool, str]:
+def _extract_model_id(model: Any) -> str | None:
+    if isinstance(model, dict):
+        for key in ("modelId", "id", "model", "name"):
+            value = model.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    for attr in ("id", "model", "name", "modelId"):
+        value = getattr(model, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _collect_model_ids(models: Any) -> set[str]:
+    """Normalize provider model list entries into a set of comparable ids."""
+    ids: set[str] = set()
+    for model in models:
+        model_id = _extract_model_id(model)
+        if not model_id:
+            continue
+        ids.add(model_id)
+        if model_id.startswith("models/"):
+            ids.add(model_id.removeprefix("models/"))
+    return ids
+
+
+def _is_model_available(configured_id: str, available: set[str]) -> bool:
+    if configured_id in available or f"models/{configured_id}" in available:
+        return True
+    return any(candidate == configured_id or candidate.startswith(f"{configured_id}:") for candidate in available)
+
+
+def _missing_configured_models(llm_config: ProviderConfig, available: set[str]) -> list[str]:
+    if not llm_config.models or not available:
+        return []
+    return [model.id for model in llm_config.models if not _is_model_available(model.id, available)]
+
+
+def _connection_message(model_count: int, missing: list[str]) -> str:
+    message = f"Connected successfully ({model_count} models available)"
+    if missing:
+        message += f". Warning: configured model(s) not in provider list: {', '.join(missing)}"
+    return message
+
+
+def _check_available_models(llm_config: ProviderConfig) -> Tuple[bool, str]:
     from nao_core.deps import require_dependency
 
     provider = llm_config.provider.value
@@ -30,7 +78,7 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
         require_dependency("openai", "openai", "for OpenAI LLM provider")
         from openai import OpenAI
 
-        kwargs = {"api_key": api_key}
+        kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
             kwargs["base_url"] = base_url
         client = OpenAI(**kwargs)
@@ -39,10 +87,10 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
         require_dependency("anthropic", "anthropic", "for Anthropic LLM provider")
         from anthropic import Anthropic
 
-        kwargs = {"api_key": api_key}
+        anthropic_kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
-            kwargs["base_url"] = base_url
-        client = Anthropic(**kwargs)
+            anthropic_kwargs["base_url"] = base_url
+        client = Anthropic(**anthropic_kwargs)
         models = client.models.list()
     elif provider == "gemini":
         require_dependency("google.genai", "gemini", "for Google Gemini LLM provider")
@@ -110,11 +158,13 @@ def _check_available_models(llm_config) -> Tuple[bool, str]:
     else:
         return False, f"Unknown provider: {provider}"
 
-    model_count = _count(models)
-    return True, f"Connected successfully ({model_count} models available)"
+    model_list = list(models)
+    available_ids = _collect_model_ids(model_list)
+    missing = _missing_configured_models(llm_config, available_ids)
+    return True, _connection_message(_count(model_list), missing)
 
 
-def check_llm_connection(llm_config) -> tuple[bool, str]:
+def check_llm_connection(llm_config: ProviderConfig) -> tuple[bool, str]:
     """Test connectivity to an LLM provider.
 
     Returns:
@@ -189,32 +239,36 @@ def debug():
 
     # Test LLM
     if config.llm:
-        console.print("[bold]LLM Provider:[/bold]")
+        console.print("[bold]LLM Providers:[/bold]")
         llm_table = Table(show_header=True, header_style="bold")
         llm_table.add_column("Provider")
+        llm_table.add_column("Models")
         llm_table.add_column("Status")
         llm_table.add_column("Details")
+        model_warnings: list[str] = []
 
-        console.print(f"  Testing [cyan]{config.llm.provider.value}[/cyan]...", end=" ")
-        success, message = check_llm_connection(config.llm)
+        for provider_config in config.llm.providers:
+            provider_name = provider_config.provider.value
+            console.print(f"  Testing [cyan]{provider_name}[/cyan]...", end=" ")
+            success, message = check_llm_connection(provider_config)
+            models = ", ".join(model.id for model in provider_config.models) or "[dim]provider default[/dim]"
+            has_model_warning = "Warning: configured model(s) not in provider list" in message
 
-        if success:
-            console.print("[bold green]✓[/bold green]")
-            llm_table.add_row(
-                config.llm.provider.value,
-                "[green]Connected[/green]",
-                message,
-            )
-        else:
-            console.print("[bold red]✗[/bold red]")
-            llm_table.add_row(
-                config.llm.provider.value,
-                "[red]Failed[/red]",
-                f"[red]{message}[/red]",
-            )
+            if success and has_model_warning:
+                console.print("[bold yellow]⚠[/bold yellow]")
+                llm_table.add_row(provider_name, models, "[yellow]Connected[/yellow]", f"[yellow]{message}[/yellow]")
+                model_warnings.append(f"{provider_name}: {message.split('Warning: ', 1)[1]}")
+            elif success:
+                console.print("[bold green]✓[/bold green]")
+                llm_table.add_row(provider_name, models, "[green]Connected[/green]", message)
+            else:
+                console.print("[bold red]✗[/bold red]")
+                llm_table.add_row(provider_name, models, "[red]Failed[/red]", f"[red]{message}[/red]")
 
         console.print()
         console.print(llm_table)
+        for warning in model_warnings:
+            console.print(f"[yellow]⚠[/yellow] {warning}")
     else:
         console.print("[dim]No LLM configured[/dim]")
 

--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -54,7 +54,7 @@ def _is_model_available(configured_id: str, available: set[str]) -> bool:
 
 
 def _missing_configured_models(llm_config: ProviderConfig, available: set[str]) -> list[str]:
-    if not llm_config.models or not available:
+    if not llm_config.models:
         return []
     return [model.id for model in llm_config.models if not _is_model_available(model.id, available)]
 

--- a/cli/nao_core/commands/init.py
+++ b/cli/nao_core/commands/init.py
@@ -9,7 +9,7 @@ from cyclopts import Parameter
 from nao_core import __version__
 from nao_core.branding import should_show_banner
 from nao_core.config import NaoConfig, NaoConfigError
-from nao_core.config.base import annotate_optional_templates
+from nao_core.config.base import annotate_llm_override, annotate_optional_templates
 from nao_core.config.exceptions import InitError
 from nao_core.tracking import track_command
 from nao_core.ui import UI, ask_confirm, ask_text
@@ -299,6 +299,7 @@ def init(
 
         config.save(project_path)
         annotate_optional_templates(project_path / "nao_config.yaml")
+        annotate_llm_override(project_path / "nao_config.yaml")
 
         created_folders, created_files = create_empty_structure(project_path)
 

--- a/cli/nao_core/commands/migrate.py
+++ b/cli/nao_core/commands/migrate.py
@@ -70,13 +70,17 @@ def migrate_llm_block(content: str) -> str | None:
         return None
 
     start, end = block
-    groups = _group_by_key(lines[start + 1 : end])
+    block_lines = lines[start + 1 : end]
+    indent = _property_indent(block_lines)
+    if indent is None:
+        return None
+
+    groups = _group_by_key(block_lines, indent)
     provider_groups = [group for group in groups if group[0] in ProviderConfig.model_fields]
     if not any(key == "provider" for key, _ in provider_groups):
         return None
 
     other_groups = [group for group in groups if group[0] not in ProviderConfig.model_fields]
-    indent = _indent_width(lines[start + 1])
 
     migrated = [
         *lines[: start + 1],
@@ -92,7 +96,7 @@ def migrate_llm_block(content: str) -> str | None:
 
 def _find_block(lines: list[str], key: str) -> tuple[int, int] | None:
     """Return the start and end line indices of a top-level mapping key's block."""
-    start = next((i for i, line in enumerate(lines) if line.rstrip() == f"{key}:"), None)
+    start = next((i for i, line in enumerate(lines) if _is_top_level_key(line, key)), None)
     if start is None:
         return None
 
@@ -107,9 +111,17 @@ def _find_block(lines: list[str], key: str) -> tuple[int, int] | None:
     return (start, end) if end > start + 1 else None
 
 
-def _group_by_key(block: list[str]) -> list[tuple[str, list[str]]]:
+def _is_top_level_key(line: str, key: str) -> bool:
+    prefix = f"{key}:"
+    if not line.startswith(prefix):
+        return False
+
+    suffix = line[len(prefix) :]
+    return not suffix.strip() or (suffix[0].isspace() and suffix.lstrip().startswith("#"))
+
+
+def _group_by_key(block: list[str], indent: int) -> list[tuple[str, list[str]]]:
     """Split a mapping block into one group per key, keeping nested lines and comments attached."""
-    indent = _indent_width(block[0])
     groups: list[tuple[str, list[str]]] = []
     pending: list[str] = []
 
@@ -128,6 +140,14 @@ def _group_by_key(block: list[str]) -> list[tuple[str, list[str]]]:
     if pending and groups:
         groups[-1][1].extend(pending)
     return groups
+
+
+def _property_indent(block: list[str]) -> int | None:
+    property_line = next(
+        (line for line in block if line.strip() and not line.lstrip().startswith("#")),
+        None,
+    )
+    return _indent_width(property_line) if property_line is not None else None
 
 
 def _render_provider(groups: list[tuple[str, list[str]]], indent: int) -> list[str]:

--- a/cli/nao_core/commands/migrate.py
+++ b/cli/nao_core/commands/migrate.py
@@ -1,0 +1,156 @@
+"""Rewrite nao_config.yaml to the latest configuration shape."""
+
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from nao_core.config import resolve_project_path
+from nao_core.config.llm import ProviderConfig
+from nao_core.tracking import track_command
+from nao_core.ui import UI
+
+MODELS_HINT = (
+    "# models:",
+    "# - id: your-model-id",
+    "#   costs:  # US dollars per million tokens",
+    "#     input_no_cache: 3",
+    "#     input_cache_read: 0.3",
+    "#     input_cache_write: 3.75",
+    "#     output: 15",
+)
+
+
+@track_command("migrate")
+def migrate(
+    dry_run: Annotated[bool, Parameter(name=["--dry-run"])] = False,
+):
+    """Rewrite nao_config.yaml to the latest configuration shape.
+
+    Moves a single inline `llm` provider under `llm.providers`, so that several providers,
+    their models and each model's costs can be configured.
+
+    Parameters
+    ----------
+    dry_run : bool
+        Print the migrated file instead of writing it.
+    """
+    config_path = resolve_project_path() / "nao_config.yaml"
+    if not config_path.exists():
+        UI.error(f"No nao_config.yaml found in {config_path.parent}")
+        return
+
+    content = config_path.read_text()
+    migrated = migrate_llm_block(content)
+
+    if migrated is None:
+        UI.success("nao_config.yaml is already using the latest shape")
+        return
+
+    if dry_run:
+        UI.print(migrated)
+        return
+
+    config_path.write_text(migrated)
+    UI.success(f"Migrated the `llm` block of {config_path}")
+    UI.info(
+        "Costs declared under the deprecated `llm.meta` apply to every model. Move them to the "
+        "matching entry under a provider's `models` to price each model separately."
+    )
+
+
+def migrate_llm_block(content: str) -> str | None:
+    """Nest a legacy single-provider `llm` block into an `llm.providers` list.
+
+    Rewrites the file as text so that comments and `{{ env(...) }}` placeholders survive.
+    Returns None when the file already uses the current shape.
+    """
+    lines = content.splitlines()
+    block = _find_block(lines, "llm")
+    if not block:
+        return None
+
+    start, end = block
+    groups = _group_by_key(lines[start + 1 : end])
+    provider_groups = [group for group in groups if group[0] in ProviderConfig.model_fields]
+    if not any(key == "provider" for key, _ in provider_groups):
+        return None
+
+    other_groups = [group for group in groups if group[0] not in ProviderConfig.model_fields]
+    indent = _indent_width(lines[start + 1])
+
+    migrated = [
+        *lines[: start + 1],
+        f"{' ' * indent}providers:",
+        *_render_provider(provider_groups, indent),
+        *(line for _, group_lines in other_groups for line in group_lines),
+        *lines[end:],
+    ]
+
+    trailing_newline = "\n" if content.endswith("\n") else ""
+    return "\n".join(migrated) + trailing_newline
+
+
+def _find_block(lines: list[str], key: str) -> tuple[int, int] | None:
+    """Return the start and end line indices of a top-level mapping key's block."""
+    start = next((i for i, line in enumerate(lines) if line.rstrip() == f"{key}:"), None)
+    if start is None:
+        return None
+
+    end = start + 1
+    while end < len(lines) and (not lines[end].strip() or _indent_width(lines[end]) > 0):
+        end += 1
+
+    # Blank lines after the block belong to whatever follows it.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+
+    return (start, end) if end > start + 1 else None
+
+
+def _group_by_key(block: list[str]) -> list[tuple[str, list[str]]]:
+    """Split a mapping block into one group per key, keeping nested lines and comments attached."""
+    indent = _indent_width(block[0])
+    groups: list[tuple[str, list[str]]] = []
+    pending: list[str] = []
+
+    for line in block:
+        stripped = line.strip()
+        is_key = stripped and not stripped.startswith("#") and _indent_width(line) == indent and ":" in stripped
+
+        if is_key:
+            groups.append((stripped.split(":", 1)[0], [*pending, line]))
+            pending = []
+        elif groups and not pending:
+            groups[-1][1].append(line)
+        else:
+            pending.append(line)
+
+    if pending and groups:
+        groups[-1][1].extend(pending)
+    return groups
+
+
+def _render_provider(groups: list[tuple[str, list[str]]], indent: int) -> list[str]:
+    """Render provider keys as the first item of the `providers` list."""
+    rendered: list[str] = []
+    awaiting_dash = True
+
+    for _, group_lines in groups:
+        for line in group_lines:
+            stripped = line.strip()
+            if not stripped:
+                rendered.append(line)
+            elif awaiting_dash and stripped.startswith("#"):
+                rendered.append(f"{' ' * (indent + 2)}{stripped}")
+            elif awaiting_dash:
+                rendered.append(f"{' ' * indent}- {stripped}")
+                awaiting_dash = False
+            else:
+                rendered.append(f"  {line}")
+
+    rendered.extend(f"{' ' * (indent + 2)}{hint}" for hint in MODELS_HINT)
+    return rendered
+
+
+def _indent_width(line: str) -> int:
+    return len(line) - len(line.lstrip())

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -170,13 +170,15 @@ def get_client(email: str | None = None, password: str | None = None) -> AgentCl
 
 
 def serialize_model_costs(costs: ModelCosts | None) -> dict[str, float] | None:
-    """Convert config costs to the backend API shape."""
+    """Convert config costs to the backend API shape, omitting the token types left unpriced."""
     if costs is None:
         return None
 
-    return {
+    priced = {
         "inputNoCache": costs.input_no_cache,
         "inputCacheRead": costs.input_cache_read,
         "inputCacheWrite": costs.input_cache_write,
         "output": costs.output,
     }
+    serialized = {key: value for key, value in priced.items() if value is not None}
+    return serialized or None

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -12,15 +12,13 @@ import pandas as pd
 from cyclopts import Parameter
 
 from nao_core.config import NaoConfig, resolve_project_path
-from nao_core.config.llm import ModelCosts
+from nao_core.config.llm import ModelCosts, parse_provider
+from nao_core.config.test import ComparisonConfig, TestConfig
 from nao_core.ui import UI
 
 from .case import TESTS_FOLDER, TestCase, discover_tests
 from .client import AgentClientError, VerificationResult, get_client
 from .compare import normalize_dataframe_numbers
-
-# Default models to test
-DEFAULT_MODELS = ["openai:gpt-4.1"]
 
 
 @dataclass
@@ -71,7 +69,7 @@ class TestRunResult:
 
 
 def check_dataframe(
-    verification: VerificationResult, rtol: float = 1e-5, atol: float = 1e-8
+    verification: VerificationResult, rtol: float = 1e-5, atol: float = 1e-8, decimals: int = 2
 ) -> tuple[bool, str, str | None]:
     """Check if actual data matches expected. Returns (passed, message, comparison).
 
@@ -79,6 +77,7 @@ def check_dataframe(
         verification: The verification result containing actual and expected data.
         rtol: Relative tolerance for float comparison.
         atol: Absolute tolerance for float comparison.
+        decimals: Decimals kept when rounding float values before comparing.
     """
     actual = pd.DataFrame(verification.data)
     expected = pd.DataFrame(verification.expectedData)
@@ -105,7 +104,7 @@ def check_dataframe(
     actual = normalize_dataframe_numbers(actual)
     expected = normalize_dataframe_numbers(expected)
 
-    def round_numeric(df: pd.DataFrame, decimals: int = 2) -> pd.DataFrame:
+    def round_numeric(df: pd.DataFrame, decimals: int) -> pd.DataFrame:
         """Round float-like columns to the given number of decimals for stable comparisons."""
         for col in df.columns:
             series = df[col]
@@ -124,9 +123,9 @@ def check_dataframe(
     actual = cast(pd.DataFrame, actual[sorted_cols])
     expected = cast(pd.DataFrame, expected[sorted_cols])
 
-    # Round float-like values to 2 decimals to avoid noisy diffs
-    actual = round_numeric(actual, decimals=2)
-    expected = round_numeric(expected, decimals=2)
+    # Round float-like values to avoid noisy diffs
+    actual = round_numeric(actual, decimals=decimals)
+    expected = round_numeric(expected, decimals=decimals)
 
     # Sort rows by all columns (in alphabetic order) to ignore row order
     actual = actual.sort_values(by=sorted_cols).reset_index(drop=True)
@@ -185,6 +184,7 @@ def run_test(
     email: str | None = None,
     password: str | None = None,
     costs: ModelCosts | None = None,
+    comparison: ComparisonConfig | None = None,
 ) -> TestRunResult:
     """Run a single test case with a specific model. Returns TestRunResult."""
     UI.print(f"[bold]Running:[/bold] {test_case.name} [dim]({model})[/dim]")
@@ -208,7 +208,13 @@ def run_test(
         UI.print(f"[dim]  Time: {result.duration_ms}ms[/dim]")
 
         if result.verification:
-            passed, msg, comparison = check_dataframe(result.verification)
+            tolerances = comparison or ComparisonConfig()
+            passed, msg, diff = check_dataframe(
+                result.verification,
+                rtol=tolerances.rtol,
+                atol=tolerances.atol,
+                decimals=tolerances.decimals,
+            )
             status = "[green]✓[/green]" if passed else "[red]✗[/red]"
             UI.print(f"  {status} {msg}")
             return TestRunResult(
@@ -224,7 +230,7 @@ def run_test(
                     response_text=result.text,
                     actual_data=result.verification.data,
                     expected_data=result.verification.expectedData,
-                    comparison=comparison,
+                    comparison=diff,
                     tool_calls=result.tool_calls,
                     reference_sql=test_case.sql,
                 ),
@@ -257,6 +263,17 @@ def run_test(
             error=str(e),
             details=TestRunDetails(reference_sql=test_case.sql),
         )
+
+
+def resolve_model_costs(config: NaoConfig, model: ModelConfig) -> ModelCosts | None:
+    """Look up the configured price of the model under test."""
+    if not config.llm:
+        return None
+
+    provider = parse_provider(model.provider)
+    if not provider:
+        return config.llm.meta.costs if config.llm.meta else None
+    return config.llm.costs(provider, model.model_id)
 
 
 def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
@@ -342,16 +359,16 @@ def test(
         list[str] | None,
         Parameter(
             name=["-m", "--model"],
-            help="Models to test (format: provider:model_id). Can be specified multiple times.",
+            help="Models to test (format: provider:model_id). Can be specified multiple times. Overrides test.models.",
         ),
     ] = None,
     threads: Annotated[
-        int,
+        int | None,
         Parameter(
             name=["-t", "--threads"],
-            help="Number of parallel threads for running tests.",
+            help="Number of parallel threads for running tests. Overrides test.threads.",
         ),
-    ] = 1,
+    ] = None,
     select: Annotated[
         str | None,
         Parameter(
@@ -376,6 +393,8 @@ def test(
 ):
     """Run tests from the tests/ folder.
 
+    Defaults come from the `test` block of nao_config.yaml, and every flag below overrides them.
+
     Examples:
         nao test
         nao test -m openai:gpt-4.1
@@ -393,16 +412,16 @@ def test(
     config = NaoConfig.try_load(resolve_project_path(), exit_on_error=True)
     assert config is not None
 
-    # Parse models
-    model_strs = models if models else DEFAULT_MODELS
+    test_config = config.test or TestConfig()
+    thread_count = threads if threads is not None else test_config.threads
+
     try:
-        model_configs = [ModelConfig.parse(m) for m in model_strs]
+        model_configs = [ModelConfig.parse(m) for m in models or test_config.models]
     except ValueError as e:
         UI.error(str(e))
         return
 
     project_path = Path.cwd()
-    model_costs = config.llm.meta.costs if config.llm and config.llm.meta else None
     tests_dir = project_path / TESTS_FOLDER
     UI.print(f"[dim]Project: {config.project_name}[/dim]")
     UI.print(f"[dim]Tests folder: {tests_dir}[/dim]")
@@ -422,23 +441,38 @@ def test(
 
     total_runs = len(test_cases) * len(model_configs)
     UI.print(f"[bold]Found {len(test_cases)} test(s) × {len(model_configs)} model(s) = {total_runs} run(s)[/bold]")
-    if threads > 1:
-        UI.print(f"[dim]Running with {threads} threads (output may be interleaved)[/dim]")
+    if thread_count > 1:
+        UI.print(f"[dim]Running with {thread_count} threads (output may be interleaved)[/dim]")
     UI.print("")
 
     # Build list of (test_case, model) pairs
     test_runs = [(test_case, model) for model in model_configs for test_case in test_cases]
 
     results: list[TestRunResult] = []
-    if threads == 1:
+    if thread_count == 1:
         for test_case, model in test_runs:
-            result = run_test(test_case, model, email=email, password=pwd, costs=model_costs)
+            result = run_test(
+                test_case,
+                model,
+                email=email,
+                password=pwd,
+                costs=resolve_model_costs(config, model),
+                comparison=test_config.comparison,
+            )
             results.append(result)
             UI.print("")
     else:
-        with ThreadPoolExecutor(max_workers=threads) as executor:
+        with ThreadPoolExecutor(max_workers=thread_count) as executor:
             futures = {
-                executor.submit(run_test, tc, m, email=email, password=pwd, costs=model_costs): (tc, m)
+                executor.submit(
+                    run_test,
+                    tc,
+                    m,
+                    email=email,
+                    password=pwd,
+                    costs=resolve_model_costs(config, m),
+                    comparison=test_config.comparison,
+                ): (tc, m)
                 for tc, m in test_runs
             }
             for future in as_completed(futures):

--- a/cli/nao_core/config/__init__.py
+++ b/cli/nao_core/config/__init__.py
@@ -14,8 +14,17 @@ from .databases import (
     TrinoConfig,
 )
 from .exceptions import InitError
-from .llm import PROVIDER_AUTH, LLMConfig, LLMProvider, ProviderAuthConfig
+from .llm import (
+    PROVIDER_AUTH,
+    LLMConfig,
+    LLMProvider,
+    ModelConfig,
+    ModelCosts,
+    ProviderAuthConfig,
+    ProviderConfig,
+)
 from .slack import SlackConfig
+from .test import ComparisonConfig, TestConfig
 
 __all__ = [
     "NaoConfig",
@@ -34,9 +43,14 @@ __all__ = [
     "DatabaseType",
     "LLMConfig",
     "LLMProvider",
+    "ModelConfig",
+    "ModelCosts",
     "PROVIDER_AUTH",
     "ProviderAuthConfig",
+    "ProviderConfig",
     "SlackConfig",
+    "ComparisonConfig",
+    "TestConfig",
     "InitError",
     "resolve_project_path",
 ]

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -24,6 +24,7 @@ from .repos import RepoConfig
 from .secrets import process_secrets
 from .skills import SkillsConfig
 from .slack import SlackConfig
+from .test import TestConfig
 
 
 class NaoConfigError(Exception):
@@ -44,6 +45,7 @@ class NaoConfig(BaseModel):
     slack: SlackConfig | None = Field(default=None, description="The Slack configuration")
     mcp: McpConfig | None = Field(default=None, description="The MCP configuration")
     skills: SkillsConfig | None = Field(default=None, description="The Skills configuration")
+    test: TestConfig | None = Field(default=None, description="The defaults used by `nao test`")
 
     _missing_secrets: dict[str, None] = {}
 
@@ -88,7 +90,7 @@ class NaoConfig(BaseModel):
         if repos:
             UI.print(f"  Repos: {', '.join(r.name for r in repos)}")
         if llm:
-            UI.print(f"  LLM: {llm.provider}")
+            UI.print(f"  LLM: {', '.join(p.provider.value for p in llm.providers)}")
         if existing.slack:
             UI.print("  Slack: configured")
         if existing.notion:
@@ -97,6 +99,8 @@ class NaoConfig(BaseModel):
             UI.print("  MCP: configured")
         if existing.skills:
             UI.print("  Skills: configured")
+        if existing.test:
+            UI.print("  Test: configured")
         UI.print()
 
         new_databases = cls._prompt_databases(has_existing=bool(existing.databases))
@@ -188,7 +192,20 @@ class NaoConfig(BaseModel):
         processed_content, missing = process_secrets(content, extra_env=extra_env)
         cls._missing_secrets = {k: None for k, v in missing.items() if v is None}
         data = yaml.safe_load(processed_content)
+        cls._warn_on_legacy_llm(data)
         return cls.model_validate(data)
+
+    @staticmethod
+    def _warn_on_legacy_llm(data: Any) -> None:
+        """Warn when the `llm` block still declares a single inline provider."""
+        if not isinstance(data, dict) or not LLMConfig.uses_legacy_shape(data.get("llm")):
+            return
+
+        UI.warn(
+            "nao_config.yaml declares a single inline `llm` provider, which is deprecated. Move it "
+            "under `llm.providers` to configure several providers, the models each one exposes and "
+            "their costs. Run `nao migrate` to rewrite it automatically."
+        )
 
     def get_connection(self, name: str) -> BaseBackend:
         """Get an Ibis connection by database name."""
@@ -263,6 +280,25 @@ class NaoConfig(BaseModel):
     def json_schema(cls) -> dict:
         """Generate JSON schema for the configuration."""
         return cls.model_json_schema()
+
+
+LLM_OVERRIDE_NOTICE = (
+    "# An LLM provider edited in the app (Settings > Project > Models) is stored in the app",
+    "# database and takes precedence over this block until it is deleted there.",
+)
+
+
+def annotate_llm_override(config_path: Path) -> None:
+    """Note, above the saved `llm` block, that editing a provider in the app overrides it."""
+    content = config_path.read_text()
+    lines = content.splitlines()
+    index = next((i for i, line in enumerate(lines) if line.rstrip() == "llm:"), None)
+    if index is None:
+        return
+
+    lines[index:index] = LLM_OVERRIDE_NOTICE
+    trailing_newline = "\n" if content.endswith("\n") else ""
+    config_path.write_text("\n".join(lines) + trailing_newline)
 
 
 def annotate_optional_templates(config_path: Path) -> None:

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -182,8 +182,9 @@ class ProviderConfig(BaseModel):
         return self
 
     @classmethod
-    def promptConfig(cls) -> "ProviderConfig":
+    def promptConfig(cls, *, excluded_providers: set[LLMProvider] | None = None) -> "ProviderConfig":
         """Interactively prompt the user for a single provider's credentials."""
+        excluded_providers = excluded_providers or set()
         provider_choices = [
             questionary.Choice("OpenAI (GPT-4, GPT-3.5)", value="openai"),
             questionary.Choice("Anthropic (Claude)", value="anthropic"),
@@ -193,6 +194,9 @@ class ProviderConfig(BaseModel):
             questionary.Choice("Ollama", value="ollama"),
             questionary.Choice("AWS Bedrock (Claude, Nova, etc)", value="bedrock"),
             questionary.Choice("Google Vertex AI (Claude, Gemini)", value="vertex"),
+        ]
+        provider_choices = [
+            choice for choice in provider_choices if LLMProvider(choice.value) not in excluded_providers
         ]
 
         llm_provider = ask_select("Select LLM provider:", choices=provider_choices)
@@ -343,8 +347,9 @@ class LLMConfig(BaseModel):
     def promptConfig(cls, *, prompt_annotation_model: bool = True) -> "LLMConfig":
         """Interactively prompt the user for LLM configuration."""
         providers = [ProviderConfig.promptConfig()]
-        while ask_confirm("Add another LLM provider?", default=False):
-            providers.append(ProviderConfig.promptConfig())
+        while len(providers) < len(LLMProvider) and ask_confirm("Add another LLM provider?", default=False):
+            configured_providers = {provider.provider for provider in providers}
+            providers.append(ProviderConfig.promptConfig(excluded_providers=configured_providers))
 
         annotation_model: str | None = None
         if prompt_annotation_model:

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
 
 import questionary
 from pydantic import BaseModel, Field, model_validator
 
-from nao_core.ui import ask_select, ask_text
+from nao_core.ui import ask_confirm, ask_select, ask_text
 
 
 class LLMProvider(str, Enum):
@@ -78,20 +78,47 @@ DEFAULT_ANNOTATION_MODELS: dict[LLMProvider, str] = {
     LLMProvider.VERTEX: "gemini-2.5-flash",
 }
 
+"""The chat backend spells the Gemini provider `google`; both spellings are accepted in config."""
+PROVIDER_ALIASES: dict[str, LLMProvider] = {"google": LLMProvider.GEMINI}
+
+
+def parse_provider(name: str) -> LLMProvider | None:
+    """Resolve a provider name, accepting the aliases used by the chat backend."""
+    if name in PROVIDER_ALIASES:
+        return PROVIDER_ALIASES[name]
+    try:
+        return LLMProvider(name)
+    except ValueError:
+        return None
+
 
 class ModelCosts(BaseModel):
-    input_no_cache: float = Field(ge=0)
-    input_cache_read: float = Field(ge=0)
-    input_cache_write: float = Field(ge=0)
-    output: float = Field(ge=0)
+    """Model price in US dollars per million tokens."""
+
+    input_no_cache: float | None = Field(default=None, ge=0, description="Price of an uncached input token")
+    input_cache_read: float | None = Field(default=None, ge=0, description="Price of an input token read from cache")
+    input_cache_write: float | None = Field(default=None, ge=0, description="Price of an input token written to cache")
+    output: float | None = Field(default=None, ge=0, description="Price of an output token")
 
 
 class LLMConfigMeta(BaseModel):
     costs: ModelCosts
 
 
-class LLMConfig(BaseModel):
-    """LLM configuration."""
+class ModelConfig(BaseModel):
+    """A model exposed to the agent by its provider."""
+
+    id: str = Field(min_length=1, description="The model identifier used by the provider")
+    name: str | None = Field(default=None, description="Display name shown in the model picker")
+    default: bool = Field(default=False, description="Preselect this model for new chats")
+    costs: ModelCosts | None = Field(default=None, description="Price in US dollars per million tokens")
+    settings: dict[str, Any] | None = Field(
+        default=None, description="Inference parameters for this model, e.g. temperature or reasoning_effort"
+    )
+
+
+class ProviderConfig(BaseModel):
+    """Credentials and models for a single LLM provider."""
 
     provider: LLMProvider = Field(description="The LLM provider to use")
     api_key: str | None = Field(default=None, description="The API key to use")
@@ -106,39 +133,57 @@ class LLMConfig(BaseModel):
     gcp_location: str | None = Field(default=None, description="GCP location (only for Vertex)")
     service_account_json: str | None = Field(default=None, description="Service account JSON (only for Vertex)")
     key_file: str | None = Field(default=None, description="Path to service account key file (only for Vertex)")
-    annotation_model: str | None = Field(
-        default=None,
-        description="Model to use for ai_summary generation via prompt(...) in Jinja templates",
+    models: list[ModelConfig] = Field(
+        default_factory=list, description="The models to expose for this provider, in display order"
     )
-    meta: LLMConfigMeta | None = Field(default=None, description="Metadata for the LLM")
 
     @property
     def requires_api_key(self) -> bool:
         return self.provider not in (LLMProvider.OLLAMA, LLMProvider.BEDROCK, LLMProvider.VERTEX)
 
-    def get_effective_api_key_for_env(self) -> str | None:
-        """Return the API key value to export via environment variables."""
-        if self.api_key:
-            return self.api_key
-        if self.requires_api_key:
-            return None
-        return f"{self.provider.value}_api_key"
+    @property
+    def default_model(self) -> ModelConfig | None:
+        """The model to preselect for new chats."""
+        for model in self.models:
+            if model.default:
+                return model
+        return self.models[0] if self.models else None
+
+    def model(self, model_id: str) -> ModelConfig | None:
+        for model in self.models:
+            if model.id == model_id:
+                return model
+        return None
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_provider_alias(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("provider") in PROVIDER_ALIASES:
+            return {**data, "provider": PROVIDER_ALIASES[data["provider"]]}
+        return data
 
     @model_validator(mode="after")
-    def validate_api_key(self) -> "LLMConfig":
+    def validate_provider(self) -> "ProviderConfig":
         auth = PROVIDER_AUTH[self.provider]
         if auth.api_key == "required" and not self.api_key:
             raise ValueError(f"api_key is required for provider {self.provider.value}")
 
-        if not self.annotation_model:
-            default_annotation_model = DEFAULT_ANNOTATION_MODELS.get(self.provider)
-            if default_annotation_model:
-                self.annotation_model = default_annotation_model
+        seen: set[str] = set()
+        for model in self.models:
+            if model.id in seen:
+                raise ValueError(f"duplicate model '{model.id}' for provider {self.provider.value}")
+            seen.add(model.id)
+
+        defaults = [model.id for model in self.models if model.default]
+        if len(defaults) > 1:
+            raise ValueError(
+                f"only one model can be the default for provider {self.provider.value}, got {', '.join(defaults)}"
+            )
         return self
 
     @classmethod
-    def promptConfig(cls, *, prompt_annotation_model: bool = True) -> "LLMConfig":
-        """Interactively prompt the user for LLM configuration."""
+    def promptConfig(cls) -> "ProviderConfig":
+        """Interactively prompt the user for a single provider's credentials."""
         provider_choices = [
             questionary.Choice("OpenAI (GPT-4, GPT-3.5)", value="openai"),
             questionary.Choice("Anthropic (Claude)", value="anthropic"),
@@ -202,16 +247,8 @@ class LLMConfig(BaseModel):
             elif vertex_auth_mode == "file":
                 key_file = ask_text("Enter path to service account key file:", password=False, required_field=True)
 
-        provider = LLMProvider(llm_provider)
-        annotation_model: str | None = None
-        if prompt_annotation_model:
-            annotation_model = ask_text(
-                "Model to use for ai_summary generation (prompt helper):",
-                default=DEFAULT_ANNOTATION_MODELS[provider],
-            )
-
-        config = LLMConfig(
-            provider=provider,
+        return cls(
+            provider=LLMProvider(llm_provider),
             api_key=api_key,
             access_key=access_key,
             secret_key=secret_key,
@@ -221,8 +258,102 @@ class LLMConfig(BaseModel):
             gcp_location=gcp_location or None,
             service_account_json=service_account_json or None,
             key_file=key_file or None,
-            annotation_model=annotation_model,
         )
+
+
+class LLMConfig(BaseModel):
+    """LLM configuration: one or more providers, each exposing one or more models."""
+
+    providers: list[ProviderConfig] = Field(default_factory=list, description="The LLM providers to use")
+    annotation_model: str | None = Field(
+        default=None,
+        description="Model to use for ai_summary generation via prompt(...) in Jinja templates",
+    )
+    meta: LLMConfigMeta | None = Field(
+        default=None, description="Deprecated: declare costs on the matching model instead"
+    )
+
+    @property
+    def primary(self) -> ProviderConfig | None:
+        """The provider backing single-provider behaviours such as annotation."""
+        return self.providers[0] if self.providers else None
+
+    def provider_config(self, provider: LLMProvider) -> ProviderConfig | None:
+        for candidate in self.providers:
+            if candidate.provider == provider:
+                return candidate
+        return None
+
+    def costs(self, provider: LLMProvider, model_id: str) -> ModelCosts | None:
+        """Resolve the price of a model, falling back to the deprecated top-level meta.costs."""
+        provider_config = self.provider_config(provider)
+        model = provider_config.model(model_id) if provider_config else None
+        if model and model.costs:
+            return model.costs
+        return self.meta.costs if self.meta else None
+
+    def annotation_target(self) -> tuple[ProviderConfig, str] | None:
+        """Resolve the provider and model used by the prompt(...) template helper."""
+        model_id = self.annotation_model
+        if model_id:
+            owner = next((p for p in self.providers if p.model(model_id)), None)
+            if owner:
+                return owner, model_id
+
+        primary = self.primary
+        if not primary:
+            return None
+        return primary, model_id or DEFAULT_ANNOTATION_MODELS.get(primary.provider, "")
+
+    @staticmethod
+    def uses_legacy_shape(data: Any) -> bool:
+        """Whether an `llm` block still declares a single inline provider."""
+        return isinstance(data, dict) and "provider" in data and "providers" not in data
+
+    @model_validator(mode="before")
+    @classmethod
+    def upgrade_legacy_shape(cls, data: Any) -> Any:
+        """Accept the pre-multi-provider shape by nesting it into a single provider entry."""
+        if not cls.uses_legacy_shape(data):
+            return data
+
+        provider_keys = set(ProviderConfig.model_fields) - {"models"}
+        provider = {key: value for key, value in data.items() if key in provider_keys}
+        rest = {key: value for key, value in data.items() if key not in provider_keys}
+        return {**rest, "providers": [provider]}
+
+    @model_validator(mode="after")
+    def validate_providers(self) -> "LLMConfig":
+        if not self.providers:
+            raise ValueError("llm requires at least one entry under `providers`")
+
+        seen: set[LLMProvider] = set()
+        for provider_config in self.providers:
+            if provider_config.provider in seen:
+                raise ValueError(f"provider {provider_config.provider.value} is configured more than once")
+            seen.add(provider_config.provider)
+
+        if not self.annotation_model:
+            primary = self.primary
+            assert primary is not None
+            self.annotation_model = DEFAULT_ANNOTATION_MODELS.get(primary.provider)
+        return self
+
+    @classmethod
+    def promptConfig(cls, *, prompt_annotation_model: bool = True) -> "LLMConfig":
+        """Interactively prompt the user for LLM configuration."""
+        providers = [ProviderConfig.promptConfig()]
+        while ask_confirm("Add another LLM provider?", default=False):
+            providers.append(ProviderConfig.promptConfig())
+
+        annotation_model: str | None = None
+        if prompt_annotation_model:
+            annotation_model = ask_text(
+                "Model to use for ai_summary generation (prompt helper):",
+                default=DEFAULT_ANNOTATION_MODELS[providers[0].provider],
+            )
+
+        config = LLMConfig(providers=providers, annotation_model=annotation_model)
 
         # Keep annotation model out of config unless ai_summary is enabled.
         # The default is still applied when needed during runtime/validation.

--- a/cli/nao_core/config/test/__init__.py
+++ b/cli/nao_core/config/test/__init__.py
@@ -1,0 +1,37 @@
+"""Test configuration module."""
+
+from pydantic import BaseModel, Field, field_validator
+
+DEFAULT_TEST_MODELS = ["openai:gpt-4.1"]
+
+
+class ComparisonConfig(BaseModel):
+    """Tolerances applied when comparing the agent result to the expected data."""
+
+    rtol: float = Field(default=1e-5, ge=0, description="Relative tolerance used to compare numeric values")
+    atol: float = Field(default=1e-8, ge=0, description="Absolute tolerance used to compare numeric values")
+    decimals: int = Field(default=2, ge=0, description="Decimals kept when rounding float values before comparing")
+
+
+class TestConfig(BaseModel):
+    """Defaults for `nao test`, each one overridable by the matching command line flag."""
+
+    __test__ = False
+
+    models: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_TEST_MODELS),
+        description="The models to run the tests against, in the format 'provider:model_id'",
+    )
+    threads: int = Field(default=1, ge=1, description="Number of test runs to execute in parallel")
+    comparison: ComparisonConfig = Field(
+        default_factory=ComparisonConfig, description="Tolerances used when comparing results to the expected data"
+    )
+
+    @field_validator("models")
+    @classmethod
+    def validate_models(cls, models: list[str]) -> list[str]:
+        for model in models:
+            provider, _, model_id = model.partition(":")
+            if not provider or not model_id:
+                raise ValueError(f"invalid model '{model}', expected the format 'provider:model_id'")
+        return models

--- a/cli/nao_core/deps.py
+++ b/cli/nao_core/deps.py
@@ -110,10 +110,11 @@ def get_required_extras(config: NaoConfig) -> list[str]:
             seen.add(extra)
 
     if config.llm:
-        extra = _resolve_extra(config.llm.provider.value)
-        if extra and extra not in seen:
-            extras.append(extra)
-            seen.add(extra)
+        for provider_config in config.llm.providers:
+            extra = _resolve_extra(provider_config.provider.value)
+            if extra and extra not in seen:
+                extras.append(extra)
+                seen.add(extra)
 
     if config.notion and "notion" not in seen:
         extras.append("notion")

--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -14,6 +14,7 @@ from nao_core.commands import (  # noqa: E402
     deploy,
     docs,
     init,
+    migrate,
     reset_password,
     skills,
     sync,
@@ -30,6 +31,7 @@ app.command(debug)
 app.command(deploy)
 app.command(docs)
 app.command(init)
+app.command(migrate)
 app.command(reset_password)
 app.command(skills)
 app.command(sync)

--- a/cli/nao_core/templates/engine.py
+++ b/cli/nao_core/templates/engine.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from nao_core.config.llm import LLMConfig, LLMProvider
+from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
 
 # Path to the default templates shipped with nao
 DEFAULT_TEMPLATES_DIR = Path(__file__).parent / "defaults"
@@ -27,18 +27,25 @@ class TemplateEngine:
         override it by creating `<project_root>/templates/databases/preview.md.j2`.
     """
 
-    def __init__(self, project_path: Path | None = None, llm_config: LLMConfig | None = None):
+    def __init__(
+        self,
+        project_path: Path | None = None,
+        llm_config: LLMConfig | ProviderConfig | None = None,
+        annotation_model: str | None = None,
+    ):
         """Initialize the template engine.
 
         Args:
             project_path: Path to the nao project root. If provided,
                           templates in `<project_path>/templates/` will
                           take precedence over defaults.
-            llm_config: Optional LLM settings used by the prompt(...) template helper.
+            llm_config: Optional LLM settings used by the prompt(...) template helper. A full
+                        `LLMConfig` is narrowed down to the provider owning the annotation model.
+            annotation_model: Model used by prompt(...), when `llm_config` is a single provider.
         """
         self.project_path = project_path
         self.user_templates_dir = project_path / "templates" if project_path else None
-        self.llm_config = llm_config
+        self.llm_config, self.annotation_model = _resolve_annotation(llm_config, annotation_model)
 
         # Build list of template directories (user templates first for override)
         loader_paths: list[Path] = []
@@ -102,17 +109,17 @@ class TemplateEngine:
         if not self.llm_config:
             raise RuntimeError(
                 "ai_summary generation requires an `llm` config in nao_config.yaml. "
-                "Configure `llm.provider`, `llm.api_key` (when required by provider), and optionally "
+                "Configure `llm.providers` with an `api_key` (when required by provider), and optionally "
                 "`llm.annotation_model`, or disable the `ai_summary` accessor."
             )
 
         if self.llm_config.requires_api_key and not self.llm_config.api_key:
             raise RuntimeError(
                 f"ai_summary generation requires an API key for provider '{self.llm_config.provider.value}'. "
-                "Set `llm.api_key` in nao_config.yaml or disable `ai_summary`."
+                "Set `api_key` on that provider in nao_config.yaml or disable `ai_summary`."
             )
 
-        model = self.llm_config.annotation_model
+        model = self.annotation_model
         if not model:
             raise RuntimeError("No annotation model configured. Set `llm.annotation_model` in nao_config.yaml.")
 
@@ -286,7 +293,8 @@ class TemplateEngine:
 
         if bool(self.llm_config.access_key) != bool(self.llm_config.secret_key):
             raise RuntimeError(
-                "Bedrock configuration is incomplete: set both `llm.access_key` and `llm.secret_key`, or neither."
+                "Bedrock configuration is incomplete: set both `access_key` and `secret_key` on the provider, "
+                "or neither."
             )
 
         import boto3
@@ -322,7 +330,7 @@ class TemplateEngine:
 
         if not project:
             raise RuntimeError(
-                "Missing GCP project for Vertex. Set `llm.gcp_project` in nao_config.yaml "
+                "Missing GCP project for Vertex. Set `gcp_project` on the vertex provider in nao_config.yaml "
                 "or the GOOGLE_VERTEX_PROJECT env var."
             )
 
@@ -395,7 +403,7 @@ class TemplateEngine:
             try:
                 info = json_lib.loads(json_str)
             except json_lib.JSONDecodeError as e:
-                raise RuntimeError(f"Invalid `llm.service_account_json`: {e}") from e
+                raise RuntimeError(f"Invalid `service_account_json`: {e}") from e
             return service_account.Credentials.from_service_account_info(info, scopes=scopes)
 
         return service_account.Credentials.from_service_account_file(key_file, scopes=scopes)
@@ -470,31 +478,50 @@ _engine: TemplateEngine | None = None
 _engine_signature: tuple[str | None, ...] | None = None
 
 
-def _llm_signature(llm_config: LLMConfig | None) -> tuple[str | None, ...]:
+def _resolve_annotation(
+    llm_config: LLMConfig | ProviderConfig | None,
+    annotation_model: str | None,
+) -> tuple[ProviderConfig | None, str | None]:
+    """Narrow an LLM config down to the provider and model used by the prompt(...) helper."""
+    if isinstance(llm_config, LLMConfig):
+        target = llm_config.annotation_target()
+        return target if target else (None, None)
+    return llm_config, annotation_model
+
+
+def _llm_signature(
+    llm_config: LLMConfig | ProviderConfig | None, annotation_model: str | None
+) -> tuple[str | None, ...]:
     """Return a tuple of LLM config values used as a cache key for the template engine."""
-    if not llm_config:
+    provider_config, model = _resolve_annotation(llm_config, annotation_model)
+    if not provider_config:
         return (None,) * 11
     return (
-        llm_config.provider.value,
-        llm_config.annotation_model,
-        llm_config.base_url,
-        llm_config.api_key,
-        llm_config.access_key,
-        llm_config.secret_key,
-        llm_config.aws_region,
-        llm_config.gcp_project,
-        llm_config.gcp_location,
-        llm_config.service_account_json,
-        llm_config.key_file,
+        provider_config.provider.value,
+        model,
+        provider_config.base_url,
+        provider_config.api_key,
+        provider_config.access_key,
+        provider_config.secret_key,
+        provider_config.aws_region,
+        provider_config.gcp_project,
+        provider_config.gcp_location,
+        provider_config.service_account_json,
+        provider_config.key_file,
     )
 
 
-def get_template_engine(project_path: Path | None = None, llm_config: LLMConfig | None = None) -> TemplateEngine:
+def get_template_engine(
+    project_path: Path | None = None,
+    llm_config: LLMConfig | ProviderConfig | None = None,
+    annotation_model: str | None = None,
+) -> TemplateEngine:
     """Get or create the template engine.
 
     Args:
         project_path: Path to the nao project root.
         llm_config: Optional LLM settings used by prompt(...) helper.
+        annotation_model: Model used by prompt(...), when `llm_config` is a single provider.
 
     Returns:
         The template engine instance
@@ -502,9 +529,13 @@ def get_template_engine(project_path: Path | None = None, llm_config: LLMConfig 
     global _engine, _engine_signature
     signature = (
         str(project_path) if project_path else None,
-        *_llm_signature(llm_config),
+        *_llm_signature(llm_config, annotation_model),
     )
     if _engine is None or _engine_signature != signature:
-        _engine = TemplateEngine(project_path=project_path, llm_config=llm_config)
+        _engine = TemplateEngine(
+            project_path=project_path,
+            llm_config=llm_config,
+            annotation_model=annotation_model,
+        )
         _engine_signature = signature
     return _engine

--- a/cli/tests/nao_core/commands/test_chat.py
+++ b/cli/tests/nao_core/commands/test_chat.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nao_core.commands.chat import (
+    build_llm_env,
     chat,
     ensure_auth_secret,
     get_fastapi_main_path,
@@ -13,6 +14,7 @@ from nao_core.commands.chat import (
     wait_for_server,
 )
 from nao_core.config.base import NaoConfig, NaoConfigError
+from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
 
 # Tests for try_load with exit_on_error=False (default, silent mode)
 
@@ -509,6 +511,51 @@ llm:
         chat_server_call = mock_popen.call_args_list[1]
         env = chat_server_call.kwargs.get("env", {})
         assert env.get("OPENAI_API_KEY") == "sk-test-key-12345"
+
+
+class TestBuildLlmEnv:
+    def test_exports_every_configured_provider(self):
+        llm = LLMConfig(
+            providers=[
+                ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-openai", base_url="http://localhost:4000"),
+                ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key="sk-ant"),
+            ]
+        )
+
+        assert build_llm_env(llm) == {
+            "OPENAI_API_KEY": "sk-openai",
+            "OPENAI_BASE_URL": "http://localhost:4000",
+            "ANTHROPIC_API_KEY": "sk-ant",
+        }
+
+    def test_exports_bedrock_and_vertex_credentials(self):
+        llm = LLMConfig(
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.BEDROCK,
+                    access_key="AKIA_TEST",
+                    secret_key="SECRET_TEST",
+                    aws_region="eu-west-1",
+                ),
+                ProviderConfig(provider=LLMProvider.VERTEX, gcp_project="my-project", gcp_location="us-east5"),
+            ]
+        )
+
+        assert build_llm_env(llm) == {
+            "AWS_ACCESS_KEY_ID": "AKIA_TEST",
+            "AWS_SECRET_ACCESS_KEY": "SECRET_TEST",
+            "AWS_REGION": "eu-west-1",
+            "GOOGLE_VERTEX_PROJECT": "my-project",
+            "GOOGLE_VERTEX_LOCATION": "us-east5",
+        }
+
+    def test_leaves_the_annotation_model_to_the_config_file(self):
+        llm = LLMConfig(
+            providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-openai")],
+            annotation_model="gpt-4.1-mini",
+        )
+
+        assert build_llm_env(llm) == {"OPENAI_API_KEY": "sk-openai"}
 
 
 class TestStartNgrokTunnel:

--- a/cli/tests/nao_core/commands/test_debug.py
+++ b/cli/tests/nao_core/commands/test_debug.py
@@ -1,10 +1,11 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nao_core.commands.debug import check_llm_connection, debug
 from nao_core.config.databases import BigQueryConfig, ClickHouseConfig, DuckDBConfig, PostgresConfig, TrinoConfig
-from nao_core.config.llm import LLMConfig, LLMProvider
+from nao_core.config.llm import LLMProvider, ModelConfig, ProviderConfig
 
 
 class TestLLMConnection:
@@ -13,7 +14,7 @@ class TestLLMConnection:
     """
 
     def test_openai_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test-api-key")
+        config = ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test-api-key")
 
         with patch("openai.OpenAI") as mock_openai_class:
             mock_client = MagicMock()
@@ -27,9 +28,101 @@ class TestLLMConnection:
             assert "3 models available" in message
             mock_openai_class.assert_called_once_with(api_key="sk-test-api-key")
 
+    def test_openai_warns_when_configured_models_missing(self):
+        config = ProviderConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test-api-key",
+            models=[ModelConfig(id="gpt-4.1"), ModelConfig(id="gpt-missing")],
+        )
+
+        with patch("openai.OpenAI") as mock_openai_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [
+                SimpleNamespace(id="gpt-4.1"),
+                SimpleNamespace(id="gpt-4o"),
+            ]
+            mock_openai_class.return_value = mock_client
+
+            success, message = check_llm_connection(config)
+
+            assert success is True
+            assert "Connected successfully" in message
+            assert "Warning: configured model(s) not in provider list: gpt-missing" in message
+
+    def test_openai_no_warning_when_configured_models_available(self):
+        config = ProviderConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test-api-key",
+            models=[ModelConfig(id="gpt-4.1"), ModelConfig(id="gpt-4o")],
+        )
+
+        with patch("openai.OpenAI") as mock_openai_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [
+                SimpleNamespace(id="gpt-4.1"),
+                SimpleNamespace(id="gpt-4o"),
+            ]
+            mock_openai_class.return_value = mock_client
+
+            success, message = check_llm_connection(config)
+
+            assert success is True
+            assert "Warning:" not in message
+
+    def test_gemini_matches_models_prefix(self):
+        config = ProviderConfig(
+            provider=LLMProvider.GEMINI,
+            api_key="test-gemini-key",
+            models=[ModelConfig(id="gemini-2.0-flash")],
+        )
+
+        with patch("google.genai.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client.models.list.return_value = [SimpleNamespace(name="models/gemini-2.0-flash")]
+            mock_client_class.return_value = mock_client
+
+            success, message = check_llm_connection(config)
+
+            assert success is True
+            assert "Warning:" not in message
+
+    def test_ollama_matches_tagged_model(self):
+        config = ProviderConfig(
+            provider=LLMProvider.OLLAMA,
+            models=[ModelConfig(id="llama3.2")],
+        )
+
+        with patch("ollama.list") as mock_list:
+            mock_list.return_value.models = [SimpleNamespace(model="llama3.2:latest")]
+
+            success, message = check_llm_connection(config)
+
+            assert success is True
+            assert "Warning:" not in message
+
+    def test_bedrock_warns_when_configured_models_missing(self):
+        config = ProviderConfig(
+            provider=LLMProvider.BEDROCK,
+            aws_region="us-east-1",
+            models=[ModelConfig(id="anthropic.claude-3-5-sonnet-20241022-v2:0")],
+        )
+
+        with patch("boto3.Session") as mock_session_class:
+            mock_client = MagicMock()
+            mock_client.list_foundation_models.return_value = {"modelSummaries": [{"modelId": "amazon.nova-pro-v1:0"}]}
+            mock_session_class.return_value.client.return_value = mock_client
+
+            success, message = check_llm_connection(config)
+
+            assert success is True
+            assert (
+                "Warning: configured model(s) not in provider list: anthropic.claude-3-5-sonnet-20241022-v2:0"
+                in message
+            )
+
     def test_openai_connection_uses_configured_base_url(self):
         """A custom base_url (e.g. a LiteLLM proxy) must reach the client, not the provider default."""
-        config = LLMConfig(
+        config = ProviderConfig(
             provider=LLMProvider.OPENAI,
             api_key="sk-test-api-key",
             base_url="https://proxy.internal/v1",
@@ -47,7 +140,7 @@ class TestLLMConnection:
 
     def test_openai_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.OPENAI, api_key="invalid")
+        config = ProviderConfig(provider=LLMProvider.OPENAI, api_key="invalid")
 
         with patch("openai.OpenAI") as mock_class:
             mock_class.return_value.models.list.side_effect = Exception("Invalid API key")
@@ -58,7 +151,7 @@ class TestLLMConnection:
             assert "Invalid API key" in message
 
     def test_anthropic_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.ANTHROPIC, api_key="sk-test-api-key")
+        config = ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key="sk-test-api-key")
 
         with patch("anthropic.Anthropic") as mock_anthropic_class:
             mock_client = MagicMock()
@@ -73,7 +166,7 @@ class TestLLMConnection:
             mock_anthropic_class.assert_called_once_with(api_key="sk-test-api-key")
 
     def test_anthropic_connection_uses_configured_base_url(self):
-        config = LLMConfig(
+        config = ProviderConfig(
             provider=LLMProvider.ANTHROPIC,
             api_key="sk-test-api-key",
             base_url="https://proxy.internal/anthropic",
@@ -93,7 +186,7 @@ class TestLLMConnection:
 
     def test_anthropic_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.ANTHROPIC, api_key="invalid")
+        config = ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key="invalid")
 
         with patch("anthropic.Anthropic") as mock_class:
             mock_class.return_value.models.list.side_effect = Exception("Authentication failed")
@@ -104,7 +197,7 @@ class TestLLMConnection:
             assert "Authentication failed" in message
 
     def test_gemini_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.GEMINI, api_key="test-gemini-key")
+        config = ProviderConfig(provider=LLMProvider.GEMINI, api_key="test-gemini-key")
 
         with patch("google.genai.Client") as mock_client_class:
             mock_client = MagicMock()
@@ -120,7 +213,7 @@ class TestLLMConnection:
 
     def test_gemini_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.GEMINI, api_key="invalid")
+        config = ProviderConfig(provider=LLMProvider.GEMINI, api_key="invalid")
 
         with patch("google.genai.Client") as mock_client_class:
             mock_client_class.return_value.models.list.side_effect = Exception("Invalid API key")
@@ -131,7 +224,7 @@ class TestLLMConnection:
             assert "Invalid API key" in message
 
     def test_mistral_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.MISTRAL, api_key="test-mistral-key")
+        config = ProviderConfig(provider=LLMProvider.MISTRAL, api_key="test-mistral-key")
 
         with patch("mistralai.Mistral") as mock_mistral_class:
             mock_client = MagicMock()
@@ -148,7 +241,7 @@ class TestLLMConnection:
 
     def test_mistral_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.MISTRAL, api_key="invalid")
+        config = ProviderConfig(provider=LLMProvider.MISTRAL, api_key="invalid")
 
         with patch("mistralai.Mistral") as mock_class:
             mock_class.return_value.models.list.side_effect = Exception("Unauthorized")
@@ -159,7 +252,7 @@ class TestLLMConnection:
             assert "Unauthorized" in message
 
     def test_openrouter_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.OPENROUTER, api_key="sk-test-api-key")
+        config = ProviderConfig(provider=LLMProvider.OPENROUTER, api_key="sk-test-api-key")
         with patch("openai.OpenAI") as mock_openai_class:
             mock_client = MagicMock()
             mock_client.models.list.return_value = [MagicMock(), MagicMock(), MagicMock()]
@@ -175,7 +268,7 @@ class TestLLMConnection:
 
     def test_openrouter_connection_uses_configured_base_url(self):
         """A configured base_url overrides the OpenRouter default endpoint."""
-        config = LLMConfig(
+        config = ProviderConfig(
             provider=LLMProvider.OPENROUTER,
             api_key="sk-test-api-key",
             base_url="https://proxy.internal/v1",
@@ -192,7 +285,7 @@ class TestLLMConnection:
 
     def test_openrouter_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.OPENROUTER, api_key="invalid")
+        config = ProviderConfig(provider=LLMProvider.OPENROUTER, api_key="invalid")
         with patch("openai.OpenAI") as mock_class:
             mock_class.return_value.models.list.side_effect = Exception("Invalid API key")
 
@@ -202,7 +295,7 @@ class TestLLMConnection:
             assert "Invalid API key" in message
 
     def test_ollama_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.OLLAMA)
+        config = ProviderConfig(provider=LLMProvider.OLLAMA)
 
         with patch("ollama.list") as mock_list:
             mock_list.return_value.models = [MagicMock(), MagicMock(), MagicMock()]
@@ -216,7 +309,7 @@ class TestLLMConnection:
 
     def test_ollama_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.OLLAMA)
+        config = ProviderConfig(provider=LLMProvider.OLLAMA)
 
         with patch("ollama.list") as mock_list:
             mock_list.side_effect = Exception("Connection refused")
@@ -228,7 +321,7 @@ class TestLLMConnection:
 
     def test_bedrock_bearer_token_success(self):
         """A configured bearer token short-circuits without calling AWS."""
-        config = LLMConfig(provider=LLMProvider.BEDROCK, api_key="bearer-token", aws_region="us-west-2")
+        config = ProviderConfig(provider=LLMProvider.BEDROCK, api_key="bearer-token", aws_region="us-west-2")
 
         success, message = check_llm_connection(config)
 
@@ -237,7 +330,7 @@ class TestLLMConnection:
         assert "us-west-2" in message
 
     def test_bedrock_connection_success(self):
-        config = LLMConfig(provider=LLMProvider.BEDROCK, aws_region="us-east-1")
+        config = ProviderConfig(provider=LLMProvider.BEDROCK, aws_region="us-east-1")
 
         with patch("boto3.Session") as mock_session_class:
             mock_client = MagicMock()
@@ -256,7 +349,7 @@ class TestLLMConnection:
 
     def test_bedrock_exception_returns_failure(self):
         """API exception should return False with error message."""
-        config = LLMConfig(provider=LLMProvider.BEDROCK, aws_region="us-east-1")
+        config = ProviderConfig(provider=LLMProvider.BEDROCK, aws_region="us-east-1")
 
         with patch("boto3.Session") as mock_session_class:
             mock_session_class.return_value.client.return_value.list_foundation_models.side_effect = Exception(
@@ -269,7 +362,7 @@ class TestLLMConnection:
             assert "Could not connect to the endpoint URL" in message
 
     def test_vertex_service_account_json_success(self):
-        config = LLMConfig(
+        config = ProviderConfig(
             provider=LLMProvider.VERTEX,
             gcp_project="my-project",
             gcp_location="us-east5",
@@ -288,7 +381,7 @@ class TestLLMConnection:
             )
 
     def test_vertex_key_file_success(self):
-        config = LLMConfig(
+        config = ProviderConfig(
             provider=LLMProvider.VERTEX,
             gcp_project="my-project",
             key_file="/path/to/key.json",
@@ -306,7 +399,7 @@ class TestLLMConnection:
             )
 
     def test_vertex_adc_success(self):
-        config = LLMConfig(provider=LLMProvider.VERTEX, gcp_project="my-project")
+        config = ProviderConfig(provider=LLMProvider.VERTEX, gcp_project="my-project")
 
         with patch("google.auth.default", return_value=(MagicMock(), "my-project")) as mock_default:
             success, message = check_llm_connection(config)
@@ -320,7 +413,7 @@ class TestLLMConnection:
 
     def test_vertex_missing_project_returns_failure(self):
         """Vertex without a gcp_project should return False."""
-        config = LLMConfig(provider=LLMProvider.VERTEX)
+        config = ProviderConfig(provider=LLMProvider.VERTEX)
 
         success, message = check_llm_connection(config)
 
@@ -563,6 +656,32 @@ llm:
         assert any("anthropic" in call for call in calls)
         assert any("[bold green]✓[/bold green]" in call for call in calls)
 
+        mock_check.assert_called_once()
+
+    def test_debug_warns_on_missing_configured_models(self, create_config):
+        create_config("""\
+project_name: test-project
+llm:
+  providers:
+    - provider: openai
+      api_key: sk-test-key
+      models:
+        - id: gpt-missing
+""")
+
+        with patch(
+            "nao_core.commands.debug.check_llm_connection",
+            return_value=(
+                True,
+                "Connected successfully (2 models available). Warning: configured model(s) not in provider list: gpt-missing",
+            ),
+        ) as mock_check:
+            with patch("nao_core.commands.debug.console") as mock_console:
+                debug()
+
+        calls = [str(call) for call in mock_console.print.call_args_list]
+        assert any("[bold yellow]⚠[/bold yellow]" in call for call in calls)
+        assert any("gpt-missing" in call for call in calls)
         mock_check.assert_called_once()
 
     def test_debug_with_llm_error(self, create_config):

--- a/cli/tests/nao_core/commands/test_init.py
+++ b/cli/tests/nao_core/commands/test_init.py
@@ -376,16 +376,16 @@ class TestNaoConfigPromptLLM:
     @patch("nao_core.config.llm.LLMConfig.promptConfig")
     def test_creates_llm_config(self, mock_prompt_config, mock_confirm):
         """Creates LLM config when configured."""
-        from nao_core.config import LLMConfig, LLMProvider, NaoConfig
+        from nao_core.config import LLMConfig, LLMProvider, NaoConfig, ProviderConfig
 
-        mock_llm = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test-key")
+        mock_llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test-key")])
         mock_prompt_config.return_value = mock_llm
         mock_confirm.return_value = True
 
         result_llm = NaoConfig._prompt_llm()
 
         assert result_llm is not None
-        assert result_llm.api_key == "sk-test-key"
+        assert result_llm.providers[0].api_key == "sk-test-key"
         mock_prompt_config.assert_called_once_with(prompt_annotation_model=False)
 
     @patch("nao_core.config.llm.ask_text")
@@ -572,7 +572,7 @@ class TestInitCommand:
     ):
         """Init command runs debug when config has LLM."""
         from nao_core.commands.init import init
-        from nao_core.config import LLMConfig, LLMProvider, NaoConfig
+        from nao_core.config import LLMConfig, LLMProvider, NaoConfig, ProviderConfig
 
         project_path = tmp_path / "test-project"
         project_path.mkdir()
@@ -582,7 +582,7 @@ class TestInitCommand:
             project_name="test-project",
             databases=[],
             repos=[],
-            llm=LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test"),
+            llm=LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")]),
             slack=None,
         )
 

--- a/cli/tests/nao_core/commands/test_migrate.py
+++ b/cli/tests/nao_core/commands/test_migrate.py
@@ -38,6 +38,25 @@ llm:
     )
 
 
+def test_finds_llm_block_with_inline_comment():
+    content = """\
+llm: # shared provider
+  provider: anthropic
+  api_key: sk-test
+"""
+
+    migrated = migrate_llm_block(content)
+
+    assert migrated is not None
+    assert migrated.startswith(
+        """\
+llm: # shared provider
+  providers:
+  - provider: anthropic
+"""
+    )
+
+
 def test_keeps_llm_level_keys_in_place():
     content = """\
 llm:
@@ -83,6 +102,28 @@ llm:
   providers:
     # our shared gateway
   - provider: openai
+"""
+    )
+
+
+def test_uses_first_property_indentation_after_blank_line():
+    content = """\
+llm:
+
+  provider: anthropic
+  api_key: sk-test
+"""
+
+    migrated = migrate_llm_block(content)
+
+    assert migrated is not None
+    assert migrated.startswith(
+        """\
+llm:
+  providers:
+
+  - provider: anthropic
+    api_key: sk-test
 """
     )
 

--- a/cli/tests/nao_core/commands/test_migrate.py
+++ b/cli/tests/nao_core/commands/test_migrate.py
@@ -1,0 +1,151 @@
+"""Unit tests for the migrate command."""
+
+from pathlib import Path
+
+from nao_core.commands.migrate import migrate_llm_block
+from nao_core.config.llm import LLMConfig, LLMProvider
+
+MODELS_HINT = """\
+    # models:
+    # - id: your-model-id
+    #   costs:  # US dollars per million tokens
+    #     input_no_cache: 3
+    #     input_cache_read: 0.3
+    #     input_cache_write: 3.75
+    #     output: 15
+"""
+
+
+def test_nests_a_single_provider_under_providers():
+    content = """\
+project_name: example
+llm:
+  provider: anthropic
+  api_key: sk-test
+slack: null
+"""
+
+    assert migrate_llm_block(content) == (
+        """\
+project_name: example
+llm:
+  providers:
+  - provider: anthropic
+    api_key: sk-test
+"""
+        + MODELS_HINT
+        + "slack: null\n"
+    )
+
+
+def test_keeps_llm_level_keys_in_place():
+    content = """\
+llm:
+  provider: anthropic
+  api_key: sk-test
+  annotation_model: claude-3-5-haiku-latest
+  meta:
+    costs:
+      output: 15
+"""
+
+    migrated = migrate_llm_block(content)
+
+    assert migrated is not None
+    assert migrated.endswith(
+        """\
+  annotation_model: claude-3-5-haiku-latest
+  meta:
+    costs:
+      output: 15
+"""
+    )
+    assert "  - provider: anthropic\n" in migrated
+
+
+def test_preserves_env_placeholders_and_comments():
+    content = """\
+llm:
+  # our shared gateway
+  provider: openai
+  api_key: ${{ env('OPENAI_API_KEY') }}
+  base_url: http://localhost:4000 # litellm
+"""
+
+    migrated = migrate_llm_block(content)
+
+    assert migrated is not None
+    assert "${{ env('OPENAI_API_KEY') }}" in migrated
+    assert "base_url: http://localhost:4000 # litellm" in migrated
+    assert migrated.startswith(
+        """\
+llm:
+  providers:
+    # our shared gateway
+  - provider: openai
+"""
+    )
+
+
+def test_multiline_credentials_keep_their_relative_indentation():
+    content = """\
+llm:
+  provider: vertex
+  gcp_project: my-project
+  service_account_json: |
+    {
+      "client_email": "sa@project.iam.gserviceaccount.com"
+    }
+"""
+
+    migrated = migrate_llm_block(content)
+
+    assert migrated is not None
+    assert "    service_account_json: |\n" in migrated
+    assert '        "client_email": "sa@project.iam.gserviceaccount.com"\n' in migrated
+
+
+def test_returns_none_when_already_migrated():
+    content = """\
+llm:
+  providers:
+  - provider: anthropic
+    api_key: sk-test
+"""
+
+    assert migrate_llm_block(content) is None
+
+
+def test_returns_none_without_an_llm_block():
+    assert migrate_llm_block("project_name: example\n") is None
+
+
+def test_migrated_output_loads_into_the_current_shape(tmp_path: Path):
+    content = """\
+project_name: example
+llm:
+  provider: bedrock
+  aws_region: eu-west-1
+  access_key: AKIA_TEST
+  secret_key: SECRET_TEST
+  annotation_model: anthropic.claude-3-5-sonnet-20241022-v2:0
+"""
+
+    migrated = migrate_llm_block(content)
+    assert migrated is not None
+
+    config_path = tmp_path / "nao_config.yaml"
+    config_path.write_text(migrated)
+
+    import yaml
+
+    data = yaml.safe_load(config_path.read_text())
+    assert not LLMConfig.uses_legacy_shape(data["llm"])
+
+    config = LLMConfig.model_validate(data["llm"])
+    provider_config = config.providers[0]
+    assert provider_config.provider == LLMProvider.BEDROCK
+    assert provider_config.aws_region == "eu-west-1"
+    assert provider_config.access_key == "AKIA_TEST"
+    assert provider_config.secret_key == "SECRET_TEST"
+    assert config.annotation_model == "anthropic.claude-3-5-sonnet-20241022-v2:0"

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -16,7 +16,12 @@ from nao_core.commands.test.client import (
     TestResult as AgentTestResult,
 )
 from nao_core.commands.test.runner import ModelConfig, check_dataframe, filter_test_cases, run_test
+from nao_core.commands.test.runner import (
+    TestRunResult as NaoTestRunResult,
+)
+from nao_core.config.base import NaoConfig
 from nao_core.config.llm import ModelCosts
+from nao_core.config.test import ComparisonConfig, TestConfig
 
 test_runner_module = importlib.import_module("nao_core.commands.test.runner")
 
@@ -261,3 +266,55 @@ def test_filter_test_cases_by_name_without_tests_dir_unchanged():
 
     assert len(filtered) == 1
     assert filtered[0].name == "users"
+
+
+def run_test_command(monkeypatch, tmp_path, config, **flags) -> list[dict]:
+    """Run the `nao test` command against stubbed collaborators and report what it ran."""
+    cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=tmp_path / "orders.yml", sql="select 1"),
+        NaoTestCase(name="users", prompt="p2", file_path=tmp_path / "users.yml", sql="select 1"),
+    ]
+    runs: list[dict] = []
+
+    def run(test_case, model, **kwargs):
+        runs.append({"case": test_case, "model": model, **kwargs})
+        return NaoTestRunResult(name=test_case.name, model=str(model), passed=True, message="match")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(test_runner_module, "NaoConfig", Mock(try_load=Mock(return_value=config)))
+    monkeypatch.setattr(test_runner_module, "discover_tests", lambda project_path: cases)
+    monkeypatch.setattr(test_runner_module, "run_test", run)
+    monkeypatch.setattr(test_runner_module, "save_results", lambda results, output_dir: output_dir / "results.json")
+    monkeypatch.setattr(test_runner_module.UI, "table", lambda *args, **kwargs: None)
+
+    test_runner_module.test(**flags)
+
+    return runs
+
+
+def test_run_uses_the_test_block_defaults(tmp_path, monkeypatch):
+    config = NaoConfig(
+        project_name="test-project",
+        test=TestConfig(models=["anthropic:claude-sonnet-4-5"], comparison=ComparisonConfig(decimals=4)),
+    )
+
+    runs = run_test_command(monkeypatch, tmp_path, config)
+
+    assert [str(run["model"]) for run in runs] == ["anthropic:claude-sonnet-4-5"] * 2
+    assert runs[0]["comparison"].decimals == 4
+
+
+def test_run_falls_back_to_defaults_without_a_test_block(tmp_path, monkeypatch):
+    runs = run_test_command(monkeypatch, tmp_path, NaoConfig(project_name="test-project"))
+
+    assert [str(run["model"]) for run in runs] == ["openai:gpt-4.1"] * 2
+    assert runs[0]["comparison"].decimals == 2
+
+
+def test_model_flag_overrides_the_test_block(tmp_path, monkeypatch):
+    config = NaoConfig(project_name="test-project", test=TestConfig(models=["anthropic:claude-sonnet-4-5"]))
+
+    runs = run_test_command(monkeypatch, tmp_path, config, models=["openai:gpt-4.1"], select="users")
+
+    assert [run["case"].name for run in runs] == ["users"]
+    assert [str(run["model"]) for run in runs] == ["openai:gpt-4.1"]

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from nao_core.config.base import NaoConfig, annotate_optional_templates
+from nao_core.config.base import LLM_OVERRIDE_NOTICE, NaoConfig, annotate_llm_override, annotate_optional_templates
 from nao_core.config.databases.base import DatabaseTemplate, ProfilingRefreshPolicy
 from nao_core.config.databases.duckdb import DuckDBConfig
-from nao_core.config.llm import LLMConfig, LLMProvider
+from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
 from nao_core.config.secrets import process_secrets
 
 
@@ -77,7 +77,7 @@ def test_threads_must_be_positive():
 @patch("nao_core.config.base.ask_confirm")
 @patch("nao_core.config.llm.LLMConfig.promptConfig")
 def test_prompt_llm_skips_annotation_model_prompt(mock_prompt_config, mock_confirm):
-    mock_llm = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test")
+    mock_llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
     mock_prompt_config.return_value = mock_llm
     mock_confirm.return_value = True
 
@@ -108,7 +108,7 @@ def test_apply_default_templates_without_llm():
 
 def test_apply_default_templates_with_llm():
     db = DuckDBConfig(name="test-db", path=":memory:")
-    llm = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test")
+    llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
 
     NaoConfig._apply_default_templates([db], llm=llm)
 
@@ -121,7 +121,7 @@ def test_apply_default_templates_with_llm():
 
 def test_fresh_prompt_flow_only_collects_database_llm_and_repos():
     db = DuckDBConfig(name="test-db", path=":memory:")
-    llm = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test")
+    llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
     prompt_order = []
 
     with (
@@ -215,6 +215,32 @@ def test_annotate_optional_templates_is_noop_without_templates_block(tmp_path):
     config_path.write_text(original)
 
     annotate_optional_templates(config_path)
+
+    assert config_path.read_text() == original
+
+
+def test_annotate_llm_override_comments_above_the_llm_block(tmp_path):
+    config_path = tmp_path / "nao_config.yaml"
+    config_path.write_text("project_name: test-project\nllm:\n  providers:\n  - provider: openai\n")
+
+    annotate_llm_override(config_path)
+
+    assert config_path.read_text() == (
+        "project_name: test-project\n"
+        f"{LLM_OVERRIDE_NOTICE[0]}\n"
+        f"{LLM_OVERRIDE_NOTICE[1]}\n"
+        "llm:\n"
+        "  providers:\n"
+        "  - provider: openai\n"
+    )
+
+
+def test_annotate_llm_override_is_noop_without_llm_block(tmp_path):
+    config_path = tmp_path / "nao_config.yaml"
+    original = "project_name: test-project\ndatabases: []\n"
+    config_path.write_text(original)
+
+    annotate_llm_override(config_path)
 
     assert config_path.read_text() == original
 

--- a/cli/tests/nao_core/config/test_llm.py
+++ b/cli/tests/nao_core/config/test_llm.py
@@ -4,53 +4,247 @@ from unittest.mock import patch
 
 import pytest
 
-from nao_core.config.llm import DEFAULT_ANNOTATION_MODELS, LLMConfig, LLMProvider
+from nao_core.config.llm import (
+    DEFAULT_ANNOTATION_MODELS,
+    LLMConfig,
+    LLMProvider,
+    ModelConfig,
+    ModelCosts,
+    ProviderConfig,
+    parse_provider,
+)
 
 
 def test_default_annotation_model_is_applied():
-    """annotation_model should default based on provider."""
-    config = LLMConfig(provider=LLMProvider.OPENAI, api_key="sk-test")
+    """annotation_model should default based on the primary provider."""
+    config = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
     assert config.annotation_model == DEFAULT_ANNOTATION_MODELS[LLMProvider.OPENAI]
 
 
 def test_ollama_allows_missing_api_key():
     """ollama provider should not require an API key."""
-    config = LLMConfig(provider=LLMProvider.OLLAMA, api_key=None)
+    config = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OLLAMA, api_key=None)])
     assert config.annotation_model == DEFAULT_ANNOTATION_MODELS[LLMProvider.OLLAMA]
 
 
 def test_non_ollama_requires_api_key():
     """providers other than ollama should require API key."""
     with pytest.raises(ValueError, match="api_key is required"):
-        LLMConfig(provider=LLMProvider.ANTHROPIC, api_key=None)
+        ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key=None)
 
 
+def test_requires_at_least_one_provider():
+    with pytest.raises(ValueError, match="at least one entry under `providers`"):
+        LLMConfig(providers=[])
+
+
+def test_rejects_duplicate_providers():
+    with pytest.raises(ValueError, match="configured more than once"):
+        LLMConfig(
+            providers=[
+                ProviderConfig(provider=LLMProvider.OPENAI, api_key="a"),
+                ProviderConfig(provider=LLMProvider.OPENAI, api_key="b"),
+            ]
+        )
+
+
+def test_rejects_duplicate_models():
+    with pytest.raises(ValueError, match="duplicate model 'gpt-4.1'"):
+        ProviderConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test",
+            models=[ModelConfig(id="gpt-4.1"), ModelConfig(id="gpt-4.1")],
+        )
+
+
+def test_rejects_several_default_models():
+    with pytest.raises(ValueError, match="only one model can be the default"):
+        ProviderConfig(
+            provider=LLMProvider.OPENAI,
+            api_key="sk-test",
+            models=[ModelConfig(id="gpt-4.1", default=True), ModelConfig(id="gpt-5", default=True)],
+        )
+
+
+def test_default_model_prefers_the_flagged_one():
+    provider = ProviderConfig(
+        provider=LLMProvider.OPENAI,
+        api_key="sk-test",
+        models=[ModelConfig(id="gpt-4.1"), ModelConfig(id="gpt-5", default=True)],
+    )
+    assert provider.default_model is not None
+    assert provider.default_model.id == "gpt-5"
+
+
+def test_default_model_falls_back_to_the_first_one():
+    provider = ProviderConfig(
+        provider=LLMProvider.OPENAI,
+        api_key="sk-test",
+        models=[ModelConfig(id="gpt-4.1"), ModelConfig(id="gpt-5")],
+    )
+    assert provider.default_model is not None
+    assert provider.default_model.id == "gpt-4.1"
+
+
+def test_costs_are_resolved_per_model():
+    config = LLMConfig(
+        providers=[
+            ProviderConfig(
+                provider=LLMProvider.OPENAI,
+                api_key="sk-test",
+                models=[
+                    ModelConfig(id="gpt-4.1", costs=ModelCosts(input_no_cache=2, output=8)),
+                    ModelConfig(id="gpt-5"),
+                ],
+            )
+        ]
+    )
+
+    priced = config.costs(LLMProvider.OPENAI, "gpt-4.1")
+    assert priced is not None
+    assert priced.input_no_cache == 2
+    assert priced.output == 8
+    assert config.costs(LLMProvider.OPENAI, "gpt-5") is None
+    assert config.costs(LLMProvider.ANTHROPIC, "gpt-4.1") is None
+
+
+def test_costs_fall_back_to_deprecated_meta():
+    config = LLMConfig.model_validate(
+        {
+            "providers": [{"provider": "openai", "api_key": "sk-test"}],
+            "meta": {"costs": {"output": 42}},
+        }
+    )
+    priced = config.costs(LLMProvider.OPENAI, "any-model")
+    assert priced is not None
+    assert priced.output == 42
+
+
+def test_annotation_target_prefers_the_provider_owning_the_model():
+    config = LLMConfig(
+        providers=[
+            ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test"),
+            ProviderConfig(
+                provider=LLMProvider.ANTHROPIC,
+                api_key="sk-ant",
+                models=[ModelConfig(id="claude-haiku-4-5")],
+            ),
+        ],
+        annotation_model="claude-haiku-4-5",
+    )
+
+    target = config.annotation_target()
+    assert target is not None
+    provider_config, model_id = target
+    assert provider_config.provider == LLMProvider.ANTHROPIC
+    assert model_id == "claude-haiku-4-5"
+
+
+def test_annotation_target_falls_back_to_the_primary_provider():
+    config = LLMConfig(
+        providers=[
+            ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test"),
+            ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key="sk-ant"),
+        ]
+    )
+
+    target = config.annotation_target()
+    assert target is not None
+    provider_config, model_id = target
+    assert provider_config.provider == LLMProvider.OPENAI
+    assert model_id == DEFAULT_ANNOTATION_MODELS[LLMProvider.OPENAI]
+
+
+def test_google_is_accepted_as_an_alias_for_gemini():
+    config = LLMConfig.model_validate({"providers": [{"provider": "google", "api_key": "key"}]})
+    assert config.providers[0].provider == LLMProvider.GEMINI
+    assert parse_provider("google") == LLMProvider.GEMINI
+    assert parse_provider("openai") == LLMProvider.OPENAI
+    assert parse_provider("nonsense") is None
+
+
+class TestLegacyShape:
+    """The pre-multi-provider `llm` block must keep working."""
+
+    def test_inline_provider_is_nested_under_providers(self):
+        config = LLMConfig.model_validate(
+            {
+                "provider": "anthropic",
+                "api_key": "sk-ant",
+                "base_url": "http://localhost:4000",
+                "annotation_model": "claude-3-5-haiku-latest",
+            }
+        )
+
+        assert len(config.providers) == 1
+        provider_config = config.providers[0]
+        assert provider_config.provider == LLMProvider.ANTHROPIC
+        assert provider_config.api_key == "sk-ant"
+        assert provider_config.base_url == "http://localhost:4000"
+        assert provider_config.models == []
+        assert config.annotation_model == "claude-3-5-haiku-latest"
+
+    def test_bedrock_credentials_are_preserved(self):
+        config = LLMConfig.model_validate(
+            {
+                "provider": "bedrock",
+                "access_key": "AKIA_TEST",
+                "secret_key": "SECRET_TEST",
+                "aws_region": "eu-west-1",
+            }
+        )
+
+        provider_config = config.providers[0]
+        assert provider_config.access_key == "AKIA_TEST"
+        assert provider_config.secret_key == "SECRET_TEST"
+        assert provider_config.aws_region == "eu-west-1"
+
+    def test_detection_only_matches_the_legacy_shape(self):
+        assert LLMConfig.uses_legacy_shape({"provider": "openai"})
+        assert not LLMConfig.uses_legacy_shape({"providers": [{"provider": "openai"}]})
+        assert not LLMConfig.uses_legacy_shape(None)
+
+
+@patch("nao_core.config.llm.ask_confirm", return_value=False)
 @patch("nao_core.config.llm.ask_text")
 @patch("nao_core.config.llm.ask_select")
-def test_prompt_config_skips_annotation_model_when_disabled(mock_select, mock_text):
+def test_prompt_config_skips_annotation_model_when_disabled(mock_select, mock_text, _mock_confirm):
     """promptConfig should not ask for annotation model when disabled."""
     mock_select.return_value = "openai"
     mock_text.return_value = "sk-test-key"
 
     config = LLMConfig.promptConfig(prompt_annotation_model=False)
 
-    assert config.provider == LLMProvider.OPENAI
-    assert config.api_key == "sk-test-key"
+    assert config.providers[0].provider == LLMProvider.OPENAI
+    assert config.providers[0].api_key == "sk-test-key"
     assert config.annotation_model is None
     assert "annotation_model" not in config.model_dump(exclude_none=True)
     assert mock_text.call_count == 1
 
 
+@patch("nao_core.config.llm.ask_confirm", return_value=False)
 @patch("nao_core.config.llm.ask_text")
 @patch("nao_core.config.llm.ask_select")
-def test_prompt_config_prompts_annotation_model_when_enabled(mock_select, mock_text):
+def test_prompt_config_prompts_annotation_model_when_enabled(mock_select, mock_text, _mock_confirm):
     """promptConfig should ask for annotation model when enabled."""
     mock_select.return_value = "openai"
     mock_text.side_effect = ["sk-test-key", "gpt-4.1"]
 
     config = LLMConfig.promptConfig(prompt_annotation_model=True)
 
-    assert config.provider == LLMProvider.OPENAI
-    assert config.api_key == "sk-test-key"
+    assert config.providers[0].provider == LLMProvider.OPENAI
     assert config.annotation_model == "gpt-4.1"
     assert mock_text.call_count == 2
+
+
+@patch("nao_core.config.llm.ask_confirm", side_effect=[True, False])
+@patch("nao_core.config.llm.ask_text")
+@patch("nao_core.config.llm.ask_select")
+def test_prompt_config_collects_several_providers(mock_select, mock_text, _mock_confirm):
+    """promptConfig should keep asking until the user declines another provider."""
+    mock_select.side_effect = ["openai", "anthropic"]
+    mock_text.side_effect = ["sk-openai", "sk-anthropic"]
+
+    config = LLMConfig.promptConfig(prompt_annotation_model=False)
+
+    assert [p.provider for p in config.providers] == [LLMProvider.OPENAI, LLMProvider.ANTHROPIC]

--- a/cli/tests/nao_core/config/test_llm.py
+++ b/cli/tests/nao_core/config/test_llm.py
@@ -248,3 +248,7 @@ def test_prompt_config_collects_several_providers(mock_select, mock_text, _mock_
     config = LLMConfig.promptConfig(prompt_annotation_model=False)
 
     assert [p.provider for p in config.providers] == [LLMProvider.OPENAI, LLMProvider.ANTHROPIC]
+    second_provider_choices = mock_select.call_args_list[1].kwargs["choices"]
+    assert {choice.value for choice in second_provider_choices} == {
+        provider.value for provider in LLMProvider if provider != LLMProvider.OPENAI
+    }

--- a/cli/tests/nao_core/config/test_test_config.py
+++ b/cli/tests/nao_core/config/test_test_config.py
@@ -1,0 +1,57 @@
+import pytest
+from pydantic import ValidationError
+
+from nao_core.config.base import NaoConfig
+from nao_core.config.test import TestConfig
+
+
+def test_test_block_is_loaded_from_config(tmp_path):
+    config_file = tmp_path / "nao_config.yaml"
+    config_file.write_text(
+        "project_name: test-project\n"
+        "test:\n"
+        "  models:\n"
+        "  - openai:gpt-4.1\n"
+        "  - anthropic:claude-sonnet-4-5\n"
+        "  threads: 4\n"
+        "  comparison:\n"
+        "    rtol: 0.001\n"
+        "    atol: 0.01\n"
+        "    decimals: 4\n"
+    )
+
+    config = NaoConfig.load(tmp_path)
+
+    assert config.test is not None
+    assert config.test.models == ["openai:gpt-4.1", "anthropic:claude-sonnet-4-5"]
+    assert config.test.threads == 4
+    assert config.test.comparison.rtol == 0.001
+    assert config.test.comparison.atol == 0.01
+    assert config.test.comparison.decimals == 4
+
+
+def test_test_block_is_optional():
+    config = NaoConfig(project_name="test-project")
+
+    assert config.test is None
+
+
+def test_defaults():
+    test_config = TestConfig()
+
+    assert test_config.models == ["openai:gpt-4.1"]
+    assert test_config.threads == 1
+    assert test_config.comparison.rtol == 1e-5
+    assert test_config.comparison.atol == 1e-8
+    assert test_config.comparison.decimals == 2
+
+
+@pytest.mark.parametrize("model", ["gpt-4.1", "openai:", ":gpt-4.1"])
+def test_models_must_declare_a_provider_and_a_model_id(model):
+    with pytest.raises(ValidationError, match="provider:model_id"):
+        TestConfig(models=[model])
+
+
+def test_threads_must_be_positive():
+    with pytest.raises(ValidationError):
+        TestConfig(threads=0)

--- a/cli/tests/nao_core/templates/test_engine.py
+++ b/cli/tests/nao_core/templates/test_engine.py
@@ -7,12 +7,33 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nao_core.config.llm import LLMConfig, LLMProvider
+from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
 from nao_core.templates.engine import (
     DEFAULT_TEMPLATES_DIR,
     TemplateEngine,
     get_template_engine,
 )
+
+
+def _openai_llm(*, api_key: str, annotation_model: str) -> LLMConfig:
+    return LLMConfig(
+        providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key=api_key)],
+        annotation_model=annotation_model,
+    )
+
+
+def _bedrock_llm(*, aws_region: str) -> LLMConfig:
+    return LLMConfig(
+        providers=[
+            ProviderConfig(
+                provider=LLMProvider.BEDROCK,
+                access_key="AKIA_TEST",
+                secret_key="SECRET_TEST",
+                aws_region=aws_region,
+            )
+        ],
+        annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
 
 
 class TestTemplateEngine:
@@ -132,8 +153,7 @@ class TestTemplateEngine:
 
     def test_ai_summary_uses_profiling_and_non_representative_preview(self):
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="sk-test",
+            providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")],
             annotation_model="gpt-4.1-mini",
         )
         engine = TemplateEngine(llm_config=llm_config)
@@ -168,8 +188,7 @@ class TestTemplateEngine:
 
     def test_ai_summary_skips_quality_claims_without_profiling(self):
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="sk-test",
+            providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")],
             annotation_model="gpt-4.1-mini",
         )
         engine = TemplateEngine(llm_config=llm_config)
@@ -195,8 +214,7 @@ class TestTemplateEngine:
 
     def test_ai_summary_skips_quality_claims_with_empty_profiling_columns(self):
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="sk-test",
+            providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")],
             annotation_model="gpt-4.1-mini",
         )
         engine = TemplateEngine(llm_config=llm_config)
@@ -279,8 +297,7 @@ class TestTemplateEngine:
         (templates_dir / "test.j2").write_text("{{ prompt('hello world') }}")
 
         llm_config = LLMConfig(
-            provider=LLMProvider.OPENAI,
-            api_key="sk-test",
+            providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")],
             annotation_model="gpt-4.1-mini",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -298,11 +315,15 @@ class TestTemplateEngine:
         (templates_dir / "test.j2").write_text("{{ prompt('summarize this') }}")
 
         llm_config = LLMConfig(
-            provider=LLMProvider.BEDROCK,
-            api_key=None,
-            access_key="AKIA_TEST",
-            secret_key="SECRET_TEST",
-            aws_region="us-east-1",
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.BEDROCK,
+                    api_key=None,
+                    access_key="AKIA_TEST",
+                    secret_key="SECRET_TEST",
+                    aws_region="us-east-1",
+                )
+            ],
             annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -316,11 +337,15 @@ class TestTemplateEngine:
     def test_generate_bedrock_uses_explicit_aws_credentials(self, tmp_path: Path, monkeypatch):
         """Bedrock client should use configured credentials and region when provided."""
         llm_config = LLMConfig(
-            provider=LLMProvider.BEDROCK,
-            api_key=None,
-            access_key="AKIA_TEST",
-            secret_key="SECRET_TEST",
-            aws_region="us-west-2",
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.BEDROCK,
+                    api_key=None,
+                    access_key="AKIA_TEST",
+                    secret_key="SECRET_TEST",
+                    aws_region="us-west-2",
+                )
+            ],
             annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -349,10 +374,14 @@ class TestTemplateEngine:
     def test_generate_bedrock_rejects_partial_static_credentials(self, tmp_path: Path):
         """Providing only one of access_key/secret_key should fail with a clear error."""
         llm_config = LLMConfig(
-            provider=LLMProvider.BEDROCK,
-            api_key=None,
-            access_key="AKIA_TEST",
-            secret_key=None,
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.BEDROCK,
+                    api_key=None,
+                    access_key="AKIA_TEST",
+                    secret_key=None,
+                )
+            ],
             annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -363,9 +392,13 @@ class TestTemplateEngine:
     def test_generate_anthropic_forwards_base_url(self, tmp_path: Path, monkeypatch):
         """Anthropic client should receive base_url when configured."""
         llm_config = LLMConfig(
-            provider=LLMProvider.ANTHROPIC,
-            api_key="sk-ant-test",
-            base_url="https://custom-endpoint.example.com/anthropic/v1",
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.ANTHROPIC,
+                    api_key="sk-ant-test",
+                    base_url="https://custom-endpoint.example.com/anthropic/v1",
+                )
+            ],
             annotation_model="claude-3-5-sonnet-latest",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -389,8 +422,7 @@ class TestTemplateEngine:
     def test_generate_anthropic_no_base_url(self, tmp_path: Path, monkeypatch):
         """Anthropic client should use default base_url when not configured."""
         llm_config = LLMConfig(
-            provider=LLMProvider.ANTHROPIC,
-            api_key="sk-ant-test",
+            providers=[ProviderConfig(provider=LLMProvider.ANTHROPIC, api_key="sk-ant-test")],
             annotation_model="claude-3-5-sonnet-latest",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -417,9 +449,13 @@ class TestTemplateEngine:
         (templates_dir / "test.j2").write_text("{{ prompt('hello world') }}")
 
         llm_config = LLMConfig(
-            provider=LLMProvider.ANTHROPIC,
-            api_key="sk-ant-test",
-            base_url="https://custom-endpoint.example.com/v1",
+            providers=[
+                ProviderConfig(
+                    provider=LLMProvider.ANTHROPIC,
+                    api_key="sk-ant-test",
+                    base_url="https://custom-endpoint.example.com/v1",
+                )
+            ],
             annotation_model="claude-3-5-sonnet-latest",
         )
         engine = TemplateEngine(project_path=tmp_path, llm_config=llm_config)
@@ -594,8 +630,8 @@ class TestGetTemplateEngine:
         engine_module._engine = None
         engine_module._engine_signature = None
 
-        llm1 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k1", annotation_model="gpt-4.1-mini")
-        llm2 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k1", annotation_model="gpt-4.1")
+        llm1 = _openai_llm(api_key="k1", annotation_model="gpt-4.1-mini")
+        llm2 = _openai_llm(api_key="k1", annotation_model="gpt-4.1")
 
         engine1 = get_template_engine(llm_config=llm1)
         engine2 = get_template_engine(llm_config=llm2)
@@ -609,8 +645,8 @@ class TestGetTemplateEngine:
         engine_module._engine = None
         engine_module._engine_signature = None
 
-        llm1 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k1", annotation_model="gpt-4.1-mini")
-        llm2 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k2", annotation_model="gpt-4.1-mini")
+        llm1 = _openai_llm(api_key="k1", annotation_model="gpt-4.1-mini")
+        llm2 = _openai_llm(api_key="k2", annotation_model="gpt-4.1-mini")
 
         engine1 = get_template_engine(llm_config=llm1)
         engine2 = get_template_engine(llm_config=llm2)
@@ -624,8 +660,8 @@ class TestGetTemplateEngine:
         engine_module._engine = None
         engine_module._engine_signature = None
 
-        llm1 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k1", annotation_model="gpt-4.1-mini")
-        llm2 = LLMConfig(provider=LLMProvider.OPENAI, api_key="k1", annotation_model="gpt-4.1-mini")
+        llm1 = _openai_llm(api_key="k1", annotation_model="gpt-4.1-mini")
+        llm2 = _openai_llm(api_key="k1", annotation_model="gpt-4.1-mini")
 
         engine1 = get_template_engine(llm_config=llm1)
         engine2 = get_template_engine(llm_config=llm2)
@@ -639,20 +675,8 @@ class TestGetTemplateEngine:
         engine_module._engine = None
         engine_module._engine_signature = None
 
-        llm1 = LLMConfig(
-            provider=LLMProvider.BEDROCK,
-            annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-            access_key="AKIA_TEST",
-            secret_key="SECRET_TEST",
-            aws_region="us-east-1",
-        )
-        llm2 = LLMConfig(
-            provider=LLMProvider.BEDROCK,
-            annotation_model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-            access_key="AKIA_TEST",
-            secret_key="SECRET_TEST",
-            aws_region="eu-west-1",
-        )
+        llm1 = _bedrock_llm(aws_region="us-east-1")
+        llm2 = _bedrock_llm(aws_region="eu-west-1")
 
         engine1 = get_template_engine(llm_config=llm1)
         engine2 = get_template_engine(llm_config=llm2)

--- a/example/nao_config.yaml
+++ b/example/nao_config.yaml
@@ -16,5 +16,13 @@ repos:
   url: https://github.com/dbt-labs/jaffle_shop_duckdb.git
   branch: null
 notion: null
-llm: null
+llm:
+  providers:
+  - provider: openai
+    api_key: sk-test
+    models:
+    - name: gpt-4.1
+      id: gpt-4.1
+    - name: gpt-4.1-turbo-mini-2026-07-19
+      id: gpt-4.1-turbo-mini-2026-07-19
 slack: null

--- a/skills/deploy-context/SKILL.md
+++ b/skills/deploy-context/SKILL.md
@@ -156,7 +156,7 @@ If the run fails, jump to the troubleshooting matrix below before changing anyth
 
 ## Guardrails
 
-- **Never commit secrets.** Every credential in `nao_config.yaml` must be `{{ env('VAR_NAME') }}` (warehouse, Notion, etc.) or `${VAR_NAME}` (LLM keys). Audit before first push.
+- **Never commit secrets.** Every credential in `nao_config.yaml`, including LLM keys, must use `${{ env('VAR_NAME') }}`. Audit before first push.
 - **Never paste the API key into chat.** Direct the user to copy it once from the UI and add it straight to GitHub Secrets.
 - **One API key per repo / per environment.** Revocations stay surgical.
 - **Use GitHub Environments for prod.** Approval gates + scoped secrets. Plain repo secrets are fine for a single staging deploy, not for production.

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -85,7 +85,7 @@ Hand off directly to `write-context-rules`. Don't ask.
 
 The key lives in `nao_config.yaml`. Two safe options:
 
-- **Preferred:** env-var ref. Write `api_key: ${ANTHROPIC_API_KEY}`; tell the user to export the key in their shell.
+- **Preferred:** env-var ref. Write `api_key: ${ANTHROPIC_API_KEY}` on the provider entry; tell the user to export the key in their shell.
 - **If they insist on a literal:** tell them to edit the yaml themselves and add it to `.gitignore`. **Never** ask them to paste a key into chat.
 
 Then `nao debug` to confirm.
@@ -136,8 +136,12 @@ databases:
       templates: [columns, preview, description]
 
 llm:
-    provider: anthropic # openai | bedrock | azure | gemini | mistral | ollama
-    api_key: ${ANTHROPIC_API_KEY}
+    providers:
+        - provider: anthropic # openai | bedrock | gemini | mistral | openrouter | ollama | vertex
+          api_key: ${ANTHROPIC_API_KEY}
+          models: # optional, defaults to the provider's built-in models
+              - id: claude-sonnet-4-5
+                default: true
 
 repos:
     - name: <repo-name>

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -45,7 +45,7 @@ Send a single message asking for:
       • scope: include=["analytics.fct_*", "analytics.dim_*"], exclude=[]
       • templates: [columns, preview, description]
       • repos: company-dbt (git@github.com:org/company-dbt.git)
-      • llm: anthropic (key via ${ANTHROPIC_API_KEY})
+      • llm: anthropic (key via ${{ env('ANTHROPIC_API_KEY') }})
     ```
 
     The model is configured in the nao UI, not in `nao_config.yaml` — don't include a model ID in the summary or the yaml.
@@ -85,7 +85,7 @@ Hand off directly to `write-context-rules`. Don't ask.
 
 The key lives in `nao_config.yaml`. Two safe options:
 
-- **Preferred:** env-var ref. Write `api_key: ${ANTHROPIC_API_KEY}` on the provider entry; tell the user to export the key in their shell.
+- **Preferred:** env-var ref. Write `api_key: ${{ env('ANTHROPIC_API_KEY') }}` on the provider entry; tell the user to export the key in their shell.
 - **If they insist on a literal:** tell them to edit the yaml themselves and add it to `.gitignore`. **Never** ask them to paste a key into chat.
 
 Then `nao debug` to confirm.
@@ -138,7 +138,7 @@ databases:
 llm:
     providers:
         - provider: anthropic # openai | bedrock | gemini | mistral | openrouter | ollama | vertex
-          api_key: ${ANTHROPIC_API_KEY}
+          api_key: ${{ env('ANTHROPIC_API_KEY') }}
           models: # optional, defaults to the provider's built-in models
               - id: claude-sonnet-4-5
                 default: true


### PR DESCRIPTION
This is a major improvement of the way we define LLMs in `nao_config.yaml`.

Starting with this PR the `nao_config.yaml` will be taken into account in the nao harness, the config defined in the YAML will be used in the agent ; in the current situation it was not the case (except for `nao chat` command) after this in production it wasn't used.

This way as an admin I will be able to see LLM configuration as a deterministic config in the YAML and change it from there. Good to know, once changed in the UI it overrides the YAML config.

Summary of the changes:

### llm key in `nao_config.yaml` is multi provider now

You can defined now multiple providers in the llm key section:

```
llm:
  providers:
  - provider: openai
    # base_url:
    api_key: sk-...
    models:
    - id: gpt-5.5
    - id: gpt-5.6-sol
      default: true
      costs:
        input_no_cache: 3
        input_cache_read: 0.3
        input_cache_write: 3.75
        output: 15
  - provider: anthropic
    models:
    - id: claude-opus-5
```

etc.

### Added a new section test in the config so you can configured which models you want to use

```
test:
  models:
  - openai:gpt-5.5
  - openai:gpt-5.6-sol
```