### PR TITLE
feat: allow editing context explorer files

### DIFF
--- a/apps/backend/src/services/context-explorer.service.ts
+++ b/apps/backend/src/services/context-explorer.service.ts
@@ -8,16 +8,36 @@ export async function getFileTree(projectFolder: string): Promise<FileTreeEntry[
 	return readDirectoryRecursive(projectFolder, projectFolder);
 }
 
+const MAX_FILE_SIZE = 1024 * 1024; // 1 MB
+
 export async function readFileContent(filePath: string, projectFolder: string): Promise<string> {
 	const realPath = resolveAndValidatePath(filePath, projectFolder);
 	const stat = await fs.stat(realPath);
 
-	const MAX_FILE_SIZE = 1024 * 1024; // 1 MB
+	if (!stat.isFile()) {
+		throw new Error('Path is not a file');
+	}
+
 	if (stat.size > MAX_FILE_SIZE) {
 		throw new Error('File is too large to display (max 1 MB)');
 	}
 
 	return fs.readFile(realPath, 'utf-8');
+}
+
+export async function writeFileContent(filePath: string, projectFolder: string, content: string): Promise<void> {
+	const realPath = resolveAndValidatePath(filePath, projectFolder);
+	const stat = await fs.stat(realPath);
+
+	if (!stat.isFile()) {
+		throw new Error('Path is not a file');
+	}
+
+	if (Buffer.byteLength(content, 'utf-8') > MAX_FILE_SIZE) {
+		throw new Error('File is too large to save (max 1 MB)');
+	}
+
+	await fs.writeFile(realPath, content, 'utf-8');
 }
 
 async function readDirectoryRecursive(dirPath: string, projectFolder: string): Promise<FileTreeEntry[]> {
@@ -61,9 +81,11 @@ async function readDirectoryRecursive(dirPath: string, projectFolder: string): P
 
 function resolveAndValidatePath(virtualPath: string, projectFolder: string): string {
 	const relativePath = virtualPath.startsWith('/') ? virtualPath.slice(1) : virtualPath;
-	const resolvedPath = path.resolve(projectFolder, relativePath);
+	const resolvedProjectFolder = path.resolve(projectFolder);
+	const resolvedPath = path.resolve(resolvedProjectFolder, relativePath);
 
-	const withinFolder = resolvedPath === projectFolder || resolvedPath.startsWith(projectFolder + path.sep);
+	const withinFolder =
+		resolvedPath === resolvedProjectFolder || resolvedPath.startsWith(resolvedProjectFolder + path.sep);
 	if (!withinFolder) {
 		throw new Error(`Access denied: path is outside the project folder`);
 	}

--- a/apps/backend/src/trpc/context-explorer.routes.ts
+++ b/apps/backend/src/trpc/context-explorer.routes.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { getFileTree, readFileContent } from '../services/context-explorer.service';
+import { getFileTree, readFileContent, writeFileContent } from '../services/context-explorer.service';
 import { adminProtectedProcedure } from './trpc';
 
 function requireProjectPath(path: string | null): string {
@@ -22,4 +22,12 @@ export const contextExplorerRoutes = {
 		const content = await readFileContent(input.path, projectPath);
 		return { content };
 	}),
+
+	writeFile: adminProtectedProcedure
+		.input(z.object({ path: z.string(), content: z.string() }))
+		.mutation(async ({ ctx, input }) => {
+			const projectPath = requireProjectPath(ctx.project.path);
+			await writeFileContent(input.path, projectPath, input.content);
+			return { success: true };
+		}),
 };

--- a/apps/frontend/src/components/settings/file-viewer.tsx
+++ b/apps/frontend/src/components/settings/file-viewer.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from 'react';
 import { Editor } from '@monaco-editor/react';
-import { File } from 'lucide-react';
+import { File, Loader2 } from 'lucide-react';
 import type { Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
+import { Button } from '@/components/ui/button';
+import { ErrorMessage } from '@/components/ui/error-message';
 import { Spinner } from '@/components/ui/spinner';
 import { useEditorTheme } from '@/hooks/use-editor-theme';
 import { isMac } from '@/lib/platform';
@@ -11,6 +14,9 @@ interface FileViewerProps {
 	content: string | undefined;
 	isLoading: boolean;
 	isError: boolean;
+	isSaving: boolean;
+	saveError?: string;
+	onSave: (content: string) => Promise<void>;
 }
 
 const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
@@ -70,12 +76,29 @@ function defineCustomThemes(monaco: Monaco) {
 	});
 }
 
