### PR TITLE
Fix xaxis value in the tooltip if not a string

### DIFF
--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -140,13 +140,14 @@ function ChartTooltipContent({
 		const [item] = payload;
 		const key = `${labelKey || item?.dataKey || item?.name || 'value'}`;
 		const itemConfig = getPayloadConfigFromPayload(config, item, key);
-		const value = !labelKey && typeof label === 'string' ? config[label]?.label || label : itemConfig?.label;
+		const isAxisValue = !labelKey && (typeof label === 'string' || typeof label === 'number');
+		const value = isAxisValue ? config[String(label)]?.label || label : itemConfig?.label;
 
 		if (labelFormatter) {
 			return <div className={cn('font-medium', labelClassName)}>{labelFormatter(value, payload)}</div>;
 		}
 
-		if (!value) {
+		if (value === undefined || value === null || value === '') {
 			return null;
 		}
 


### PR DESCRIPTION
fixes #1287 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

