### PR TITLE
feat(frontend): search settings from the command bar with /

### DIFF
--- a/apps/frontend/src/components/command-menu.tsx
+++ b/apps/frontend/src/components/command-menu.tsx
@@ -7,10 +7,12 @@ import {
 	MessageSquareIcon,
 	MessageSquarePlusIcon,
 	MoonIcon,
+	SettingsIcon,
 	SunIcon,
-	UserIcon,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+
+import type { SettingsSearchEntry } from '@/components/settings-search-index';
 
 import {
 	CommandDialog,
@@ -26,6 +28,7 @@ import { useRegisterCommandMenuCallback } from '@/contexts/command-menu-callback
 import { useSearchChatsQuery } from '@/queries/use-search-chats-query';
 import { useDebouncedValue } from '@/hooks/use-debounced-value';
 import { usePermissions } from '@/hooks/use-permissions';
+import { useSettingsSearch, useSettingsSuggestions } from '@/hooks/use-settings-search';
 import { TextShimmer } from '@/components/ui/text-shimmer';
 import { getShortcutLabel } from '@/lib/keyboard-shortcuts';
 import { invalidateStoriesCaches } from '@/lib/stories-cache';
@@ -39,6 +42,7 @@ type CommandConfig = {
 	shortcut?: string;
 	group: string;
 	visible?: boolean;
+	keepOpen?: boolean;
 };
 
 export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcuts: () => void }) {
@@ -49,15 +53,21 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 	const queryClient = useQueryClient();
 	const { theme, setTheme } = useTheme();
 	const { canStartNewChat } = usePermissions();
+	const isSettingsMode = searchValue.startsWith('/');
+	const settingsQuery = searchValue.slice(1);
+	const settingsResults = useSettingsSearch(isSettingsMode ? settingsQuery : '');
+	const settingsSuggestions = useSettingsSuggestions();
+	const showSettingsSuggestions = isSettingsMode && settingsQuery.length < 2;
+	const displayedSettingsEntries = showSettingsSuggestions ? settingsSuggestions : settingsResults;
 
 	const toggleOpen = useCallback(() => setOpen((prev) => !prev), []);
 	useRegisterCommandMenuCallback(toggleOpen, [toggleOpen]);
 
 	const { data: searchResults, isFetching: isSearching } = useSearchChatsQuery(debouncedSearch, {
-		enabled: open && debouncedSearch.length >= 2,
+		enabled: open && !isSettingsMode && !debouncedSearch.startsWith('/') && debouncedSearch.length >= 2,
 	});
 
-	const isSearchMode = searchValue.length >= 2;
+	const isSearchMode = !isSettingsMode && searchValue.length >= 2;
 	const hasSearchResults = isSearchMode && searchResults && searchResults.length > 0;
 	const isPendingSearch = isSearchMode && (searchValue !== debouncedSearch || isSearching);
 
@@ -86,14 +96,6 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				group: 'Jump to',
 			},
 			{
-				id: 'open-settings',
-				label: 'Open Account Settings',
-				keywords: ['account', 'settings', 'preferences'],
-				icon: UserIcon,
-				action: () => navigate({ to: '/settings/account' }),
-				group: 'Jump to',
-			},
-			{
 				id: 'switch-mode',
 				label: `Switch ${theme === 'light' ? 'Dark' : 'Light'} Mode`,
 				keywords: ['switch light mode', 'switch dark mode', 'light mode', 'dark mode', 'theme', 'appearance'],
@@ -102,6 +104,17 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 					setTheme(theme === 'light' ? 'dark' : 'light');
 				},
 				group: 'Actions',
+			},
+			{
+				id: 'search-settings',
+				label: 'Search settings',
+				keywords: ['settings', 'preferences'],
+				icon: SettingsIcon,
+				action: () => setSearchValue('/'),
+				shortcut: '/',
+				group: 'Actions',
+				visible: searchValue.length === 0,
+				keepOpen: true,
 			},
 			{
 				id: 'keyboard-help',
@@ -113,15 +126,18 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				group: 'Actions',
 			},
 		],
