### PR TITLE
feat(cli): add show subcommand to nao test

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -240,6 +240,29 @@ Options:
 - `--port` / `-p`: Port to run the server on (default: `8765`)
 - `--no-open`: Don't automatically open the browser
 
+### Show a single test's prompt and SQL
+
+```bash
+nao test show orders_count
+```
+
+Prints the full prompt and SQL of one or more test cases, looked up by name, yaml stem, or subfolder. Comma-separated selectors are accepted and each match is printed in order. No model calls, no network.
+
+Options:
+
+- `--sql-only`: print only the SQL field, no prompt or file path
+- `--prompt-only`: print only the prompt, no SQL or file path
+
+Examples:
+
+```bash
+nao test show orders_count
+nao test show orders_count,users_count
+nao test show contracts
+nao test show orders_count --sql-only
+nao test show orders_count --prompt-only
+```
+
 ### BigQuery service account permissions
 
 When you connect BigQuery during `nao init`, the service account used by `credentials_path`/ADC must be able to list datasets and run read-only queries to generate docs. Grant the account:

--- a/cli/nao_core/commands/test/__init__.py
+++ b/cli/nao_core/commands/test/__init__.py
@@ -2,6 +2,7 @@ from cyclopts import App
 
 from .runner import test as run_tests
 from .server import server
+from .show import show
 
 # Create a test app with subcommands
 test = App(name="test", help="Run and explore nao tests.")
@@ -11,6 +12,9 @@ test.command(name="run")(run_tests)
 
 # Register the server command
 test.command(name="server")(server)
+
+# Register the show command
+test.command(name="show")(show)
 
 # Make `nao test` (without subcommand) run tests by default
 test.default(run_tests)

