### PR TITLE
Verify nao test answers with a DuckDB query over query results

### DIFF
--- a/apps/backend/src/routes/test.ts
+++ b/apps/backend/src/routes/test.ts
@@ -1,4 +1,5 @@
 import type { LlmSelectedModel } from '@nao/shared/types';
+import { NoObjectGeneratedError } from 'ai';
 import { z } from 'zod/v4';
 
 import { executeQuery } from '../agents/tools/execute-sql';
@@ -8,6 +9,21 @@ import { authMiddleware } from '../middleware/auth';
 import { retrieveProjectById } from '../queries/project.queries';
 import { TestAgentService, testAgentService } from '../services/test-agent.service';
 import { customModelCostSchema, llmSelectedModelSchema } from '../types/llm';
+import { truncateMiddle } from '../utils/utils';
+
+const describeRunError = (err: unknown): string => {
+	if (!NoObjectGeneratedError.isInstance(err)) {
+		return err instanceof Error ? err.message : 'Unknown error';
+	}
+
+	const details = [
+		`finishReason=${err.finishReason ?? 'unknown'}`,
+		`outputTokens=${err.usage?.outputTokens ?? 'unknown'}`,
+		`text=${JSON.stringify(truncateMiddle(err.text ?? '', 500))}`,
+	].join(', ');
+
+	return `${err.message} (${details})`;
+};
 
 export const testRoutes = async (app: App) => {
 	app.addHook('preHandler', authMiddleware);
@@ -65,13 +81,13 @@ export const testRoutes = async (app: App) => {
 							generatedArtifacts: { charts: [], stories: [] },
 						},
 					);
-					const { data } = await testAgentService.runVerification(
+					const verified = await testAgentService.runVerification(
 						projectId,
 						result,
 						expectedColumns,
 						modelSelection,
 					);
-					verification = { data, expectedData, expectedColumns };
+					verification = { ...verified, expectedData, expectedColumns };
 				}
 
 				return reply.send({
@@ -84,8 +100,7 @@ export const testRoutes = async (app: App) => {
 					verification,
 				});
 			} catch (err) {
-				const message = err instanceof Error ? err.message : 'Unknown error';
-				return reply.status(500).send({ error: message });
+				return reply.status(500).send({ error: describeRunError(err) });
 			}
 		},
 	);

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -46,7 +46,7 @@ import {
 } from '../types/chat';
 import type { ModelCosts } from '../types/llm';
 import { Provider } from '../types/messaging-provider';