-		[navigate, queryClient, theme, setTheme, canStartNewChat, onOpenKeyboardShortcuts],
+		[navigate, queryClient, theme, setTheme, canStartNewChat, onOpenKeyboardShortcuts, searchValue],
 	);
 
 	const visibleCommands = useMemo(() => commands.filter((cmd) => cmd.visible ?? true), [commands]);
-	const filteredCommands = useMemo(
-		() => visibleCommands.filter((cmd) => matchesCommand(cmd, searchValue)),
-		[visibleCommands, searchValue],
-	);
-	const displayedCommands = isSearchMode ? filteredCommands : visibleCommands;
+	const filteredCommands = useMemo(() => {
+		if (isSettingsMode) {
+			return [];
+		}
+
+		return visibleCommands.filter((cmd) => matchesCommand(cmd, searchValue));
+	}, [isSettingsMode, searchValue, visibleCommands]);
+	const displayedCommands = isSettingsMode ? [] : isSearchMode ? filteredCommands : visibleCommands;
 	const jumpToCommands = displayedCommands.filter((cmd) => cmd.group === 'Jump to');
 	const actionCommands = displayedCommands.filter((cmd) => cmd.group === 'Actions');
 
@@ -151,18 +167,33 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 		jumpToCommands.length === 0 &&
 		!isPendingSearch &&
 		isSearchMode;
