### PR TITLE
Added Langfuse support for llm observability

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -214,6 +214,9 @@ jobs:
                         -e GOOGLE_APPLICATION_CREDENTIALS_JSON='${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}' \
                         -e "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" \
                         -e "ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" \
+                        -e "LANGFUSE_PUBLIC_KEY=${{ secrets.MOON_LANGFUSE_PUBLIC_KEY }}" \
+                        -e "LANGFUSE_SECRET_KEY=${{ secrets.MOON_LANGFUSE_SECRET_KEY }}" \
+                        -e "LANGFUSE_BASE_URL=${{ secrets.MOON_LANGFUSE_BASE_URL }}" \
                         -e "BETTER_AUTH_SECRET=${{ secrets.BETTER_AUTH_SECRET }}" \
                         -e "ENABLE_USER_SIGNUP=false" \
                         -e "BETA_AUTOMATIONS_ENABLED=true" \
@@ -259,6 +262,9 @@ jobs:
                           -e "NAO_MODE=cloud" \
                           -e "GITHUB_CLIENT_ID=${{ secrets.CLOUD_GITHUB_CLIENT_ID }}" \
                           -e "GITHUB_CLIENT_SECRET=${{ secrets.CLOUD_GITHUB_CLIENT_SECRET }}" \
+                          -e "LANGFUSE_PUBLIC_KEY=${{ secrets.CLOUD_LANGFUSE_PUBLIC_KEY }}" \
+                          -e "LANGFUSE_SECRET_KEY=${{ secrets.CLOUD_LANGFUSE_SECRET_KEY }}" \
+                          -e "LANGFUSE_BASE_URL=${{ secrets.CLOUD_LANGFUSE_BASE_URL }}" \
                           -e "GITHUB_SSO=true" \
                           -e "POSTHOG_DISABLED=true" \
                           -e "NAO_CONTEXT_SOURCE=api" \

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -61,7 +61,6 @@
 		"@fastify/multipart": "^10.0.0",
 		"@fastify/static": "^8.1.0",
 		"@langfuse/otel": "^5.9.1",
-		"@langfuse/tracing": "^5.9.1",
 		"@microsoft/microsoft-graph-client": "^3.0.7",
 		"@modelcontextprotocol/ext-apps": "^1.7.1",
 		"@modelcontextprotocol/sdk": "^1.29.0",

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -117,9 +117,19 @@ const envSchema = z.object({
 		.optional()
 		.transform((val) => val === 'true'),
 
-	LANGFUSE_PUBLIC_KEY: z.string().optional(),
-	LANGFUSE_SECRET_KEY: z.string().optional(),
-	LANGFUSE_BASE_URL: z.url({ message: 'LANGFUSE_BASE_URL must be a valid URL' }).optional(),
+	LANGFUSE_PUBLIC_KEY: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined),
+	LANGFUSE_SECRET_KEY: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined),
+	LANGFUSE_BASE_URL: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined)
+		.pipe(z.url({ message: 'LANGFUSE_BASE_URL must be a valid URL' }).optional()),
 
 	BETA_AUTOMATIONS_ENABLED: z
 		.enum(['true', 'false'])

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,6 @@
         "@fastify/multipart": "^10.0.0",
         "@fastify/static": "^8.1.0",
         "@langfuse/otel": "^5.9.1",
-        "@langfuse/tracing": "^5.9.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@modelcontextprotocol/ext-apps": "^1.7.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -617,8 +616,6 @@
     "@langfuse/core": ["@langfuse/core@5.9.1", "", { "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-KvyAskAO+2ixJwr9wy148ttR/Zn3oapvOJ2Br4Xcp6zhDpjSIIGB4jW/jkp53/KU9MyEHj0RSFPK/yKoxLC4KA=="],
 
     "@langfuse/otel": ["@langfuse/otel@5.9.1", "", { "dependencies": { "@langfuse/core": "^5.9.1" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0", "@opentelemetry/sdk-trace-base": "^2.0.1" } }, "sha512-viM5Qq/AIPZPXfO7YdSmDHxEDSrNU/MyGzuE9zKA6hGBII1iLowU+qL99O+TjnXqxoADqlNibhY2pg1/WTIPcw=="],
-
-    "@langfuse/tracing": ["@langfuse/tracing@5.9.1", "", { "dependencies": { "@langfuse/core": "^5.9.1" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-tJRyVAv1JkuOPh4Uz5eWUNH8U4jcJVtK2F5QNy5cZUzXCSrXobCSHusPbxY6VFZcLcFgtpDtSaxL7ev1tV2JNQ=="],
 
     "@libsql/client": ["@libsql/client@0.15.15", "", { "dependencies": { "@libsql/core": "^0.15.14", "@libsql/hrana-client": "^0.7.0", "js-base64": "^3.7.5", "libsql": "^0.5.22", "promise-limit": "^2.7.0" } }, "sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,13 @@ services:
             ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
 
             # =================================================================
+            # Langfuse LLM tracing (optional)
+            # =================================================================
+            LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY:-}
+            LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY:-}
+            LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-}
+
+            # =================================================================
             # Database for nao chat history
             # =================================================================
             DB_URI: postgres://${POSTGRES_USER:-nao}:${POSTGRES_PASSWORD:-nao}@postgres:5432/${POSTGRES_DB:-nao}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
 				"@fastify/multipart": "^10.0.0",
 				"@fastify/static": "^8.1.0",
 				"@langfuse/otel": "^5.9.1",
-				"@langfuse/tracing": "^5.9.1",
 				"@microsoft/microsoft-graph-client": "^3.0.7",
 				"@modelcontextprotocol/ext-apps": "^1.7.1",
 				"@modelcontextprotocol/sdk": "^1.29.0",
@@ -4524,21 +4523,6 @@
 				"@opentelemetry/core": "^2.0.1",
 				"@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0",
 				"@opentelemetry/sdk-trace-base": "^2.0.1"
-			}
-		},
-		"node_modules/@langfuse/tracing": {
-			"version": "5.9.1",
-			"resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.9.1.tgz",
-			"integrity": "sha512-tJRyVAv1JkuOPh4Uz5eWUNH8U4jcJVtK2F5QNy5cZUzXCSrXobCSHusPbxY6VFZcLcFgtpDtSaxL7ev1tV2JNQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@langfuse/core": "^5.9.1"
-			},
-			"engines": {
-				"node": ">=20"
-			},
-			"peerDependencies": {
-				"@opentelemetry/api": "^1.9.0"
 			}
 		},
 		"node_modules/@lukeed/ms": {


### PR DESCRIPTION
## Summary

- nao can now send its LLM traces to Langfuse when running in Docker: the container only receives a fixed list of settings, and the Langfuse ones are now on it.
- Turned tracing on for moon and cloud, each with its own keys from new `MOON_LANGFUSE_*` / `CLOUD_LANGFUSE_*` secrets, so they report into separate Langfuse projects.
- Dropped `@langfuse/tracing`, which was installed but never imported.

Tracing stays off unless all three env variables are present, and still refuses to run without an explicit destination URL, so nothing is exported by accident.

Closes #573

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

