### PR TITLE
Summarize nao test runs per model in the CLI and the results server

### DIFF
--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -19,6 +19,7 @@ from nao_core.ui import UI
 from .case import TESTS_FOLDER, TestCase, discover_tests
 from .client import AgentClientError, VerificationResult, get_client
 from .compare import normalize_dataframe_numbers
+from .summary import ModelSummary, summarize, summarize_by_model
 
 
 @dataclass
@@ -289,28 +290,89 @@ def save_results(results: list[TestRunResult], output_dir: Path) -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     output_file = output_dir / f"results_{timestamp}.json"
 
-    total_duration_ms = sum(r.duration_ms or 0 for r in results)
-    total_tool_calls = sum(r.tool_call_count or 0 for r in results)
-
+    runs = [asdict(r) for r in results]
     data = {
         "timestamp": datetime.now().isoformat(),
-        "results": [asdict(r) for r in results],
-        "summary": {
-            "total": len(results),
-            "passed": sum(1 for r in results if r.passed),
-            "failed": sum(1 for r in results if not r.passed),
-            "total_tokens": sum(r.tokens or 0 for r in results),
-            "total_cost": sum(r.cost or 0 for r in results),
-            "total_duration_ms": total_duration_ms,
-            "total_duration_s": round(total_duration_ms / 1000, 2),
-            "total_tool_calls": total_tool_calls,
-            "avg_duration_ms": round(total_duration_ms / len(results), 0) if results else 0,
-            "avg_tool_calls": round(total_tool_calls / len(results), 1) if results else 0,
-        },
+        "results": runs,
+        "summary": summarize(runs),
+        "by_model": [asdict(s) for s in summarize_by_model(runs)],
     }
 
     output_file.write_text(json.dumps(data, indent=2))
     return output_file
