### PR TITLE
Compare nao test results against the full query result

### DIFF
--- a/apps/backend/src/services/test-agent.service.ts
+++ b/apps/backend/src/services/test-agent.service.ts
@@ -1,3 +1,4 @@
+import type { executeSql } from '@nao/shared/tools';
 import type { LlmSelectedModel } from '@nao/shared/types';
 import { generateText, ModelMessage, Output } from 'ai';
 import { z } from 'zod/v4';
@@ -47,6 +48,9 @@ export class TestAgentService extends AgentService {
 	/**
 	 * Run a verification prompt to extract structured data from the agent's response.
 	 * Uses the responseMessages directly from the agent result to avoid double transformation.
+	 *
+	 * The model only picks which query result answers the question; the rows come from
+	 * the raw execute_sql output, which is never truncated the way the transcript is.
 	 */
 	async runVerification(
 		projectId: string,
@@ -71,7 +75,39 @@ export class TestAgentService extends AgentService {
 			experimental_telemetry: llmTelemetry('nao-test-verification', { projectId }),
 		});
 
-		return { data: result.output.data ?? null };
+		const { queryId, columns, data } = result.output;
+		const queryRows = queryId
+			? TestAgentService.resolveQueryRows(agentResult, { queryId, columns }, expectedColumns)
+			: null;
+
+		return { data: queryRows ?? data ?? null };
+	}
+
+	/**
+	 * Read the complete rows of a query the agent ran, renamed to the expected columns.
+	 * Returns null when the query id is unknown, so the caller can fall back.
+	 */
+	static resolveQueryRows(
+		agentResult: AgentRunResult,
+		selection: { queryId: string; columns: string[] | null },
+		expectedColumns: string[],
+	): VerificationData {
+		const output = TestAgentService.extractToolCalls(agentResult)
+			.filter((call) => call.toolName === 'execute_sql')
+			.map((call) => call.result as executeSql.Output | undefined)
+			.filter((result) => result?.id === selection.queryId)
+			.at(-1);
+
+		if (!output?.data) {
+			return null;
+		}
+
+		const sourceColumns =
+			selection.columns?.length === expectedColumns.length ? selection.columns : expectedColumns;
+
+		return output.data.map((row) =>
+			Object.fromEntries(expectedColumns.map((column, index) => [column, row[sourceColumns[index]] ?? null])),
+		);
 	}
 
 	private static _buildUserMessage(text: string): UIMessage {
@@ -85,11 +121,13 @@ export class TestAgentService extends AgentService {
 	private static _buildVerificationPrompt(columns: string[]): string {
 		return `Based on your previous analysis, provide the final answer to the original question.
 
-Format the data with these columns: ${columns.join(', ')}
+The answer has these columns: ${columns.join(', ')}
 
-Return the data as an array of rows, where each row is an object with the column names as keys.
+If one execute_sql result already holds the final answer, set queryId to its Query ID and set columns to that result's column names matching the ones above, in the same order. Leave data null: the full rows are read from the query itself, so never retype them.
 
-If you cannot answer, set data to null.`;
+Only when no single query result holds the answer, set queryId to null and return the rows in data.
+
+If you cannot answer, set every field to null.`;
 	}
 
 	private static _buildVerificationSchema(columns: string[]) {
@@ -99,9 +137,15 @@ If you cannot answer, set data to null.`;
 		);
 
 		return z.object({
+			queryId: z
+				.nullable(z.string())
+				.describe('Query ID of the execute_sql result holding the answer. Null if no single query holds it.'),
+			columns: z
+				.nullable(z.array(z.string()))
+				.describe(`Columns of that query result matching, in order: ${columns.join(', ')}`),
 			data: z
 				.nullable(z.array(rowSchema))
-				.describe('Array of rows with the data. Return null if unable to answer.'),
+				.describe('Array of rows with the data. Only fill this when queryId is null.'),
 		});
 	}
 

--- a/apps/backend/tests/test-agent-verification.test.ts
+++ b/apps/backend/tests/test-agent-verification.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The agent stack pulls in bun:sqlite, which the node runner cannot load.
+vi.mock('../src/services/agent', () => ({ AgentService: class {} }));
+
+import type { AgentRunResult } from '../src/services/agent';
+import { TestAgentService } from '../src/services/test-agent.service';
+
+function agentResultWithQuery(id: string, columns: string[], data: Record<string, unknown>[]): AgentRunResult {
+	return {
+		steps: [
+			{
+				toolCalls: [{ toolName: 'execute_sql', toolCallId: 'call_1', input: { sql_query: 'select 1' } }],
+				toolResults: [
+					{
+						toolCallId: 'call_1',
+						output: { _version: '1', id, columns, data, row_count: data.length },
+					},
+				],
+			},
+		],
+	} as unknown as AgentRunResult;
+}
+
+describe('TestAgentService.resolveQueryRows', () => {
+	it('returns every row of the query, past the 40 rows the transcript shows', () => {
+		const data = Array.from({ length: 250 }, (_, index) => ({ country: `c${index}`, total: index }));
+		const agentResult = agentResultWithQuery('query_abc123', ['country', 'total'], data);
+
+		const rows = TestAgentService.resolveQueryRows(
+			agentResult,
+			{ queryId: 'query_abc123', columns: ['country', 'total'] },
+			['country', 'total'],
+		);
+
+		expect(rows).toHaveLength(250);
+		expect(rows?.at(-1)).toEqual({ country: 'c249', total: 249 });
+	});
+
+	it('renames the query columns to the expected columns, in order', () => {
+		const agentResult = agentResultWithQuery('query_abc123', ['nation', 'revenue'], [{ nation: 'FR', revenue: 7 }]);
+
+		const rows = TestAgentService.resolveQueryRows(
+			agentResult,
+			{ queryId: 'query_abc123', columns: ['nation', 'revenue'] },
+			['country', 'total'],
+		);
+
+		expect(rows).toEqual([{ country: 'FR', total: 7 }]);
+	});
+
+	it('returns null for an unknown query id so the caller can fall back', () => {
+		const agentResult = agentResultWithQuery('query_abc123', ['total'], [{ total: 1 }]);
+
+		expect(TestAgentService.resolveQueryRows(agentResult, { queryId: 'query_zzz', columns: null }, ['total'])).toBe(
+			null,
+		);
+	});
+});


### PR DESCRIPTION
Closes #1291

## Summary

- `nao test` now compares against the agent's real query result instead of a retyped copy of it, so a test whose golden SQL returns more rows than the transcript shows no longer fails on row count.
- The verification model now only names the `execute_sql` result that answers the question and maps its columns onto the expected ones. The rows are read from the raw tool output.
- Retyping rows inline is kept as a fallback, for answers that no single query backs.

Two files, +108 / -5.

## Root cause

The "actual" side of the comparison was never the agent's query result. A second LLM call re-read the conversation and retyped the answer as rows, and `execute_sql` output is rendered to the model at `MAX_ROWS = 40` (`apps/backend/src/components/tool-outputs/execute-sql.tsx:7`). The CLI requires row-count equality before it compares a single value (`cli/nao_core/commands/test/runner.py:101`), so the run dies on `row count: 40 vs N`.

The complete rows were available the whole time. Truncation applies to the model-facing rendering, not to the tool output kept in `result.steps[].toolResults[].output`, so verification can read them directly instead of asking a model to recite them.

## One correction to the issue

The transcript is not always capped at 40 rows. The truncation notice tells the model to call `read_query_result`, which defaults to 20 rows but enforces no maximum (`apps/backend/src/agents/tools/read-query-result.ts`).

At 250 rows the agent asked for `limit: 250`, pulled the entire result into the transcript in one call, and the old code passed. So the bug is not "always fails past 40 rows" — it is "grading depends on whether the model chooses to page and can retype N rows without error". That dependency breaks outright once retyping stops being practical, which is where the failure below comes from.

## Tests

**Unit** — one test added on the existing vitest setup (`apps/backend/tests/test-agent-verification.test.ts`), covering the full-row read, the column remap, and the unknown-query-id fallback. Confirmed failing before the change:

```
TypeError: TestAgentService.resolveQueryRows is not a function
      Tests  3 failed (3)
```

and passing after:

```
      Tests  3 passed (3)
```

**Suite** — full backend suite run twice, clean runs, `570 passed` both times. Two failures in `tests/auth-hooks-oidc.test.ts` are pre-existing: they reproduce with this branch's change stashed, and are unrelated (OIDC allowlist reading injected env).

**Lint** — `npm run lint` clean across backend, frontend and shared. Pre-commit hook also ran prettier, the migration check and `make lint` in `cli/`.

**End to end, against real services** — DuckDB warehouse seeded with 10,000 rows of random values, so nothing can be extrapolated from the 40 the model sees. Agent on `openai/gpt-5-nano` via OpenRouter. Golden SQL returns all 10,000 rows. Only the fix differs between the two runs:

| build | result | agent tokens |
| --- | --- | --- |
| before | `✗ row count: 40 vs 10000` | 36,967 |
| after | `✓ match` — actual 10,000 vs expected 10,000 | 30,632 |

Re-ran the same test against the committed commit rather than the working tree, on a freshly rebuilt environment: `✓ match`, 10,000 vs 10,000.

## Cost

Running the whole live verification, every run including the discarded ones, cost **$0.023** on OpenRouter.

The fix also makes each test cheaper, because the model no longer pages through rows and retypes them. Same 250-row test, same model:

| build | tokens |
| --- | --- |
| before | 48,334 |
| after | 40,976 |

15% fewer tokens, and the grader stops depending on the model's transcription accuracy.

## Noticed while testing, not fixed here

`runVerification` spreads `...modelConfig` into `generateText`, but inference settings sit nested under `callSettings` (`apps/backend/src/agents/providers.ts:178-183`), so `maxOutputTokens` and `temperature` are silently dropped for that call. `AgentManager` unpacks them explicitly (`apps/backend/src/services/agent.ts:379-382`). Observed directly: `max_output_tokens: 8000` was honored by the agent run and ignored by the verification call, which still requested 65536. Happy to open a separate issue.

This PR was written using Claude Opus 5 (claude-opus-5).
