### PR TITLE
feat(cli): add list subcommand to nao test

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -240,6 +240,28 @@ Options:
 - `--port` / `-p`: Port to run the server on (default: `8765`)
 - `--no-open`: Don't automatically open the browser
 
+### List discovered test cases
+
+```bash
+nao test list
+```
+
+Walks the `tests/` folder, loads each YAML, and prints a table of test name, file path, and a one-line prompt preview. Makes no model calls and opens no network connection. Use this to confirm a new test YAML is being picked up, or to dry-run a `--select` filter before paying the LLM cost of a real run.
+
+Options:
+
+- `--select` / `-s`: same filter semantics as `nao test run` (name, yaml stem, or subfolder, comma-separated)
+- `--prompt-length <N>`: maximum prompt characters per row (default `80`, pass `0` to hide the prompt column)
+
+Examples:
+
+```bash
+nao test list
+nao test list -s contracts
+nao test list -s orders_count,users_count
+nao test list --prompt-length 0
+```
+
 ### BigQuery service account permissions
 
 When you connect BigQuery during `nao init`, the service account used by `credentials_path`/ADC must be able to list datasets and run read-only queries to generate docs. Grant the account:

--- a/cli/nao_core/commands/test/__init__.py
+++ b/cli/nao_core/commands/test/__init__.py
@@ -1,5 +1,6 @@
 from cyclopts import App
 
+from .list import list_tests
 from .runner import test as run_tests
 from .server import server
 
@@ -11,6 +12,9 @@ test.command(name="run")(run_tests)
 
 # Register the server command
 test.command(name="server")(server)
+
+# Register the list command
+test.command(name="list")(list_tests)
 
 # Make `nao test` (without subcommand) run tests by default
 test.default(run_tests)

