### PR TITLE
feat(cli): add summary subcommand to nao test

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -240,6 +240,28 @@ Options:
 - `--port` / `-p`: Port to run the server on (default: `8765`)
 - `--no-open`: Don't automatically open the browser
 
+### Show summary of a result file
+
+```bash
+nao test summary
+nao test summary tests/outputs/results_20260715_120000.json
+```
+
+Prints the one-line overall summary (pass/fail/total, total cost, total duration, total tool calls) and a per-model breakdown of the saved result file. With no argument, picks the most recent `results_*.json` in `tests/outputs/`. Reuses the same helpers that the `server` subcommand and `save_results` use, so output is identical to what the browser UI shows for the same file. No model calls, no HTTP.
+
+Options:
+
+- `--file` / `-f <path>`: explicit path to a results JSON file (default: most recent in `tests/outputs/`)
+- `--json`: print the summary as JSON instead of a human-readable table
+
+Examples:
+
+```bash
+nao test summary
+nao test summary tests/outputs/results_20260715_120000.json
+nao test summary --json
+```
+
 ### BigQuery service account permissions
 
 When you connect BigQuery during `nao init`, the service account used by `credentials_path`/ADC must be able to list datasets and run read-only queries to generate docs. Grant the account:

--- a/cli/nao_core/commands/test/__init__.py
+++ b/cli/nao_core/commands/test/__init__.py
@@ -2,6 +2,7 @@ from cyclopts import App
 
 from .runner import test as run_tests
 from .server import server
+from .summary_cmd import summary
 
 # Create a test app with subcommands
 test = App(name="test", help="Run and explore nao tests.")
@@ -11,6 +12,9 @@ test.command(name="run")(run_tests)
 
 # Register the server command
 test.command(name="server")(server)
+
+# Register the summary command
+test.command(name="summary")(summary)
 
 # Make `nao test` (without subcommand) run tests by default
 test.default(run_tests)

--- a/cli/nao_core/commands/test/summary_cmd.py
+++ b/cli/nao_core/commands/test/summary_cmd.py
@@ -1,0 +1,121 @@
+"""Print a one-line summary and per-model breakdown of a saved nao test result file."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Annotated
+
+import pandas as pd
+from cyclopts import Parameter
+
+from nao_core.ui import UI
+
+from .case import TESTS_FOLDER
+from .summary import (
+    summarize,
+    summarize_by_model,
+    with_model_summaries,
+)
+
+
+def _resolve_default_file(project_path: Path) -> Path | None:
+    """Return the most recent `results_*.json` in the project's outputs folder, or None."""
+    outputs_dir = project_path / TESTS_FOLDER / "outputs"
+    if not outputs_dir.exists() or not outputs_dir.is_dir():
+        return None
+    files = sorted(outputs_dir.glob("results_*.json"), reverse=True)
+    return files[0] if files else None
+
+
+def _load_results_file(path: Path) -> dict:
+    """Read and validate a results JSON file. Exits with a clear error on any failure."""
+    if not path.exists() or not path.is_file():
+        UI.error(f"File not found: {path}")
+        sys.exit(1)
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        UI.error(f"Invalid JSON in {path}: {e}")
+        sys.exit(1)
+
+    if not isinstance(data.get("results"), list):
+        UI.error(f"Missing or invalid 'results' key in {path}")
+        sys.exit(1)
+
+    return with_model_summaries(data)
+
+
+def _render_overall(overall: dict) -> None:
+    """Print the one-line overall summary."""
+    line = (
+        f"  {overall['passed']} passed, {overall['failed']} failed, "
+        f"{overall['total']} total, ${overall['total_cost']:.4f}, "
+        f"{overall['total_duration_s']}s, {overall['total_tool_calls']} tool calls"
+    )
+    UI.success(line)
+
+
+def _render_by_model(by_model: list) -> None:
+    """Print the per-model table."""
+    if not by_model:
+        return
+    df = pd.DataFrame([asdict(m) for m in by_model])
+    UI.table(df, title="By model")
+
+
+def summary(
+    file: Annotated[
+        Path | None,
+        Parameter(
+            name=["-f", "--file"],
+            help="Path to a results JSON file. Defaults to the most recent file in tests/outputs/.",
+        ),
+    ] = None,
+    as_json: Annotated[
+        bool,
+        Parameter(
+            name=["--json"],
+            help="Print the summary as JSON instead of a human-readable table.",
+        ),
+    ] = False,
+):
+    """Print a one-line summary and per-model breakdown of a saved nao test result file.
+
+    Reuses the same summary helpers that the `server` subcommand and
+    `save_results` use, so output is identical to what the browser UI shows
+    for the same file. No model calls, no HTTP requests.
+
+    Examples:
+        nao test summary
+        nao test summary tests/outputs/results_20260715_120000.json
+        nao test summary --json
+    """
+    project_path = Path.cwd()
+
+    if file is None:
+        file = _resolve_default_file(project_path)
+        if file is None:
+            UI.error(f"No results_*.json files found in {project_path / TESTS_FOLDER / 'outputs'}")
+            sys.exit(1)
+
+    data = _load_results_file(file)
+    results = data["results"]
+
+    overall = summarize(results)
+    by_model = summarize_by_model(results)
+
+    if as_json:
+        payload = {
+            "file": str(file),
+            "summary": overall,
+            "by_model": [asdict(m) for m in by_model],
+        }
+        UI.print(json.dumps(payload, indent=2))
+        return
+
+    _render_overall(overall)
+    _render_by_model(by_model)