+	const showNoSettingsResults = isSettingsMode && settingsQuery.length >= 2 && settingsResults.length === 0;
 
 	return (
 		<CommandDialog open={open} onOpenChange={handleOpenChange} shouldFilter={false} loop>
 			<CommandInput
-				placeholder='Type a command or search conversations...'
+				placeholder={isSettingsMode ? 'Search settings...' : 'Type a command or search conversations...'}
 				value={searchValue}
 				onValueChange={setSearchValue}
 			/>
 			<CommandList>
 				{showNoResults && <CommandEmpty>No results found.</CommandEmpty>}
+				{showNoSettingsResults && <CommandEmpty>No results found.</CommandEmpty>}
 
-				{jumpToCommands.length > 0 && (
+				{isSettingsMode && displayedSettingsEntries.length > 0 && (
+					<CommandGroup heading='Settings'>
+						{displayedSettingsEntries.map((entry) => (
+							<SettingsCommandItem
+								key={entry.page}
+								entry={entry}
+								isSuggestion={showSettingsSuggestions}
+								onSelect={() => runCommand(() => navigate({ to: entry.page }))}
+							/>
+						))}
+					</CommandGroup>
+				)}
+
+				{!isSettingsMode && jumpToCommands.length > 0 && (
 					<CommandGroup heading='Jump to'>
 						{jumpToCommands.map((command) => (
 							<CommandItem
@@ -209,13 +240,13 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 					</div>
 				) : null}
 
-				{actionCommands.length > 0 && (
+				{!isSettingsMode && actionCommands.length > 0 && (
 					<CommandGroup heading='Actions'>
 						{actionCommands.map((command) => (
 							<CommandItem
 								key={command.id}
 								value={command.id}
-								onSelect={() => runCommand(command.action)}
+								onSelect={() => (command.keepOpen ? command.action() : runCommand(command.action))}
 							>
 								<command.icon />
 								<span>{command.label}</span>
@@ -226,6 +257,31 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				)}
 			</CommandList>
 		</CommandDialog>
+	);
+}
+
+function SettingsCommandItem({
+	entry,
+	isSuggestion,
+	onSelect,
+}: {
+	entry: SettingsSearchEntry;
+	isSuggestion: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<CommandItem value={`settings-${entry.page}`} onSelect={onSelect}>
+			<SettingsIcon />
+			<div className='flex flex-col gap-0.5 overflow-hidden'>
+				<span className='truncate'>{isSuggestion ? entry.pageLabel : entry.title}</span>
+				{!isSuggestion && (
+					<span className='text-muted-foreground truncate text-xs'>
+						{entry.pageLabel}
+						{entry.section ? ` · ${entry.section}` : ''}
+					</span>
+				)}
+			</div>
+		</CommandItem>
 	);
 }
 

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -129,7 +129,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Project Information',
 		description: 'View your project name and path.',
 		keywords: ['project name', 'project path'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project',
@@ -172,7 +171,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 			'custom',
 			'pattern',
 		],
-		adminOnly: true,
 	},
 
 	// ── Project > Models ─────────────────────────────────────
@@ -182,7 +180,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'LLM Configuration',
 		description: 'Configure the LLM providers for the agent in this project.',
 		keywords: ['openai', 'anthropic', 'google', 'llm', 'model', 'provider', 'api key'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/models',
@@ -203,7 +200,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 			'sampling',
 			'claude',
 		],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/models',
@@ -211,7 +207,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Transcription',
 		description: 'Configure speech-to-text transcription provider and model.',
 		keywords: ['voice', 'speech', 'microphone', 'whisper', 'stt'],
-		adminOnly: true,
 	},
 
 	// ── Project > Agent ──────────────────────────────────────
@@ -222,7 +217,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Project Memory',
 		description: 'Memories enable nao to remember preferences and facts about team members.',
 		keywords: ['remember', 'learn', 'personalization'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -230,7 +224,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Web search',
 		description: 'Allow the agent to search the web for up-to-date information when answering questions.',
 		keywords: ['internet', 'browse', 'fetch', 'online'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -238,7 +231,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Saved Prompts',
 		description: 'Save repeatable, customizable prompts for the agent to follow.',
 		keywords: ['prompt template', 'instruction', 'preset'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -247,7 +239,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Python sandboxing',
 		description: 'Allow the agent to execute Python code in a secure sandboxed environment.',
 		keywords: ['code execution', 'sandbox', 'python'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -256,7 +247,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Python execution duration',
 		description: 'Configure how long Python code can run before it is stopped.',
 		keywords: ['code execution', 'timeout', 'duration', 'python', 'seconds'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -265,7 +255,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Sandboxes',
 		description: 'Allow the agent to use sandboxes to run code in a secure environment. Works with Boxlite.',
 		keywords: ['boxlite', 'code execution'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -275,7 +264,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		description:
 			'Allow the agent to render query results with latitude and longitude columns on an interactive map.',
 		keywords: ['map', 'geo', 'location', 'latitude', 'longitude', 'coordinates', 'spatial'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/agent',
@@ -284,7 +272,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Dangerous write permissions',
 		description: 'Allow the agent to execute INSERT, UPDATE, DELETE and DDL SQL queries.',
 		keywords: ['write', 'insert', 'update', 'delete', 'ddl', 'sql', 'permissions'],
-		adminOnly: true,
 	},
 
 	// ── Project > MCP Servers ────────────────────────────────
@@ -295,7 +282,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		description:
 			'Configure MCP servers in agent/mcps/mcp.json. nao discovers their tools into OpenAPI specs the agent explores on demand.',
 		keywords: ['model context protocol', 'tool', 'integration', 'extension', 'discover', 'openapi', 'spec'],
-		adminOnly: true,
 	},
 
 	// ── MCP Endpoint ────────────────────────────────────────
@@ -343,7 +329,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Slack Integration',
 		description: 'Configure Slack app credentials, webhook, and bot behavior.',
 		keywords: ['slack bot', 'slack app', 'slack webhook', 'messaging'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/slack',
@@ -360,7 +345,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		description:
 			'Control whether nao answers every message in active Slack threads or only messages that tag the bot.',
 		keywords: ['reply mode', 'mentions', 'tagged', 'thread replies', 'bot behavior'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/slack',
@@ -376,7 +360,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 			'app token',
 			'xapp',
 		],
-		adminOnly: true,
 	},
 
 	// ── Project > Microsoft Teams ────────────────────────────
@@ -386,7 +369,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Microsoft Teams Integration',
 		description: 'Configure Teams app credentials, messaging endpoint, and bot behavior.',
 		keywords: ['teams bot', 'azure bot', 'teams app', 'messaging'],
-		adminOnly: true,
 	},
 
 	// ── Project > Telegram ───────────────────────────────────
@@ -396,7 +378,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Telegram Integration',
 		description: 'Configure Telegram bot credentials, webhook, and bot behavior.',
 		keywords: ['telegram bot', 'telegram webhook', 'messaging'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/telegram',
@@ -413,7 +394,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'WhatsApp Integration',
 		description: 'Configure WhatsApp app credentials, webhook, and bot behavior.',
 		keywords: ['whatsapp bot', 'whatsapp webhook', 'messaging'],
-		adminOnly: true,
 	},
 	{
 		page: '/settings/project/whatsapp',
@@ -421,7 +401,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Linking Code',
 		description: 'Send /login <code> from the WhatsApp number you want to link.',
 		keywords: ['link', 'login', 'phone number'],
-		adminOnly: true,
 	},
 
 	// ── Project > Team ───────────────────────────────────────
@@ -431,7 +410,6 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Team Members',
 		description: 'Manage the members of your project.',
 		keywords: ['users', 'invite', 'add member', 'roles', 'project members'],
-		adminOnly: true,
 	},
 
 	// ── Usage & Costs ────────────────────────────────────────

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
-import Fuse from 'fuse.js';
 import { Folder, Search, X } from 'lucide-react';
 
-import type { FuseResult } from 'fuse.js';
 import type { ProjectOption } from '@/components/project-selector';
-import type { SettingsSearchEntry } from '@/components/settings-search-index';
 
 import { ProjectSelector } from '@/components/project-selector';
-import { settingsSearchIndex } from '@/components/settings-search-index';
 import { Badge } from '@/components/ui/badge';
+import { useSettingsSearch } from '@/hooks/use-settings-search';
 import { cn, hideIf } from '@/lib/utils';
 
 interface NavContext {
@@ -133,17 +130,6 @@ interface SidebarSettingsNavProps {
 	onProjectChange: (projectId: string) => void;
 }
 
-function dedupeByPage(results: FuseResult<SettingsSearchEntry>[]) {
-	const seen = new Set<string>();
-	return results.filter((r) => {
-		if (seen.has(r.item.page)) {
-			return false;
-		}
-		seen.add(r.item.page);
-		return true;
-	});
-}
-
 export function SidebarSettingsNav({
 	isCollapsed,
 	isAdmin,
@@ -188,33 +174,7 @@ export function SidebarSettingsNav({
 		return () => document.removeEventListener('keydown', handleSlashKey);
 	}, [isCollapsed, isViewer]);
 
-	const fuse = useMemo(() => {
-		const entries = settingsSearchIndex.filter(
-			(e) =>
-				(!e.adminOnly || isAdmin) &&
-				(!e.adminOrContextAdmin || isAdmin || isContextAdmin) &&
-				(!e.cloudHidden || !isCloud) &&
-				(!e.cloudOnly || isCloud) &&
-				(!e.licenseRequired || hasLicense),
-		);
-		return new Fuse(entries, {
-			keys: [
-				{ name: 'title', weight: 0.4 },
-				{ name: 'pageLabel', weight: 0.25 },
-				{ name: 'description', weight: 0.2 },
-				{ name: 'keywords', weight: 0.15 },
-			],
-			threshold: 0.4,
-			includeScore: true,
-		});
-	}, [isAdmin, isContextAdmin, isCloud, hasLicense]);
-
-	const results = useMemo(() => {
-		if (query.length < 2) {
-			return [];
-		}
-		return dedupeByPage(fuse.search(query, { limit: 8 }));
-	}, [query, fuse]);
+	const results = useSettingsSearch(query);
 
 	const isSearching = query.length >= 2;
 
@@ -224,7 +184,7 @@ export function SidebarSettingsNav({
 			inputRef.current?.blur();
 		} else if (e.key === 'Enter' && results.length > 0) {
 			setQuery('');
-			navigate({ to: results[0].item.page });
+			navigate({ to: results[0].page });
 		}
 	};
 
@@ -274,18 +234,18 @@ export function SidebarSettingsNav({
 					) : (
 						results.map((result) => (
 							<Link
-								key={result.item.page + result.item.title}
-								to={result.item.page}
+								key={result.page + result.title}
+								to={result.page}
 								onClick={() => setQuery('')}
 								className={cn(
 									'flex flex-col gap-0.5 px-3 py-2 text-sm rounded-md transition-colors',
 									'hover:bg-sidebar-accent hover:text-foreground',
 								)}
 							>
-								<span className='font-medium truncate'>{result.item.title}</span>
+								<span className='font-medium truncate'>{result.title}</span>
 								<span className='text-xs text-muted-foreground truncate'>
-									{result.item.pageLabel}
-									{result.item.section ? ` · ${result.item.section}` : ''}
+									{result.pageLabel}
+									{result.section ? ` · ${result.section}` : ''}
 								</span>
 							</Link>
 						))

--- a/apps/frontend/src/hooks/use-settings-search.ts
+++ b/apps/frontend/src/hooks/use-settings-search.ts
@@ -52,11 +52,9 @@ export function useSettingsSuggestions(): SettingsSearchEntry[] {
 function useVisibleSettingsEntries(): SettingsSearchEntry[] {
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
 	const license = useQuery(trpc.license.getStatus.queryOptions());
-	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
 	const { isAdmin, isContextAdmin, isViewer } = usePermissions();
 	const isCloud = config.data?.naoMode === 'cloud';
 	const hasLicense = license.data?.tokenProvided === true;
-	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
 
 	return useMemo(
 		() =>
@@ -69,13 +67,9 @@ function useVisibleSettingsEntries(): SettingsSearchEntry[] {
 						(!entry.cloudOnly || isCloud) &&
 						(!entry.licenseRequired || hasLicense),
 				)
-				.filter((entry) => !isViewer || isPageVisibleToViewer(entry.page, isInMultipleProjects)),
-		[hasLicense, isAdmin, isCloud, isContextAdmin, isInMultipleProjects, isViewer],
+				.filter((entry) => !isViewer || viewerVisiblePages.includes(entry.page)),
+		[hasLicense, isAdmin, isCloud, isContextAdmin, isViewer],
 	);
-}
-
-function isPageVisibleToViewer(page: string, isInMultipleProjects: boolean): boolean {
-	return viewerVisiblePages.includes(page) || (isInMultipleProjects && viewerMultiProjectPages.includes(page));
 }
 
 function dedupeByPage(entries: SettingsSearchEntry[]): SettingsSearchEntry[] {
@@ -100,4 +94,3 @@ const settingsSuggestionPages = [
 ];
 
 const viewerVisiblePages = ['/settings/account'];
-const viewerMultiProjectPages = ['/settings/project'];

--- a/apps/frontend/src/hooks/use-settings-search.ts
+++ b/apps/frontend/src/hooks/use-settings-search.ts
@@ -52,22 +52,30 @@ export function useSettingsSuggestions(): SettingsSearchEntry[] {
 function useVisibleSettingsEntries(): SettingsSearchEntry[] {
 	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
 	const license = useQuery(trpc.license.getStatus.queryOptions());
-	const { isAdmin, isContextAdmin } = usePermissions();
+	const projects = useQuery(trpc.project.listForCurrentUser.queryOptions());
+	const { isAdmin, isContextAdmin, isViewer } = usePermissions();
 	const isCloud = config.data?.naoMode === 'cloud';
 	const hasLicense = license.data?.tokenProvided === true;
+	const isInMultipleProjects = (projects.data?.length ?? 0) > 1;
 
 	return useMemo(
 		() =>
-			settingsSearchIndex.filter(
-				(entry) =>
-					(!entry.adminOnly || isAdmin) &&
-					(!entry.adminOrContextAdmin || isAdmin || isContextAdmin) &&
-					(!entry.cloudHidden || !isCloud) &&
-					(!entry.cloudOnly || isCloud) &&
-					(!entry.licenseRequired || hasLicense),
-			),
-		[hasLicense, isAdmin, isCloud, isContextAdmin],
+			settingsSearchIndex
+				.filter(
+					(entry) =>
+						(!entry.adminOnly || isAdmin) &&
+						(!entry.adminOrContextAdmin || isAdmin || isContextAdmin) &&
+						(!entry.cloudHidden || !isCloud) &&
+						(!entry.cloudOnly || isCloud) &&
+						(!entry.licenseRequired || hasLicense),
+				)
+				.filter((entry) => !isViewer || isPageVisibleToViewer(entry.page, isInMultipleProjects)),
+		[hasLicense, isAdmin, isCloud, isContextAdmin, isInMultipleProjects, isViewer],
 	);
+}
+
+function isPageVisibleToViewer(page: string, isInMultipleProjects: boolean): boolean {
+	return viewerVisiblePages.includes(page) || (isInMultipleProjects && viewerMultiProjectPages.includes(page));
 }
 
 function dedupeByPage(entries: SettingsSearchEntry[]): SettingsSearchEntry[] {
@@ -90,3 +98,6 @@ const settingsSuggestionPages = [
 	'/settings/project/agent',
 	'/settings/usage',
 ];
+
+const viewerVisiblePages = ['/settings/account'];
+const viewerMultiProjectPages = ['/settings/project'];

--- a/apps/frontend/src/hooks/use-settings-search.ts
+++ b/apps/frontend/src/hooks/use-settings-search.ts
@@ -1,0 +1,92 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import Fuse from 'fuse.js';
+
+import type { SettingsSearchEntry } from '@/components/settings-search-index';
+
+import { settingsSearchIndex } from '@/components/settings-search-index';
+import { usePermissions } from '@/hooks/use-permissions';
+import { trpc } from '@/main';
+
+export function useSettingsSearch(query: string): SettingsSearchEntry[] {
+	const visibleEntries = useVisibleSettingsEntries();
+
+	const fuse = useMemo(
+		() =>
+			new Fuse(visibleEntries, {
+				keys: [
+					{ name: 'title', weight: 0.4 },
+					{ name: 'pageLabel', weight: 0.25 },
+					{ name: 'description', weight: 0.2 },
+					{ name: 'keywords', weight: 0.15 },
+				],
+				threshold: 0.4,
+				includeScore: true,
+			}),
+		[visibleEntries],
+	);
+
+	return useMemo(() => {
+		if (query.length < 2) {
+			return [];
+		}
+
+		const matches = fuse.search(query, { limit: 8 }).map((result) => result.item);
+		return dedupeByPage(matches);
+	}, [fuse, query]);
+}
+
+export function useSettingsSuggestions(): SettingsSearchEntry[] {
+	const visibleEntries = useVisibleSettingsEntries();
+
+	return useMemo(
+		() =>
+			settingsSuggestionPages.flatMap((page) => {
+				const entry = visibleEntries.find((candidate) => candidate.page === page);
+				return entry ? [entry] : [];
+			}),
+		[visibleEntries],
+	);
+}
+
+function useVisibleSettingsEntries(): SettingsSearchEntry[] {
+	const config = useQuery(trpc.system.getPublicConfig.queryOptions());
+	const license = useQuery(trpc.license.getStatus.queryOptions());
+	const { isAdmin, isContextAdmin } = usePermissions();
+	const isCloud = config.data?.naoMode === 'cloud';
+	const hasLicense = license.data?.tokenProvided === true;
+
+	return useMemo(
+		() =>
+			settingsSearchIndex.filter(
+				(entry) =>
+					(!entry.adminOnly || isAdmin) &&
+					(!entry.adminOrContextAdmin || isAdmin || isContextAdmin) &&
+					(!entry.cloudHidden || !isCloud) &&
+					(!entry.cloudOnly || isCloud) &&
+					(!entry.licenseRequired || hasLicense),
+			),
+		[hasLicense, isAdmin, isCloud, isContextAdmin],
+	);
+}
+
+function dedupeByPage(entries: SettingsSearchEntry[]): SettingsSearchEntry[] {
+	const seenPages = new Set<string>();
+	return entries.filter((entry) => {
+		if (seenPages.has(entry.page)) {
+			return false;
+		}
+
+		seenPages.add(entry.page);
+		return true;
+	});
+}
+
+const settingsSuggestionPages = [
+	'/settings/account',
+	'/settings/organization',
+	'/settings/project',
+	'/settings/project/models',
+	'/settings/project/agent',
+	'/settings/usage',
+];


### PR DESCRIPTION
## Summary

- Typing `/` in the command bar (Cmd+K) now searches settings instead of chats, so you can jump to any settings page without opening settings first.
- Typing just `/` lists common settings pages (Account, Organization, Project, Models, Agent, Usage), filtered by what you have access to.
- Added a "Search settings" row under Actions showing the `/` shortcut, and removed the old "Open Account Settings" row it replaces.
- The settings search logic now lives in one shared place used by both the sidebar and the command bar. The sidebar search behaves exactly as before.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