+
+
+def print_run_table(results: list[TestRunResult]) -> None:
+    """Print one row per run, i.e. per (test, model) pair."""
+    df = pd.DataFrame(
+        [
+            {
+                "Test": r.name,
+                "Model": r.model,
+                "Status": status_icon(r.passed),
+                "Message": r.message,
+                "Tokens": r.tokens or 0,
+                "Cost": r.cost or 0,
+                "Time (s)": round((r.duration_ms or 0) / 1000, 1),
+                "Tools": r.tool_call_count or 0,
+            }
+            for r in results
+        ]
+    )
+
+    UI.table(df, title="Test Results", sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
+
+
+def print_model_table(summaries: list[ModelSummary]) -> None:
+    """Print one row per model, ranked from best to worst pass rate."""
+    df = pd.DataFrame(
+        [
+            {
+                "Model": column_label(s.model),
+                "Pass Rate": format_pass_rate(s.pass_rate),
+                "Passed": f"{s.passed}/{s.total}",
+                "Tokens": s.total_tokens,
+                "Cost": s.total_cost,
+                "Avg Time (s)": round(s.avg_duration_ms / 1000, 1),
+                "Avg Tools": s.avg_tool_calls,
+            }
+            for s in summaries
+        ]
+    )
+
+    UI.table(df, title="Performance by Model", sum_columns={"Tokens": "", "Cost": "$"}, fixed_columns={"Model"})
+
+
+def print_model_matrix(results: list[TestRunResult]) -> None:
+    """Print a test × model grid to show which model passes which test."""
+    models = list(dict.fromkeys(r.model for r in results))
+    statuses: dict[tuple[str, str], list[str]] = {}
+    for result in results:
+        statuses.setdefault((result.name, result.model), []).append(status_icon(result.passed))
+
+    rows = [
+        {"Test": name}
+        | {column_label(model): " ".join(statuses.get((name, model), ["[dim]-[/dim]"])) for model in models}
+        for name in dict.fromkeys(r.name for r in results)
+    ]
+
+    UI.table(pd.DataFrame(rows), title="Pass / Fail by Test and Model")
+
+
+def column_label(model: str) -> str:
+    """Stack the provider above the model id to keep matrix columns narrow."""
+    return model.replace(":", "\n")
+
+
+def status_icon(passed: bool) -> str:
+    """Render a pass/fail marker for terminal tables."""
+    return "[green]✓[/green]" if passed else "[red]✗[/red]"
+
+
+def format_pass_rate(pass_rate: float) -> str:
+    """Colour a pass rate from green (all passing) to red (mostly failing)."""
+    color = "green" if pass_rate == 100 else "red" if pass_rate < 50 else "yellow"
+    return f"[{color}]{pass_rate}%[/{color}]"
 
 
 def filter_test_cases(
@@ -469,6 +531,8 @@ def test(
             results.append(result)
             UI.print("")
     else:
+        # Results are collected by submission order so the summaries stay grouped by model.
+        completed: dict[int, TestRunResult] = {}
         with ThreadPoolExecutor(max_workers=thread_count) as executor:
             futures = {
                 executor.submit(
@@ -479,45 +543,33 @@ def test(
                     password=pwd,
                     costs=resolve_model_costs(config, m),
                     comparison=test_config.comparison,
-                ): (tc, m)
-                for tc, m in test_runs
+                ): index
+                for index, (tc, m) in enumerate(test_runs)
             }
             for future in as_completed(futures):
-                result = future.result()
-                results.append(result)
+                completed[futures[future]] = future.result()
                 UI.print("")
+        results = [completed[index] for index in sorted(completed)]
 
     # Save results to JSON
     output_file = save_results(results, project_path / TESTS_FOLDER / "outputs")
     UI.print(f"[dim]Results saved to: {output_file}[/dim]\n")
 
-    # Print summary table
-    df = pd.DataFrame(
-        [
-            {
-                "Test": r.name,
-                "Model": r.model,
-                "Status": "[green]✓[/green]" if r.passed else "[red]✗[/red]",
-                "Message": r.message,
-                "Tokens": r.tokens or 0,
-                "Cost": r.cost or 0,
-                "Time (s)": round((r.duration_ms or 0) / 1000, 1),
-                "Tools": r.tool_call_count or 0,
-            }
-            for r in results
-        ]
-    )
+    print_run_table(results)
 
-    UI.table(df, title="Test Results", sum_columns={"Tokens": "", "Cost": "$", "Time (s)": "", "Tools": ""})
+    model_summaries = summarize_by_model([asdict(r) for r in results])
+    if len(model_summaries) > 1:
+        print_model_table(model_summaries)
+        print_model_matrix(results)
 
-    # Print summary
     passed = sum(1 for r in results if r.passed)
     failed = sum(1 for r in results if not r.passed)
     total = len(results)
+    unit = "run" if len(model_summaries) > 1 else "test"
 
     UI.print("")
     if failed == 0:
-        UI.success(f"All {total} test(s) passed")
+        UI.success(f"All {total} {unit}(s) passed")
     else:
         UI.print(f"[green]{passed} passed[/green], [red]{failed} failed[/red], {total} total")
         sys.exit(1)

--- a/cli/nao_core/commands/test/server.py
+++ b/cli/nao_core/commands/test/server.py
@@ -12,6 +12,7 @@ from nao_core.config import NaoConfig, resolve_project_path
 from nao_core.ui import UI
 
 from .case import TESTS_FOLDER
+from .summary import with_model_summaries
 
 # Default port for the server
 DEFAULT_PORT = 8765
@@ -55,6 +56,22 @@ def get_html_template() -> str:
         .status.pass { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
         .status.fail { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
         .model-badge { display: inline-block; padding: 0.125rem 0.5rem; background: #333; border-radius: 4px; font-size: 0.75rem; color: #aaa; font-family: monospace; }
+        .model-badge.active { background: #3f3f3f; color: #fff; }
+        .section { margin-bottom: 2rem; }
+        .section-title { font-size: 0.75rem; color: #888; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.75rem; }
+        .rate { display: flex; align-items: center; gap: 0.625rem; }
+        .rate-value { font-family: monospace; font-size: 0.875rem; min-width: 3.25rem; }
+        .rate-bar { flex: 1; min-width: 60px; height: 6px; background: #333; border-radius: 3px; overflow: hidden; }
+        .rate-fill { height: 100%; background: #22c55e; }
+        .rate-fill.warn { background: #eab308; }
+        .rate-fill.error { background: #ef4444; }
+        .filters { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin-bottom: 1rem; }
+        .chip { padding: 0.375rem 0.75rem; background: #1a1a1a; border: 1px solid #333; border-radius: 999px; color: #aaa; font-family: monospace; font-size: 0.8125rem; cursor: pointer; }
+        .chip:hover { border-color: #555; }
+        .chip.active { background: #333; color: #fff; border-color: #666; }
+        .matrix th, .matrix td { text-align: center; }
+        .matrix th:first-child, .matrix td:first-child { text-align: left; }
+        .cell-status { cursor: pointer; }
         .mono { font-family: monospace; font-size: 0.875rem; }
         .text-muted { color: #888; }
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0, 0, 0, 0.8); z-index: 1000; display: flex; align-items: center; justify-content: center; }
@@ -163,7 +180,17 @@ def get_html_template() -> str:
 
         function Results({ data, onSelect }) {
             const { summary, results, timestamp } = data;
+            const byModel = data.by_model || [];
+            const models = byModel.map(m => m.model);
+            const multiModel = models.length > 1;
+            const [modelFilter, setModelFilter] = useState('all');
+
+            useEffect(() => {
+                setModelFilter('all');
+            }, [timestamp]);
+
             const passRate = summary.total > 0 ? Math.round((summary.passed / summary.total) * 100) : 0;
+            const visibleResults = modelFilter === 'all' ? results : results.filter(r => r.model === modelFilter);
 
             return (
                 <>
@@ -171,46 +198,164 @@ def get_html_template() -> str:
                         <Card label="Pass Rate" value={passRate + '%'} className={passRate === 100 ? 'success' : passRate < 50 ? 'error' : ''} />
                         <Card label="Passed" value={summary.passed} className="success" />
                         <Card label="Failed" value={summary.failed} className={summary.failed > 0 ? 'error' : ''} />
-                        <Card label="Total Tests" value={summary.total} />
+                        <Card label={multiModel ? 'Total Runs' : 'Total Tests'} value={summary.total} />
+                        {multiModel && <Card label="Models" value={models.length} />}
                         <Card label="Total Tokens" value={summary.total_tokens.toLocaleString()} />
                         <Card label="Total Cost" value={'$' + summary.total_cost.toFixed(4)} />
                         <Card label="Duration" value={summary.total_duration_s + 's'} />
                         <Card label="Tool Calls" value={summary.total_tool_calls} />
                     </div>
 
-                    <p className="text-muted" style={{ marginBottom: '1rem', fontSize: '0.875rem' }}>
+                    <p className="text-muted" style={{ marginBottom: '2rem', fontSize: '0.875rem' }}>
                         Run at: {new Date(timestamp).toLocaleString()} &bull; Avg duration: {summary.avg_duration_ms}ms &bull; Avg tool calls: {summary.avg_tool_calls}
                     </p>
 
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Status</th>
-                                <th>Test Name</th>
-                                <th>Model</th>
-                                <th>Message</th>
-                                <th>Tokens</th>
-                                <th>Cost</th>
-                                <th>Duration</th>
-                                <th>Tools</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {results.map((r, i) => (
-                                <tr key={i} className="clickable" onClick={() => onSelect(r)}>
-                                    <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
-                                    <td><strong>{r.name}</strong></td>
-                                    <td><span className="model-badge">{r.model}</span></td>
-                                    <td className="text-muted">{r.message}</td>
-                                    <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
-                                    <td className="mono">${(r.cost || 0).toFixed(4)}</td>
-                                    <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
-                                    <td className="mono">{r.tool_call_count || 0}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                    {multiModel && (
+                        <>
+                            <div className="section">
+                                <h2 className="section-title">Performance by Model</h2>
+                                <ModelTable byModel={byModel} activeModel={modelFilter} onSelectModel={setModelFilter} />
+                            </div>
+
+                            <div className="section">
+                                <h2 className="section-title">Pass / Fail by Test and Model</h2>
+                                <ModelMatrix results={results} models={models} onSelect={onSelect} />
+                            </div>
+                        </>
+                    )}
+
+                    <div className="section">
+                        <h2 className="section-title">{multiModel ? 'Runs' : 'Tests'}</h2>
+                        {multiModel && <ModelFilter models={models} active={modelFilter} onChange={setModelFilter} />}
+                        <RunTable results={visibleResults} onSelect={onSelect} />
+                    </div>
                 </>
+            );
+        }
+
+        function ModelTable({ byModel, activeModel, onSelectModel }) {
+            return (
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Model</th>
+                            <th>Pass Rate</th>
+                            <th>Passed</th>
+                            <th>Failed</th>
+                            <th>Tokens</th>
+                            <th>Cost</th>
+                            <th>Avg Duration</th>
+                            <th>Avg Tools</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {byModel.map(m => (
+                            <tr key={m.model} className="clickable" onClick={() => onSelectModel(activeModel === m.model ? 'all' : m.model)}>
+                                <td><span className={'model-badge' + (activeModel === m.model ? ' active' : '')}>{m.model}</span></td>
+                                <td><PassRate rate={m.pass_rate} /></td>
+                                <td className="mono">{m.passed}/{m.total}</td>
+                                <td className="mono">{m.failed}</td>
+                                <td className="mono">{m.total_tokens.toLocaleString()}</td>
+                                <td className="mono">${m.total_cost.toFixed(4)}</td>
+                                <td className="mono">{(m.avg_duration_ms / 1000).toFixed(1)}s</td>
+                                <td className="mono">{m.avg_tool_calls}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            );
+        }
+
+        function PassRate({ rate }) {
+            const tone = rate === 100 ? '' : rate < 50 ? ' error' : ' warn';
+            return (
+                <div className="rate">
+                    <span className="rate-value">{rate}%</span>
+                    <div className="rate-bar"><div className={'rate-fill' + tone} style={{ width: rate + '%' }} /></div>
+                </div>
+            );
+        }
+
+        function ModelMatrix({ results, models, onSelect }) {
+            const testNames = [...new Set(results.map(r => r.name))];
+            const runs = {};
+            results.forEach(r => { runs[r.name + '\\u0000' + r.model] = r; });
+
+            return (
+                <table className="matrix">
+                    <thead>
+                        <tr>
+                            <th>Test</th>
+                            {models.map(m => <th key={m}>{m}</th>)}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {testNames.map(name => (
+                            <tr key={name}>
+                                <td><strong>{name}</strong></td>
+                                {models.map(m => {
+                                    const run = runs[name + '\\u0000' + m];
+                                    if (!run) return <td key={m} className="text-muted">&mdash;</td>;
+                                    return (
+                                        <td key={m}>
+                                            <span
+                                                className={'status cell-status ' + (run.passed ? 'pass' : 'fail')}
+                                                title={run.message}
+                                                onClick={() => onSelect(run)}
+                                            >
+                                                {run.passed ? '✓' : '✗'} {((run.duration_ms || 0) / 1000).toFixed(1)}s
+                                            </span>
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            );
+        }
+
+        function ModelFilter({ models, active, onChange }) {
+            return (
+                <div className="filters">
+                    <button className={'chip' + (active === 'all' ? ' active' : '')} onClick={() => onChange('all')}>All models</button>
+                    {models.map(m => (
+                        <button key={m} className={'chip' + (active === m ? ' active' : '')} onClick={() => onChange(m)}>{m}</button>
+                    ))}
+                </div>
+            );
+        }
+
+        function RunTable({ results, onSelect }) {
+            return (
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Status</th>
+                            <th>Test Name</th>
+                            <th>Model</th>
+                            <th>Message</th>
+                            <th>Tokens</th>
+                            <th>Cost</th>
+                            <th>Duration</th>
+                            <th>Tools</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {results.map((r, i) => (
+                            <tr key={i} className="clickable" onClick={() => onSelect(r)}>
+                                <td><span className={'status ' + (r.passed ? 'pass' : 'fail')}>{r.passed ? '✓ Pass' : '✗ Fail'}</span></td>
+                                <td><strong>{r.name}</strong></td>
+                                <td><span className="model-badge">{r.model}</span></td>
+                                <td className="text-muted">{r.message}</td>
+                                <td className="mono">{(r.tokens || 0).toLocaleString()}</td>
+                                <td className="mono">${(r.cost || 0).toFixed(4)}</td>
+                                <td className="mono">{((r.duration_ms || 0) / 1000).toFixed(1)}s</td>
+                                <td className="mono">{r.tool_call_count || 0}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             );
         }
 
@@ -438,7 +583,7 @@ class TestResultsHandler(http.server.BaseHTTPRequestHandler):
 
         try:
             data = json.loads(filepath.read_text())
-            self.send_json_response(data)
+            self.send_json_response(with_model_summaries(data))
         except Exception as e:
             self.send_error(500, str(e))
 

--- a/cli/nao_core/commands/test/summary.py
+++ b/cli/nao_core/commands/test/summary.py
@@ -1,0 +1,89 @@
+"""Aggregation of test run results, shared by the CLI output and the results server."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+Runs = Sequence[Mapping[str, Any]]
+
+UNKNOWN_MODEL = "unknown"
+
+
+@dataclass
+class ModelSummary:
+    """Aggregated performance of a single model across the runs it was used for."""
+
+    model: str
+    total: int
+    passed: int
+    failed: int
+    pass_rate: float
+    total_tokens: int
+    total_cost: float
+    total_duration_ms: int
+    avg_duration_ms: float
+    total_tool_calls: int
+    avg_tool_calls: float
+
+
+def summarize(runs: Runs) -> dict[str, Any]:
+    """Aggregate every run, regardless of the model that produced it."""
+    total = len(runs)
+    total_duration_ms = _sum(runs, "duration_ms")
+    total_tool_calls = _sum(runs, "tool_call_count")
+    passed = sum(1 for run in runs if run.get("passed"))
+
+    return {
+        "total": total,
+        "passed": passed,
+        "failed": total - passed,
+        "total_tokens": _sum(runs, "tokens"),
+        "total_cost": _sum(runs, "cost"),
+        "total_duration_ms": total_duration_ms,
+        "total_duration_s": round(total_duration_ms / 1000, 2),
+        "total_tool_calls": total_tool_calls,
+        "avg_duration_ms": round(total_duration_ms / total, 0) if total else 0,
+        "avg_tool_calls": round(total_tool_calls / total, 1) if total else 0,
+    }
+
+
+def summarize_by_model(runs: Runs) -> list[ModelSummary]:
+    """Aggregate runs per model, best pass rate first and cheapest as tie-breaker."""
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for run in runs:
+        grouped.setdefault(str(run.get("model") or UNKNOWN_MODEL), []).append(run)
+
+    summaries = [_summarize_model(model, model_runs) for model, model_runs in grouped.items()]
+    return sorted(summaries, key=lambda summary: (-summary.pass_rate, summary.total_cost, summary.model))
+
+
+def with_model_summaries(data: dict[str, Any]) -> dict[str, Any]:
+    """Backfill `by_model` for result files written before per-model summaries existed."""
+    if data.get("by_model"):
+        return data
+    return {**data, "by_model": [asdict(summary) for summary in summarize_by_model(data.get("results") or [])]}
+
+
+def _summarize_model(model: str, runs: Runs) -> ModelSummary:
+    total = len(runs)
+    passed = sum(1 for run in runs if run.get("passed"))
+    total_duration_ms = _sum(runs, "duration_ms")
+    total_tool_calls = _sum(runs, "tool_call_count")
+
+    return ModelSummary(
+        model=model,
+        total=total,
+        passed=passed,
+        failed=total - passed,
+        pass_rate=round(passed / total * 100, 1) if total else 0.0,
+        total_tokens=int(_sum(runs, "tokens")),
+        total_cost=round(_sum(runs, "cost"), 6),
+        total_duration_ms=int(total_duration_ms),
+        avg_duration_ms=round(total_duration_ms / total, 0) if total else 0.0,
+        total_tool_calls=int(total_tool_calls),
+        avg_tool_calls=round(total_tool_calls / total, 1) if total else 0.0,
+    )
+
+
+def _sum(runs: Runs, field: str) -> float:
+    return sum(run.get(field) or 0 for run in runs)

--- a/cli/nao_core/ui.py
+++ b/cli/nao_core/ui.py
@@ -72,6 +72,7 @@ class UI:
         df: pd.DataFrame,
         title: str | None = None,
         sum_columns: dict[str, str] | None = None,
+        fixed_columns: set[str] | None = None,
     ) -> None:
         """Print a DataFrame as a table.
 
@@ -79,11 +80,12 @@ class UI:
             df: DataFrame to display.
             title: Optional table title.
             sum_columns: Dict of column names to sum with their unit (e.g. {"Cost": "$", "Tokens": ""}).
+            fixed_columns: Columns to keep at full width instead of shrinking them to fit the terminal.
         """
         table = Table(title=title)
 
         for col in df.columns:
-            table.add_column(str(col))
+            table.add_column(str(col), no_wrap=col in (fixed_columns or set()))
 
         for _, row in df.iterrows():
             table.add_row(*[str(v) for v in row])

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -1,4 +1,6 @@
 import importlib
+import json
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -285,8 +287,11 @@ def test_filter_test_cases_by_name_without_tests_dir_unchanged():
     assert filtered[0].name == "users"
 
 
-def run_test_command(monkeypatch, tmp_path, config, **flags) -> list[dict]:
-    """Run the `nao test` command against stubbed collaborators and report what it ran."""
+def run_test_command(monkeypatch, tmp_path, config, tables: list | None = None, **flags) -> list[dict]:
+    """Run the `nao test` command against stubbed collaborators and report what it ran.
+
+    Pass ``tables`` to also collect the (title, dataframe) pairs printed as summaries.
+    """
     cases = [
         NaoTestCase(name="orders", prompt="p1", file_path=tmp_path / "orders.yml", sql="select 1"),
         NaoTestCase(name="users", prompt="p2", file_path=tmp_path / "users.yml", sql="select 1"),
@@ -297,12 +302,16 @@ def run_test_command(monkeypatch, tmp_path, config, **flags) -> list[dict]:
         runs.append({"case": test_case, "model": model, **kwargs})
         return NaoTestRunResult(name=test_case.name, model=str(model), passed=True, message="match")
 
+    def table(df, title=None, **kwargs):
+        if tables is not None:
+            tables.append((title, df))
+
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(test_runner_module, "NaoConfig", Mock(try_load=Mock(return_value=config)))
     monkeypatch.setattr(test_runner_module, "discover_tests", lambda project_path: cases)
     monkeypatch.setattr(test_runner_module, "run_test", run)
     monkeypatch.setattr(test_runner_module, "save_results", lambda results, output_dir: output_dir / "results.json")
-    monkeypatch.setattr(test_runner_module.UI, "table", lambda *args, **kwargs: None)
+    monkeypatch.setattr(test_runner_module.UI, "table", table)
 
     test_runner_module.test(**flags)
 
@@ -335,3 +344,98 @@ def test_model_flag_overrides_the_test_block(tmp_path, monkeypatch):
 
     assert [run["case"].name for run in runs] == ["users"]
     assert [str(run["model"]) for run in runs] == ["openai:gpt-4.1"]
+
+
+def test_single_model_runs_only_print_the_run_table(tmp_path, monkeypatch):
+    tables: list = []
+
+    run_test_command(monkeypatch, tmp_path, NaoConfig(project_name="test-project"), tables=tables)
+
+    assert [title for title, _ in tables] == ["Test Results"]
+
+
+def test_multi_model_runs_print_per_model_summaries(tmp_path, monkeypatch):
+    config = NaoConfig(project_name="test-project", test=TestConfig(models=["openai:gpt-4.1", "anthropic:claude-4-5"]))
+    tables: list = []
+
+    run_test_command(monkeypatch, tmp_path, config, tables=tables)
+
+    titles = [title for title, _ in tables]
+    assert titles == ["Test Results", "Performance by Model", "Pass / Fail by Test and Model"]
+
+    matrix = dict(tables)["Pass / Fail by Test and Model"]
+    assert list(matrix.columns) == ["Test", "openai\ngpt-4.1", "anthropic\nclaude-4-5"]
+    assert matrix["Test"].tolist() == ["orders", "users"]
+
+
+def test_threaded_runs_are_reported_grouped_by_model(tmp_path, monkeypatch):
+    config = NaoConfig(project_name="test-project", test=TestConfig(models=["openai:gpt-4.1", "anthropic:claude-4-5"]))
+    cases = [
+        NaoTestCase(name="orders", prompt="p1", file_path=tmp_path / "orders.yml", sql="select 1"),
+        NaoTestCase(name="users", prompt="p2", file_path=tmp_path / "users.yml", sql="select 1"),
+    ]
+    # Slowest run is submitted first so completions finish in reverse of submission order.
+    delays = {
+        ("openai:gpt-4.1", "orders"): 0.04,
+        ("openai:gpt-4.1", "users"): 0.03,
+        ("anthropic:claude-4-5", "orders"): 0.02,
+        ("anthropic:claude-4-5", "users"): 0.01,
+    }
+    saved: list[NaoTestRunResult] = []
+
+    def run(test_case, model, **kwargs):
+        time.sleep(delays[(str(model), test_case.name)])
+        return NaoTestRunResult(name=test_case.name, model=str(model), passed=True, message="match")
+
+    def save_results(results, output_dir):
+        saved.extend(results)
+        return output_dir / "results.json"
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(test_runner_module, "NaoConfig", Mock(try_load=Mock(return_value=config)))
+    monkeypatch.setattr(test_runner_module, "discover_tests", lambda project_path: cases)
+    monkeypatch.setattr(test_runner_module, "run_test", run)
+    monkeypatch.setattr(test_runner_module, "save_results", save_results)
+    monkeypatch.setattr(test_runner_module.UI, "table", lambda *args, **kwargs: None)
+
+    test_runner_module.test(threads=4)
+
+    assert [(r.model, r.name) for r in saved] == [
+        ("openai:gpt-4.1", "orders"),
+        ("openai:gpt-4.1", "users"),
+        ("anthropic:claude-4-5", "orders"),
+        ("anthropic:claude-4-5", "users"),
+    ]
+
+
+def test_save_results_records_per_model_summaries(tmp_path):
+    results = [
+        NaoTestRunResult(
+            name="orders",
+            model="openai:gpt-4.1",
+            passed=True,
+            message="match",
+            tokens=100,
+            cost=0.2,
+            duration_ms=1000,
+            tool_call_count=2,
+        ),
+        NaoTestRunResult(
+            name="orders",
+            model="anthropic:claude-4-5",
+            passed=False,
+            message="values differ",
+            tokens=200,
+            cost=0.1,
+            duration_ms=3000,
+            tool_call_count=4,
+        ),
+    ]
+
+    output_file = test_runner_module.save_results(results, tmp_path / "outputs")
+    data = json.loads(output_file.read_text())
+
+    assert data["summary"]["total"] == 2
+    assert [model["model"] for model in data["by_model"]] == ["openai:gpt-4.1", "anthropic:claude-4-5"]
+    assert data["by_model"][0]["pass_rate"] == 100.0
+    assert data["by_model"][1]["avg_duration_ms"] == 3000

--- a/cli/tests/nao_core/commands/test_summary.py
+++ b/cli/tests/nao_core/commands/test_summary.py
@@ -1,0 +1,75 @@
+from nao_core.commands.test.summary import summarize, summarize_by_model, with_model_summaries
+
+
+def run(model: str, passed: bool, **overrides) -> dict:
+    return {
+        "name": overrides.get("name", "orders"),
+        "model": model,
+        "passed": passed,
+        "message": "match" if passed else "values differ",
+        "tokens": overrides.get("tokens", 100),
+        "cost": overrides.get("cost", 0.01),
+        "duration_ms": overrides.get("duration_ms", 2000),
+        "tool_call_count": overrides.get("tool_call_count", 3),
+    }
+
+
+def test_summarize_aggregates_every_run():
+    summary = summarize([run("openai:gpt-4.1", True), run("anthropic:claude-sonnet-4-5", False)])
+
+    assert summary["total"] == 2
+    assert summary["passed"] == 1
+    assert summary["failed"] == 1
+    assert summary["total_tokens"] == 200
+    assert summary["total_duration_s"] == 4.0
+    assert summary["avg_tool_calls"] == 3.0
+
+
+def test_summarize_by_model_groups_runs_per_model():
+    runs = [
+        run("openai:gpt-4.1", True, name="orders"),
+        run("openai:gpt-4.1", False, name="users"),
+        run("anthropic:claude-sonnet-4-5", True, name="orders", tokens=50, duration_ms=1000),
+        run("anthropic:claude-sonnet-4-5", True, name="users", tokens=50, duration_ms=3000),
+    ]
+
+    summaries = summarize_by_model(runs)
+
+    assert [s.model for s in summaries] == ["anthropic:claude-sonnet-4-5", "openai:gpt-4.1"]
+    best, worst = summaries
+    assert (best.passed, best.failed, best.pass_rate) == (2, 0, 100.0)
+    assert best.total_tokens == 100
+    assert best.avg_duration_ms == 2000
+    assert (worst.passed, worst.failed, worst.pass_rate) == (1, 1, 50.0)
+
+
+def test_summarize_by_model_ranks_the_cheapest_model_first_on_equal_pass_rates():
+    runs = [
+        run("openai:gpt-4.1", True, cost=0.5),
+        run("anthropic:claude-sonnet-4-5", True, cost=0.1),
+    ]
+
+    assert [s.model for s in summarize_by_model(runs)] == ["anthropic:claude-sonnet-4-5", "openai:gpt-4.1"]
+
+
+def test_summarize_by_model_handles_runs_without_metrics():
+    summaries = summarize_by_model([{"name": "orders", "model": "openai:gpt-4.1", "passed": False}])
+
+    assert summaries[0].total_tokens == 0
+    assert summaries[0].avg_duration_ms == 0
+    assert summaries[0].pass_rate == 0.0
+
+
+def test_with_model_summaries_backfills_older_result_files():
+    data = {"results": [run("openai:gpt-4.1", True), run("openai:gpt-4.1", False)], "summary": {"total": 2}}
+
+    backfilled = with_model_summaries(data)
+
+    assert [s["model"] for s in backfilled["by_model"]] == ["openai:gpt-4.1"]
+    assert backfilled["by_model"][0]["pass_rate"] == 50.0
+
+
+def test_with_model_summaries_keeps_existing_summaries():
+    data = {"results": [run("openai:gpt-4.1", True)], "by_model": [{"model": "kept"}]}
+
+    assert with_model_summaries(data)["by_model"] == [{"model": "kept"}]


### PR DESCRIPTION
## Summary

- Stacked on #1311 — review that one first; the base will move to `main` once it merges.
- Multi-model runs only produced a flat list of runs, so comparing models was manual.
- Aggregation moves to a new `summary.py` shared by the CLI output and the results web server: an overall summary plus a per-model one, ranked by pass rate with cost as tie-breaker.
- The CLI gains a **Performance by Model** table and a **test x model pass/fail matrix** when more than one model ran; single-model runs are unchanged.
- The results web UI gains the same two sections plus model filter chips, and backfills `by_model` for result files written before this change.
- Threaded runs are collected by submission order so the output stays grouped by model instead of by completion time.

## Test plan

- [x] `cd cli && uv run pytest tests/nao_core/commands/test_runner.py tests/nao_core/commands/test_summary.py` (31 tests)
- [x] `cd cli && make lint`
- [ ] `nao test` with a single model: only the run table is printed
- [ ] `nao test` with several models: model table, matrix and filters render in terminal and in `nao test --serve`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