-import { McpToolContext, ToolContext } from '../types/tools';
+import { McpToolContext, QueryResult, ToolContext } from '../types/tools';
 import {
 	convertToCost,
 	convertToTokenUsage,
@@ -91,6 +91,8 @@ export interface AgentRunResult {
 	}>;
 	/** All message parts (step-starts, tool calls, text) for persisting to the DB */
 	responseParts: UIMessagePart[];
+	/** Rows returned by every `execute_sql` call of the run, keyed by query id */
+	queryResults: Map<string, QueryResult>;
 }
 
 export type AgentChat = Pick<DBChat, 'id' | 'projectId' | 'userId'> & {
@@ -829,6 +831,7 @@ class AgentManager {
 				responseMessages: result.response.messages,
 				steps: result.steps as AgentRunResult['steps'],
 				responseParts: [],
+				queryResults: this._toolContext.queryResults,
 			};
 		} finally {
 			this._finish();

--- a/apps/backend/src/services/duckdb.service.ts
+++ b/apps/backend/src/services/duckdb.service.ts
@@ -5,16 +5,22 @@ import { join } from 'node:path';
 import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
 
 import type { QueryResult } from '../types/tools';
+import { validateReadOnlyAllowlistedSql } from '../utils/sql-allowlist';
 
 /**
  * Runs a query in an in-memory DuckDB where every given query result is a table
  * named after its query id. Lets callers reshape warehouse rows they already
  * hold instead of moving them through an LLM.
+ *
+ * The SQL is treated as untrusted: only read-only SELECT/WITH over the provided
+ * tables is allowed, and DuckDB external access is disabled before execution.
  */
 export async function runSqlOverQueryResults(
 	queryResults: Map<string, QueryResult>,
 	sql: string,
 ): Promise<QueryResult> {
+	await assertSafeQueryResultsSql(sql, [...queryResults.keys()]);
+
 	const workspace = await mkdtemp(join(tmpdir(), 'nao-query-results-'));
 	const instance = await DuckDBInstance.create(':memory:');
 	const connection = await instance.connect();
@@ -24,6 +30,8 @@ export async function runSqlOverQueryResults(
 			await createQueryResultTable(connection, workspace, queryId, queryResult);
 		}
 
+		await lockDownExternalAccess(connection);
+
 		const reader = await connection.runAndReadAll(sql);
 		return { columns: reader.columnNames(), data: reader.getRowObjectsJson() };
 	} finally {
@@ -31,6 +39,22 @@ export async function runSqlOverQueryResults(
 		instance.closeSync();
 		await rm(workspace, { recursive: true, force: true });
 	}
+}
+
+async function assertSafeQueryResultsSql(sql: string, allowedTables: string[]): Promise<void> {
+	const verdict = await validateReadOnlyAllowlistedSql(sql, {
+		allowedTables,
+		parserDialect: 'postgresql',
+		dialectName: 'DuckDB',
+	});
+	if (!verdict.ok) {
+		throw new Error(verdict.reason);
+	}
+}
+
+async function lockDownExternalAccess(connection: DuckDBConnection): Promise<void> {
+	await connection.run('SET enable_external_access = false');
+	await connection.run('SET lock_configuration = true');
 }
 
 /**
@@ -51,7 +75,7 @@ async function createQueryResultTable(
 		return;
 	}
 
-	const rowsFile = join(workspace, `${queryId}.jsonl`);
+	const rowsFile = join(workspace, `${crypto.randomUUID()}.jsonl`);
 	await writeFile(rowsFile, queryResult.data.map((row) => JSON.stringify(row, replaceUnsupportedJson)).join('\n'));
 	await connection.run(
 		`CREATE TABLE ${table} AS SELECT * FROM read_json_auto(${quoteLiteral(rowsFile)}, format = 'newline_delimited', sample_size = -1)`,

--- a/apps/backend/src/services/duckdb.service.ts
+++ b/apps/backend/src/services/duckdb.service.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+
+import type { QueryResult } from '../types/tools';
+
+/**
+ * Runs a query in an in-memory DuckDB where every given query result is a table
+ * named after its query id. Lets callers reshape warehouse rows they already
+ * hold instead of moving them through an LLM.
+ */
+export async function runSqlOverQueryResults(
+	queryResults: Map<string, QueryResult>,
+	sql: string,
+): Promise<QueryResult> {
+	const workspace = await mkdtemp(join(tmpdir(), 'nao-query-results-'));
+	const instance = await DuckDBInstance.create(':memory:');
+	const connection = await instance.connect();
+
+	try {
+		for (const [queryId, queryResult] of queryResults) {
+			await createQueryResultTable(connection, workspace, queryId, queryResult);
+		}
+
+		const reader = await connection.runAndReadAll(sql);
+		return { columns: reader.columnNames(), data: reader.getRowObjectsJson() };
+	} finally {
+		connection.closeSync();
+		instance.closeSync();
+		await rm(workspace, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Loads rows through a newline-delimited JSON file so DuckDB infers the column
+ * types itself rather than us guessing them from JavaScript values.
+ */
+async function createQueryResultTable(
+	connection: DuckDBConnection,
+	workspace: string,
+	queryId: string,
+	queryResult: QueryResult,
+): Promise<void> {
+	const table = quoteIdentifier(queryId);
+
+	if (queryResult.data.length === 0) {
+		const columns = queryResult.columns.map((column) => `${quoteIdentifier(column)} VARCHAR`);
+		await connection.run(`CREATE TABLE ${table} (${columns.join(', ') || '"_empty" VARCHAR'})`);
+		return;
+	}
+
+	const rowsFile = join(workspace, `${queryId}.jsonl`);
+	await writeFile(rowsFile, queryResult.data.map((row) => JSON.stringify(row, replaceUnsupportedJson)).join('\n'));
+	await connection.run(
+		`CREATE TABLE ${table} AS SELECT * FROM read_json_auto(${quoteLiteral(rowsFile)}, format = 'newline_delimited', sample_size = -1)`,
+	);
+}
+
+function replaceUnsupportedJson(_key: string, value: unknown): unknown {
+	return typeof value === 'bigint' ? value.toString() : value;
+}
+
+function quoteIdentifier(identifier: string): string {
+	return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function quoteLiteral(literal: string): string {
+	return `'${literal.replaceAll("'", "''")}'`;
+}

--- a/apps/backend/src/services/test-agent.service.ts
+++ b/apps/backend/src/services/test-agent.service.ts
@@ -5,9 +5,17 @@ import { z } from 'zod/v4';
 import { llmTelemetry } from '../agents/telemetry';
 import type { UIMessage } from '../types/chat';
 import type { ModelCosts } from '../types/llm';
+import type { QueryResult } from '../types/tools';
 import { AgentRunResult, AgentService } from './agent';
+import { runSqlOverQueryResults } from './duckdb.service';
 
-type VerificationData = Record<string, string | number | boolean | null>[] | null;
+export interface VerificationResult {
+	/** Rows the verification query returned, or null when no answer could be produced */
+	data: Record<string, unknown>[] | null;
+	/** The DuckDB query the agent wrote over its own query results */
+	sql: string | null;
+	error: string | null;
+}
 
 export interface ToolCallResult {
 	toolName: string;
@@ -15,6 +23,15 @@ export interface ToolCallResult {
 	args: Record<string, unknown>;
 	result?: unknown;
 }
+
+/** Attempts allowed for the verification query, so a broken one can be repaired once. */
+const MAX_VERIFICATION_ATTEMPTS = 2;
+
+const verificationSchema = z.object({
+	sql: z
+		.nullable(z.string())
+		.describe('DuckDB query over the query result tables. Null if the question cannot be answered from them.'),
+});
 
 export class TestAgentService extends AgentService {
 	/**
@@ -45,33 +62,58 @@ export class TestAgentService extends AgentService {
 	}
 
 	/**
-	 * Run a verification prompt to extract structured data from the agent's response.
-	 * Uses the responseMessages directly from the agent result to avoid double transformation.
+	 * Ask the agent to express its final answer as a DuckDB query over the rows it
+	 * already fetched, then run it. Reusing the stored rows keeps the answer exact
+	 * and costs a few tokens of SQL instead of a full serialisation of the data.
 	 */
 	async runVerification(
 		projectId: string,
 		agentResult: AgentRunResult,
 		expectedColumns: string[],
 		modelSelection?: LlmSelectedModel,
-	): Promise<{ data: VerificationData }> {
+	): Promise<VerificationResult> {
+		const { queryResults } = agentResult;
+		if (queryResults.size === 0) {
+			return { data: null, sql: null, error: 'The agent did not run any SQL query.' };
+		}
+
 		const resolvedSelectedModel = await this._getResolvedLlmSelectedModel(projectId, modelSelection);
 		const modelConfig = await this._getModelConfig(projectId, resolvedSelectedModel);
 
-		// Use responseMessages directly and append verification request
 		const messages: ModelMessage[] = [
 			...agentResult.responseMessages,
-			{ role: 'user', content: TestAgentService._buildVerificationPrompt(expectedColumns) },
+			{ role: 'user', content: TestAgentService._buildVerificationPrompt(expectedColumns, queryResults) },
 		];
 
-		const schema = TestAgentService._buildVerificationSchema(expectedColumns);
-		const result = await generateText({
-			...modelConfig,
-			output: Output.object({ schema }),
-			messages,
-			experimental_telemetry: llmTelemetry('nao-test-verification', { projectId }),
-		});
+		let sql: string | null = null;
+		let error: string | null = null;
 
-		return { data: result.output.data ?? null };
+		for (let attempt = 0; attempt < MAX_VERIFICATION_ATTEMPTS; attempt++) {
+			const result = await generateText({
+				...modelConfig,
+				output: Output.object({ schema: verificationSchema }),
+				messages,
+				experimental_telemetry: llmTelemetry('nao-test-verification', { projectId }),
+			});
+
+			sql = result.output.sql?.trim() || null;
+			if (!sql) {
+				return { data: null, sql: null, error: 'The agent could not answer from its query results.' };
+			}
+
+			try {
+				const { data } = await runSqlOverQueryResults(queryResults, sql);
+				return { data, sql, error: null };
+			} catch (err) {
+				error = err instanceof Error ? err.message : String(err);
+				messages.push(
+					{ role: 'assistant', content: sql },
+					{ role: 'user', content: TestAgentService._buildRepairPrompt(error) },
+				);
+			}
+		}
+
+		return { data: null, sql, error };
 	}
 
 	private static _buildUserMessage(text: string): UIMessage {
@@ -82,27 +124,28 @@ export class TestAgentService extends AgentService {
 		};
 	}
 
-	private static _buildVerificationPrompt(columns: string[]): string {
-		return `Based on your previous analysis, provide the final answer to the original question.
+	private static _buildVerificationPrompt(columns: string[], queryResults: Map<string, QueryResult>): string {
+		const tables = [...queryResults.entries()]
+			.map(([queryId, result]) => `- ${queryId} (${result.data.length} rows): ${result.columns.join(', ')}`)
+			.join('\n');
 
-Format the data with these columns: ${columns.join(', ')}
+		return `Based on your previous analysis, write a DuckDB query returning the final answer to the original question.
 
-Return the data as an array of rows, where each row is an object with the column names as keys.
+Every query you ran is loaded in DuckDB as a table named after its query id:
+${tables}
 
-If you cannot answer, set data to null.`;
+Rules:
+- Only read from the tables above, the warehouse is not reachable anymore.
+- Return exactly these columns, with these names: ${columns.join(', ')}
+- Read the values from the tables, never retype them as literals.
+- Apply the same filters, aggregations and ordering as the answer you gave.
+- Set sql to null if these tables cannot answer the question.`;
 	}
 
-	private static _buildVerificationSchema(columns: string[]) {
-		const valueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
-		const rowSchema = z.object(
-			Object.fromEntries(columns.map((col) => [col, valueSchema.describe(`Value for column ${col}`)])),
-		);
+	private static _buildRepairPrompt(error: string): string {
+		return `That query failed with: ${error}
 
-		return z.object({
-			data: z
-				.nullable(z.array(rowSchema))
-				.describe('Array of rows with the data. Return null if unable to answer.'),
-		});
+Return a corrected DuckDB query, or set sql to null if the tables cannot answer the question.`;
 	}
 
 	/**

--- a/apps/backend/src/utils/app-db-allowlist.ts
+++ b/apps/backend/src/utils/app-db-allowlist.ts
@@ -1,7 +1,5 @@
-import { Parser } from 'node-sql-parser';
-
 import dbConfig, { Dialect } from '../db/dbConfig';
-import { isReadOnlySqlQuery } from './sql-filter';
+import { SqlValidationResult, validateReadOnlyAllowlistedSql } from './sql-allowlist';
 
 export const ALLOWED_APP_DB_VIEWS = [
 	'v_messages',
@@ -12,66 +10,14 @@ export const ALLOWED_APP_DB_VIEWS = [
 	'v_analytics_event',
 ] as const;
 
-export interface SqlValidationResult {
-	ok: boolean;
-	reason?: string;
-}
-
 export async function validateAppDbQuery(
 	sql: string,
 	dialect: Dialect = dbConfig.dialect,
 ): Promise<SqlValidationResult> {
-	if (!(await isReadOnlySqlQuery(sql))) {
-		return { ok: false, reason: 'Only read-only SELECT/WITH queries are allowed.' };
-	}
-
-	let referenced: string[];
-	try {
-		referenced = referencedBaseTables(sql, dialect);
-	} catch (error) {
-		const detail = error instanceof Error ? error.message : String(error);
-		const dialectName = dialect === Dialect.Postgres ? 'PostgreSQL' : 'SQLite';
-		return {
-			ok: false,
-			reason: `Could not parse the query as ${dialectName}; rejected for safety. Rewrite it in ${dialectName} syntax. ${detail}`,
-		};
-	}
-
-	const allowed = new Set<string>(ALLOWED_APP_DB_VIEWS);
-	const disallowed = [...new Set(referenced)].filter((name) => !allowed.has(name));
-	if (disallowed.length > 0) {
-		return {
-			ok: false,
-			reason: `Query references objects outside the allowlist: ${disallowed.join(', ')}. Allowed views: ${ALLOWED_APP_DB_VIEWS.join(', ')}.`,
-		};
-	}
-
-	return { ok: true };
-}
-
-function referencedBaseTables(sql: string, dialect: Dialect): string[] {
-	const parser = new Parser();
-	const opt = { database: dialect === Dialect.Postgres ? ('postgresql' as const) : ('sqlite' as const) };
-	// tableList entries look like "select::null::v_chat".
-	const tables = parser.tableList(sql, opt).map((entry) => entry.split('::').pop() as string);
-	const cteNames = collectCteNames(parser.astify(sql, opt));
-	return tables.filter((name) => !cteNames.has(name));
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function collectCteNames(ast: any): Set<string> {
-	const names = new Set<string>();
-	const statements = Array.isArray(ast) ? ast : [ast];
-	for (const stmt of statements) {
-		const withClause = stmt?.with;
-		if (Array.isArray(withClause)) {
-			for (const cte of withClause) {
-				const name = cte?.name?.value ?? cte?.name;
-				if (typeof name === 'string') {
-					names.add(name);
-				}
-			}
-		}
-	}
-	return names;
+	const isPostgres = dialect === Dialect.Postgres;
+	return validateReadOnlyAllowlistedSql(sql, {
+		allowedTables: ALLOWED_APP_DB_VIEWS,
+		parserDialect: isPostgres ? 'postgresql' : 'sqlite',
+		dialectName: isPostgres ? 'PostgreSQL' : 'SQLite',
+	});
 }

--- a/apps/backend/src/utils/sql-allowlist.ts
+++ b/apps/backend/src/utils/sql-allowlist.ts
@@ -1,0 +1,76 @@
+import { Parser } from 'node-sql-parser';
+
+import { isReadOnlySqlQuery } from './sql-filter';
+
+export interface SqlValidationResult {
+	ok: boolean;
+	reason?: string;
+}
+
+export interface SqlAllowlistOptions {
+	allowedTables: readonly string[];
+	parserDialect: 'postgresql' | 'sqlite';
+	dialectName: string;
+}
+
+/**
+ * Validates untrusted SQL against a read-only, table-allowlisted policy:
+ * only SELECT/WITH statements that reference the allowed tables pass.
+ */
+export async function validateReadOnlyAllowlistedSql(
+	sql: string,
+	{ allowedTables, parserDialect, dialectName }: SqlAllowlistOptions,
+): Promise<SqlValidationResult> {
+	if (!(await isReadOnlySqlQuery(sql))) {
+		return { ok: false, reason: 'Only read-only SELECT/WITH queries are allowed.' };
+	}
+
+	let referenced: string[];
+	try {
+		referenced = referencedBaseTables(sql, parserDialect);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		return {
+			ok: false,
+			reason: `Could not parse the query as ${dialectName}; rejected for safety. Rewrite it in ${dialectName} syntax. ${detail}`,
+		};
+	}
+
+	const allowed = new Set(allowedTables);
+	const disallowed = [...new Set(referenced)].filter((name) => !allowed.has(name));
+	if (disallowed.length > 0) {
+		return {
+			ok: false,
+			reason: `Query references objects outside the allowlist: ${disallowed.join(', ')}. Allowed: ${allowedTables.join(', ') || '(none)'}.`,
+		};
+	}
+
+	return { ok: true };
+}
+
+function referencedBaseTables(sql: string, parserDialect: 'postgresql' | 'sqlite'): string[] {
+	const parser = new Parser();
+	const opt = { database: parserDialect };
+	// tableList entries look like "select::null::v_chat".
+	const tables = parser.tableList(sql, opt).map((entry) => entry.split('::').pop() as string);
+	const cteNames = collectCteNames(parser.astify(sql, opt));
+	return tables.filter((name) => !cteNames.has(name));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function collectCteNames(ast: any): Set<string> {
+	const names = new Set<string>();
+	const statements = Array.isArray(ast) ? ast : [ast];
+	for (const stmt of statements) {
+		const withClause = stmt?.with;
+		if (Array.isArray(withClause)) {
+			for (const cte of withClause) {
+				const name = cte?.name?.value ?? cte?.name;
+				if (typeof name === 'string') {
+					names.add(name);
+				}
+			}
+		}
+	}
+	return names;
+}

--- a/apps/backend/tests/duckdb-query-results.test.ts
+++ b/apps/backend/tests/duckdb-query-results.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { runSqlOverQueryResults } from '../src/services/duckdb.service';
+import type { QueryResult } from '../src/types/tools';
+
+const orders: QueryResult = {
+	columns: ['customer_id', 'total_amount'],
+	data: [
+		{ customer_id: 51, total_amount: 99.5 },
+		{ customer_id: 3, total_amount: 65 },
+		{ customer_id: 51, total_amount: 0.5 },
+	],
+};
+
+const customers: QueryResult = {
+	columns: ['id', 'name'],
+	data: [
+		{ id: 51, name: 'Acme' },
+		{ id: 3, name: 'Globex' },
+	],
+};
+
+describe('runSqlOverQueryResults', () => {
+	it('exposes every query result as a table named after its query id', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([
+				['query_orders', orders],
+				['query_customers', customers],
+			]),
+			`SELECT c.name, SUM(o.total_amount) AS revenue
+			 FROM query_orders o JOIN query_customers c ON c.id = o.customer_id
+			 GROUP BY c.name ORDER BY revenue DESC`,
+		);
+
+		expect(result.columns).toEqual(['name', 'revenue']);
+		expect(result.data).toEqual([
+			{ name: 'Acme', revenue: 100 },
+			{ name: 'Globex', revenue: 65 },
+		]);
+	});
+
+	it('keeps column types so numeric aggregations work', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([['query_orders', orders]]),
+			'SELECT COUNT(*) AS rows_count, MAX(total_amount) AS biggest FROM query_orders',
+		);
+
+		expect(result.data).toEqual([{ rows_count: '3', biggest: 99.5 }]);
+	});
+
+	it('registers an empty result as an empty table', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([['query_empty', { columns: ['id'], data: [] }]]),
+			'SELECT * FROM query_empty',
+		);
+
+		expect(result.columns).toEqual(['id']);
+		expect(result.data).toEqual([]);
+	});
+
+	it('surfaces invalid SQL as an error', async () => {
+		await expect(
+			runSqlOverQueryResults(new Map([['query_orders', orders]]), 'SELECT missing FROM query_orders'),
+		).rejects.toThrow(/missing/);
+	});
+});

--- a/apps/backend/tests/duckdb-query-results.test.ts
+++ b/apps/backend/tests/duckdb-query-results.test.ts
@@ -63,4 +63,45 @@ describe('runSqlOverQueryResults', () => {
 			runSqlOverQueryResults(new Map([['query_orders', orders]]), 'SELECT missing FROM query_orders'),
 		).rejects.toThrow(/missing/);
 	});
+
+	it('still exposes tables when the query id contains path separators', async () => {
+		const queryId = 'query_../../escape';
+		const result = await runSqlOverQueryResults(
+			new Map([[queryId, orders]]),
+			`SELECT COUNT(*) AS rows_count FROM "${queryId}"`,
+		);
+
+		expect(result.data).toEqual([{ rows_count: '3' }]);
+	});
+
+	it('rejects write statements before execution', async () => {
+		await expect(
+			runSqlOverQueryResults(new Map([['query_orders', orders]]), 'DELETE FROM query_orders'),
+		).rejects.toThrow(/read-only/i);
+	});
+
+	it('rejects references to tables outside the allowlist', async () => {
+		await expect(
+			runSqlOverQueryResults(new Map([['query_orders', orders]]), 'SELECT * FROM query_customers'),
+		).rejects.toThrow(/allowlist/i);
+	});
+
+	it('allows CTEs that only read allowlisted tables', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([['query_orders', orders]]),
+			`WITH totals AS (SELECT customer_id, SUM(total_amount) AS revenue FROM query_orders GROUP BY 1)
+			 SELECT * FROM totals ORDER BY revenue DESC`,
+		);
+
+		expect(result.data).toEqual([
+			{ customer_id: '51', revenue: 100 },
+			{ customer_id: '3', revenue: 65 },
+		]);
+	});
+
+	it('blocks reading local files after tables are loaded', async () => {
+		await expect(
+			runSqlOverQueryResults(new Map([['query_orders', orders]]), `SELECT * FROM read_json_auto('/etc/hosts')`),
+		).rejects.toThrow();
+	});
 });

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -306,7 +306,6 @@ const SidebarLayoutSettingsUsageReplayChatIdRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof SidebarLayoutChatLayoutIndexRoute
   '/consent': typeof ConsentRoute
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
@@ -330,9 +329,10 @@ export interface FileRoutesByFullPath {
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/embed/chart/$chartEmbedId': typeof EmbedChartChartEmbedIdRoute
   '/embed/story/$storyId': typeof EmbedStoryStoryIdRoute
-  '/feed/': typeof SidebarLayoutFeedIndexRoute
+  '/': typeof SidebarLayoutChatLayoutIndexRoute
+  '/feed': typeof SidebarLayoutFeedIndexRoute
   '/settings/': typeof SidebarLayoutSettingsIndexRoute
-  '/stories/': typeof SidebarLayoutStoriesIndexRoute
+  '/stories': typeof SidebarLayoutStoriesIndexRoute
   '/settings/project/agent': typeof SidebarLayoutSettingsProjectAgentRoute
   '/settings/project/budgets': typeof SidebarLayoutSettingsProjectBudgetsRoute
   '/settings/project/mcp-endpoint': typeof SidebarLayoutSettingsProjectMcpEndpointRoute
@@ -350,7 +350,6 @@ export interface FileRoutesByFullPath {
   '/stories/preview/$chatId/$storySlug': typeof SidebarLayoutStoriesPreviewChatIdStorySlugRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof SidebarLayoutChatLayoutIndexRoute
   '/consent': typeof ConsentRoute
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
@@ -372,6 +371,7 @@ export interface FileRoutesByTo {
   '/shared-chat/$shareId': typeof SidebarLayoutSharedChatShareIdRoute
   '/embed/chart/$chartEmbedId': typeof EmbedChartChartEmbedIdRoute
   '/embed/story/$storyId': typeof EmbedStoryStoryIdRoute
+  '/': typeof SidebarLayoutChatLayoutIndexRoute
   '/feed': typeof SidebarLayoutFeedIndexRoute
   '/settings': typeof SidebarLayoutSettingsIndexRoute
   '/stories': typeof SidebarLayoutStoriesIndexRoute
@@ -441,7 +441,6 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | '/'
     | '/consent'
     | '/embed'
     | '/forgot-password'
@@ -465,9 +464,10 @@ export interface FileRouteTypes {
     | '/shared-chat/$shareId'
     | '/embed/chart/$chartEmbedId'
     | '/embed/story/$storyId'
-    | '/feed/'
+    | '/'
+    | '/feed'
     | '/settings/'
-    | '/stories/'
+    | '/stories'
     | '/settings/project/agent'
     | '/settings/project/budgets'
     | '/settings/project/mcp-endpoint'
@@ -485,7 +485,6 @@ export interface FileRouteTypes {
     | '/stories/preview/$chatId/$storySlug'
   fileRoutesByTo: FileRoutesByTo
   to:
-    | '/'
     | '/consent'
     | '/embed'
     | '/forgot-password'
@@ -507,6 +506,7 @@ export interface FileRouteTypes {
     | '/shared-chat/$shareId'
     | '/embed/chart/$chartEmbedId'
     | '/embed/story/$storyId'
+    | '/'
     | '/feed'
     | '/settings'
     | '/stories'
@@ -630,7 +630,7 @@ declare module '@tanstack/react-router' {
     '/_sidebar-layout': {
       id: '/_sidebar-layout'
       path: ''
-      fullPath: '/'
+      fullPath: ''
       preLoaderRoute: typeof SidebarLayoutRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -644,14 +644,14 @@ declare module '@tanstack/react-router' {
     '/_sidebar-layout/_chat-layout': {
       id: '/_sidebar-layout/_chat-layout'
       path: ''
-      fullPath: '/'
+      fullPath: ''
       preLoaderRoute: typeof SidebarLayoutChatLayoutRouteImport
       parentRoute: typeof SidebarLayoutRoute
     }
     '/_sidebar-layout/stories/': {
       id: '/_sidebar-layout/stories/'
       path: '/stories'
-      fullPath: '/stories/'
+      fullPath: '/stories'
       preLoaderRoute: typeof SidebarLayoutStoriesIndexRouteImport
       parentRoute: typeof SidebarLayoutRoute
     }
@@ -665,7 +665,7 @@ declare module '@tanstack/react-router' {
     '/_sidebar-layout/feed/': {
       id: '/_sidebar-layout/feed/'
       path: '/feed'
-      fullPath: '/feed/'
+      fullPath: '/feed'
       preLoaderRoute: typeof SidebarLayoutFeedIndexRouteImport
       parentRoute: typeof SidebarLayoutRoute
     }

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -42,9 +42,11 @@ class TokenCost:
 class VerificationResult:
     """Result from running a verification prompt."""
 
-    data: list[dict[str, Any]]
+    data: list[dict[str, Any]] | None
     expectedData: list[dict[str, Any]]
     expectedColumns: list[str]
+    sql: str | None = None
+    error: str | None = None
 
 
 @dataclass

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -19,6 +19,7 @@ from nao_core.ui import UI
 from .case import TESTS_FOLDER, TestCase, discover_tests
 from .client import AgentClientError, VerificationResult, get_client
 from .compare import normalize_dataframe_numbers
+from .summary import ModelSummary, summarize, summarize_by_model
 
 
 @dataclass
@@ -289,28 +290,89 @@ def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_file = output_dir / f"results_{timestamp}.json"
 
-    total_duration_ms = sum(r.duration_ms or 0 for r in results)
-    total_tool_calls = sum(r.tool_call_count or 0 for r in results)
-
+    runs = [asdict(r) for r in results]
     data = {
         "timestamp": datetime.now().isoformat(),
-        "results": [asdict(r) for r in results],
-        "summary": {
-            "total": len(results),
-            "passed": sum(1 for r in results if r.passed),
-            "failed": sum(1 for r in results if not r.passed),
-            "total_tokens": sum(r.tokens or 0 for r in results),
-            "total_cost": sum(r.cost or 0 for r in results),
-            "total_duration_ms": total_duration_ms,
-            "total_duration_s": round(total_duration_ms / 1000, 2),
-            "total_tool_calls": total_tool_calls,
-            "avg_duration_ms": round(total_duration_ms / len(results), 0) if results else 0,
-            "avg_tool_calls": round(total_tool_calls / len(results), 1) if results else 0,
-        },
+        "results": runs,
+        "summary": summarize(runs),
+        "by_model": [asdict(s) for s in summarize_by_model(runs)],
     }
 
     output_file.write_text(json.dumps(data, indent=2))
     return output_file
+
+
+def print_run_table(results: list[TestRunResult]) -> None:
+    """Print one row per run, i.e. per (test, model) pair."""
+    df = pd.DataFrame(
+        [
+            {
+                "Test": r.name,
+                "Model": r.model,
+                "Status": status_icon(r.passed),
+                "Message": r.message,
+                "Tokens": r.tokens or 0,
+                "Cost": r.cost or 0,
+                "Time (s)": round((r.duration_ms or 0) / 1000, 1),
+                "Tools": r.tool_call_count or 0,
+            }
+            for r in results
+        ]
+    )
+
+    UI.table(df, title="Test Results", sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
+
+
+def print_model_table(summaries: list[ModelSummary]) -> None:
+    """Print one row per model, ranked from best to worst pass rate."""
+    df = pd.DataFrame(
+        [
+            {
+                "Model": column_label(s.model),
+                "Pass Rate": format_pass_rate(s.pass_rate),
+                "Passed": f"{s.passed}/{s.total}",
+                "Tokens": s.total_tokens,
+                "Cost": s.total_cost,
+                "Avg Time (s)": round(s.avg_duration_ms / 1000, 1),
+                "Avg Tools": s.avg_tool_calls,
+            }
+            for s in summaries
+        ]
+    )
+
+    UI.table(df, title="Performance by Model", sum_columns={"Tokens": "", "Cost": "$"}, fixed_columns={"Model"})
+
+
+def print_model_matrix(results: list[TestRunResult]) -> None:
+    """Print a test × model grid to show which model passes which test."""
+    models = list(dict.fromkeys(r.model for r in results))
+    statuses: dict[tuple[str, str], list[str]] = {}
+    for result in results:
+        statuses.setdefault((result.name, result.model), []).append(status_icon(result.passed))
+
+    rows = [
+        {"Test": name}
+        | {column_label(model): " ".join(statuses.get((name, model), ["[dim]-[/dim]"])) for model in models}
+        for name in dict.fromkeys(r.name for r in results)
+    ]
+
+    UI.table(pd.DataFrame(rows), title="Pass / Fail by Test and Model")
+
+
+def column_label(model: str) -> str:
+    """Stack the provider above the model id to keep matrix columns narrow."""
+    return model.replace(":", "\n")
+
+
+def status_icon(passed: bool) -> str:
+    """Render a pass/fail marker for terminal tables."""
+    return "[green]✓[/green]" if passed else "[red]✗[/red]"
+
+
+def format_pass_rate(pass_rate: float) -> str:
+    """Colour a pass rate from green (all passing) to red (mostly failing)."""
+    color = "green" if pass_rate == 100 else "red" if pass_rate < 50 else "yellow"
+    return f"[{color}]{pass_rate}%[/{color}]"
 
 
 def filter_test_cases(
@@ -469,6 +531,8 @@ def test(
             results.append(result)
             UI.print("")
     else:
+        # Results are collected by submission order so the summaries stay grouped by model.
+        completed: dict[int, TestRunResult] = {}
         with ThreadPoolExecutor(max_workers=thread_count) as executor:
             futures = {
                 executor.submit(
@@ -479,45 +543,33 @@ def test(
                     password=pwd,
                     costs=resolve_model_costs(config, m),
                     comparison=test_config.comparison,
-                ): (tc, m)
-                for tc, m in test_runs
+                ): index
+                for index, (tc, m) in enumerate(test_runs)
             }
             for future in as_completed(futures):
-                result = future.result()
-                results.append(result)
+                completed[futures[future]] = future.result()
                 UI.print("")
+        results = [completed[index] for index in sorted(completed)]
 
     # Save results to JSON
     output_file = save_results(results, project_path / TESTS_FOLDER / "outputs")
     UI.print(f"[dim]Results saved to: {output_file}[/dim]\n")
 
-    # Print summary table
-    df = pd.DataFrame(
-        [
-            {
-                "Test": r.name,
-                "Model": r.model,
-                "Status": "[green]✓[/green]" if r.passed else "[red]✗[/red]",
-                "Message": r.message,
-                "Tokens": r.tokens or 0,
-                "Cost": r.cost or 0,
-                "Time (s)": round((r.duration_ms or 0) / 1000, 1),
-                "Tools": r.tool_call_count or 0,
-            }
-            for r in results
-        ]
-    )
+    print_run_table(results)
 
-    UI.table(df, title="Test Results", sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
+    model_summaries = summarize_by_model([asdict(r) for r in results])
+    if len(model_summaries) > 1:
+        print_model_table(model_summaries)
+        print_model_matrix(results)
 
-    # Print summary
     passed = sum(1 for r in results if r.passed)
     failed = sum(1 for r in results if not r.passed)
     total = len(results)
+    unit = "run" if len(model_summaries) > 1 else "test"
 
     UI.print("")
     if failed == 0:
-        UI.success(f"All {total} test(s) passed")
+        UI.success(f"All {total} {unit}(s) passed")
     else:
         UI.print(f"[green]{passed} passed[/green], [red]{failed} failed[/red], {total} total")
         sys.exit(1)

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -50,6 +50,7 @@ class TestRunDetails:
     comparison: str | None = None
     tool_calls: list[dict] | None = None
     reference_sql: str | None = None
+    verification_sql: str | None = None
 
 
 @dataclass
@@ -79,6 +80,9 @@ def check_dataframe(
         atol: Absolute tolerance for float comparison.
         decimals: Decimals kept when rounding float values before comparing.
     """
+    if verification.data is None:
+        return False, verification.error or "no data returned", None
+
     actual = pd.DataFrame(verification.data)
     expected = pd.DataFrame(verification.expectedData)
     cols = verification.expectedColumns
@@ -209,6 +213,8 @@ def run_test(
 
         if result.verification:
             tolerances = comparison or ComparisonConfig()
+            if result.verification.sql:
+                UI.print(f"[dim]  Verification SQL: {result.verification.sql}[/dim]")
             passed, msg, diff = check_dataframe(
                 result.verification,
                 rtol=tolerances.rtol,
@@ -233,6 +239,7 @@ def run_test(
                     comparison=diff,
                     tool_calls=result.tool_calls,
                     reference_sql=test_case.sql,
+                    verification_sql=result.verification.sql,
                 ),
             )
 

--- a/cli/nao_core/commands/test/server.py
+++ b/cli/nao_core/commands/test/server.py
@@ -12,6 +12,7 @@ from nao_core.config import NaoConfig, resolve_project_path
 from nao_core.ui import UI
 
 from .case import TESTS_FOLDER
+from .summary import with_model_summaries
 
 # Default port for the server
 DEFAULT_PORT = 8765
@@ -55,6 +56,22 @@ def get_html_template() -> str:
         .status.pass { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
         .status.fail { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
         .model-badge { display: inline-block; padding: 0.125rem 0.5rem; background: #333; border-radius: 4px; font-size: 0.75rem; color: #aaa; font-family: monospace; }
+        .model-badge.active { background: #3f3f3f; color: #fff; }
+        .section { margin-bottom: 2rem; }
+        .section-title { font-size: 0.75rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.75rem; }
+        .rate { display: flex; align-items: center; gap: 0.625rem; }
+        .rate-value { font-family: monospace; font-size: 0.875rem; min-width: 3.25rem; }
+        .rate-bar { flex: 1; min-width: 60px; height: 6px; background: #333; border-radius: 3px; overflow: hidden; }
+        .rate-fill { height: 100%; background: #22c55e; }
+        .rate-fill.warn { background: #eab308; }
+        .rate-fill.error { background: #ef4444; }
+        .filters { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin-bottom: 1rem; }
+        .chip { padding: 0.375rem 0.75rem; background: #1a1a1a; border: 1px solid #333; border-radius: 999px; color: #aaa; font-family: monospace; font-size: 0.8125rem; cursor: pointer; }
+        .chip:hover { border-color: #555; }
+        .chip.active { background: #333; color: #fff; border-color: #666; }
+        .matrix th, .matrix td { text-align: center; }
+        .matrix th:first-child, .matrix td:first-child { text-align: left; }
+        .cell-status { cursor: pointer; }
         .mono { font-family: monospace; font-size: 0.875rem; }
         .text-muted { color: #888; }
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.8); z-index: 1000; display: flex; align-items: center; justify-content: center; }
@@ -163,7 +180,17 @@ def get_html_template() -> str:
 
         function Results({ data, onSelect }) {
             const { summary, results, timestamp } = data;
+            const byModel = data.by_model || [];
+            const models = byModel.map(m => m.model);
+            const multiModel = models.length > 1;
+            const [modelFilter, setModelFilter] = useState('all');
+
+            useEffect(() => {
+                setModelFilter('all');
+            }, [timestamp]);
+
             const passRate = summary.total > 0 ? Math.round((summary.passed / summary.total) * 100) : 0;
+            const visibleResults = modelFilter === 'all' ? results : results.filter(r => r.model === modelFilter);
 
             return (
                 <>
@@ -171,46 +198,164 @@ def get_html_template() -> str:
                         <Card label="Pass Rate" value={passRate + '%'} className={passRate === 100 ? 'success' : passRate < 50 ? 'error' : ''} />
                         <Card label="Passed" value={summary.passed} className="success" />
                         <Card label="Failed" value={summary.failed} className={summary.failed > 0 ? 'error' : ''} />
-                        <Card label="Total Tests" value={summary.total} />
+                        <Card label={multiModel ? 'Total Runs' : 'Total Tests'} value={summary.total} />
+                        {multiModel && <Card label="Models" value={models.length} />}
                         <Card label="Total Tokens" value={summary.total_tokens.toLocaleString()} />
                         <Card label="Total Cost" value={'$' + summary.total_cost.toFixed(4)} />
                         <Card label="Duration" value={summary.total_duration_s + 's'} />
                         <Card label="Tool Calls" value={summary.total_tool_calls} />
                     </div>
 
-                    <p className="text-muted" style={{ marginBottom: '1rem', fontSize: '0.875rem' }}>
+                    <p className="text-muted" style={{ marginBottom: '2rem', fontSize: '0.875rem' }}>
                         Run at: {new Date(timestamp).toLocaleString()} &bull; Avg duration: {summary.avg_duration_ms}ms &bull; Avg tool calls: {summary.avg_tool_calls}
                     </p>
 
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Status</th>
-                                <th>Test Name</th>
-                                <th>Model</th>
-                                <th>Message</th>
-                                <th>Tokens</th>
-                                <th>Cost</th>
-                                <th>Duration</th>
-                                <th>Tools</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {results.map((r, i) => (
-                                <tr key={i} className="clickable" onClick={() => onSelect(r)}>
-                                    <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
-                                    <td><strong>{r.name}</strong></td>
-                                    <td><span className="model-badge">{r.model}</span></td>
-                                    <td className="text-muted">{r.message}</td>
-                                    <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
-                                    <td className="mono">${(r.cost || 0).toFixed(4)}</td>
-                                    <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
-                                    <td className="mono">{r.tool_call_count || 0}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                    {multiModel && (
+                        <>
+                            <div className="section">
+                                <h2 className="section-title">Performance by Model</h2>
+                                <ModelTable byModel={byModel} activeModel={modelFilter} onSelectModel={setModelFilter} />
+                            </div>
+
+                            <div className="section">
+                                <h2 className="section-title">Pass / Fail by Test and Model</h2>
+                                <ModelMatrix results={results} models={models} onSelect={onSelect} />
+                            </div>
+                        </>
+                    )}
+
+                    <div className="section">
+                        <h2 className="section-title">{multiModel ? 'Runs' : 'Tests'}</h2>
+                        {multiModel && <ModelFilter models={models} active={modelFilter} onChange={setModelFilter} />}
+                        <RunTable results={visibleResults} onSelect={onSelect} />
+                    </div>
                 </>
+            );
+        }
+
+        function ModelTable({ byModel, activeModel, onSelectModel }) {
+            return (
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Model</th>
+                            <th>Pass Rate</th>
+                            <th>Passed</th>
+                            <th>Failed</th>
+                            <th>Tokens</th>
+                            <th>Cost</th>
+                            <th>Avg Duration</th>
+                            <th>Avg Tools</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {byModel.map(m => (
+                            <tr key={m.model} className="clickable" onClick={() => onSelectModel(activeModel === m.model ? 'all' : m.model)}>
+                                <td><span className={'model-badge' + (activeModel === m.model ? ' active' : '')}>{m.model}</span></td>
+                                <td><PassRate rate={m.pass_rate} /></td>
+                                <td className="mono">{m.passed}/{m.total}</td>
+                                <td className="mono">{m.failed}</td>
+                                <td className="mono">{m.total_tokens.toLocaleString()}</td>
+                                <td className="mono">${m.total_cost.toFixed(4)}</td>
+                                <td className="mono">{(m.avg_duration_ms / 1000).toFixed(1)}s</td>
+                                <td className="mono">{m.avg_tool_calls}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            );
+        }
+
+        function PassRate({ rate }) {
+            const tone = rate === 100 ? '' : rate < 50 ? ' error' : ' warn';
+            return (
+                <div className="rate">
+                    <span className="rate-value">{rate}%</span>
+                    <div className="rate-bar"><div className={'rate-fill' + tone} style={{ width: rate + '%' }} /></div>
+                </div>
+            );
+        }
+
+        function ModelMatrix({ results, models, onSelect }) {
+            const testNames = [...new Set(results.map(r => r.name))];
+            const runs = {};
+            results.forEach(r => { runs[r.name + '\\u0000' + r.model] = r; });
+
+            return (
+                <table className="matrix">
+                    <thead>
+                        <tr>
+                            <th>Test</th>
+                            {models.map(m => <th key={m}>{m}</th>)}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {testNames.map(name => (
+                            <tr key={name}>
+                                <td><strong>{name}</strong></td>
+                                {models.map(m => {
+                                    const run = runs[name + '\\u0000' + m];
+                                    if (!run) return <td key={m} className="text-muted">&mdash;</td>;
+                                    return (
+                                        <td key={m}>
+                                            <span
+                                                className={'status cell-status ' + (run.passed ? 'pass' : 'fail')}
+                                                title={run.message}
+                                                onClick={() => onSelect(run)}
+                                            >
+                                                {run.passed ? '✓' : '✗'} {((run.duration_ms || 0) / 1000).toFixed(1)}s
+                                            </span>
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            );
+        }
+
+        function ModelFilter({ models, active, onChange }) {
+            return (
+                <div className="filters">
+                    <button className={'chip' + (active === 'all' ? ' active' : '')} onClick={() => onChange('all')}>All models</button>
+                    {models.map(m => (
+                        <button key={m} className={'chip' + (active === m ? ' active' : '')} onClick={() => onChange(m)}>{m}</button>
+                    ))}
+                </div>
+            );
+        }
+
+        function RunTable({ results, onSelect }) {
+            return (
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Status</th>
+                            <th>Test Name</th>
+                            <th>Model</th>
+                            <th>Message</th>
+                            <th>Tokens</th>
+                            <th>Cost</th>
+                            <th>Duration</th>
+                            <th>Tools</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {results.map((r, i) => (
+                            <tr key={i} className="clickable" onClick={() => onSelect(r)}>
+                                <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
+                                <td><strong>{r.name}</strong></td>
+                                <td><span className="model-badge">{r.model}</span></td>
+                                <td className="text-muted">{r.message}</td>
+                                <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
+                                <td className="mono">${(r.cost || 0).toFixed(4)}</td>
+                                <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
+                                <td className="mono">{r.tool_call_count || 0}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             );
         }
 
@@ -438,7 +583,7 @@ class TestResultsHandler(http.server.BaseHTTPRequestHandler):
 
         try:
             data = json.loads(filepath.read_text())
-            self.send_json_response(data)
+            self.send_json_response(with_model_summaries(data))
         except Exception as e:
             self.send_error(500, str(e))
 

--- a/cli/nao_core/commands/test/summary.py
+++ b/cli/nao_core/commands/test/summary.py
@@ -1,0 +1,89 @@
+"""Aggregation of test run results, shared by the CLI output and the results server."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+Runs = Sequence[Mapping[str, Any]]
+
+UNKNOWN_MODEL = "unknown"
+
+
+@dataclass
+class ModelSummary:
+    """Aggregated performance of a single model across the runs it was used for."""
+
+    model: str
+    total: int
+    passed: int
+    failed: int
+    pass_rate: float
+    total_tokens: int
+    total_cost: float
+    total_duration_ms: int
+    avg_duration_ms: float
+    total_tool_calls: int
+    avg_tool_calls: float
+
+
+def summarize(runs: Runs) -> dict[str, Any]:
+    """Aggregate every run, regardless of the model that produced it."""
+    total = len(runs)
+    total_duration_ms = _sum(runs, "duration_ms")
+    total_tool_calls = _sum(runs, "tool_call_count")
+    passed = sum(1 for run in runs if run.get("passed"))
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "total_tokens": _sum(runs, "tokens"),
+        "total_cost": _sum(runs, "cost"),
+        "total_duration_ms": total_duration_ms,
+        "total_duration_s": round(total_duration_ms / 1000, 2),
+        "total_tool_calls": total_tool_calls,
+        "avg_duration_ms": round(total_duration_ms / total, 0) if total else 0,
+        "avg_tool_calls": round(total_tool_calls / total, 1) if total else 0,
+    }
+
+
+def summarize_by_model(runs: Runs) -> list[ModelSummary]:
+    """Aggregate runs per model, best pass rate first and cheapest as tie-breaker."""
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for run in runs:
+        grouped.setdefault(str(run.get("model") or UNKNOWN_MODEL), []).append(run)
+
+    summaries = [_summarize_model(model, model_runs) for model, model_runs in grouped.items()]
+    return sorted(summaries, key=lambda summary: (-summary.pass_rate, summary.total_cost, summary.model))
+
+
+def with_model_summaries(data: dict[str, Any]) -> dict[str, Any]:
+    """Backfill `by_model` for result files written before per-model summaries existed."""
+    if data.get("by_model"):
+        return data
+    return {**data, "by_model": [asdict(summary) for summary in summarize_by_model(data.get("results") or [])]}
+
+
+def _summarize_model(model: str, runs: Runs) -> ModelSummary:
+    total = len(runs)
+    passed = sum(1 for run in runs if run.get("passed"))
+    total_duration_ms = _sum(runs, "duration_ms")
+    total_tool_calls = _sum(runs, "tool_call_count")
+
+    return ModelSummary(
+        model=model,
+        total=total,
+        passed=passed,
+        failed=total - passed,
+        pass_rate=round(passed / total * 100, 1) if total else 0.0,
+        total_tokens=int(_sum(runs, "tokens")),
+        total_cost=round(_sum(runs, "cost"), 6),
+        total_duration_ms=int(total_duration_ms),
+        avg_duration_ms=round(total_duration_ms / total, 0) if total else 0.0,
+        total_tool_calls=int(total_tool_calls),
+        avg_tool_calls=round(total_tool_calls / total, 1) if total else 0.0,
+    )
+
+
+def _sum(runs: Runs, field: str) -> float:
+    return sum(run.get(field) or 0 for run in runs)

--- a/cli/nao_core/ui.py
+++ b/cli/nao_core/ui.py
@@ -72,6 +72,7 @@ class UI:
         df: pd.DataFrame,
         title: str | None = None,
         sum_columns: dict[str, str] | None = None,
+        fixed_columns: set[str] | None = None,
     ) -> None:
         """Print a DataFrame as a table.
 
@@ -79,11 +80,12 @@ class UI:
             df: DataFrame to display.
             title: Optional table title.
             sum_columns: Dict of column names to sum with their unit (e.g. {"Cost": "$", "Tokens": ""}).
+            fixed_columns: Columns to keep at full width instead of shrinking them to fit the terminal.
         """
         table = Table(title=title)
 
         for col in df.columns:
-            table.add_column(str(col))
+            table.add_column(str(col), no_wrap=col in (fixed_columns or set()))
 
         for _, row in df.iterrows():
             table.add_row(*[str(v) for v in row])

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -1,4 +1,6 @@
 import importlib
+import json
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -285,8 +287,11 @@ def test_filter_test_cases_by_name_without_tests_dir_unchanged():
     assert filtered[0].name == "users"
 
 
-def run_test_command(monkeypatch, tmp_path, config, **flags) -> list[dict]:
-    """Run the `nao test` command against stubbed collaborators and report what it ran."""
+def run_test_command(monkeypatch, tmp_path, config, tables: list | None = None, **flags) -> list[dict]:
+    """Run the `nao test` command against stubbed collaborators and report what it ran.
+
+    Pass ``tables`` to also collect the (title, dataframe) pairs printed as summaries.
+    """
     cases = [
         NaoTestCase(name="orders", prompt="p1", file_path=tmp_path / "orders.yml", sql="select 1"),
         NaoTestCase(name="users", prompt="p2", file_path=tmp_path / "users.yml", sql="select 1"),
@@ -297,12 +302,16 @@ def run_test_command(monkeypatch, tmp_path, config, **flags) -> list[dict]:
         runs.append({"case": test_case, "model": model, **kwargs})
         return NaoTestRunResult(name=test_case.name, model=str(model), passed=True, message="match")
 
+    def table(df, title=None, **kwargs):
+        if tables is not None:
+            tables.append((title, df))
+
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(test_runner_module, "NaoConfig", Mock(try_load=Mock(return_value=config)))
     monkeypatch.setattr(test_runner_module, "discover_tests", lambda project_path: cases)
     monkeypatch.setattr(test_runner_module, "run_test", run)
     monkeypatch.setattr(test_runner_module, "save_results", lambda results, output_dir: output_dir / "results.json")
-    monkeypatch.setattr(test_runner_module.UI, "table", lambda *args, **kwargs: None)
+    monkeypatch.setattr(test_runner_module.UI, "table", table)
 
     test_runner_module.test(**flags)
 
@@ -335,3 +344,98 @@ def test_model_flag_overrides_the_test_block(tmp_path, monkeypatch):
 
     assert [run["case"].name for run in runs] == ["users"]
     assert [str(run["model"]) for run in runs] == ["openai:gpt-4.1"]
+
+
+def test_single_model_runs_only_print_the_run_table(tmp_path, monkeypatch):
+    tables: list = []
+
+    run_test_command(monkeypatch, tmp_path, NaoConfig(project_name="test-project"), tables=tables)
+
+    assert [title for title, _ in tables] == ["Test Results"]
+
+
+def test_multi_model_runs_print_per_model_summaries(tmp_path, monkeypatch):
+    config = NaoConfig(project_name="test-project", test=TestConfig(models=["openai:gpt-4.1", "anthropic:claude-4-5"]))
+    tables: list = []
+
+    run_test_command(monkeypatch, tmp_path, config, tables=tables)
+
+    titles = [title for title, _ in tables]
+    assert titles == ["Test Results", "Performance by Model", "Pass / Fail by Test and Model"]
+
+    matrix = dict(tables)["Pass / Fail by Test and Model"]
+    assert list(matrix.columns) == ["Test", "openai\ngpt-4.1", "anthropic\nclaude-4-5"]
+    assert matrix["Test"].tolist() == ["orders", "users"]
+
+
+def test_threaded_runs_are_reported_grouped_by_model(tmp_path, monkeypatch):
+    config = NaoConfig(project_name="test-project", test=TestConfig(models=["openai:gpt-4.1", "anthropic:claude-4-5"]))
+    cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=tmp_path / "orders.yml", sql="select 1"),
+        NaoTestCase(name="users", prompt="p2", file_path=tmp_path / "users.yml", sql="select 1"),
+    ]
+    # Slowest run is submitted first so completions finish in reverse of submission order.
+    delays = {
+        ("openai:gpt-4.1", "orders"): 0.04,
+        ("openai:gpt-4.1", "users"): 0.03,
+        ("anthropic:claude-4-5", "orders"): 0.02,
+        ("anthropic:claude-4-5", "users"): 0.01,
+    }
+    saved: list[NaoTestRunResult] = []
+
+    def run(test_case, model, **kwargs):
+        time.sleep(delays[(str(model), test_case.name)])
+        return NaoTestRunResult(name=test_case.name, model=str(model), passed=True, message="match")
+
+    def save_results(results, output_dir):
+        saved.extend(results)
+        return output_dir / "results.json"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(test_runner_module, "NaoConfig", Mock(try_load=Mock(return_value=config)))
+    monkeypatch.setattr(test_runner_module, "discover_tests", lambda project_path: cases)
+    monkeypatch.setattr(test_runner_module, "run_test", run)
+    monkeypatch.setattr(test_runner_module, "save_results", save_results)
+    monkeypatch.setattr(test_runner_module.UI, "table", lambda *args, **kwargs: None)
+
+    test_runner_module.test(threads=4)
+
+    assert [(r.model, r.name) for r in saved] == [
+        ("openai:gpt-4.1", "orders"),
+        ("openai:gpt-4.1", "users"),
+        ("anthropic:claude-4-5", "orders"),
+        ("anthropic:claude-4-5", "users"),
+    ]
+
+
+def test_save_results_records_per_model_summaries(tmp_path):
+    results = [
+        NaoTestRunResult(
+            name="orders",
+            model="openai:gpt-4.1",
+            passed=True,
+            message="match",
+            tokens=100,
+            cost=0.2,
+            duration_ms=1000,
+            tool_call_count=2,
+        ),
+        NaoTestRunResult(
+            name="orders",
+            model="anthropic:claude-4-5",
+            passed=False,
+            message="values differ",
+            tokens=200,
+            cost=0.1,
+            duration_ms=3000,
+            tool_call_count=4,
+        ),
+    ]
+
+    output_file = test_runner_module.save_results(results, tmp_path / "outputs")
+    data = json.loads(output_file.read_text())
+
+    assert data["summary"]["total"] == 2
+    assert [model["model"] for model in data["by_model"]] == ["openai:gpt-4.1", "anthropic:claude-4-5"]
+    assert data["by_model"][0]["pass_rate"] == 100.0
+    assert data["by_model"][1]["avg_duration_ms"] == 3000

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -67,6 +67,21 @@ def test_check_dataframe_rounds_to_two_decimals():
     assert comparison is None
 
 
+def test_check_dataframe_reports_the_verification_error_when_no_data_was_produced():
+    verification = VerificationResult(
+        data=None,
+        expectedData=[{"total": 1}],
+        expectedColumns=["total"],
+        error="Binder Error: column total does not exist",
+    )
+
+    passed, msg, comparison = check_dataframe(verification)
+
+    assert passed is False
+    assert msg == "Binder Error: column total does not exist"
+    assert comparison is None
+
+
 def test_filter_test_cases_by_name():
     test_cases = [
         NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1"),
@@ -188,6 +203,7 @@ def test_run_test_records_reference_sql_with_verification(monkeypatch):
             data=[{"total": 1}],
             expectedData=[{"total": 1}],
             expectedColumns=["total"],
+            sql="SELECT total FROM query_abc",
         ),
     )
     monkeypatch.setattr(test_runner_module, "get_client", lambda **_: client)
@@ -197,6 +213,7 @@ def test_run_test_records_reference_sql_with_verification(monkeypatch):
     assert result.passed is True
     assert result.details is not None
     assert result.details.reference_sql == "select 1"
+    assert result.details.verification_sql == "SELECT total FROM query_abc"
 
 
 def test_run_test_records_reference_sql_without_verification(monkeypatch):

--- a/cli/tests/nao_core/commands/test_summary.py
+++ b/cli/tests/nao_core/commands/test_summary.py
@@ -1,0 +1,75 @@
+from nao_core.commands.test.summary import summarize, summarize_by_model, with_model_summaries
+
+
+def run(model: str, passed: bool, **overrides) -> dict:
+    return {
+        "name": overrides.get("name", "orders"),
+        "model": model,
+        "passed": passed,
+        "message": "match" if passed else "values differ",
+        "tokens": overrides.get("tokens", 100),
+        "cost": overrides.get("cost", 0.01),
+        "duration_ms": overrides.get("duration_ms", 2000),
+        "tool_call_count": overrides.get("tool_call_count", 3),
+    }
+
+
+def test_summarize_aggregates_every_run():
+    summary = summarize([run("openai:gpt-4.1", True), run("anthropic:claude-sonnet-4-5", False)])
+
+    assert summary["total"] == 2
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["total_tokens"] == 200
+    assert summary["total_duration_s"] == 4.0
+    assert summary["avg_tool_calls"] == 3.0
+
+
+def test_summarize_by_model_groups_runs_per_model():
+    runs = [
+        run("openai:gpt-4.1", True, name="orders"),
+        run("openai:gpt-4.1", False, name="users"),
+        run("anthropic:claude-sonnet-4-5", True, name="orders", tokens=50, duration_ms=1000),
+        run("anthropic:claude-sonnet-4-5", True, name="users", tokens=50, duration_ms=3000),
+    ]
+
+    summaries = summarize_by_model(runs)
+
+    assert [s.model for s in summaries] == ["anthropic:claude-sonnet-4-5", "openai:gpt-4.1"]
+    best, worst = summaries
+    assert (best.passed, best.failed, best.pass_rate) == (2, 0, 100.0)
+    assert best.total_tokens == 100
+    assert best.avg_duration_ms == 2000
+    assert (worst.passed, worst.failed, worst.pass_rate) == (1, 1, 50.0)
+
+
+def test_summarize_by_model_ranks_the_cheapest_model_first_on_equal_pass_rates():
+    runs = [
+        run("openai:gpt-4.1", True, cost=0.5),
+        run("anthropic:claude-sonnet-4-5", True, cost=0.1),
+    ]
+
+    assert [s.model for s in summarize_by_model(runs)] == ["anthropic:claude-sonnet-4-5", "openai:gpt-4.1"]
+
+
+def test_summarize_by_model_handles_runs_without_metrics():
+    summaries = summarize_by_model([{"name": "orders", "model": "openai:gpt-4.1", "passed": False}])
+
+    assert summaries[0].total_tokens == 0
+    assert summaries[0].avg_duration_ms == 0
+    assert summaries[0].pass_rate == 0.0
+
+
+def test_with_model_summaries_backfills_older_result_files():
+    data = {"results": [run("openai:gpt-4.1", True), run("openai:gpt-4.1", False)], "summary": {"total": 2}}
+
+    backfilled = with_model_summaries(data)
+
+    assert [s["model"] for s in backfilled["by_model"]] == ["openai:gpt-4.1"]
+    assert backfilled["by_model"][0]["pass_rate"] == 50.0
+
+
+def test_with_model_summaries_keeps_existing_summaries():
+    data = {"results": [run("openai:gpt-4.1", True)], "by_model": [{"model": "kept"}]}
+
+    assert with_model_summaries(data)["by_model"] == [{"model": "kept"}]


### PR DESCRIPTION
## Summary

- `nao test` verification used to ask the model to retype its final answer as JSON rows, which loses precision on large or wide results and costs a full serialisation of the data.
- The model is now asked for a **DuckDB query over the rows it already fetched**: every `execute_sql` result of the run is loaded in an in-memory DuckDB as a table named after its query id, and the query runs locally.
- Rows are loaded through newline-delimited JSON so DuckDB infers the column types instead of us guessing them from JavaScript values.
- One repair attempt is allowed: a failing query is sent back with its error so the model can fix it.
- The verification SQL and the error are reported back to the CLI, which prints the query and uses the error as the failure message.
- Run failures now include `finishReason`, output tokens and truncated text when the model produced no object.

## Test plan

- [x] `npm run -w @nao/backend test -- --run tests/duckdb-query-results.test.ts` (4 tests: table per query id, type preservation, empty result, invalid SQL)
- [x] `cd cli && uv run pytest tests/nao_core/commands/test_runner.py` (21 tests)
- [x] `npm run lint` and `cd cli && make lint`
- [ ] Run `nao test` against a real project and confirm the verification SQL is printed and results match

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