-export function FileViewer({ filePath, content, isLoading, isError }: FileViewerProps) {
+export function FileViewer({ filePath, content, isLoading, isError, isSaving, saveError, onSave }: FileViewerProps) {
 	const editorTheme = useEditorTheme();
 	const themeName = editorTheme === 'vs-dark' ? 'nao-dark' : 'nao-light';
+	const [isEditing, setIsEditing] = useState(false);
+	const [draftContent, setDraftContent] = useState(content ?? '');
+
+	useEffect(() => {
+		setIsEditing(false);
+		setDraftContent(content ?? '');
+	}, [content, filePath]);
 
 	const handleBeforeMount = (monaco: Monaco) => {
 		defineCustomThemes(monaco);
+	};
+
+	const handleSave = async () => {
+		await onSave(draftContent);
+		setIsEditing(false);
+	};
+
+	const handleCancel = () => {
+		setDraftContent(content ?? '');
+		setIsEditing(false);
 	};
 
 	const handleMount = (editorInstance: editor.IStandaloneCodeEditor, monaco: Monaco) => {
@@ -129,16 +152,37 @@ export function FileViewer({ filePath, content, isLoading, isError }: FileViewer
 				<File className='size-3.5' />
 				<span className='font-mono truncate'>{fileName}</span>
 				<span className='text-xs opacity-60 ml-auto truncate'>{filePath}</span>
+				{isEditing ? (
+					<div className='flex items-center gap-2 ml-2'>
+						<Button variant='ghost' size='sm' onClick={handleCancel} disabled={isSaving}>
+							Cancel
+						</Button>
+						<Button size='sm' onClick={handleSave} disabled={isSaving}>
+							{isSaving && <Loader2 className='size-3.5 animate-spin' />}
+							Save
+						</Button>
+					</div>
+				) : (
+					<Button variant='secondary' size='sm' className='ml-2' onClick={() => setIsEditing(true)}>
+						Edit
+					</Button>
+				)}
 			</div>
+			{saveError && (
+				<div className='mx-4 mt-2 shrink-0'>
+					<ErrorMessage message={saveError} />
+				</div>
+			)}
 			<div className='flex-1 min-h-0'>
 				<Editor
-					value={content ?? ''}
+					value={isEditing ? draftContent : (content ?? '')}
 					language={language}
 					theme={themeName}
 					beforeMount={handleBeforeMount}
 					onMount={handleMount}
+					onChange={(value) => setDraftContent(value ?? '')}
 					options={{
-						readOnly: true,
+						readOnly: !isEditing,
 						minimap: { enabled: false },
 						scrollBeyondLastLine: false,
 						fontSize: 13,
@@ -146,7 +190,7 @@ export function FileViewer({ filePath, content, isLoading, isError }: FileViewer
 						renderLineHighlight: 'line',
 						padding: { top: 8, bottom: 8 },
 						wordWrap: 'on',
-						domReadOnly: true,
+						domReadOnly: !isEditing,
 					}}
 				/>
 			</div>

--- a/apps/frontend/src/routes/_sidebar-layout.settings.context-explorer.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.context-explorer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { FileTree } from '@/components/settings/file-tree';
 import { FileViewer } from '@/components/settings/file-viewer';
@@ -22,6 +22,12 @@ function ContextExplorerPage() {
 	const fileContent = useQuery({
 		...trpc.contextExplorer.readFile.queryOptions({ path: selectedPath! }),
 		enabled: !!selectedPath,
+	});
+	const writeFile = useMutation({
+		...trpc.contextExplorer.writeFile.mutationOptions(),
+		onSuccess: () => {
+			void fileContent.refetch();
+		},
 	});
 
 	return (
@@ -48,7 +54,10 @@ function ContextExplorerPage() {
 							<FileTree
 								entries={fileTree.data ?? []}
 								selectedPath={selectedPath}
-								onSelectFile={setSelectedPath}
+								onSelectFile={(path) => {
+									writeFile.reset();
+									setSelectedPath(path);
+								}}
 							/>
 						)}
 					</div>
@@ -63,6 +72,14 @@ function ContextExplorerPage() {
 							content={fileContent.data?.content}
 							isLoading={fileContent.isLoading && fileContent.fetchStatus !== 'idle'}
 							isError={fileContent.isError}
+							isSaving={writeFile.isPending}
+							saveError={writeFile.error?.message}
+							onSave={(content) => {
+								if (!selectedPath) {
+									return Promise.resolve();
+								}
+								return writeFile.mutateAsync({ path: selectedPath, content }).then(() => undefined);
+							}}
 						/>
 					</div>
 				</ResizablePanel>


### PR DESCRIPTION
Closes #1129

## Summary

Adds edit/save support to the admin Context Explorer. Files were previously view-only — this adds a minimal edit flow so admins can open a file, edit it, and save the change back to the configured project folder.

## What changed

**Backend:** new admin-only tRPC mutation `contextExplorer.writeFile({ path, content })`. Writes the content using UTF-8, reuses the existing path validation so writes stay scoped to the project folder (paths come from the UI and shouldn't be trusted directly), and checks the file exists before writing.

**Frontend:** Edit button switches the Monaco editor to writable. Save calls `writeFile` and refetches the file. Cancel discards local changes and returns to read-only. Save errors show in the viewer.

## Scope

Kept intentionally small so the core flow can be reviewed first.

**Included:** editing existing files, saving to the project folder, admin-only mutation, server-side path validation.
**Not included:** create/delete/rename files or folders, git commit/push, conflict detection for external changes.

## Testing

Tested locally with `NAO_DEFAULT_PROJECT_PATH` set to the example project: opened Context Explorer, selected a file, clicked Edit, changed content, saved, confirmed it wrote to disk, then tested Cancel to confirm it discards changes.

Pre-commit checks (`lint`, `format:check`, `db:check-migrations`, `cli:check`) all passed — some pre-existing unrelated lint warnings, no new errors.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

