### PR TITLE
Let users connect MCP servers no admin ever connected

### DIFF
--- a/apps/backend/src/agents/tools/index.ts
+++ b/apps/backend/src/agents/tools/index.ts
@@ -14,6 +14,7 @@ import executeSql from './execute-sql';
 import grep from './grep';
 import list from './list';
 import { createMcpCallTool } from './mcp-call';
+import { createMcpConnectTool } from './mcp-connect';
 import read from './read';
 import readQueryResult from './read-query-result';
 import search from './search';
@@ -73,7 +74,10 @@ export const getTools = (
 			? configuredServers.size > 0
 			: options.mcpServers.some((server) => configuredServers.has(server)));
 	const mcpTools: Record<string, Tool> = includeMcp
-		? { mcp_call: createMcpCallTool(options.mcpServers ?? null) }
+		? {
+				mcp_call: createMcpCallTool(options.mcpServers ?? null),
+				mcp_connect: createMcpConnectTool(options.mcpServers ?? null),
+			}
 		: {};
 
 	const {

--- a/apps/backend/src/agents/tools/mcp-call.ts
+++ b/apps/backend/src/agents/tools/mcp-call.ts
@@ -18,6 +18,7 @@ const DESCRIPTION = [
 	'',
 	'Some servers require the user to connect their account first. If a call returns an AUTH_REQUIRED',
 	'result, stop and ask the user to connect — a Connect button is shown to them automatically.',
+	'An empty server folder means its tools are not discovered yet: run `mcp_connect` on that server.',
 ].join('\n');
 
 type McpContentBlock = { type: string; text?: string };
@@ -38,13 +39,21 @@ export interface McpValidationErrorOutput {
 	issues: string[];
 }
 
-const authRequiredOutput = (server: string): McpAuthRequiredOutput => ({
+export const authRequiredOutput = (server: string): McpAuthRequiredOutput => ({
 	mcpAuthRequired: true,
 	server,
 	[MCP_AUTH_REQUIRED_MARKER]: true,
 });
 
-const isAuthRequired = (output: unknown): output is McpAuthRequiredOutput =>
+/** Text shown to the model when the user still has to connect their account to a server. */
+export const authRequiredText = (server: string): string =>
+	[
+		`AUTH_REQUIRED: The user has not connected their account to the MCP server "${server}".`,
+		'Stop and ask the user to connect using the Connect button shown below the conversation.',
+		'Do not retry this tool until they have connected.',
+	].join(' ');
+
+export const isAuthRequired = (output: unknown): output is McpAuthRequiredOutput =>
 	!!output &&
 	typeof output === 'object' &&
 	(output as Partial<McpAuthRequiredOutput>)[MCP_AUTH_REQUIRED_MARKER] === true;
@@ -54,11 +63,7 @@ const isValidationError = (output: unknown): output is McpValidationErrorOutput 
 
 const extractText = (output: unknown): string => {
 	if (isAuthRequired(output)) {
-		return [
-			`AUTH_REQUIRED: The user has not connected their account to the MCP server "${output.server}".`,
-			'Stop and ask the user to connect using the Connect button shown below the conversation.',
-			'Do not retry this tool until they have connected.',
-		].join(' ');
+		return authRequiredText(output.server);
 	}
 
 	if (isValidationError(output)) {

--- a/apps/backend/src/agents/tools/mcp-connect.ts
+++ b/apps/backend/src/agents/tools/mcp-connect.ts
@@ -1,0 +1,69 @@
+import { mcpConnect } from '@nao/shared/tools';
+
+import { mcpService } from '../../services/mcp';
+import { McpAuthRequiredError } from '../../services/mcp-oauth';
+import { createTool } from '../../utils/tools';
+import { authRequiredOutput, authRequiredText, isAuthRequired } from './mcp-call';
+
+const DESCRIPTION = [
+	'Connect an MCP server so its tools become usable, and list the tools it exposes.',
+	'',
+	'Use this when a server folder under /agent/mcps/ is empty or missing: its tools have not been',
+	'discovered yet, which does not mean the server has none. Use it too when a call returned',
+	'AUTH_REQUIRED. If the user must connect their account, a Connect button appears in the chat —',
+	'stop there and let them connect, then read the tool specs and call the tool with `mcp_call`.',
+].join('\n');
+
+interface McpConnectedOutput {
+	server: string;
+	tools: string[];
+}
+
+const isConnected = (output: unknown): output is McpConnectedOutput =>
+	!!output && typeof output === 'object' && Array.isArray((output as McpConnectedOutput).tools);
+
+const connectedText = ({ server, tools }: McpConnectedOutput): string => {
+	if (tools.length === 0) {
+		return `Connected to "${server}", but it exposes no tool you are allowed to use.`;
+	}
+	return [
+		`Connected to "${server}". Its tools are now available: ${tools.join(', ')}.`,
+		`Read /agent/mcps/${server}/<tool>.json for a tool's request schema, then invoke it with mcp_call.`,
+	].join(' ');
+};
+
+const extractText = (output: unknown): string => {
+	if (isAuthRequired(output)) {
+		return authRequiredText(output.server);
+	}
+	if (isConnected(output)) {
+		return connectedText(output);
+	}
+	return JSON.stringify(output);
+};
+
+/** Connects a server on behalf of the chatting user, so a project no admin ever connected still works. */
+export const createMcpConnectTool = (allowedServers: string[] | null) =>
+	createTool<mcpConnect.Input, unknown>({
+		description: DESCRIPTION,
+		inputSchema: mcpConnect.InputSchema,
+		execute: async ({ server }, context) => {
+			if (allowedServers && !allowedServers.includes(server)) {
+				throw new Error(`MCP server "${server}" is not available in this context.`);
+			}
+			try {
+				const tools = await mcpService.connectForUser({
+					projectId: context.projectId,
+					userId: context.userId,
+					server,
+				});
+				return { server, tools } satisfies McpConnectedOutput;
+			} catch (error) {
+				if (error instanceof McpAuthRequiredError) {
+					return authRequiredOutput(error.server);
+				}
+				throw error;
+			}
+		},
+		toModelOutput: ({ output }) => ({ type: 'text', value: extractText(output) }),
+	});

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -309,6 +309,10 @@ function McpServersBlock({ servers }: { servers: string[] }) {
 				Some servers require the user to connect their own account first. If a call returns an{' '}
 				<Bold>AUTH_REQUIRED</Bold> result, stop and ask the user to connect — a Connect button is shown to them
 				automatically. Do not retry until they have connected.
+				<Br />
+				An empty or missing server folder means its tools have not been discovered yet, not that the server has
+				none. Call <Bold>mcp_connect</Bold> with that server to discover them, then continue — never tell the
+				user the server exposes no tool without trying it.
 			</Span>
 			<List>
 				{servers.map((server) => (

--- a/apps/backend/src/queries/mcp-oauth.queries.ts
+++ b/apps/backend/src/queries/mcp-oauth.queries.ts
@@ -40,6 +40,19 @@ export const setMcpDiscoveryUser = async (
 		.execute();
 };
 
+export const claimMcpDiscoveryUser = async (
+	projectId: string,
+	serverName: string,
+	userId: string,
+): Promise<boolean> => {
+	const client = await getMcpOAuthClient(projectId, serverName);
+	if (!client || client.discoveryUserId) {
+		return false;
+	}
+	await setMcpDiscoveryUser(projectId, serverName, userId);
+	return true;
+};
+
 export const getMcpUserToken = async (
 	userId: string,
 	projectId: string,

--- a/apps/backend/src/routes/mcp-oauth.ts
+++ b/apps/backend/src/routes/mcp-oauth.ts
@@ -1,9 +1,11 @@
 import crypto from 'node:crypto';
 
+import type { UserRole } from '@nao/shared';
+
 import type { App } from '../app';
 import { getAuth } from '../auth';
 import { env } from '../env';
-import { setMcpDiscoveryUser } from '../queries/mcp-oauth.queries';
+import { claimMcpDiscoveryUser, setMcpDiscoveryUser } from '../queries/mcp-oauth.queries';
 import * as projectQueries from '../queries/project.queries';
 import { mcpService } from '../services/mcp';
 import { buildAuthorizationRedirect, completeAuthorization } from '../services/mcp-oauth';
@@ -73,6 +75,19 @@ export function resultPage(status: 'connected' | 'error', server: string, return
 	if (window.opener) { window.close(); } else { window.location.href = ${target}; }
 </script>
 </body></html>`;
+}
+
+/**
+ * Tool discovery runs with a single user's token. An admin always takes it over on connect;
+ * a regular user only claims it when no admin ever connected the server, so the agent still
+ * gets its tool specs instead of seeing an empty server.
+ */
+async function claimDiscovery(role: UserRole, projectId: string, server: string, userId: string): Promise<boolean> {
+	if (role === 'admin') {
+		await setMcpDiscoveryUser(projectId, server, userId);
+		return true;
+	}
+	return claimMcpDiscoveryUser(projectId, server, userId);
 }
 
 export const mcpOAuthRoutes = async (app: App) => {
@@ -168,8 +183,7 @@ export const mcpOAuthRoutes = async (app: App) => {
 				code,
 			});
 
-			if (role === 'admin') {
-				await setMcpDiscoveryUser(decoded.projectId, decoded.server, decoded.userId);
+			if (await claimDiscovery(role, decoded.projectId, decoded.server, decoded.userId)) {
 				await mcpService.discoverServer(decoded.projectId, decoded.server);
 			}
 

--- a/apps/backend/src/services/mcp.ts
+++ b/apps/backend/src/services/mcp.ts
@@ -11,7 +11,12 @@ import { mkdir, readdir, readFile, unlink, writeFile } from 'fs/promises';
 import { createRuntime, type Runtime, ServerDefinition } from 'mcporter';
 import { isAbsolute, join, relative, resolve, sep } from 'path';
 
-import { deleteMcpUserToken, getMcpOAuthClient, hasMcpUserToken } from '../queries/mcp-oauth.queries';
+import {
+	claimMcpDiscoveryUser,
+	deleteMcpUserToken,
+	getMcpOAuthClient,
+	hasMcpUserToken,
+} from '../queries/mcp-oauth.queries';
 import { getDisabledMcpServers, getDisabledMcpTools, retrieveProjectById } from '../queries/project.queries';
 import { logger } from '../utils/logger';
 import { replaceEnvVars } from '../utils/utils';
@@ -163,6 +168,17 @@ export class McpService {
 		);
 	}
 
+	/** Whether the server exposes at least one known tool, from this session or an on-disk spec. */
+	public async hasDiscoveredTools(projectId: string, server: string): Promise<boolean> {
+		await this.initializeMcpState(projectId);
+		const discovered = this._discovered[server];
+		if (discovered) {
+			return discovered.length > 0;
+		}
+		const fromDisk = await this._readSpecTools(server);
+		return !!fromDisk?.length;
+	}
+
 	/** (Re)connects every configured server and rewrites the enabled per-tool specs. */
 	public async discover(projectId?: string): Promise<void> {
 		if (projectId) {
@@ -190,6 +206,54 @@ export class McpService {
 				await this._writeEnabledSpecs(name, disabled);
 			}
 		}
+	}
+
+	/**
+	 * Makes a server usable by the calling user and returns the tools they may call. When nobody has
+	 * connected the server yet the user's own OAuth token is used for discovery, so a project where
+	 * no admin ever connected still works. Throws `McpAuthRequiredError` when the user must connect.
+	 */
+	public async connectForUser(opts: { projectId: string; userId: string; server: string }): Promise<string[]> {
+		const { projectId, userId, server } = opts;
+		await this.initializeMcpState(projectId);
+
+		const config = this._mcpServers[server];
+		if (!config) {
+			const configured = this.getConfiguredServerNames().join(', ') || '(none)';
+			throw new Error(`MCP server "${server}" is not configured. Configured servers: ${configured}.`);
+		}
+		const disabled = await this._loadDisabled();
+		if (disabled.servers.has(server)) {
+			throw new Error(`MCP server "${server}" is disabled by the project admin.`);
+		}
+
+		const discoveryUserId = (await this._ensureOAuthFlag(server, config))
+			? await this._claimDiscoveryForUser(projectId, userId, server, config)
+			: undefined;
+		await this._discoverServer(server, disabled, discoveryUserId);
+
+		const error = this._failedConnections[server];
+		if (error) {
+			throw new Error(error);
+		}
+		return (this._discovered[server] ?? [])
+			.filter((tool) => !disabled.tools.has(this._toolKey(server, tool.name)))
+			.map((tool) => tool.name);
+	}
+
+	/** Checks the user can authenticate against an OAuth server and hands them discovery if it is unowned. */
+	private async _claimDiscoveryForUser(
+		projectId: string,
+		userId: string,
+		server: string,
+		config: McpServerConfig,
+	): Promise<string> {
+		const token = await getValidAccessToken({ userId, projectId, server, serverUrl: config.url!.toString() });
+		if (!token) {
+			throw new McpAuthRequiredError(server);
+		}
+		await claimMcpDiscoveryUser(projectId, server, userId);
+		return userId;
 	}
 
 	public async callTool(opts: {
@@ -455,7 +519,7 @@ export class McpService {
 		await Promise.all(Object.keys(this._mcpServers).map((name) => this._discoverServer(name, disabled)));
 	}
 
-	private async _discoverServer(name: string, disabled: DisabledSets): Promise<void> {
+	private async _discoverServer(name: string, disabled: DisabledSets, discoveryUserId?: string): Promise<void> {
 		const config = this._mcpServers[name];
 		if (!config) {
 			return;
@@ -464,11 +528,12 @@ export class McpService {
 		this._clearValidators(name);
 
 		try {
-			this._discovered[name] = await this._listTools(name, config);
+			this._discovered[name] = await this._listTools(name, config, discoveryUserId);
 			delete this._failedConnections[name];
 		} catch (error) {
 			if (error instanceof McpAuthRequiredError) {
-				this._failedConnections[name] = 'OAuth connection required — an admin must connect this server.';
+				this._failedConnections[name] =
+					'OAuth connection required — connect this server to discover its tools.';
 			} else {
 				if (isUnauthorizedError(error) && !this._hasStaticAuth(config)) {
 					this._oauth[name] = true;
@@ -486,11 +551,15 @@ export class McpService {
 		await this._writeEnabledSpecs(name, disabled);
 	}
 
-	/** Lists the tools of a server, using the admin's OAuth token for OAuth-protected servers. */
-	private async _listTools(name: string, config: McpServerConfig): Promise<McpToolDefinition[]> {
+	/** Lists the tools of a server, using the discovery user's OAuth token for OAuth-protected servers. */
+	private async _listTools(
+		name: string,
+		config: McpServerConfig,
+		discoveryUserId?: string,
+	): Promise<McpToolDefinition[]> {
 		if (await this._ensureOAuthFlag(name, config)) {
 			const url = config.url!.toString();
-			const token = await this._discoveryToken(name, url);
+			const token = await this._discoveryToken(name, url, discoveryUserId);
 			if (!token) {
 				throw new McpAuthRequiredError(name);
 			}
@@ -512,20 +581,15 @@ export class McpService {
 		return tools.map((tool) => ({ name: tool.name, description: tool.description, inputSchema: tool.inputSchema }));
 	}
 
-	private async _discoveryToken(server: string, serverUrl: string): Promise<string | null> {
+	private async _discoveryToken(server: string, serverUrl: string, preferredUserId?: string): Promise<string | null> {
 		if (!this._projectId) {
 			return null;
 		}
-		const client = await getMcpOAuthClient(this._projectId, server);
-		if (!client?.discoveryUserId) {
+		const userId = preferredUserId ?? (await getMcpOAuthClient(this._projectId, server))?.discoveryUserId;
+		if (!userId) {
 			return null;
 		}
-		return getValidAccessToken({
-			userId: client.discoveryUserId,
-			projectId: this._projectId,
-			server,
-			serverUrl,
-		});
+		return getValidAccessToken({ userId, projectId: this._projectId, server, serverUrl });
 	}
 
 	/**
@@ -576,13 +640,30 @@ export class McpService {
 		return { ...(config.headers ?? {}), Authorization: `Bearer ${token}` };
 	}
 
-	/** Writes one OpenAPI spec file per enabled tool, removing any stale spec files. */
+	/**
+	 * Writes one OpenAPI spec file per enabled tool, removing any stale spec files.
+	 * A read-only project folder degrades the server to unusable rather than failing the caller.
+	 */
 	private async _writeEnabledSpecs(name: string, disabled: DisabledSets): Promise<void> {
 		const config = this._mcpServers[name];
 		if (!config) {
 			return;
 		}
 
+		try {
+			await this._writeSpecFiles(name, config, disabled);
+		} catch (error) {
+			const message = (error as Error).message;
+			this._failedConnections[name] = `Cannot write tool specs to ${this._virtualServerDir(name)}: ${message}`;
+			logger.error(`MCP spec write failed: ${name}`, {
+				source: 'tool',
+				projectId: this._projectId ?? undefined,
+				context: { server: name, error: message },
+			});
+		}
+	}
+
+	private async _writeSpecFiles(name: string, config: McpServerConfig, disabled: DisabledSets): Promise<void> {
 		const dir = this._serverDir(name);
 		await mkdir(dir, { recursive: true });
 		await this._clearSpecFiles(dir);

--- a/apps/backend/src/services/mcp.ts
+++ b/apps/backend/src/services/mcp.ts
@@ -104,6 +104,9 @@ export class McpService {
 			this._fileWatcher.close();
 			this._fileWatcher = null;
 		}
+		if (this._projectId !== projectId) {
+			this._resetDiscovery();
+		}
 
 		this._projectId = projectId;
 		this._initPromise = this._initialize(projectId).catch((err) => {
@@ -247,13 +250,13 @@ export class McpService {
 		userId: string,
 		server: string,
 		config: McpServerConfig,
-	): Promise<string> {
+	): Promise<string | undefined> {
 		const token = await getValidAccessToken({ userId, projectId, server, serverUrl: config.url!.toString() });
 		if (!token) {
 			throw new McpAuthRequiredError(server);
 		}
-		await claimMcpDiscoveryUser(projectId, server, userId);
-		return userId;
+		const claimed = await claimMcpDiscoveryUser(projectId, server, userId);
+		return claimed ? userId : undefined;
 	}
 
 	public async callTool(opts: {
@@ -465,6 +468,11 @@ export class McpService {
 		this._registered = new Set();
 		this._oauth = {};
 		this._validators.clear();
+	}
+
+	private _resetDiscovery(): void {
+		this._discovered = {};
+		this._failedConnections = {};
 	}
 
 	private async _loadConfig(): Promise<void> {

--- a/apps/backend/src/trpc/mcp.routes.ts
+++ b/apps/backend/src/trpc/mcp.routes.ts
@@ -1,8 +1,10 @@
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod/v4';
 
+import { claimMcpDiscoveryUser } from '../queries/mcp-oauth.queries';
 import { setMcpServerEnabled, setMcpToolEnabled, setMcpToolsEnabled } from '../queries/project.queries';
 import { mcpService } from '../services/mcp';
-import { adminProtectedProcedure, projectProtectedProcedure, router } from './trpc';
+import { adminProtectedProcedure, canSendProcedure, projectProtectedProcedure, router } from './trpc';
 
 export const mcpRoutes = router({
 	getServers: projectProtectedProcedure.query(({ ctx }) => mcpService.getServersStatus(ctx.project.id, ctx.user.id)),
@@ -14,12 +16,13 @@ export const mcpRoutes = router({
 		return mcpService.getServersStatus(ctx.project.id, ctx.user.id);
 	}),
 
-	discoverServer: adminProtectedProcedure
-		.input(z.object({ serverName: z.string() }))
-		.mutation(async ({ ctx, input }) => {
-			await mcpService.discoverServer(ctx.project.id, input.serverName);
-			return mcpService.getServersStatus(ctx.project.id, ctx.user.id);
-		}),
+	discoverServer: canSendProcedure.input(z.object({ serverName: z.string() })).mutation(async ({ ctx, input }) => {
+		if (ctx.userRole !== 'admin') {
+			await claimFirstDiscovery(ctx.project.id, input.serverName, ctx.user.id);
+		}
+		await mcpService.discoverServer(ctx.project.id, input.serverName);
+		return mcpService.getServersStatus(ctx.project.id, ctx.user.id);
+	}),
 
 	setServerEnabled: adminProtectedProcedure
 		.input(z.object({ serverName: z.string(), enabled: z.boolean() }))
@@ -46,3 +49,10 @@ export const mcpRoutes = router({
 			return mcpService.getServersStatus(ctx.project.id, ctx.user.id);
 		}),
 });
+
+async function claimFirstDiscovery(projectId: string, serverName: string, userId: string): Promise<void> {
+	if (await mcpService.hasDiscoveredTools(projectId, serverName)) {
+		throw new TRPCError({ code: 'FORBIDDEN', message: 'Only admins can rediscover this server.' });
+	}
+	await claimMcpDiscoveryUser(projectId, serverName, userId);
+}

--- a/apps/backend/tests/mcp-review-fixes.test.ts
+++ b/apps/backend/tests/mcp-review-fixes.test.ts
@@ -7,8 +7,10 @@ vi.mock('../src/db/db', () => ({ db: {} }));
 import { getTools } from '../src/agents/tools';
 import { authRequiredOutput, createMcpCallTool } from '../src/agents/tools/mcp-call';
 import { createMcpConnectTool } from '../src/agents/tools/mcp-connect';
+import * as mcpOAuthQueries from '../src/queries/mcp-oauth.queries';
 import { normalizeReturnTo, resultPage } from '../src/routes/mcp-oauth';
 import { McpArgsValidationError, McpService, mcpService } from '../src/services/mcp';
+import * as mcpOAuthService from '../src/services/mcp-oauth';
 import { extractToolsFromOpenApi } from '../src/services/mcp-openapi';
 
 afterEach(() => {
@@ -107,6 +109,45 @@ describe('MCP first discovery', () => {
 
 		expect(await service.hasDiscoveredTools('project', 'unconnected')).toBe(false);
 		expect(await service.hasDiscoveredTools('project', 'connected')).toBe(true);
+	});
+
+	it('does not inherit the tools discovered for another project', async () => {
+		const service = new McpService() as unknown as {
+			_projectId: string;
+			_projectPath: string;
+			_initPromise: Promise<void> | null;
+			_discovered: Record<string, unknown[]>;
+			_initialize: (projectId: string) => Promise<void>;
+			hasDiscoveredTools: (projectId: string, server: string) => Promise<boolean>;
+		};
+		service._projectId = 'previous-project';
+		service._projectPath = resolve('/tmp/nao-missing-project');
+		service._initPromise = Promise.resolve();
+		service._discovered = { shared: [{ name: 'search' }] };
+		vi.spyOn(service, '_initialize').mockResolvedValue();
+
+		expect(await service.hasDiscoveredTools('current-project', 'shared')).toBe(false);
+	});
+});
+
+describe('MCP discovery ownership', () => {
+	it('uses the stored discovery owner when another user already owns the server', async () => {
+		vi.spyOn(mcpOAuthService, 'getValidAccessToken').mockResolvedValue('user-token');
+		vi.spyOn(mcpOAuthQueries, 'claimMcpDiscoveryUser').mockResolvedValue(false);
+		const service = new McpService() as unknown as {
+			_claimDiscoveryForUser: (
+				projectId: string,
+				userId: string,
+				server: string,
+				config: { url: URL },
+			) => Promise<string | undefined>;
+		};
+
+		const discoveryUserId = await service._claimDiscoveryForUser('project', 'regular-user', 'server', {
+			url: new URL('https://mcp.example.com'),
+		});
+
+		expect(discoveryUserId).toBeUndefined();
 	});
 });
 

--- a/apps/backend/tests/mcp-review-fixes.test.ts
+++ b/apps/backend/tests/mcp-review-fixes.test.ts
@@ -5,7 +5,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../src/db/db', () => ({ db: {} }));
 
 import { getTools } from '../src/agents/tools';
-import { createMcpCallTool } from '../src/agents/tools/mcp-call';
+import { authRequiredOutput, createMcpCallTool } from '../src/agents/tools/mcp-call';
+import { createMcpConnectTool } from '../src/agents/tools/mcp-connect';
 import { normalizeReturnTo, resultPage } from '../src/routes/mcp-oauth';
 import { McpArgsValidationError, McpService, mcpService } from '../src/services/mcp';
 import { extractToolsFromOpenApi } from '../src/services/mcp-openapi';
@@ -92,6 +93,23 @@ describe('MCP argument validation', () => {
 	});
 });
 
+describe('MCP first discovery', () => {
+	it('only reports servers that expose at least one tool as discovered', async () => {
+		const service = new McpService() as unknown as {
+			_projectId: string;
+			_initPromise: Promise<void>;
+			_discovered: Record<string, unknown[]>;
+			hasDiscoveredTools: (projectId: string, server: string) => Promise<boolean>;
+		};
+		service._projectId = 'project';
+		service._initPromise = Promise.resolve();
+		service._discovered = { unconnected: [], connected: [{ name: 'search' }] };
+
+		expect(await service.hasDiscoveredTools('project', 'unconnected')).toBe(false);
+		expect(await service.hasDiscoveredTools('project', 'connected')).toBe(true);
+	});
+});
+
 describe('MCP auth-required tool output', () => {
 	it('does not treat colliding remote payloads as internal auth sentinels', () => {
 		const tool = createMcpCallTool(null) as unknown as {
@@ -105,13 +123,35 @@ describe('MCP auth-required tool output', () => {
 	});
 });
 
+describe('MCP connect tool', () => {
+	it('tells the model to wait for the user, then reports the tools once connected', () => {
+		const tool = createMcpConnectTool(null) as unknown as {
+			toModelOutput: (args: { output: unknown }) => { value: string };
+		};
+
+		expect(tool.toModelOutput({ output: authRequiredOutput('metabase') }).value).toContain('AUTH_REQUIRED');
+		expect(tool.toModelOutput({ output: { server: 'metabase', tools: ['search'] } }).value).toContain('search');
+	});
+
+	it('refuses servers outside the run allowlist', async () => {
+		const tool = createMcpConnectTool(['allowed']) as unknown as {
+			execute: (input: { server: string }, options: unknown) => Promise<unknown>;
+		};
+
+		await expect(tool.execute({ server: 'other' }, { experimental_context: {} })).rejects.toThrow(
+			'not available in this context',
+		);
+	});
+});
+
 describe('MCP tool registration', () => {
-	it('omits mcp_call when the requested allowlist is empty or unavailable', () => {
+	it('omits the MCP tools when the requested allowlist is empty or unavailable', () => {
 		vi.spyOn(mcpService, 'getConfiguredServerNames').mockReturnValue(['configured']);
 
 		expect(getTools(null, undefined, { mcpServers: [] })).not.toHaveProperty('mcp_call');
 		expect(getTools(null, undefined, { mcpServers: ['missing'] })).not.toHaveProperty('mcp_call');
 		expect(getTools(null, undefined, { mcpServers: ['configured'] })).toHaveProperty('mcp_call');
+		expect(getTools(null, undefined, { mcpServers: ['configured'] })).toHaveProperty('mcp_connect');
 		expect(getTools(null, undefined, {})).toHaveProperty('mcp_call');
 	});
 });

--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -8,7 +8,7 @@ import type { UIMessage, UIToolPart } from '@nao/backend/chat';
 import { useAgentContext } from '@/contexts/agent.provider';
 import { useChatId } from '@/hooks/use-chat-id';
 import { useInactivityTrigger } from '@/hooks/use-inactivity-trigger';
-import { checkAssistantMessageHasContent, getToolName, NEW_CHAT_ID } from '@/lib/ai';
+import { checkAssistantMessageHasContent, NEW_CHAT_ID } from '@/lib/ai';
 import { countDisplayCharts } from '@/lib/charts.utils';
 import { createLocalStorage } from '@/lib/local-storage';
 import { lastUserMessagePayload } from '@/lib/mcp-auth-retry';
@@ -250,7 +250,7 @@ function useMcpAuthSuggestion(): McpAuthSuggestion {
 	return { isVisible: !!pendingServer && !isRunning, server: pendingServer, connecting, connect, dismiss };
 }
 
-/** Returns the server from the most recent `mcp_call` that reported it needs the user to connect. */
+/** Returns the server from the most recent MCP tool call that reported it needs the user to connect. */
 function findPendingAuthServer(messages: UIMessage[]): string | null {
 	for (let i = messages.length - 1; i >= 0; i--) {
 		const message = messages[i];
@@ -261,9 +261,6 @@ function findPendingAuthServer(messages: UIMessage[]): string | null {
 			const part = message.parts[j];
 			const type = (part as { type: string }).type;
 			if (type !== 'dynamic-tool' && !type.startsWith('tool-')) {
-				continue;
-			}
-			if (getToolName(part as UIToolPart) !== 'mcp_call') {
 				continue;
 			}
 			const output = (part as UIToolPart).output as { mcpAuthRequired?: boolean; server?: string } | undefined;

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -294,8 +294,17 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'MCP Servers',
 		description:
 			'Configure MCP servers in agent/mcps/mcp.json. nao discovers their tools into OpenAPI specs the agent explores on demand.',
-		keywords: ['model context protocol', 'tool', 'integration', 'extension', 'discover', 'openapi', 'spec'],
-		adminOnly: true,
+		keywords: [
+			'model context protocol',
+			'tool',
+			'integration',
+			'extension',
+			'discover',
+			'openapi',
+			'spec',
+			'connect',
+			'oauth',
+		],
 	},
 
 	// ── MCP Endpoint ────────────────────────────────────────

--- a/apps/frontend/src/components/settings/display-mcp.tsx
+++ b/apps/frontend/src/components/settings/display-mcp.tsx
@@ -283,7 +283,8 @@ export function McpSettings({ isAdmin }: Props) {
 						{servers.map((server) => {
 							const isExpanded = expandedServers.includes(server.name);
 							const connection = connectionLabel(server);
-							const canDiscover = isAdmin || server.toolCount === 0;
+							const canDiscover =
+								isAdmin || (server.toolCount === 0 && (!server.oauth || server.oauthConnected));
 
 							return (
 								<>

--- a/apps/frontend/src/components/settings/display-mcp.tsx
+++ b/apps/frontend/src/components/settings/display-mcp.tsx
@@ -144,15 +144,7 @@ const groupToolsByCategory = (tools: McpToolSummary[]): { category: ToolCategory
 	}));
 };
 
-function McpOAuthConnect({
-	server,
-	isAdmin,
-	onConnected,
-}: {
-	server: McpServerStatus;
-	isAdmin: boolean;
-	onConnected: () => void;
-}) {
+function McpOAuthConnect({ server, onConnected }: { server: McpServerStatus; onConnected: () => void }) {
 	const [connecting, setConnecting] = useState(false);
 
 	const handleConnect = async () => {
@@ -166,10 +158,6 @@ function McpOAuthConnect({
 
 	if (server.oauthConnected) {
 		return <Badge className='bg-green-500/10 text-green-600'>OAuth connected</Badge>;
-	}
-
-	if (!isAdmin) {
-		return <Badge className='bg-amber-500/10 text-amber-600'>OAuth required</Badge>;
 	}
 
 	return (
@@ -295,6 +283,7 @@ export function McpSettings({ isAdmin }: Props) {
 						{servers.map((server) => {
 							const isExpanded = expandedServers.includes(server.name);
 							const connection = connectionLabel(server);
+							const canDiscover = isAdmin || server.toolCount === 0;
 
 							return (
 								<>
@@ -312,11 +301,7 @@ export function McpSettings({ isAdmin }: Props) {
 											<div className='flex items-center gap-2'>
 												<span className={connection.className}>{connection.label}</span>
 												{server.oauth && (
-													<McpOAuthConnect
-														server={server}
-														isAdmin={isAdmin}
-														onConnected={refresh}
-													/>
+													<McpOAuthConnect server={server} onConnected={refresh} />
 												)}
 											</div>
 										</TableCell>
@@ -337,7 +322,7 @@ export function McpSettings({ isAdmin }: Props) {
 										</TableCell>
 										<TableCell className='w-0'>
 											<div className='flex items-center gap-1'>
-												{isAdmin && (
+												{canDiscover && (
 													<Button
 														variant='ghost'
 														size='icon-sm'
@@ -484,7 +469,10 @@ export function McpSettings({ isAdmin }: Props) {
 													) : (
 														!server.error && (
 															<div className='text-sm text-muted-foreground'>
-																No tools discovered yet. Click Connect all MCP servers.
+																No tools discovered yet.{' '}
+																{isAdmin
+																	? 'Click Connect all MCP servers.'
+																	: 'Connect this server to discover its tools.'}
 															</div>
 														)
 													)}

--- a/apps/frontend/src/components/tool-calls/index.tsx
+++ b/apps/frontend/src/components/tool-calls/index.tsx
@@ -50,6 +50,7 @@ export const dynamicToolComponents = {
 	query_app_db: QueryAppDbToolCall,
 	record_recommendation: RecordRecommendationToolCall,
 	mcp_call: McpToolCall,
+	mcp_connect: McpToolCall,
 } satisfies Record<string, React.ComponentType<ToolCallComponentProps>>;
 
 export type DynamicToolName = keyof typeof dynamicToolComponents;

--- a/apps/frontend/src/components/tool-calls/mcp.tsx
+++ b/apps/frontend/src/components/tool-calls/mcp.tsx
@@ -160,14 +160,22 @@ const McpOutputContent = ({ text }: { text: string }) => {
 
 const getMcpTitle = (toolPart: UIToolPart, fallback: string): ReactNode | string => {
 	const input = (toolPart as { input?: { server?: string; tool?: string } }).input;
-	if (input?.server && input?.tool) {
-		return (
-			<McpTitle server={input.server}>
-				Using <em>{input.tool}</em> from {input.server}
-			</McpTitle>
-		);
+	if (!input?.server) {
+		return fallback;
 	}
-	return fallback;
+	if (!input.tool) {
+		return <McpTitle server={input.server}>Connecting to {input.server}</McpTitle>;
+	}
+	return (
+		<McpTitle server={input.server}>
+			Using <em>{input.tool}</em> from {input.server}
+		</McpTitle>
+	);
+};
+
+const getConnectedTools = (output: unknown): string[] | null => {
+	const tools = isPlainObject(output) ? output.tools : null;
+	return Array.isArray(tools) ? tools.map(String) : null;
 };
 
 const getAuthRequiredServer = (output: unknown): string | null => {
@@ -189,6 +197,19 @@ export const McpToolCall = ({ toolPart }: ToolCallComponentProps) => {
 				<ToolCallWrapper title={title}>
 					<div className='px-3 py-2 text-sm text-muted-foreground'>
 						Waiting for you to connect to <span className='font-medium text-foreground'>{authServer}</span>.
+					</div>
+				</ToolCallWrapper>
+			);
+		}
+
+		const connectedTools = getConnectedTools(toolPart.output);
+		if (connectedTools) {
+			return (
+				<ToolCallWrapper title={title}>
+					<div className='px-3 py-2 text-sm text-muted-foreground'>
+						{connectedTools.length > 0
+							? `${connectedTools.length} tools available: ${connectedTools.join(', ')}`
+							: 'No tool available on this server.'}
 					</div>
 				</ToolCallWrapper>
 			);

--- a/apps/frontend/src/lib/mcp.ts
+++ b/apps/frontend/src/lib/mcp.ts
@@ -25,7 +25,7 @@ export const getPartMcpServer = (part: GroupablePart): string | null => {
 	}
 
 	const toolName = getToolName(part);
-	if (toolName === 'mcp_call') {
+	if (toolName === 'mcp_call' || toolName === 'mcp_connect') {
 		return (part.input as { server?: string } | undefined)?.server ?? null;
 	}
 	if (toolName === 'list') {
@@ -43,7 +43,7 @@ export const isMcpPart = (part: GroupablePart): boolean => {
 	}
 
 	const toolName = getToolName(part);
-	if (toolName === 'mcp_call') {
+	if (toolName === 'mcp_call' || toolName === 'mcp_connect') {
 		return true;
 	}
 	if (toolName === 'list') {

--- a/apps/shared/src/tools/index.ts
+++ b/apps/shared/src/tools/index.ts
@@ -7,6 +7,7 @@ export * as executeSql from './execute-sql';
 export * as grep from './grep';
 export * as list from './list';
 export * as mcpCall from './mcp-call';
+export * as mcpConnect from './mcp-connect';
 export * as readFile from './read';
 export * as readQueryResult from './read-query-result';
 export * as searchFiles from './search';

--- a/apps/shared/src/tools/mcp-connect.ts
+++ b/apps/shared/src/tools/mcp-connect.ts
@@ -1,0 +1,7 @@
+import z from 'zod/v3';
+
+export const InputSchema = z.object({
+	server: z.string().describe('Name of the MCP server, matching a folder under /agent/mcps/.'),
+});
+
+export type Input = z.infer<typeof InputSchema>;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -74,6 +74,10 @@ EOF
             ;;
     esac
     
+    # Git runs as root here while the repo is owned by `nao` (see the chown below),
+    # which git rejects as "dubious ownership" on subsequent starts.
+    git config --global --replace-all safe.directory "$NAO_DEFAULT_PROJECT_PATH"
+
     # Clone or pull
     if [ -d "$NAO_DEFAULT_PROJECT_PATH/.git" ]; then
         echo "Repository exists, pulling latest..."
@@ -105,6 +109,10 @@ EOF
         fi
         echo "✓ Context cloned"
     fi
+    
+    # The clone runs as root but the services run as `nao`, which writes into the
+    # context (discovered MCP specs, query results, refreshed metadata).
+    chown -R nao:nao "$NAO_DEFAULT_PROJECT_PATH"
     
     # Resolve project path (subpath if set, else repo root)
     if [ -n "$NAO_CONTEXT_GIT_SUBPATH" ]; then
@@ -151,6 +159,14 @@ else
     echo "ERROR: Unknown NAO_CONTEXT_SOURCE: $NAO_CONTEXT_SOURCE"
     echo "Must be 'local', 'git', or 'api'"
     exit 1
+fi
+
+# The agent writes into the context (discovered MCP specs, query results), so the
+# `nao` user needs write access. A root-owned bind mount is the usual culprit.
+if [ -n "$NAO_DEFAULT_PROJECT_PATH" ] && ! su nao -s /bin/sh -c "test -w '$NAO_DEFAULT_PROJECT_PATH'"; then
+    echo "⚠ $NAO_DEFAULT_PROJECT_PATH is not writable by the nao user (uid $(id -u nao))."
+    echo "  MCP tool discovery and other context writes will fail."
+    echo "  Fix the ownership on the host: chown -R $(id -u nao):$(id -g nao) <context-folder>"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Hotfix for two failure modes that left MCP servers unusable.

**Nobody ever connected the server.** Tool discovery only ran with an admin's OAuth token, so on a project where no admin connected, the agent saw an empty server folder and told users the server exposed no tool.

- New `mcp_connect` tool: connects a server on behalf of the chatting user, claims the first discovery when it is unowned, and returns the tools they may call. `AUTH_REQUIRED` surfaces the usual Connect button.
- The OAuth callback hands discovery to a regular user only when no admin ever connected; an admin still always takes it over.
- `discoverServer` over tRPC is open to non-admins for a server with no discovered tool, and admin-only afterwards.
- Settings shows the Connect button and the rediscover action to non-admins for undiscovered servers, and the Connect suggestion in the chat now triggers on any MCP tool call, not just `mcp_call`.
- The system prompt tells the agent an empty folder means "not discovered yet", not "no tools".

**Permission denied writing tool specs.** A root-owned context folder made spec writes throw at the caller.

- Spec write failures mark the server unusable with the failing path and reason, and are logged instead of propagated.
- The Docker entrypoint sets `safe.directory`, chowns the cloned context to `nao`, and warns when the context is not writable by the `nao` user.

## Test plan

- [x] `npm run -w @nao/backend test -- --run tests/mcp-review-fixes.test.ts` (11 tests, incl. first-discovery detection and the connect tool)
- [x] `npm run lint`, `bash -n docker/entrypoint.sh`
- [ ] As a non-admin on a project where no admin connected an OAuth server: ask a question that needs it, connect from the chat, confirm tools are discovered and callable
- [ ] As an admin: connect the same server and confirm discovery is taken over
- [ ] Docker run with a root-owned context mount: confirm the warning and that specs are written after the chown

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