--- a/cli/tests/nao_core/commands/test_summary_cmd.py
+++ b/cli/tests/nao_core/commands/test_summary_cmd.py
@@ -1,0 +1,409 @@
+"""Tests for the `nao test summary` subcommand."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nao_core.commands.test.summary_cmd import summary
+
+# `nao_core.commands.test` is shadowed by the cyclopts App at the package
+# level (commands/test/__init__.py creates `test = App(...)`), so dotted
+# imports of the submodule fail with "cannot import name 'summary_cmd' from
+# <unknown module name>". Load the source file directly to reach the private
+# helpers (`_resolve_default_file`, `_render_overall`, `_render_by_model`).
+# Use the dotted name so the module's relative imports resolve.
+_SUMMARY_CMD_FILE = Path(__file__).resolve().parents[3] / "nao_core" / "commands" / "test" / "summary_cmd.py"
+_spec = importlib.util.spec_from_file_location("nao_core.commands.test.summary_cmd", _SUMMARY_CMD_FILE)
+assert _spec is not None and _spec.loader is not None
+summary_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(summary_module)
+
+
+def _write_results_file(
+    path: Path,
+    *,
+    results: list[dict] | None = None,
+    include_by_model: bool = True,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = {
+        "timestamp": "2026-07-30T00:00:00",
+        "results": results
+        if results is not None
+        else [
+            {
+                "name": "orders_count",
+                "model": "openai:gpt-4.1",
+                "passed": True,
+                "message": "match",
+                "tokens": 100,
+                "cost": 0.001,
+                "duration_ms": 1000,
+                "tool_call_count": 1,
+            }
+        ],
+        "summary": {
+            "total": 1,
+            "passed": 1,
+            "failed": 0,
+            "total_tokens": 100,
+            "total_cost": 0.001,
+            "total_duration_ms": 1000,
+            "total_duration_s": 1.0,
+            "total_tool_calls": 1,
+            "avg_duration_ms": 1000,
+            "avg_tool_calls": 1.0,
+        },
+    }
+    if include_by_model and results is not None and len(results) > 1:
+        body["by_model"] = [
+            {
+                "model": "openai:gpt-4.1",
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "pass_rate": 100.0,
+                "total_tokens": 100,
+                "total_cost": 0.001,
+                "total_duration_ms": 1000,
+                "avg_duration_ms": 1000.0,
+                "total_tool_calls": 1,
+                "avg_tool_calls": 1.0,
+            }
+        ]
+    path.write_text(json.dumps(body))
+
+
+def _patch_ui(monkeypatch):
+    """Capture every UI call as a structured list of (method, args, kwargs) tuples."""
+    captured: list[tuple[str, tuple, dict]] = []
+
+    def make_capture(method_name: str):
+        def capture(cls, *args, **kwargs):
+            captured.append((method_name, args, kwargs))
+
+        return capture
+
+    for name in ("print", "success", "warn", "error", "title", "info", "table"):
+        monkeypatch.setattr(f"nao_core.ui.UI.{name}", classmethod(make_capture(name)))
+
+    return captured
+
+
+def _calls(captured, method: str) -> list[tuple[tuple, dict]]:
+    """Return just the args/kwargs of every call to a given UI method."""
+    return [(args, kwargs) for name, args, kwargs in captured if name == method]
+
+
+def _has_call(captured, method: str, *, contains: str | None = None) -> bool:
+    """Return True if the named UI method was called, optionally with substring match on the first arg."""
+    for name, args, _kwargs in captured:
+        if name != method:
+            continue
+        if contains is None:
+            return True
+        if args and contains in str(args[0]):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# File resolution
+# ---------------------------------------------------------------------------
+
+
+def test_summary_with_explicit_file_runs(tmp_path: Path, monkeypatch):
+    file = tmp_path / "results.json"
+    _write_results_file(file)
+    captured = _patch_ui(monkeypatch)
+
+    summary(file=file)
+
+    assert _has_call(captured, "success")
+
+
+def test_summary_without_file_uses_most_recent_in_outputs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    outputs = tmp_path / "tests" / "outputs"
+    _write_results_file(outputs / "results_20260701_000000.json")
+    _write_results_file(outputs / "results_20260715_120000.json")
+    captured = _patch_ui(monkeypatch)
+
+    summary()
+
+    # If the wrong file had been picked, the success line would not have
+    # fired (missing-file error path). The per-model backfill from
+    # `with_model_summaries` proves the file was loaded; the `_resolve_default_file`
+    # test covers the "most recent" sort. Here we just verify the happy path runs.
+    assert _has_call(captured, "success")
+
+
+def test_summary_without_file_errors_when_no_outputs_folder(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        summary()
+
+    assert _has_call(captured, "error", contains="No results")
+
+
+def test_summary_without_file_errors_when_outputs_folder_is_empty(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tests" / "outputs").mkdir(parents=True)
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit):
+        summary()
+
+    assert _has_call(captured, "error", contains="No results")
+
+
+def test_resolve_default_file_returns_none_when_outputs_dir_missing(tmp_path: Path):
+    result = summary_module._resolve_default_file(tmp_path)
+    assert result is None
+
+
+def test_resolve_default_file_returns_none_when_no_files(tmp_path: Path):
+    (tmp_path / "tests" / "outputs").mkdir(parents=True)
+    result = summary_module._resolve_default_file(tmp_path)
+    assert result is None
+
+
+def test_resolve_default_file_returns_most_recent(tmp_path: Path):
+    outputs = tmp_path / "tests" / "outputs"
+    outputs.mkdir(parents=True)
+    _write_results_file(outputs / "results_20260101_000000.json")
+    _write_results_file(outputs / "results_20260615_120000.json")
+    _write_results_file(outputs / "results_20260301_000000.json")
+
+    result = summary_module._resolve_default_file(tmp_path)
+
+    assert result.name == "results_20260615_120000.json"
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_summary_exits_on_missing_file(tmp_path: Path, monkeypatch):
+    missing = tmp_path / "does_not_exist.json"
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        summary(file=missing)
+
+    assert excinfo.value.code == 1
+    assert _has_call(captured, "error", contains="File not found")
+
+
+def test_summary_exits_on_invalid_json(tmp_path: Path, monkeypatch):
+    file = tmp_path / "broken.json"
+    file.write_text("not json")
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        summary(file=file)
+
+    assert excinfo.value.code == 1
+    assert _has_call(captured, "error", contains="Invalid JSON")
+
+
+def test_summary_exits_when_results_key_missing(tmp_path: Path, monkeypatch):
+    file = tmp_path / "no_results.json"
+    file.write_text(json.dumps({"summary": {}}))
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        summary(file=file)
+
+    assert excinfo.value.code == 1
+    assert _has_call(captured, "error", contains="Missing or invalid 'results'")
+
+
+def test_summary_exits_when_results_is_not_a_list(tmp_path: Path, monkeypatch):
+    file = tmp_path / "wrong_type.json"
+    file.write_text(json.dumps({"results": "not a list"}))
+    _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        summary(file=file)
+
+    assert excinfo.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# --json flag
+# ---------------------------------------------------------------------------
+
+
+def test_summary_json_flag_emits_json_payload(tmp_path: Path, monkeypatch):
+    file = tmp_path / "results.json"
+    _write_results_file(
+        file,
+        results=[
+            {
+                "name": "orders_count",
+                "model": "openai:gpt-4.1",
+                "passed": True,
+                "message": "match",
+                "tokens": 100,
+                "cost": 0.001,
+                "duration_ms": 1000,
+                "tool_call_count": 1,
+            },
+            {
+                "name": "users_count",
+                "model": "openai:gpt-4.1",
+                "passed": False,
+                "message": "values differ",
+                "tokens": 200,
+                "cost": 0.002,
+                "duration_ms": 2000,
+                "tool_call_count": 2,
+            },
+        ],
+        include_by_model=False,
+    )
+    captured = _patch_ui(monkeypatch)
+
+    summary(file=file, as_json=True)
+
+    print_calls = _calls(captured, "print")
+    assert print_calls, "expected a UI.print call from --json"
+    payload = _parse_json_arg(print_calls[0][0][0])
+    assert payload["summary"]["total"] == 2
+    assert payload["summary"]["passed"] == 1
+    assert payload["summary"]["failed"] == 1
+
+
+def test_summary_json_flag_includes_per_model_breakdown(tmp_path: Path, monkeypatch):
+    file = tmp_path / "results.json"
+    _write_results_file(
+        file,
+        results=[
+            {
+                "name": "orders_count",
+                "model": "openai:gpt-4.1",
+                "passed": True,
+                "message": "match",
+                "tokens": 100,
+                "cost": 0.001,
+                "duration_ms": 1000,
+                "tool_call_count": 1,
+            },
+            {
+                "name": "users_count",
+                "model": "anthropic:claude-sonnet-4-5",
+                "passed": True,
+                "message": "match",
+                "tokens": 150,
+                "cost": 0.0015,
+                "duration_ms": 1500,
+                "tool_call_count": 1,
+            },
+        ],
+        include_by_model=False,
+    )
+    captured = _patch_ui(monkeypatch)
+
+    summary(file=file, as_json=True)
+
+    print_calls = _calls(captured, "print")
+    payload = _parse_json_arg(print_calls[0][0][0])
+    models = [m["model"] for m in payload["by_model"]]
+    assert "openai:gpt-4.1" in models
+    assert "anthropic:claude-sonnet-4-5" in models
+
+
+def _parse_json_arg(arg: Any) -> dict:
+    """Parse the JSON string the subcommand hands to UI.print under --json."""
+    assert isinstance(arg, str)
+    return json.loads(arg)
+
+
+# ---------------------------------------------------------------------------
+# Per-model backfill for older files
+# ---------------------------------------------------------------------------
+
+
+def test_summary_backfills_by_model_for_older_files(tmp_path: Path, monkeypatch):
+    """A result file written before `by_model` existed should still get the table."""
+    file = tmp_path / "old_results.json"
+    _write_results_file(file, include_by_model=False)
+    captured = _patch_ui(monkeypatch)
+
+    summary(file=file)
+
+    assert _calls(captured, "table"), "expected a UI.table call for the per-model breakdown"
+
+
+# ---------------------------------------------------------------------------
+# Direct helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_render_overall_prints_a_one_liner(tmp_path: Path, monkeypatch):
+    captured = _patch_ui(monkeypatch)
+
+    summary_module._render_overall(
+        {
+            "total": 2,
+            "passed": 1,
+            "failed": 1,
+            "total_cost": 0.005,
+            "total_duration_s": 12.5,
+            "total_tool_calls": 3,
+        }
+    )
+
+    assert _has_call(captured, "success", contains="1 passed, 1 failed")
+
+
+def test_render_by_model_skips_when_empty(tmp_path: Path, monkeypatch):
+    captured = _patch_ui(monkeypatch)
+
+    summary_module._render_by_model([])
+
+    assert captured == []
+
+
+def test_render_by_model_renders_a_table(tmp_path: Path, monkeypatch):
+    from nao_core.commands.test.summary import ModelSummary
+
+    captured = _patch_ui(monkeypatch)
+
+    summary_module._render_by_model(
+        [
+            ModelSummary(
+                model="openai:gpt-4.1",
+                total=1,
+                passed=1,
+                failed=0,
+                pass_rate=100.0,
+                total_tokens=100,
+                total_cost=0.001,
+                total_duration_ms=1000,
+                avg_duration_ms=1000.0,
+                total_tool_calls=1,
+                avg_tool_calls=1.0,
+            )
+        ]
+    )
+
+    table_calls = _calls(captured, "table")
+    assert table_calls
+    title = table_calls[0][1].get("title", "")
+    assert title == "By model"


### PR DESCRIPTION
## What

`nao test` now has a `summary` subcommand that loads a saved `results_*.json` file and prints the overall summary as one line, plus a per-model breakdown table. With no argument, it picks the most recent file in `tests/outputs/`.

```bash
nao test summary
nao test summary tests/outputs/results_20260715_120000.json
nao test summary --json
```

Output:

```
  2 passed, 1 failed, 3 total, $0.0045, 4.5s, 4 tool calls
                            By model
┏━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━┓
┃ model           ┃ tot… ┃ pas… ┃ pas… ┃ tot… ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━┩
│ openai:gpt-4.1  │    2 │    2 │ 100… │ 0.0… │
│ anthropic:clau… │    1 │    0 │  0.0 │ 0.0… │
└─────────────────┴──────┴──────┴──────┴──────┘
```

Options:

- `--file` / `-f <path>`: explicit path to a results JSON file
- `--json`: print the summary as JSON instead of a human-readable table

The new subcommand registers alongside `run` and `server` in `nao test --help`. It does NOT register the `diff` (#1307) or `list` (#1322) subcommands, which are on separate branches and still pending maintainer review.

## Why

`save_results` already writes an aggregated `summary` block to every result file, and (post-#1290) a per-model `by_model` block. None of that is reachable from the terminal: the only way to see the saved totals is `nao test server` (a full local browser) or `jq '.summary, .by_model' <file>` (shell). A `nao test summary` subcommand closes that gap with very little new code.

## How

- `cli/nao_core/commands/test/summary_cmd.py` (new, 125 lines): the `summary` subcommand. The file is named with a `_cmd` suffix to avoid shadowing the existing `summary.py` helper module that `server.py` and `runner.py` already use. The function imports `summarize`, `summarize_by_model`, and `with_model_summaries` from the helper module, so the print path matches what the browser UI shows for the same file (including the backfill of `by_model` for older files that pre-date the field).
- `cli/nao_core/commands/test/__init__.py`: registered `summary` as a third subcommand alongside `run` and `server` with `test.command(name="summary")(summary)`.
- `cli/tests/nao_core/commands/test_summary_cmd.py` (new, 17 tests): covers file resolution, `_resolve_default_file` directly, the four error paths, the `--json` flag, the per-model backfill for older files, and the direct `_render_overall` and `_render_by_model` helpers.
- `cli/README.md`: one new subsection "Show summary of a result file" under "Run tests", between "Explore test results" and "BigQuery service account permissions".

No new dependencies. No changes to the `summary.py` helpers, `save_results`, `TestCase`, or any other call site. The new subcommand is pure composition of existing helpers.

## Verification

- `make lint` clean (ty + ruff check + ruff check --select I + ruff format --check)
- `pytest tests/`: 977 passed, 245 skipped, 0 failed (17 new in `test_summary_cmd.py`)
- End-to-end smoke: created a 3-result / 2-model fixture in `tests/outputs/`, ran the subcommand via `python -m nao_core.main test summary` and confirmed the overall line, per-model table, and `--json` payload render correctly.

## Risks

Low. The new subcommand is read-only on disk. It reuses three existing helpers (`summarize`, `summarize_by_model`, `with_model_summaries`) that are already exercised by the `server` subcommand and `save_results`. If any of those helpers ever changes signature, the new subcommand will need a matching update, but that is the same maintenance burden the rest of the `nao test` family already carries.

## Future

- `nao test diff --last` (natural follow-up to PR #1307) would also reuse `with_model_summaries` to read the two most recent result files without the user having to type paths.
- `nao test show <name>` could print the full prompt and SQL of a single test case, useful for "what does this test actually ask?" without opening the YAML.

Fixes #1329.

This PR was written using Claude Sonnet 4.5 (claude-sonnet-4-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

