### PR TITLE
Add Claude Opus 5 and the GPT-5.6 Sol/Terra/Luna models

### DIFF
--- a/apps/backend/src/agents/provider-meta.ts
+++ b/apps/backend/src/agents/provider-meta.ts
@@ -1,6 +1,7 @@
 import type { LlmProvider } from '@nao/shared/types';
 
 import {
+	type ActiveEffort,
 	type ExtraParamKey,
 	mediaResolutionSchema,
 	type ModelCapabilities,
@@ -22,8 +23,8 @@ const GEMINI_PRO_EFFORTS: ReasoningEffort[] = ['off', 'low', 'medium', 'high'];
 const GEMINI_FLASH_EFFORTS: ReasoningEffort[] = ['off', 'minimal', 'low', 'medium', 'high'];
 /** Custom/unlisted Gemini models: only low/high are accepted by every thinking-level model. */
 const GEMINI_CUSTOM_EFFORTS: ReasoningEffort[] = ['off', 'low', 'high'];
-
-export type ActiveEffort = Exclude<ReasoningEffort, 'off'>;
+/** GPT-5.6 dropped `minimal` and split the top of the scale, so `max` is a level above `xhigh`. */
+const OPENAI_5_6_EFFORTS: ReasoningEffort[] = ['off', 'low', 'medium', 'high', 'max'];
 
 export const EFFORT_TO_OPENAI: Record<ActiveEffort, string> = {
 	minimal: 'minimal',
@@ -32,6 +33,8 @@ export const EFFORT_TO_OPENAI: Record<ActiveEffort, string> = {
 	high: 'high',
 	max: 'xhigh',
 };
+
+export const EFFORT_TO_OPENAI_5_6: Record<ActiveEffort, string> = { ...EFFORT_TO_OPENAI, minimal: 'low', max: 'max' };
 
 export const EFFORT_TO_ANTHROPIC: Record<ActiveEffort, string> = {
 	minimal: 'low',
@@ -124,6 +127,12 @@ const OPENAI_REASONING: ModelCapabilities = {
 const OPENAI_REASONING_CUSTOM: ModelCapabilities = {
 	...OPENAI_REASONING,
 	effortOptions: undefined,
+};
+/** GPT-5.6 (Sol/Terra/Luna): same surface as GPT-5.x, on the wider none…max effort scale. */
+const OPENAI_5_6_REASONING: ModelCapabilities = {
+	...OPENAI_REASONING,
+	effortOptions: OPENAI_5_6_EFFORTS,
+	effortMap: EFFORT_TO_OPENAI_5_6,
 };
 /**
  * Custom Azure deployments: user-named, so nothing reveals whether they host a reasoning or a
@@ -255,6 +264,13 @@ export const PROVIDER_META: ProviderMetaMap = {
 				capabilities: ANTHROPIC_ADAPTIVE,
 			},
 			{
+				id: 'claude-opus-5',
+				name: 'Claude Opus 5',
+				contextWindow: 1_000_000,
+				costPerM: { inputNoCache: 5, inputCacheRead: 0.5, inputCacheWrite: 6.25, output: 25 },
+				capabilities: ANTHROPIC_ADAPTIVE,
+			},
+			{
 				id: 'claude-opus-4-8',
 				name: 'Claude Opus 4.8',
 				contextWindow: 200_000,
@@ -313,6 +329,28 @@ export const PROVIDER_META: ProviderMetaMap = {
 		extractorModelId: 'gpt-4.1-mini',
 		summaryModelId: 'gpt-4.1-mini',
 		models: [
+			{
+				id: 'gpt-5.6-sol',
+				name: 'GPT 5.6 Sol',
+				contextWindow: 1_050_000,
+				// GPT-5.6 is the first family to bill cache writes, at 1.25x the uncached input rate.
+				costPerM: { inputNoCache: 5, inputCacheRead: 0.5, inputCacheWrite: 6.25, output: 30 },
+				capabilities: OPENAI_5_6_REASONING,
+			},
+			{
+				id: 'gpt-5.6-terra',
+				name: 'GPT 5.6 Terra',
+				contextWindow: 1_050_000,
+				costPerM: { inputNoCache: 2.5, inputCacheRead: 0.25, inputCacheWrite: 3.125, output: 15 },
+				capabilities: OPENAI_5_6_REASONING,
+			},
+			{
+				id: 'gpt-5.6-luna',
+				name: 'GPT 5.6 Luna',
+				contextWindow: 1_050_000,
+				costPerM: { inputNoCache: 1, inputCacheRead: 0.1, inputCacheWrite: 1.25, output: 6 },
+				capabilities: OPENAI_5_6_REASONING,
+			},
 			{
 				id: 'gpt-5.5',
 				name: 'GPT 5.5',

--- a/apps/backend/src/agents/providers.ts
+++ b/apps/backend/src/agents/providers.ts
@@ -12,6 +12,7 @@ import { createOpenRouter, LanguageModelV3 } from '@openrouter/ai-sdk-provider';
 import { createOllama } from 'ai-sdk-ollama';
 
 import type {
+	ActiveEffort,
 	LlmProvidersType,
 	ModelCapabilities,
 	ModelInferenceSettings,
@@ -20,7 +21,6 @@ import type {
 	ReasoningEffort,
 } from '../types/llm';
 import {
-	type ActiveEffort,
 	DEFAULT_TEMPERATURE_MAX,
 	EFFORT_OPTIONS,
 	EFFORT_TO_ANTHROPIC,
@@ -358,7 +358,9 @@ function resolveThinking(
 	switch (provider) {
 		case 'openai':
 		case 'azure':
-			return resolveEffortThinking(effort, (e) => ({ reasoningEffort: EFFORT_TO_OPENAI[e] }));
+			return resolveEffortThinking(effort, (e) => ({
+				reasoningEffort: (capabilities?.effortMap ?? EFFORT_TO_OPENAI)[e],
+			}));
 		case 'openrouter':
 			return resolveEffortThinking(effort, (e) => ({
 				reasoning: { enabled: true, effort: EFFORT_TO_OPENAI[e] },

--- a/apps/backend/src/types/llm.ts
+++ b/apps/backend/src/types/llm.ts
@@ -39,6 +39,9 @@ export type CustomModelMetadata = z.infer<typeof customModelMetadataSchema>;
 export const reasoningEffortSchema = z.enum(['off', 'minimal', 'low', 'medium', 'high', 'max']);
 export type ReasoningEffort = z.infer<typeof reasoningEffortSchema>;
 
+/** Every effort level that is actually sent to a provider (`off` means "leave it to the model"). */
+export type ActiveEffort = Exclude<ReasoningEffort, 'off'>;
+
 export const serviceTierSchema = z.enum(['auto', 'default', 'standard', 'flex', 'priority', 'reserved']);
 export type ServiceTier = z.infer<typeof serviceTierSchema>;
 
@@ -127,6 +130,8 @@ export type ModelCapabilities = {
 	topK: boolean;
 	maxOutputTokens: boolean;
 	effortOptions?: ReasoningEffort[];
+	/** Effort vocabulary of this model, when it differs from its provider's default translation. */
+	effortMap?: Record<ActiveEffort, string>;
 	temperatureMax?: number;
 	extraParams?: ExtraParamKey[];
 	serviceTierOptions?: ServiceTier[];

--- a/apps/backend/tests/inference-options.test.ts
+++ b/apps/backend/tests/inference-options.test.ts
@@ -113,6 +113,16 @@ describe('Anthropic (live-validated Claude rules)', () => {
 		expect(options).toHaveProperty('contextManagement');
 	});
 
+	it('applies the adaptive Claude rules to Opus 5 and reports its 1M window', () => {
+		const { model, providerOptions, contextWindow } = createProviderModel('anthropic', SETTINGS, 'claude-opus-5', {
+			reasoningEffort: 'max',
+		});
+
+		expect(model.modelId).toBe('claude-opus-5');
+		expect(contextWindow).toBe(1_000_000);
+		expect(providerOptions.anthropic).toMatchObject({ thinking: { type: 'adaptive' }, effort: 'max' });
+	});
+
 	it('clamps a stale minimal effort to low (not in the Claude vocabulary)', () => {
 		const { options } = resolve('anthropic', 'claude-sonnet-4-6', { reasoningEffort: 'minimal' });
 
@@ -138,6 +148,20 @@ describe('OpenAI / Azure', () => {
 		const { options } = resolve('openai', 'gpt-6-codex-max', { reasoningEffort: 'max' });
 
 		expect(options.reasoningEffort).toBe('xhigh');
+	});
+
+	it('sends max as its own level on GPT-5.6, which ranks it above xhigh', () => {
+		const sol = resolve('openai', 'gpt-5.6-sol', { reasoningEffort: 'max' });
+		const luna = resolve('openai', 'gpt-5.6-luna', { reasoningEffort: 'high' });
+
+		expect(sol.options.reasoningEffort).toBe('max');
+		expect(luna.options.reasoningEffort).toBe('high');
+	});
+
+	it('snaps a stale minimal effort to low on GPT-5.6, which dropped minimal', () => {
+		const { options } = resolve('openai', 'gpt-5.6-terra', { reasoningEffort: 'minimal' });
+
+		expect(options.reasoningEffort).toBe('low');
 	});
 
 	it('skips sampling params when the model does not support sampling', () => {

--- a/apps/backend/tests/provider-meta.test.ts
+++ b/apps/backend/tests/provider-meta.test.ts
@@ -195,6 +195,14 @@ describe('getModelParameterSpec', () => {
 		});
 	});
 
+	it('offers the wider GPT-5.6 effort scale, without minimal', () => {
+		const controls = getModelParameterSpec('openai', 'gpt-5.6-sol');
+
+		expect(controlByKey(controls, 'reasoningEffort')).toMatchObject({
+			options: ['off', 'low', 'medium', 'high', 'max'],
+		});
+	});
+
 	it('exposes the full effort surface for custom OpenAI models', () => {
 		const controls = getModelParameterSpec('openai', 'gpt-6-codex-max');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds four models to the built-in catalog in `provider-meta.ts`.

| Model | Context | Input | Cached in | Cache write | Output |
| --- | --- | --- | --- | --- | --- |
| `claude-opus-5` | 1M | $5 | $0.50 | $6.25 | $25 |
| `gpt-5.6-sol` | 1.05M | $5 | $0.50 | $6.25 | $30 |
| `gpt-5.6-terra` | 1.05M | $2.50 | $0.25 | $3.125 | $15 |
| `gpt-5.6-luna` | 1.05M | $1 | $0.10 | $1.25 | $6 |

GPT-5.6 replaces the mini/nano suffixes with durable capability tiers, so Sol, Terra and Luna are separate model ids rather than variants of one. The `gpt-5.6` alias routes to Sol and is not listed separately — users who want it can add it as a custom model.

## Effort scale

GPT-5.6 changes the OpenAI effort vocabulary in two ways: `minimal` is gone, and `max` is now a level *above* `xhigh` rather than a synonym for it. The existing `EFFORT_TO_OPENAI` map is shared by every OpenAI and Azure model and maps `max` to `xhigh`, which would have made GPT-5.6's top level unreachable.

Rather than branching on the model id, `ModelCapabilities` gains an optional `effortMap`, alongside the `effortOptions` it already carries. GPT-5.6 declares both, so the settings UI offers `off/low/medium/high/max` (no `minimal`) and `max` goes out as `max`. Everything else keeps using the provider-level map unchanged — `gpt-5.5` still clamps a stored `max` down to `high`. A stored `minimal` snaps to `low` through the existing `clampEffort` path, so stale settings cannot produce a 400.

This required moving `ActiveEffort` from `provider-meta.ts` to `types/llm.ts` so `ModelCapabilities` can reference it; `provider-meta.ts` imports from `types/llm.ts`, not the other way round.

## Cache-write pricing

GPT-5.6 is the first OpenAI family to bill cache writes, at 1.25x the uncached input rate. Every earlier OpenAI entry keeps `inputCacheWrite: 0`, which stays correct for them.

## Defaults

Left alone deliberately: `claude-sonnet-4-6` and `gpt-5.5` remain the per-provider defaults, so nothing changes for projects that do not pin a model. The new models are listed first, so they appear at the top of the picker. Say the word if you want Sol and/or Opus 5 promoted to default.

Also out of scope: Opus 5 on Bedrock (`anthropic.claude-opus-5`) and Vertex (`claude-opus-5`), and GPT-5.6's `reasoning.mode: "pro"`, which has no equivalent control today.

## Tests

`apps/backend/tests/inference-options.test.ts` covers `max` going out as `max` on GPT-5.6 while `gpt-5.5` still clamps to `high`, `minimal` snapping to `low`, and Opus 5 getting the adaptive Claude rules with its 1M window. `apps/backend/tests/provider-meta.test.ts` covers the derived effort options.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba2e4546-30dd-4124-b8fb-960c4db0106d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba2e4546-30dd-4124-b8fb-960c4db0106d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