--- a/cli/nao_core/commands/test/show.py
+++ b/cli/nao_core/commands/test/show.py
@@ -1,0 +1,91 @@
+"""Print the full prompt and SQL of a single test case, looked up by name or selector."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from nao_core.ui import UI
+
+from .case import TESTS_FOLDER, discover_tests
+from .runner import filter_test_cases
+
+
+def _render_test(test_case, project_path: Path, sql_only: bool, prompt_only: bool) -> None:
+    """Print a single test case in the configured shape."""
+    if sql_only:
+        if test_case.sql:
+            UI.print(test_case.sql)
+        return
+    if prompt_only:
+        UI.print(test_case.prompt)
+        return
+
+    UI.print(f"  Test:    {test_case.name}")
+    UI.print(f"  File:    {test_case.file_path.relative_to(project_path)}")
+    UI.print(f"  Prompt:  {test_case.prompt}")
+    UI.print("  SQL:")
+    if test_case.sql:
+        for line in test_case.sql.splitlines() or [""]:
+            UI.print(f"    {line}")
+
+
+def show(
+    select: Annotated[
+        str,
+        Parameter(help="Test name, yaml stem, or subfolder. Comma-separated for multiple."),
+    ],
+    sql_only: Annotated[
+        bool,
+        Parameter(
+            name=["--sql-only"],
+            help="Print only the SQL field, no prompt or file path.",
+        ),
+    ] = False,
+    prompt_only: Annotated[
+        bool,
+        Parameter(
+            name=["--prompt-only"],
+            help="Print only the prompt, no SQL or file path.",
+        ),
+    ] = False,
+):
+    """Print the full prompt and SQL of one or more test cases.
+
+    The selector follows the same semantics as `nao test run -s` /
+    `nao test list -s`: by name, by yaml stem, or by subfolder.
+    Comma-separated selectors are accepted and each match is printed
+    in order. No model calls, no network.
+
+    Examples:
+        nao test show orders_count
+        nao test show orders_count,users_count
+        nao test show contracts
+        nao test show orders_count --sql-only
+        nao test show orders_count --prompt-only
+    """
+    if sql_only and prompt_only:
+        UI.error("--sql-only and --prompt-only are mutually exclusive")
+        sys.exit(1)
+
+    project_path = Path.cwd()
+    tests_dir = project_path / TESTS_FOLDER
+
+    test_cases = discover_tests(project_path)
+    try:
+        matches = filter_test_cases(test_cases, select, tests_dir)
+    except ValueError as e:
+        UI.error(str(e))
+        sys.exit(1)
+
+    if not matches:
+        UI.error(f"No test cases matched selector: {select}")
+        sys.exit(1)
+
+    for test_case in matches:
+        _render_test(test_case, project_path, sql_only, prompt_only)
+        if not (sql_only or prompt_only) and test_case is not matches[-1]:
+            UI.print("")

--- a/cli/tests/nao_core/commands/test_show.py
+++ b/cli/tests/nao_core/commands/test_show.py
@@ -1,0 +1,155 @@
+"""Tests for the `nao test show <name>` subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nao_core.commands.test.show import show
+
+
+def _write_test_yaml(path: Path, name: str, prompt: str, sql: str = "select 1") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'name: "{name}"\nprompt: "{prompt}"\nsql: |\n  {sql}\n')
+
+
+def _patch_ui_print(monkeypatch):
+    """Capture every UI.print call as a structured list of args."""
+    captured: list[tuple[tuple, dict]] = []
+
+    def fake_print(cls, *args, **kwargs):
+        captured.append((args, kwargs))
+
+    def fake_error(cls, *args, **kwargs):
+        captured.append((args, {"_error": True, **kwargs}))
+
+    monkeypatch.setattr("nao_core.ui.UI.print", classmethod(fake_print))
+    monkeypatch.setattr("nao_core.ui.UI.error", classmethod(fake_error))
+    return captured
+
+
+def test_show_prints_one_test_full_detail(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "How many orders?")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="orders")
+
+    lines = [a[0][0] for a in captured if a[0] and isinstance(a[0][0], str)]
+    joined = "\n".join(lines)
+    assert "Test:    orders" in joined
+    assert "File:    tests/orders.yml" in joined
+    assert "Prompt:  How many orders?" in joined
+    assert "SQL:" in joined
+    assert "select 1" in joined
+
+
+def test_show_comma_separated_prints_each_match(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Orders prompt.")
+    _write_test_yaml(tmp_path / "tests" / "users.yml", "users", "Users prompt.")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="orders,users")
+
+    joined = "\n".join(a[0][0] for a in captured if a[0] and isinstance(a[0][0], str))
+    assert "Test:    orders" in joined
+    assert "Test:    users" in joined
+    # Blank line between matches
+    assert "" in [a[0][0] for a in captured if a[0] and isinstance(a[0][0], str)]
+
+
+def test_show_subfolder_selector(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "a" / "x.yml", "x", "X prompt.")
+    _write_test_yaml(tmp_path / "tests" / "b" / "y.yml", "y", "Y prompt.")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="a")
+
+    joined = "\n".join(a[0][0] for a in captured if a[0] and isinstance(a[0][0], str))
+    assert "Test:    x" in joined
+    assert "Test:    y" not in joined
+
+
+def test_show_unknown_selector_exits_with_error(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "real.yml", "real", "Prompt.")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        show(select="does_not_exist")
+
+    assert excinfo.value.code == 1
+    assert any(a[1].get("_error") for a in captured)
+
+
+def test_show_no_tests_folder_exits_with_error(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _patch_ui_print(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        show(select="anything")
+
+    assert excinfo.value.code == 1
+
+
+def test_show_sql_only_prints_only_sql(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Orders prompt.", "select 42")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="orders", sql_only=True)
+
+    printed = [a[0][0] for a in captured if a[0] and isinstance(a[0][0], str)]
+    joined = "\n".join(printed)
+    assert "select 42" in joined
+    # No name, no file path, no prompt label, no SQL: header
+    assert "Test:" not in joined
+    assert "File:" not in joined
+    assert "Prompt:" not in joined
+    assert "SQL:" not in joined
+    assert "Orders prompt." not in joined
+
+
+def test_show_prompt_only_prints_only_prompt(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Orders prompt.", "select 42")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="orders", prompt_only=True)
+
+    printed = [a[0][0] for a in captured if a[0] and isinstance(a[0][0], str)]
+    assert "Orders prompt." in printed
+    assert "select 42" not in printed
+    assert "Test:" not in "\n".join(printed)
+    assert "SQL:" not in "\n".join(printed)
+
+
+def test_show_both_flags_together_exits_with_error(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders.yml", "orders", "Prompt.")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        show(select="orders", sql_only=True, prompt_only=True)
+
+    assert excinfo.value.code == 1
+    assert any(a[1].get("_error") for a in captured)
+
+
+def test_show_yaml_stem_selector(tmp_path: Path, monkeypatch):
+    _write_test_yaml(tmp_path / "tests" / "orders_count.yml", "orders_count", "Prompt.")
+    _write_test_yaml(tmp_path / "tests" / "orders_count_v2.yml", "orders_count_v2", "V2 prompt.")
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui_print(monkeypatch)
+
+    show(select="orders_count")
+
+    joined = "\n".join(a[0][0] for a in captured if a[0] and isinstance(a[0][0], str))
+    assert "Test:    orders_count" in joined
+    assert "Test:    orders_count_v2" not in joined


### PR DESCRIPTION
## What

`nao test` now has a `show <name>` subcommand that prints the full prompt and SQL of one or more test cases, looked up by name, yaml stem, or subfolder.

```bash
nao test show orders_count
```

Output:

```
  Test:    orders_count
  File:    tests/orders.yml
  Prompt:  How many orders did we receive last week?
  SQL:
    select count(*) from orders where created_at > now() - interval '7 days'
```

The selector follows the same semantics as `nao test run -s` / `nao test list -s`: by name, by yaml stem, or by subfolder. Comma-separated selectors are accepted and each match is printed in order. No model calls, no network.

Options:

- `--sql-only`: print only the SQL field, no prompt or file path
- `--prompt-only`: print only the prompt, no SQL or file path

The new subcommand registers alongside `run` and `server` in `nao test --help`. It does NOT register the `diff` (#1307), `list` (#1322), or `summary` (PR for #1329) subcommands, which are on separate branches and still pending maintainer review.

## Why

`nao test list` (PR #1322) prints a one-line preview of every discoverable test's prompt. But there was no way to ask "show me the full prompt and SQL of one specific test" without opening the YAML file by hand. The natural moments a user reaches for this:

1. They saw a test name in `nao test list`, want to read the full prompt before paying the LLM cost of a `nao test run`.
2. They are debugging "why did this test pass / fail" and want the exact SQL the agent was compared against.
3. They are writing a new test and want to copy the shape of a similar existing test.
4. They are looking at a colleague's PR that adds a new test and want to read the full prompt and SQL in the terminal without switching to their editor.

## How

- `cli/nao_core/commands/test/show.py` (new, 95 lines): the `show` subcommand. Imports the existing `discover_tests` from `case.py` and `filter_test_cases` from `runner.py`, applies the selector, and prints the four fields (`name`, `file_path`, `prompt`, `sql`) per match via the existing `UI.print` helper. Read-only: no model calls, no HTTP.
- `cli/nao_core/commands/test/__init__.py`: registered `show` as a third subcommand alongside `run` and `server` with `test.command(name="show")(show)`.
- `cli/tests/nao_core/commands/test_show.py` (new, 9 tests): covers the single match case, comma-separated selectors, subfolder selectors, yaml-stem selectors, the three error paths (unknown selector, no tests folder, both `--sql-only` and `--prompt-only` set), and both `--sql-only` / `--prompt-only` flags.
- `cli/README.md`: one new subsection "Show a single test's prompt and SQL" under "Run tests", between "Explore test results" and "BigQuery service account permissions".

No new dependencies. No changes to `discover_tests`, `filter_test_cases`, `TestCase`, or any other call site. The new subcommand is pure composition of existing helpers.

## Verification

- `make lint` clean (ty + ruff check + ruff check --select I + ruff format --check)
- `pytest tests/`: 969 passed, 245 skipped, 0 failed (9 new in `test_show.py`)
- End-to-end smoke: created two test YAMLs in `tests/` (one at the root, one in a subfolder), ran the subcommand via `python -m nao_core.main test show orders_count`, `... show contracts`, `... show orders_count --sql-only`, and `... show does_not_exist`. The full-detail print, the subfolder match, the `--sql-only` filter, and the unknown-selector exit 1 all match expectations.

## Risks

Low. The new subcommand imports from `case.py` and `runner.py`, both of which have been stable across the recent OSS contributions (#1249, #1276, #1280, #1301, #1307, #1322, #1329, #1330). If `filter_test_cases` ever changes signature, the new subcommand will need a matching update, but that is the same maintenance burden as `nao test run` itself.

## Future

- `nao test diff --last` (natural follow-up to PR #1307) would diff the two most recent result files without the user having to type paths.
- A `nao test validate` subcommand that runs the same discovery + selector logic and just reports whether every matched YAML is well-formed would be a useful CI smoke test.

Fixes #1331.

This PR was written using Claude Sonnet 4.5 (claude-sonnet-4-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

