### PR TITLE
Exclude sql calls from Langfuse tracing

### DIFF
--- a/apps/backend/src/instrumentation.ts
+++ b/apps/backend/src/instrumentation.ts
@@ -2,6 +2,7 @@ import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 
 import { env } from './env';
+import { DataToolRedactingSpanProcessor } from './utils/langfuse-redaction';
 
 /**
  * Langfuse tracing is opt-in and requires an explicit destination: it only
@@ -25,7 +26,7 @@ if (keysPresent && !baseUrl) {
 
 if (langfuseSpanProcessor) {
 	const tracerProvider = new NodeTracerProvider({
-		spanProcessors: [langfuseSpanProcessor],
+		spanProcessors: [new DataToolRedactingSpanProcessor(langfuseSpanProcessor)],
 	});
 	tracerProvider.register();
 

--- a/apps/backend/src/utils/langfuse-redaction.ts
+++ b/apps/backend/src/utils/langfuse-redaction.ts
@@ -1,0 +1,198 @@
+import type { Attributes, Context } from '@opentelemetry/api';
+import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-node';
+
+export const REDACTED_DATA_TOOL_NAMES: ReadonlySet<string> = new Set(['execute_sql', 'read_query_result']);
+export const LANGFUSE_REDACTION_PLACEHOLDER = '[redacted]';
+
+type JsonObject = Record<string, unknown>;
+type JsonRedactor = (value: unknown) => boolean;
+
+export function redactDataToolAttributes(attributes: Attributes): void {
+	redactToolSpanAttributes(attributes);
+	redactJsonAttribute(attributes, 'ai.prompt.messages', redactMessages);
+	redactJsonAttribute(attributes, 'ai.prompt', redactPrompt);
+	redactJsonAttribute(attributes, 'ai.response.toolCalls', redactResponseToolCalls);
+}
+
+export class DataToolRedactingSpanProcessor implements SpanProcessor {
+	constructor(private readonly delegate: SpanProcessor) {}
+
+	onStart(span: Span, parentContext: Context): void {
+		this.delegate.onStart(span, parentContext);
+	}
+
+	onEnd(span: ReadableSpan): void {
+		redactDataToolAttributes(span.attributes);
+		redactToolSpanExceptions(span);
+		this.delegate.onEnd(span);
+	}
+
+	forceFlush(): Promise<void> {
+		return this.delegate.forceFlush();
+	}
+
+	shutdown(): Promise<void> {
+		return this.delegate.shutdown();
+	}
+}
+
+function redactToolSpanAttributes(attributes: Attributes): void {
+	if (!isRedactedToolName(attributes['ai.toolCall.name'])) {
+		return;
+	}
+
+	redactAttributeIfPresent(attributes, 'ai.toolCall.args');
+	redactAttributeIfPresent(attributes, 'ai.toolCall.result');
+}
+
+function redactPrompt(value: unknown): boolean {
+	if (!isJsonObject(value)) {
+		return false;
+	}
+
+	return redactMessages(value.messages);
+}
+
+function redactMessages(value: unknown): boolean {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	let wasRedacted = false;
+	for (const message of value) {
+		if (!isJsonObject(message) || !Array.isArray(message.content)) {
+			continue;
+		}
+
+		for (const part of message.content) {
+			wasRedacted = redactMessagePart(part) || wasRedacted;
+		}
+	}
+
+	return wasRedacted;
+}
+
+function redactMessagePart(value: unknown): boolean {
+	if (!isJsonObject(value) || !isRedactedToolName(value.toolName)) {
+		return false;
+	}
+
+	if (value.type === 'tool-call') {
+		return redactToolInput(value);
+	}
+
+	if (value.type === 'tool-result') {
+		return redactToolOutput(value);
+	}
+
+	return false;
+}
+
+function redactResponseToolCalls(value: unknown): boolean {
+	if (!Array.isArray(value)) {
+		return false;
+	}
+
+	let wasRedacted = false;
+	for (const toolCall of value) {
+		if (isJsonObject(toolCall) && isRedactedToolName(toolCall.toolName)) {
+			wasRedacted = redactToolInput(toolCall) || wasRedacted;
+		}
+	}
+
+	return wasRedacted;
+}
+
+function redactToolInput(toolCall: JsonObject): boolean {
+	let wasRedacted = false;
+
+	if (hasOwn(toolCall, 'input')) {
+		toolCall.input = LANGFUSE_REDACTION_PLACEHOLDER;
+		wasRedacted = true;
+	}
+	if (hasOwn(toolCall, 'args')) {
+		toolCall.args = LANGFUSE_REDACTION_PLACEHOLDER;
+		wasRedacted = true;
+	}
+
+	return wasRedacted;
+}
+
+function redactToolOutput(toolResult: JsonObject): boolean {
+	let wasRedacted = false;
+
+	if (hasOwn(toolResult, 'output')) {
+		toolResult.output = {
+			type: 'text',
+			value: LANGFUSE_REDACTION_PLACEHOLDER,
+		};
+		wasRedacted = true;
+	}
+	if (hasOwn(toolResult, 'result')) {
+		toolResult.result = LANGFUSE_REDACTION_PLACEHOLDER;
+		wasRedacted = true;
+	}
+
+	return wasRedacted;
+}
+
+function redactJsonAttribute(attributes: Attributes, attributeName: string, redact: JsonRedactor): void {
+	const rawValue = attributes[attributeName];
+	if (typeof rawValue !== 'string') {
+		return;
+	}
+
+	try {
+		const value = JSON.parse(rawValue) as unknown;
+		if (redact(value)) {
+			attributes[attributeName] = JSON.stringify(value);
+		}
+	} catch {
+		if (containsRedactedToolName(rawValue)) {
+			attributes[attributeName] = LANGFUSE_REDACTION_PLACEHOLDER;
+		}
+	}
+}
+
+function redactToolSpanExceptions(span: ReadableSpan): void {
+	if (!isRedactedToolName(span.attributes['ai.toolCall.name'])) {
+		return;
+	}
+
+	for (const event of span.events) {
+		if (!event.attributes) {
+			continue;
+		}
+
+		redactAttributeIfPresent(event.attributes, 'exception.message');
+		redactAttributeIfPresent(event.attributes, 'exception.stacktrace');
+	}
+}
+
+function redactAttributeIfPresent(attributes: Attributes, attributeName: string): void {
+	if (hasOwn(attributes, attributeName)) {
+		attributes[attributeName] = LANGFUSE_REDACTION_PLACEHOLDER;
+	}
+}
+
+function containsRedactedToolName(value: string): boolean {
+	for (const toolName of REDACTED_DATA_TOOL_NAMES) {
+		if (value.includes(toolName)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function isRedactedToolName(value: unknown): value is string {
+	return typeof value === 'string' && REDACTED_DATA_TOOL_NAMES.has(value);
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(value: object, key: string): boolean {
+	return Object.prototype.hasOwnProperty.call(value, key);
+}

--- a/apps/backend/src/utils/langfuse-redaction.ts
+++ b/apps/backend/src/utils/langfuse-redaction.ts
@@ -1,142 +1,43 @@
 import type { Attributes, Context } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor } from '@opentelemetry/sdk-trace-node';
 
-export const REDACTED_DATA_TOOL_NAMES: ReadonlySet<string> = new Set(['execute_sql', 'read_query_result']);
+const REDACTED_DATA_TOOL_NAMES = new Set(['execute_sql', 'read_query_result']);
+const JSON_ATTRIBUTE_NAMES = ['ai.prompt', 'ai.prompt.messages', 'ai.response.toolCalls'];
+const TOOL_PAYLOAD_KEYS = ['input', 'args', 'output', 'result'];
+const TOOL_SPAN_PAYLOAD_KEYS = ['ai.toolCall.args', 'ai.toolCall.result'];
+const EXCEPTION_DETAIL_KEYS = ['exception.message', 'exception.stacktrace'];
 export const LANGFUSE_REDACTION_PLACEHOLDER = '[redacted]';
 
 type JsonObject = Record<string, unknown>;
-type JsonRedactor = (value: unknown) => boolean;
 
 export function redactDataToolAttributes(attributes: Attributes): void {
-	redactToolSpanAttributes(attributes);
-	redactJsonAttribute(attributes, 'ai.prompt.messages', redactMessages);
-	redactJsonAttribute(attributes, 'ai.prompt', redactPrompt);
-	redactJsonAttribute(attributes, 'ai.response.toolCalls', redactResponseToolCalls);
+	if (REDACTED_DATA_TOOL_NAMES.has(attributes['ai.toolCall.name'] as string)) {
+		redactKeys(attributes, TOOL_SPAN_PAYLOAD_KEYS);
+	}
+	for (const attributeName of JSON_ATTRIBUTE_NAMES) {
+		redactJsonAttribute(attributes, attributeName);
+	}
 }
 
 export class DataToolRedactingSpanProcessor implements SpanProcessor {
 	constructor(private readonly delegate: SpanProcessor) {}
-
 	onStart(span: Span, parentContext: Context): void {
 		this.delegate.onStart(span, parentContext);
 	}
-
 	onEnd(span: ReadableSpan): void {
 		redactDataToolAttributes(span.attributes);
 		redactToolSpanExceptions(span);
 		this.delegate.onEnd(span);
 	}
-
 	forceFlush(): Promise<void> {
 		return this.delegate.forceFlush();
 	}
-
 	shutdown(): Promise<void> {
 		return this.delegate.shutdown();
 	}
 }
 
-function redactToolSpanAttributes(attributes: Attributes): void {
-	if (!isRedactedToolName(attributes['ai.toolCall.name'])) {
-		return;
-	}
-
-	redactAttributeIfPresent(attributes, 'ai.toolCall.args');
-	redactAttributeIfPresent(attributes, 'ai.toolCall.result');
-}
-
-function redactPrompt(value: unknown): boolean {
-	if (!isJsonObject(value)) {
-		return false;
-	}
-
-	return redactMessages(value.messages);
-}
-
-function redactMessages(value: unknown): boolean {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-
-	let wasRedacted = false;
-	for (const message of value) {
-		if (!isJsonObject(message) || !Array.isArray(message.content)) {
-			continue;
-		}
-
-		for (const part of message.content) {
-			wasRedacted = redactMessagePart(part) || wasRedacted;
-		}
-	}
-
-	return wasRedacted;
-}
-
-function redactMessagePart(value: unknown): boolean {
-	if (!isJsonObject(value) || !isRedactedToolName(value.toolName)) {
-		return false;
-	}
-
-	if (value.type === 'tool-call') {
-		return redactToolInput(value);
-	}
-
-	if (value.type === 'tool-result') {
-		return redactToolOutput(value);
-	}
-
-	return false;
-}
-
-function redactResponseToolCalls(value: unknown): boolean {
-	if (!Array.isArray(value)) {
-		return false;
-	}
-
-	let wasRedacted = false;
-	for (const toolCall of value) {
-		if (isJsonObject(toolCall) && isRedactedToolName(toolCall.toolName)) {
-			wasRedacted = redactToolInput(toolCall) || wasRedacted;
-		}
-	}
-
-	return wasRedacted;
-}
-
-function redactToolInput(toolCall: JsonObject): boolean {
-	let wasRedacted = false;
-
-	if (hasOwn(toolCall, 'input')) {
-		toolCall.input = LANGFUSE_REDACTION_PLACEHOLDER;
-		wasRedacted = true;
-	}
-	if (hasOwn(toolCall, 'args')) {
-		toolCall.args = LANGFUSE_REDACTION_PLACEHOLDER;
-		wasRedacted = true;
-	}
-
-	return wasRedacted;
-}
-
-function redactToolOutput(toolResult: JsonObject): boolean {
-	let wasRedacted = false;
-
-	if (hasOwn(toolResult, 'output')) {
-		toolResult.output = {
-			type: 'text',
-			value: LANGFUSE_REDACTION_PLACEHOLDER,
-		};
-		wasRedacted = true;
-	}
-	if (hasOwn(toolResult, 'result')) {
-		toolResult.result = LANGFUSE_REDACTION_PLACEHOLDER;
-		wasRedacted = true;
-	}
-
-	return wasRedacted;
-}
-
-function redactJsonAttribute(attributes: Attributes, attributeName: string, redact: JsonRedactor): void {
+function redactJsonAttribute(attributes: Attributes, attributeName: string): void {
 	const rawValue = attributes[attributeName];
 	if (typeof rawValue !== 'string') {
 		return;
@@ -144,55 +45,51 @@ function redactJsonAttribute(attributes: Attributes, attributeName: string, reda
 
 	try {
 		const value = JSON.parse(rawValue) as unknown;
-		if (redact(value)) {
+		if (redactJsonValue(value)) {
 			attributes[attributeName] = JSON.stringify(value);
 		}
 	} catch {
-		if (containsRedactedToolName(rawValue)) {
+		if ([...REDACTED_DATA_TOOL_NAMES].some((toolName) => rawValue.includes(toolName))) {
 			attributes[attributeName] = LANGFUSE_REDACTION_PLACEHOLDER;
 		}
 	}
 }
 
+function redactJsonValue(value: unknown): boolean {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const object = value as JsonObject;
+	let wasRedacted =
+		!Array.isArray(value) &&
+		REDACTED_DATA_TOOL_NAMES.has(object.toolName as string) &&
+		redactKeys(object, TOOL_PAYLOAD_KEYS);
+	for (const nestedValue of Array.isArray(value) ? value : Object.values(object)) {
+		wasRedacted = redactJsonValue(nestedValue) || wasRedacted;
+	}
+	return wasRedacted;
+}
+
 function redactToolSpanExceptions(span: ReadableSpan): void {
-	if (!isRedactedToolName(span.attributes['ai.toolCall.name'])) {
+	if (!REDACTED_DATA_TOOL_NAMES.has(span.attributes['ai.toolCall.name'] as string)) {
 		return;
 	}
 
 	for (const event of span.events) {
-		if (!event.attributes) {
-			continue;
-		}
-
-		redactAttributeIfPresent(event.attributes, 'exception.message');
-		redactAttributeIfPresent(event.attributes, 'exception.stacktrace');
-	}
-}
-
-function redactAttributeIfPresent(attributes: Attributes, attributeName: string): void {
-	if (hasOwn(attributes, attributeName)) {
-		attributes[attributeName] = LANGFUSE_REDACTION_PLACEHOLDER;
-	}
-}
-
-function containsRedactedToolName(value: string): boolean {
-	for (const toolName of REDACTED_DATA_TOOL_NAMES) {
-		if (value.includes(toolName)) {
-			return true;
+		if (event.attributes) {
+			redactKeys(event.attributes, EXCEPTION_DETAIL_KEYS);
 		}
 	}
-
-	return false;
 }
 
-function isRedactedToolName(value: unknown): value is string {
-	return typeof value === 'string' && REDACTED_DATA_TOOL_NAMES.has(value);
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function hasOwn(value: object, key: string): boolean {
-	return Object.prototype.hasOwnProperty.call(value, key);
+function redactKeys(value: JsonObject, keys: string[]): boolean {
+	let wasRedacted = false;
+	for (const key of keys) {
+		if (Object.hasOwn(value, key)) {
+			value[key] = LANGFUSE_REDACTION_PLACEHOLDER;
+			wasRedacted = true;
+		}
+	}
+	return wasRedacted;
 }

--- a/apps/backend/tests/langfuse-redaction.test.ts
+++ b/apps/backend/tests/langfuse-redaction.test.ts
@@ -1,0 +1,272 @@
+import type { Attributes } from '@opentelemetry/api';
+import type { ReadableSpan, SpanProcessor, TimedEvent } from '@opentelemetry/sdk-trace-node';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	DataToolRedactingSpanProcessor,
+	LANGFUSE_REDACTION_PLACEHOLDER,
+	redactDataToolAttributes,
+} from '../src/utils/langfuse-redaction';
+
+const DISTINCTIVE_SQL = 'SELECT customer_email FROM customers';
+const DISTINCTIVE_ROW_VALUE = 'private-customer@example.com';
+
+describe('redactDataToolAttributes', () => {
+	it('redacts execute_sql arguments and results while preserving tool identity', () => {
+		const attributes: Attributes = {
+			'ai.toolCall.name': 'execute_sql',
+			'ai.toolCall.id': 'tool-call-1',
+			'ai.toolCall.args': JSON.stringify({ query: DISTINCTIVE_SQL }),
+			'ai.toolCall.result': JSON.stringify([{ customer_email: DISTINCTIVE_ROW_VALUE }]),
+		};
+
+		redactDataToolAttributes(attributes);
+
+		expect(attributes).toEqual({
+			'ai.toolCall.name': 'execute_sql',
+			'ai.toolCall.id': 'tool-call-1',
+			'ai.toolCall.args': LANGFUSE_REDACTION_PLACEHOLDER,
+			'ai.toolCall.result': LANGFUSE_REDACTION_PLACEHOLDER,
+		});
+	});
+
+	it('redacts read_query_result arguments and results while preserving tool identity', () => {
+		const attributes: Attributes = {
+			'ai.toolCall.name': 'read_query_result',
+			'ai.toolCall.id': 'tool-call-2',
+			'ai.toolCall.args': JSON.stringify({ queryId: 'query-123' }),
+			'ai.toolCall.result': JSON.stringify([{ customer_email: DISTINCTIVE_ROW_VALUE }]),
+		};
+
+		redactDataToolAttributes(attributes);
+
+		expect(attributes).toEqual({
+			'ai.toolCall.name': 'read_query_result',
+			'ai.toolCall.id': 'tool-call-2',
+			'ai.toolCall.args': LANGFUSE_REDACTION_PLACEHOLDER,
+			'ai.toolCall.result': LANGFUSE_REDACTION_PLACEHOLDER,
+		});
+	});
+
+	it('leaves non-redacted tool spans untouched', () => {
+		const attributes: Attributes = {
+			'ai.toolCall.name': 'search',
+			'ai.toolCall.id': 'tool-call-3',
+			'ai.toolCall.args': JSON.stringify({ query: 'quarterly plan' }),
+			'ai.toolCall.result': JSON.stringify({ matches: ['forecast'] }),
+		};
+		const originalAttributes = structuredClone(attributes);
+
+		redactDataToolAttributes(attributes);
+
+		expect(attributes).toEqual(originalAttributes);
+	});
+
+	it('redacts data tool calls and results from message history only', () => {
+		const messages = [
+			{
+				role: 'user',
+				content: [{ type: 'text', text: 'Show customer activity' }],
+			},
+			{
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolCallId: 'sql-call',
+						toolName: 'execute_sql',
+						input: { query: DISTINCTIVE_SQL },
+					},
+					{
+						type: 'tool-call',
+						toolCallId: 'search-call',
+						toolName: 'search',
+						input: { query: 'customer activity definition' },
+					},
+				],
+			},
+			{
+				role: 'tool',
+				content: [
+					{
+						type: 'tool-result',
+						toolCallId: 'sql-call',
+						toolName: 'execute_sql',
+						output: {
+							type: 'json',
+							value: [{ customer_email: DISTINCTIVE_ROW_VALUE }],
+						},
+					},
+				],
+			},
+		];
+		const responseToolCalls = [
+			{
+				type: 'tool-call',
+				toolCallId: 'response-sql-call',
+				toolName: 'execute_sql',
+				input: { query: DISTINCTIVE_SQL },
+			},
+		];
+		const attributes: Attributes = {
+			'ai.prompt.messages': JSON.stringify(messages),
+			'ai.response.toolCalls': JSON.stringify(responseToolCalls),
+		};
+
+		redactDataToolAttributes(attributes);
+
+		const sanitizedMessages = JSON.parse(attributes['ai.prompt.messages'] as string) as typeof messages;
+		const assistantContent = sanitizedMessages[1]?.content;
+		const toolContent = sanitizedMessages[2]?.content;
+		expect(sanitizedMessages[0]).toEqual(messages[0]);
+		expect(assistantContent?.[0]?.input).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
+		expect(assistantContent?.[1]).toEqual(messages[1]?.content[1]);
+		expect(toolContent?.[0]?.output).toEqual({
+			type: 'text',
+			value: LANGFUSE_REDACTION_PLACEHOLDER,
+		});
+
+		const sanitizedResponseToolCalls = JSON.parse(
+			attributes['ai.response.toolCalls'] as string,
+		) as typeof responseToolCalls;
+		expect(sanitizedResponseToolCalls[0]?.input).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
+
+		const serializedAttributes = JSON.stringify(attributes);
+		expect(serializedAttributes).not.toContain(DISTINCTIVE_SQL);
+		expect(serializedAttributes).not.toContain(DISTINCTIVE_ROW_VALUE);
+		expect(serializedAttributes).toContain('Show customer activity');
+		expect(serializedAttributes).toContain('customer activity definition');
+	});
+
+	it('redacts older tool payload shapes inside ai.prompt messages', () => {
+		const attributes: Attributes = {
+			'ai.prompt': JSON.stringify({
+				messages: [
+					{
+						role: 'assistant',
+						content: [
+							{
+								type: 'tool-call',
+								toolName: 'read_query_result',
+								args: { queryId: 'query-123' },
+							},
+						],
+					},
+					{
+						role: 'tool',
+						content: [
+							{
+								type: 'tool-result',
+								toolName: 'read_query_result',
+								result: [{ customer_email: DISTINCTIVE_ROW_VALUE }],
+							},
+						],
+					},
+				],
+			}),
+		};
+
+		redactDataToolAttributes(attributes);
+
+		const prompt = JSON.parse(attributes['ai.prompt'] as string) as {
+			messages: Array<{ content: JsonPart[] }>;
+		};
+		expect(prompt.messages[0]?.content[0]?.args).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
+		expect(prompt.messages[1]?.content[0]?.result).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
+	});
+
+	it('fails closed for malformed JSON that names a redacted tool', () => {
+		const attributes: Attributes = {
+			'ai.prompt.messages': `{"toolName":"execute_sql","input":{"query":"${DISTINCTIVE_SQL}"}`,
+		};
+
+		redactDataToolAttributes(attributes);
+
+		expect(attributes['ai.prompt.messages']).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
+	});
+
+	it('leaves malformed JSON alone when no redacted tool is named', () => {
+		const rawMessages = '{"toolName":"search","input":';
+		const attributes: Attributes = {
+			'ai.prompt.messages': rawMessages,
+		};
+
+		redactDataToolAttributes(attributes);
+
+		expect(attributes['ai.prompt.messages']).toBe(rawMessages);
+	});
+});
+
+describe('DataToolRedactingSpanProcessor', () => {
+	it('scrubs exception details on redacted tool spans', () => {
+		const attributes: Attributes = {
+			'ai.toolCall.name': 'execute_sql',
+		};
+		const events: TimedEvent[] = [
+			{
+				name: 'exception',
+				time: [0, 0],
+				attributes: {
+					'exception.type': 'DatabaseError',
+					'exception.message': `Query failed: ${DISTINCTIVE_SQL}`,
+					'exception.stacktrace': `DatabaseError: ${DISTINCTIVE_ROW_VALUE}`,
+				},
+			},
+			{
+				name: 'event-without-attributes',
+				time: [0, 0],
+			},
+		];
+
+		runSpanThroughProcessor(attributes, events);
+
+		expect(events[0]?.attributes).toEqual({
+			'exception.type': 'DatabaseError',
+			'exception.message': LANGFUSE_REDACTION_PLACEHOLDER,
+			'exception.stacktrace': LANGFUSE_REDACTION_PLACEHOLDER,
+		});
+	});
+
+	it('preserves exception details on normal tool spans', () => {
+		const attributes: Attributes = {
+			'ai.toolCall.name': 'search',
+		};
+		const events: TimedEvent[] = [
+			{
+				name: 'exception',
+				time: [0, 0],
+				attributes: {
+					'exception.message': 'Search service unavailable',
+					'exception.stacktrace': 'SearchError: unavailable',
+				},
+			},
+		];
+		const originalEvents = structuredClone(events);
+
+		runSpanThroughProcessor(attributes, events);
+
+		expect(events).toEqual(originalEvents);
+	});
+});
+
+interface JsonPart {
+	input?: unknown;
+	args?: unknown;
+	output?: unknown;
+	result?: unknown;
+}
+
+function runSpanThroughProcessor(attributes: Attributes, events: TimedEvent[]): void {
+	const delegate: SpanProcessor = {
+		onStart: vi.fn(),
+		onEnd: vi.fn(),
+		forceFlush: vi.fn().mockResolvedValue(undefined),
+		shutdown: vi.fn().mockResolvedValue(undefined),
+	};
+	const processor = new DataToolRedactingSpanProcessor(delegate);
+	const span = { attributes, events } as unknown as ReadableSpan;
+
+	processor.onEnd(span);
+
+	expect(delegate.onEnd).toHaveBeenCalledWith(span);
+}

--- a/apps/backend/tests/langfuse-redaction.test.ts
+++ b/apps/backend/tests/langfuse-redaction.test.ts
@@ -121,10 +121,7 @@ describe('redactDataToolAttributes', () => {
 		expect(sanitizedMessages[0]).toEqual(messages[0]);
 		expect(assistantContent?.[0]?.input).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
 		expect(assistantContent?.[1]).toEqual(messages[1]?.content[1]);
-		expect(toolContent?.[0]?.output).toEqual({
-			type: 'text',
-			value: LANGFUSE_REDACTION_PLACEHOLDER,
-		});
+		expect(toolContent?.[0]?.output).toBe(LANGFUSE_REDACTION_PLACEHOLDER);
 
 		const sanitizedResponseToolCalls = JSON.parse(
 			attributes['ai.response.toolCalls'] as string,


### PR DESCRIPTION
## Summary

- Query data never reaches Langfuse anymore. Anything belonging to `execute_sql` and
  `read_query_result` (the SQL text, the returned rows, and error messages) is replaced
  with `[redacted]` before traces are sent.
- The calls stay visible in the trace: you still see that a query ran, how long it took and
  whether it failed. Only the contents are gone.
- Redaction covers both places the data showed up: the tool call itself, and the
  conversation history that gets replayed on every following model call. Redacting only the
  tool call would have left the SQL and rows in every later prompt.
- Everything else is unchanged - questions, answers, other tools, timings, token usage.
- Always on, no setting to turn it off.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