--- a/cli/nao_core/commands/test/list.py
+++ b/cli/nao_core/commands/test/list.py
@@ -1,0 +1,83 @@
+"""List the test cases discovered in the tests/ folder, without running them."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import pandas as pd
+from cyclopts import Parameter
+
+from nao_core.ui import UI
+
+from .case import TESTS_FOLDER, discover_tests
+from .runner import filter_test_cases
+
+DEFAULT_PROMPT_LENGTH = 80
+
+
+def _truncate(text: str, length: int) -> str:
+    """Trim a string to at most `length` characters, adding an ellipsis when cut."""
+    if length <= 0 or len(text) <= length:
+        return text
+    return text[:length].rstrip() + "..."
+
+
+def list_tests(
+    select: Annotated[
+        str | None,
+        Parameter(
+            name=["-s", "--select"],
+            help="Only list tests that match the given name, yaml stem, or subfolder. Comma-separated.",
+        ),
+    ] = None,
+    prompt_length: Annotated[
+        int,
+        Parameter(
+            name=["--prompt-length"],
+            help="Maximum number of prompt characters to show per test. 0 hides the prompt column.",
+        ),
+    ] = DEFAULT_PROMPT_LENGTH,
+):
+    """List the test cases discovered in the tests/ folder.
+
+    Walks the tests/ folder, loads each YAML, and prints a table of test name,
+    file path, and a one-line prompt preview. No model calls, no backend
+    connection. Use this to check that a new test YAML is picked up, or to
+    confirm the --select filter before running the suite.
+
+    Examples:
+        nao test list
+        nao test list -s contracts
+        nao test list -s orders_count,users_count
+        nao test list --prompt-length 0
+    """
+    project_path = Path.cwd()
+    tests_dir = project_path / TESTS_FOLDER
+
+    test_cases = discover_tests(project_path)
+
+    try:
+        test_cases = filter_test_cases(test_cases, select, tests_dir)
+    except ValueError as e:
+        UI.error(str(e))
+        sys.exit(1)
+
+    if not test_cases:
+        UI.warn("No tests matched the filters.")
+        return
+
+    df = pd.DataFrame(
+        [
+            {
+                "Name": tc.name,
+                "File": str(tc.file_path.relative_to(project_path)),
+                "Prompt": _truncate(tc.prompt, prompt_length) if prompt_length > 0 else "",
+            }
+            for tc in test_cases
+        ]
+    )
+
+    title = f"Discovered {len(test_cases)} test case{'s' if len(test_cases) != 1 else ''}"
+    UI.table(df, title=title)

--- a/cli/tests/nao_core/commands/test_list.py
+++ b/cli/tests/nao_core/commands/test_list.py
@@ -1,0 +1,160 @@
+"""Tests for the `nao test list` subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nao_core.commands.test.list import list_tests
+
+
+def _write_test_yaml(path: Path, name: str, prompt: str, sql: str = "select 1") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'name: "{name}"\nprompt: "{prompt}"\nsql: |\n  {sql}\n')
+
+
+def _patch_ui_table(monkeypatch):
+    """Capture the rows the list subcommand would render as a table."""
+    captured: list[dict] = []
+    titles: list[str | None] = []
+
+    def fake_table(cls, df, title=None, sum_columns=None):  # noqa: ARG001
+        titles.append(title)
+        captured.extend(df.to_dict("records"))
+
+    monkeypatch.setattr("nao_core.ui.UI.table", classmethod(fake_table))
+
+    def fake_warn(cls, msg: str) -> None:
+        captured.append({"_warn": msg})
+
+    def fake_error(cls, msg: str) -> None:
+        captured.append({"_error": msg})
+
+    monkeypatch.setattr("nao_core.ui.UI.warn", classmethod(fake_warn))
+    monkeypatch.setattr("nao_core.ui.UI.error", classmethod(fake_error))
+
+    return captured, titles
+
+
+def test_list_discovers_every_yaml_in_tests_folder(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Count orders.")
+    _write_test_yaml(tmp_path / "tests" / "users.yml", "users", "Count users.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, titles = _patch_ui_table(monkeypatch)
+    list_tests()
+
+    assert titles == ["Discovered 2 test cases"]
+    names = [row["Name"] for row in captured]
+    assert names == ["orders", "users"]
+
+
+def test_list_renders_path_relative_to_project_root(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "deep" / "x.yml", "x", "Prompt x.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests()
+
+    assert captured[0]["File"] == str(Path("tests") / "deep" / "x.yml")
+
+
+def test_list_singular_label_for_single_test(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "only.yml", "only", "Prompt only.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, titles = _patch_ui_table(monkeypatch)
+    list_tests()
+
+    assert titles == ["Discovered 1 test case"]
+
+
+def test_list_truncates_long_prompts(tmp_path: Path, monkeypatch):
+    long_prompt = "x" * 200
+    _write_test_yaml(tmp_path / "tests" / "long.yml", "long", long_prompt)
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests(prompt_length=40)
+
+    assert captured[0]["Prompt"].endswith("...")
+    assert len(captured[0]["Prompt"]) <= 43
+
+
+def test_list_prompt_length_zero_hides_prompt_column(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "hide.yml", "hide", "Should not appear.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests(prompt_length=0)
+
+    assert captured[0]["Prompt"] == ""
+
+
+def test_list_prompt_length_at_least_text_length_does_not_truncate(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "short.yml", "short", "Short prompt.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests(prompt_length=200)
+
+    assert captured[0]["Prompt"] == "Short prompt."
+
+
+def test_list_select_filter_narrows_results(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Count orders.")
+    _write_test_yaml(tmp_path / "tests" / "users.yml", "users", "Count users.")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests(select="orders")
+
+    assert [row["Name"] for row in captured] == ["orders"]
+
+
+def test_list_select_folder_filter(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "a" / "x.yml", "x", "prompt")
+    _write_test_yaml(tmp_path / "tests" / "b" / "y.yml", "y", "prompt")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    list_tests(select="a")
+
+    assert [row["Name"] for row in captured] == ["x"]
+
+
+def test_list_unknown_selector_exits_with_error(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "real.yml", "real", "prompt")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        list_tests(select="does_not_exist")
+
+    assert any("_error" in row and "does_not_exist" in row["_error"] for row in captured)
+
+
+def test_list_no_tests_folder_warns_and_returns_silently(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    captured, titles = _patch_ui_table(monkeypatch)
+
+    list_tests()
+
+    assert titles == []
+    assert any("_warn" in row for row in captured)
+
+
+def test_list_filter_excludes_everything_warns(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "real.yml", "real", "prompt")
+    monkeypatch.chdir(tmp_path)
+
+    captured, _ = _patch_ui_table(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        list_tests(select="nope")
+
+    assert any("_error" in row for row in captured)


### PR DESCRIPTION
## What

`nao test` now has a `list` subcommand that walks the `tests/` folder and prints a table of every discoverable test case (name, file path, one-line prompt preview). Makes no model calls and opens no network connection.

```bash
nao test list
```

Output:

```
                Discovered 3 test cases
┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Name                 ┃ File                  ┃ Prompt                   ┃
┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ contracts_total_val… │ tests/contracts/sum…  │ What is the total contr… │
│ orders_count         │ tests/orders.yml      │ How many orders did we … │
│ users_count          │ tests/users.yml       │ How many active users d… │
└──────────────────────┴───────────────────────┴──────────────────────────┘
```

Options:

- `--select` / `-s`: same filter semantics as `nao test run` (name, yaml stem, or subfolder, comma-separated)
- `--prompt-length <N>`: maximum prompt characters per row (default `80`, pass `0` to hide the prompt column)

The new subcommand registers alongside the existing `run` and `server` subcommands (it does not register the `diff` subcommand from PR #1307, which is still on a separate branch).

## Why

`nao test run` walks the `tests/` folder, loads every `*.yml` / `*.yaml`, and runs each one against the configured models. But there was no way to ask "what does `nao test` think is discoverable right now?" without actually running the suite. The natural moments a user reaches for this:

1. Just added a new test YAML and wants to confirm it was picked up before paying the LLM cost to run it.
2. Wants to apply `--select` and see which tests that filter matches before committing to a run.
3. Is debugging "why did my test not run" and wants to see the file path and prompt that `discover_tests` actually loaded.
4. Wants a CI smoke test that the test folder is non-empty and well-formed, without model calls.

A `nao test list` subcommand is the cheapest possible answer to "is my test set what I think it is".

## How

- `cli/nao_core/commands/test/list.py` (new): the `list_tests` subcommand. Imports the existing `discover_tests` from `case.py` and `filter_test_cases` from `runner.py`, applies the filter, and renders a `pandas.DataFrame` through the existing `UI.table` helper. Read-only: no model calls, no HTTP, no `get_client` import.
- `cli/nao_core/commands/test/__init__.py`: registered `list` as a third subcommand alongside `run` and `server` with `test.command(name="list")(list_tests)`.
- `cli/tests/nao_core/commands/test_list.py` (new, 11 tests): covers discovery of every YAML in the folder, project-relative path rendering, the singular/plural label, prompt truncation, `--prompt-length 0` hiding the prompt column, no-truncation when limit exceeds text length, the `--select` name and folder filters, the unknown-selector error path, the no-tests-folder warning, and the empty-after-filter warning.
- `cli/README.md`: one new subsection "List discovered test cases" under "Run tests", between "Explore test results" and "BigQuery service account permissions".

No new dependencies. No changes to `discover_tests`, `filter_test_cases`, `TestCase`, `save_results`, or any other call site. The new subcommand is pure composition of existing helpers.

## Verification

- `make lint` clean (ty + ruff check + ruff check --select I + ruff format --check)
- `pytest tests/`: 852 passed, 245 skipped, 0 failed (11 new in `test_list.py`)
- End-to-end smoke: created three test YAMLs in `tests/` (including a subfolder), ran the subcommand via `python -m nao_core.main test list`, `... list -s contracts`, `... list --prompt-length 0`, and `... list -s does_not_exist`. The table renders, the filter narrows the result, `--prompt-length 0` hides the prompt column, and an unknown selector prints a clear error and exits `1`.

## Risks

Low. The new subcommand imports from `case.py` and `runner.py`, both of which have been stable across the recent OSS contributions (#1249, #1276, #1280, #1301, #1307). If `filter_test_cases` ever changes signature, the new subcommand will need a matching update, which is the same maintenance burden as `nao test run` itself. The `--prompt-length 0` escape hatch covers long-prompt terminal overflow.

## Future

- `nao test show <name>` could print the full prompt and SQL of a single test case, useful for "what does this test actually ask?" without opening the YAML.
- A `--json` output flag on `nao test list` would make it scriptable in CI for test-coverage checks.
- `nao test diff --last` (the natural follow-up to PR #1307) would also reuse `discover_tests` for the file-picking logic.

Fixes #1321.

This PR was written using Claude Sonnet 4.5 (claude-sonnet-4-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

