### PR TITLE
feat(cli): add --last flag to nao test diff

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -254,6 +254,7 @@ Options:
 - `--test <name>`: only show rows for one test name
 - `--quiet` / `-q`: only print the summary line
 - `--no-fail`: print the report but always exit `0` (useful in scripts that just want the report)
+- `--last`: use the two most recent `results_*.json` files in `tests/outputs/` instead of explicit paths
 
 Examples:
 
@@ -263,6 +264,8 @@ nao test diff a.json b.json --model openai:gpt-4.1
 nao test diff a.json b.json --test orders_count
 nao test diff a.json b.json --quiet
 nao test diff a.json b.json --no-fail
+nao test diff --last
+nao test diff --last --quiet
 ```
 
 ### BigQuery service account permissions

--- a/cli/README.md
+++ b/cli/README.md
@@ -240,6 +240,31 @@ Options:
 - `--port` / `-p`: Port to run the server on (default: `8765`)
 - `--no-open`: Don't automatically open the browser
 
+### Diff two result files
+
+```bash
+nao test diff tests/outputs/results_before.json tests/outputs/results_after.json
+```
+
+Compares two `tests/outputs/results_*.json` files and prints a table of every `(test, model)` pair with its before/after status, plus a one-line summary (`X regressions, Y fixes, Z unchanged, ...`). Pairs only in the first file are reported as `removed`; only in the second as `added`. The command exits `1` if any pair is a regression, so it doubles as a CI guard.
+
+Options:
+
+- `--model <provider:model>`: only show rows for one model
+- `--test <name>`: only show rows for one test name
+- `--quiet` / `-q`: only print the summary line
+- `--no-fail`: print the report but always exit `0` (useful in scripts that just want the report)
+
+Examples:
+
+```bash
+nao test diff results_before.json results_after.json
+nao test diff a.json b.json --model openai:gpt-4.1
+nao test diff a.json b.json --test orders_count
+nao test diff a.json b.json --quiet
+nao test diff a.json b.json --no-fail
+```
+
 ### BigQuery service account permissions
 
 When you connect BigQuery during `nao init`, the service account used by `credentials_path`/ADC must be able to list datasets and run read-only queries to generate docs. Grant the account:

--- a/cli/nao_core/commands/test/__init__.py
+++ b/cli/nao_core/commands/test/__init__.py
@@ -1,5 +1,6 @@
 from cyclopts import App
 
+from .diff import diff
 from .runner import test as run_tests
 from .server import server
 
@@ -11,6 +12,9 @@ test.command(name="run")(run_tests)
 
 # Register the server command
 test.command(name="server")(server)
+
+# Register the diff command
+test.command(name="diff")(diff)
 
 # Make `nao test` (without subcommand) run tests by default
 test.default(run_tests)

--- a/cli/nao_core/commands/test/diff.py
+++ b/cli/nao_core/commands/test/diff.py
@@ -13,6 +13,8 @@ from cyclopts import Parameter
 
 from nao_core.ui import UI
 
+from .case import TESTS_FOLDER
+
 # Change labels for the (test, model) pair between two result files.
 UNCHANGED = "unchanged"
 REGRESSION = "regression"
@@ -137,15 +139,34 @@ def _render_summary(counts: dict[str, int]) -> str:
     return ", ".join(parts)
 
 
+def _resolve_last_two(project_path: Path) -> list[Path] | None:
+    """Return the two most recent `results_*.json` files, or None if there are fewer than two.
+
+    Names sort chronologically because `save_results` uses a `%Y%m%d_%H%M%S` prefix.
+    """
+    outputs_dir = project_path / TESTS_FOLDER / "outputs"
+    if not outputs_dir.exists():
+        return None
+    files = sorted(outputs_dir.glob("results_*.json"))
+    return files[-2:] if len(files) >= 2 else None
+
+
 def diff(
     file1: Annotated[
-        Path,
-        Parameter(help="Path to the first results JSON file (before)."),
-    ],
+        Path | None,
+        Parameter(help="Path to the first results JSON file (before). Mutually exclusive with --last."),
+    ] = None,
     file2: Annotated[
-        Path,
-        Parameter(help="Path to the second results JSON file (after)."),
-    ],
+        Path | None,
+        Parameter(help="Path to the second results JSON file (after). Mutually exclusive with --last."),
+    ] = None,
+    last: Annotated[
+        bool,
+        Parameter(
+            name=["--last"],
+            help="Use the two most recent results_*.json files in tests/outputs/ instead of explicit paths.",
+        ),
+    ] = False,
     model: Annotated[
         str | None,
         Parameter(
@@ -180,7 +201,8 @@ def diff(
     Pairs are matched on (test name, model). Use this to track what changed
     between two runs of `nao test` -- a passing→failing pair is a regression,
     a failing→passing pair is a fix, and a pair only in one file is added or
-    removed.
+    removed. Pass two file paths, or pass `--last` to use the two most recent
+    results_*.json files in tests/outputs/.
 
     Examples:
         nao test diff tests/outputs/results_before.json tests/outputs/results_after.json
@@ -188,7 +210,23 @@ def diff(
         nao test diff a.json b.json --test orders_count
         nao test diff a.json b.json --quiet
         nao test diff a.json b.json --no-fail
+        nao test diff --last
+        nao test diff --last --quiet
     """
+    if last and (file1 or file2):
+        UI.error("--last is mutually exclusive with the two file path arguments")
+        sys.exit(1)
+    if not last and not (file1 and file2):
+        UI.error("Provide two file paths, or pass --last to use the two most recent results files")
+        sys.exit(1)
+    if last:
+        resolved = _resolve_last_two(Path.cwd())
+        if resolved is None:
+            UI.error("Need at least two results_*.json files in tests/outputs/ for --last")
+            sys.exit(1)
+        file1, file2 = resolved
+
+    assert file1 is not None and file2 is not None
     left = _load_results(file1)
     right = _load_results(file2)
 

--- a/cli/nao_core/commands/test/diff.py
+++ b/cli/nao_core/commands/test/diff.py
@@ -1,0 +1,220 @@
+"""Diff two nao test result files to surface regressions, fixes, and additions."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Any
+
+import pandas as pd
+from cyclopts import Parameter
+
+from nao_core.ui import UI
+
+# Change labels for the (test, model) pair between two result files.
+UNCHANGED = "unchanged"
+REGRESSION = "regression"
+FIX = "fix"
+ADDED = "added"
+REMOVED = "removed"
+
+
+@dataclass(frozen=True)
+class DiffRow:
+    """One row in the diff table."""
+
+    test: str
+    model: str
+    before: str  # "PASS" | "FAIL" | "-"
+    after: str  # "PASS" | "FAIL" | "-"
+    change: str  # one of UNCHANGED/REGRESSION/FIX/ADDED/REMOVED
+
+
+def _load_results(path: Path) -> list[dict[str, Any]]:
+    """Read a results JSON file and return its `results` list.
+
+    Exits with a clear error if the file is missing, unreadable, not JSON,
+    or does not contain a `results` list.
+    """
+    if not path.exists() or not path.is_file():
+        UI.error(f"File not found: {path}")
+        sys.exit(1)
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        UI.error(f"Invalid JSON in {path}: {e}")
+        sys.exit(1)
+
+    results = data.get("results")
+    if not isinstance(results, list):
+        UI.error(f"Missing or invalid 'results' key in {path}")
+        sys.exit(1)
+
+    return results
+
+
+def _index_by_pair(results: list[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    """Index results by the (name, model) pair key."""
+    return {(r["name"], r["model"]): r for r in results}
+
+
+def _status(result: dict[str, Any] | None) -> str:
+    """Render a single side of a pair as PASS/FAIL/-."""
+    if result is None:
+        return "-"
+    return "PASS" if result.get("passed") else "FAIL"
+
+
+def compute_diff(
+    left: list[dict[str, Any]],
+    right: list[dict[str, Any]],
+) -> list[DiffRow]:
+    """Compute the diff between two `results` lists.
+
+    Pair key is (name, model). The change label is one of:
+    - ADDED: pair only in `right`
+    - REMOVED: pair only in `left`
+    - REGRESSION: passed in `left`, failed in `right`
+    - FIX: failed in `left`, passed in `right`
+    - UNCHANGED: same outcome on both sides
+    """
+    left_idx = _index_by_pair(left)
+    right_idx = _index_by_pair(right)
+    pairs = sorted(set(left_idx) | set(right_idx))
+
+    rows: list[DiffRow] = []
+    for key in pairs:
+        test, model = key
+        left_row = left_idx.get(key)
+        right_row = right_idx.get(key)
+        if left_row is None:
+            change = ADDED
+        elif right_row is None:
+            change = REMOVED
+        elif left_row.get("passed") == right_row.get("passed"):
+            change = UNCHANGED
+        elif right_row.get("passed"):
+            change = FIX
+        else:
+            change = REGRESSION
+        rows.append(DiffRow(test=test, model=model, before=_status(left_row), after=_status(right_row), change=change))
+    return rows
+
+
+def _filter_rows(
+    rows: list[DiffRow],
+    model: str | None,
+    test: str | None,
+) -> list[DiffRow]:
+    """Apply --model and --test filters to the row list."""
+    if model:
+        rows = [r for r in rows if r.model == model]
+    if test:
+        rows = [r for r in rows if r.test == test]
+    return rows
+
+
+def _summary_counts(rows: list[DiffRow]) -> dict[str, int]:
+    """Count rows by change label."""
+    counts = {REGRESSION: 0, FIX: 0, UNCHANGED: 0, ADDED: 0, REMOVED: 0}
+    for r in rows:
+        counts[r.change] += 1
+    return counts
+
+
+def _render_summary(counts: dict[str, int]) -> str:
+    """Render the one-line summary."""
+    parts = [
+        f"{counts[REGRESSION]} regression{'s' if counts[REGRESSION] != 1 else ''}",
+        f"{counts[FIX]} fix{'es' if counts[FIX] != 1 else ''}",
+        f"{counts[UNCHANGED]} unchanged",
+        f"{counts[ADDED]} added",
+        f"{counts[REMOVED]} removed",
+    ]
+    return ", ".join(parts)
+
+
+def diff(
+    file1: Annotated[
+        Path,
+        Parameter(help="Path to the first results JSON file (before)."),
+    ],
+    file2: Annotated[
+        Path,
+        Parameter(help="Path to the second results JSON file (after)."),
+    ],
+    model: Annotated[
+        str | None,
+        Parameter(
+            name=["--model"],
+            help="Only show rows for this model (e.g. openai:gpt-4.1).",
+        ),
+    ] = None,
+    test: Annotated[
+        str | None,
+        Parameter(
+            name=["--test"],
+            help="Only show rows for this test name.",
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        Parameter(
+            name=["--quiet", "-q"],
+            help="Only print the summary line, no per-row table.",
+        ),
+    ] = False,
+    no_fail: Annotated[
+        bool,
+        Parameter(
+            name=["--no-fail"],
+            help="Print the report but always exit 0, even on regressions.",
+        ),
+    ] = False,
+):
+    """Diff two nao test result files to surface regressions, fixes, and additions.
+
+    Pairs are matched on (test name, model). Use this to track what changed
+    between two runs of `nao test` -- a passing→failing pair is a regression,
+    a failing→passing pair is a fix, and a pair only in one file is added or
+    removed.
+
+    Examples:
+        nao test diff tests/outputs/results_before.json tests/outputs/results_after.json
+        nao test diff a.json b.json --model openai:gpt-4.1
+        nao test diff a.json b.json --test orders_count
+        nao test diff a.json b.json --quiet
+        nao test diff a.json b.json --no-fail
+    """
+    left = _load_results(file1)
+    right = _load_results(file2)
+
+    rows = compute_diff(left, right)
+    rows = _filter_rows(rows, model=model, test=test)
+    counts = _summary_counts(rows)
+
+    if not quiet:
+        if rows:
+            df = pd.DataFrame(
+                [
+                    {
+                        "Test": r.test,
+                        "Model": r.model,
+                        "Before": r.before,
+                        "After": r.after,
+                        "Change": r.change,
+                    }
+                    for r in rows
+                ]
+            )
+            UI.table(df, title=f"Diff: {file1.name} -> {file2.name}")
+        else:
+            UI.warn("No matching rows after applying filters.")
+
+    UI.print(f"\nSummary: {_render_summary(counts)}")
+
+    if counts[REGRESSION] > 0 and not no_fail:
+        sys.exit(1)

--- a/cli/tests/nao_core/commands/test_diff.py
+++ b/cli/tests/nao_core/commands/test_diff.py
@@ -1,0 +1,461 @@
+"""Tests for the `nao test diff` subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nao_core.commands.test.diff import (
+    ADDED,
+    FIX,
+    REGRESSION,
+    REMOVED,
+    UNCHANGED,
+    DiffRow,
+    _filter_rows,
+    _load_results,
+    _render_summary,
+    _summary_counts,
+    compute_diff,
+    diff,
+)
+
+
+def _row(name: str, model: str, passed: bool) -> dict:
+    return {
+        "name": name,
+        "model": model,
+        "passed": passed,
+        "message": "match" if passed else "values differ",
+        "tokens": 100,
+        "cost": 0.001,
+        "duration_ms": 1000,
+        "tool_call_count": 1,
+    }
+
+
+def _write_results(path: Path, results: list[dict]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-30T00:00:00",
+                "results": results,
+                "summary": {
+                    "total": len(results),
+                    "passed": sum(1 for r in results if r["passed"]),
+                    "failed": sum(1 for r in results if not r["passed"]),
+                },
+            }
+        )
+    )
+
+
+def test_compute_diff_unchanged_when_status_matches():
+    left = [_row("orders", "openai:gpt-4.1", True)]
+    right = [_row("orders", "openai:gpt-4.1", True)]
+
+    rows = compute_diff(left, right)
+
+    assert rows == [DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED)]
+
+
+def test_compute_diff_regression_when_passing_becomes_failing():
+    left = [_row("orders", "openai:gpt-4.1", True)]
+    right = [_row("orders", "openai:gpt-4.1", False)]
+
+    rows = compute_diff(left, right)
+
+    assert rows[0].change == REGRESSION
+    assert rows[0].before == "PASS"
+    assert rows[0].after == "FAIL"
+
+
+def test_compute_diff_fix_when_failing_becomes_passing():
+    left = [_row("orders", "openai:gpt-4.1", False)]
+    right = [_row("orders", "openai:gpt-4.1", True)]
+
+    rows = compute_diff(left, right)
+
+    assert rows[0].change == FIX
+    assert rows[0].before == "FAIL"
+    assert rows[0].after == "PASS"
+
+
+def test_compute_diff_added_when_pair_only_in_right():
+    left = []
+    right = [_row("orders", "openai:gpt-4.1", True)]
+
+    rows = compute_diff(left, right)
+
+    assert rows[0].change == ADDED
+    assert rows[0].before == "-"
+    assert rows[0].after == "PASS"
+
+
+def test_compute_diff_removed_when_pair_only_in_left():
+    left = [_row("orders", "openai:gpt-4.1", True)]
+    right = []
+
+    rows = compute_diff(left, right)
+
+    assert rows[0].change == REMOVED
+    assert rows[0].before == "PASS"
+    assert rows[0].after == "-"
+
+
+def test_compute_diff_mixed_pairs():
+    left = [
+        _row("unchanged_test", "openai:gpt-4.1", True),
+        _row("regression_test", "openai:gpt-4.1", True),
+        _row("fix_test", "openai:gpt-4.1", False),
+        _row("removed_test", "openai:gpt-4.1", True),
+    ]
+    right = [
+        _row("unchanged_test", "openai:gpt-4.1", True),
+        _row("regression_test", "openai:gpt-4.1", False),
+        _row("fix_test", "openai:gpt-4.1", True),
+        _row("added_test", "openai:gpt-4.1", True),
+    ]
+
+    rows = compute_diff(left, right)
+    by_pair = {(r.test, r.model): r for r in rows}
+
+    assert by_pair[("unchanged_test", "openai:gpt-4.1")].change == UNCHANGED
+    assert by_pair[("regression_test", "openai:gpt-4.1")].change == REGRESSION
+    assert by_pair[("fix_test", "openai:gpt-4.1")].change == FIX
+    assert by_pair[("removed_test", "openai:gpt-4.1")].change == REMOVED
+    assert by_pair[("added_test", "openai:gpt-4.1")].change == ADDED
+
+
+def test_compute_diff_multiple_models_treated_as_distinct_pairs():
+    left = [
+        _row("orders", "openai:gpt-4.1", True),
+        _row("orders", "anthropic:claude-sonnet-4-5", True),
+    ]
+    right = [
+        _row("orders", "openai:gpt-4.1", False),
+        _row("orders", "anthropic:claude-sonnet-4-5", True),
+    ]
+
+    rows = compute_diff(left, right)
+    by_pair = {(r.test, r.model): r for r in rows}
+
+    assert by_pair[("orders", "openai:gpt-4.1")].change == REGRESSION
+    assert by_pair[("orders", "anthropic:claude-sonnet-4-5")].change == UNCHANGED
+
+
+def test_compute_diff_empty_inputs_returns_empty():
+    assert compute_diff([], []) == []
+
+
+def test_compute_diff_pairs_are_sorted():
+    left = [_row("zeta", "openai:gpt-4.1", True), _row("alpha", "openai:gpt-4.1", True)]
+    right = [_row("zeta", "openai:gpt-4.1", True), _row("alpha", "openai:gpt-4.1", True)]
+
+    rows = compute_diff(left, right)
+
+    assert [r.test for r in rows] == ["alpha", "zeta"]
+
+
+def test_load_results_reads_results_list(tmp_path: Path):
+    file = tmp_path / "results.json"
+    _write_results(file, [_row("orders", "openai:gpt-4.1", True)])
+
+    results = _load_results(file)
+
+    assert len(results) == 1
+    assert results[0]["name"] == "orders"
+
+
+def test_load_results_exits_on_missing_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+    with pytest.raises(SystemExit):
+        _load_results(tmp_path / "does_not_exist.json")
+
+
+def test_load_results_exits_on_invalid_json(tmp_path: Path, monkeypatch):
+    file = tmp_path / "broken.json"
+    file.write_text("not json {")
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+    with pytest.raises(SystemExit):
+        _load_results(file)
+
+
+def test_load_results_exits_when_results_key_missing(tmp_path: Path, monkeypatch):
+    file = tmp_path / "no_results.json"
+    file.write_text(json.dumps({"summary": {}}))
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+    with pytest.raises(SystemExit):
+        _load_results(file)
+
+
+def test_load_results_exits_when_results_not_a_list(tmp_path: Path, monkeypatch):
+    file = tmp_path / "wrong_type.json"
+    file.write_text(json.dumps({"results": "not a list"}))
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+    with pytest.raises(SystemExit):
+        _load_results(file)
+
+
+def test_filter_rows_keeps_rows_matching_model():
+    rows = [
+        DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED),
+        DiffRow("orders", "anthropic:claude-sonnet-4-5", "PASS", "PASS", UNCHANGED),
+    ]
+
+    filtered = _filter_rows(rows, model="openai:gpt-4.1", test=None)
+
+    assert [r.model for r in filtered] == ["openai:gpt-4.1"]
+
+
+def test_filter_rows_keeps_rows_matching_test_name():
+    rows = [
+        DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED),
+        DiffRow("users", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED),
+    ]
+
+    filtered = _filter_rows(rows, model=None, test="orders")
+
+    assert [r.test for r in filtered] == ["orders"]
+
+
+def test_filter_rows_combines_model_and_test():
+    rows = [
+        DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED),
+        DiffRow("orders", "anthropic:claude-sonnet-4-5", "PASS", "PASS", UNCHANGED),
+        DiffRow("users", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED),
+    ]
+
+    filtered = _filter_rows(rows, model="openai:gpt-4.1", test="orders")
+
+    assert filtered == [DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED)]
+
+
+def test_filter_rows_no_filters_returns_all():
+    rows = [DiffRow("orders", "openai:gpt-4.1", "PASS", "PASS", UNCHANGED)]
+    assert _filter_rows(rows, model=None, test=None) == rows
+
+
+def test_summary_counts_categorises_each_change_type():
+    rows = [
+        DiffRow("a", "m", "PASS", "PASS", UNCHANGED),
+        DiffRow("b", "m", "PASS", "FAIL", REGRESSION),
+        DiffRow("c", "m", "FAIL", "PASS", FIX),
+        DiffRow("d", "m", "-", "PASS", ADDED),
+        DiffRow("e", "m", "PASS", "-", REMOVED),
+        DiffRow("f", "m", "PASS", "PASS", UNCHANGED),
+    ]
+
+    counts = _summary_counts(rows)
+
+    assert counts == {REGRESSION: 1, FIX: 1, UNCHANGED: 2, ADDED: 1, REMOVED: 1}
+
+
+def test_render_summary_singular_and_plural_labels():
+    counts = {REGRESSION: 1, FIX: 2, UNCHANGED: 0, ADDED: 0, REMOVED: 0}
+    rendered = _render_summary(counts)
+
+    assert "1 regression, " in rendered
+    assert "2 fixes, " in rendered
+
+
+def test_render_summary_with_zero_counts():
+    counts = {REGRESSION: 0, FIX: 0, UNCHANGED: 0, ADDED: 0, REMOVED: 0}
+    rendered = _render_summary(counts)
+
+    assert rendered == "0 regressions, 0 fixes, 0 unchanged, 0 added, 0 removed"
+
+
+def _patch_ui(monkeypatch):
+    """Capture UI output without rendering to the terminal."""
+    captured: list[str] = []
+
+    def fake_print(cls, msg: str = "") -> None:
+        captured.append(str(msg))
+
+    def fake_warn(cls, msg: str) -> None:
+        captured.append(f"[warn] {msg}")
+
+    def fake_error(cls, msg: str) -> None:
+        captured.append(f"[error] {msg}")
+
+    def fake_table(cls, df, title=None, sum_columns=None):  # noqa: ARG001
+        captured.append(f"[table] {title} -> {df.to_dict('records')}")
+
+    monkeypatch.setattr("nao_core.ui.UI.print", classmethod(fake_print))
+    monkeypatch.setattr("nao_core.ui.UI.warn", classmethod(fake_warn))
+    monkeypatch.setattr("nao_core.ui.UI.error", classmethod(fake_error))
+    monkeypatch.setattr("nao_core.ui.UI.table", classmethod(fake_table))
+    return captured
+
+
+def test_diff_function_exits_zero_on_no_regressions(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("orders", "openai:gpt-4.1", True)])
+
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    diff(a, b)
+
+    joined = "\n".join(captured)
+    assert "1 unchanged" in joined
+
+
+def test_diff_function_exits_one_on_regression(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("orders", "openai:gpt-4.1", False)])
+
+    _patch_ui(monkeypatch)
+
+    def fake_exit(code=0):
+        raise SystemExit(code)
+
+    monkeypatch.setattr("sys.exit", fake_exit)
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(a, b)
+
+    assert excinfo.value.code == 1
+
+
+def test_diff_function_no_fail_overrides_exit_code(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("orders", "openai:gpt-4.1", False)])
+
+    _patch_ui(monkeypatch)
+
+    def fake_exit(code=0):
+        raise SystemExit(code)
+
+    monkeypatch.setattr("sys.exit", fake_exit)
+
+    diff(a, b, no_fail=True)
+
+
+def test_diff_function_exits_on_missing_file(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "missing.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+
+    captured = _patch_ui(monkeypatch)
+
+    def fake_exit(code=0):
+        raise SystemExit(code)
+
+    monkeypatch.setattr("sys.exit", fake_exit)
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(a, b)
+
+    assert excinfo.value.code == 1
+    assert any("File not found" in line for line in captured)
+
+
+def test_diff_function_exits_on_invalid_json(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    b.write_text("not json")
+
+    captured = _patch_ui(monkeypatch)
+
+    def fake_exit(code=0):
+        raise SystemExit(code)
+
+    monkeypatch.setattr("sys.exit", fake_exit)
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(a, b)
+
+    assert excinfo.value.code == 1
+    assert any("Invalid JSON" in line for line in captured)
+
+
+def test_diff_function_quiet_skips_table(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("orders", "openai:gpt-4.1", True)])
+
+    captured = _patch_ui(monkeypatch)
+
+    diff(a, b, quiet=True)
+
+    assert not any("[table]" in line for line in captured)
+    assert any("1 unchanged" in line for line in captured)
+
+
+def test_diff_function_model_filter_narrows_table(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(
+        a,
+        [
+            _row("orders", "openai:gpt-4.1", True),
+            _row("orders", "anthropic:claude-sonnet-4-5", True),
+        ],
+    )
+    _write_results(
+        b,
+        [
+            _row("orders", "openai:gpt-4.1", False),
+            _row("orders", "anthropic:claude-sonnet-4-5", True),
+        ],
+    )
+
+    captured = _patch_ui(monkeypatch)
+    diff(a, b, model="openai:gpt-4.1", no_fail=True)
+
+    joined = "\n".join(captured)
+    assert "1 regression" in joined
+    assert "0 fixes" in joined
+    assert "0 unchanged" in joined
+    assert "[table]" in joined
+
+
+def test_diff_function_test_filter_narrows_table(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(
+        a,
+        [
+            _row("orders", "openai:gpt-4.1", True),
+            _row("users", "openai:gpt-4.1", True),
+        ],
+    )
+    _write_results(
+        b,
+        [
+            _row("orders", "openai:gpt-4.1", False),
+            _row("users", "openai:gpt-4.1", True),
+        ],
+    )
+
+    captured = _patch_ui(monkeypatch)
+    diff(a, b, test="orders", no_fail=True)
+
+    joined = "\n".join(captured)
+    assert "1 regression" in joined
+
+
+def test_diff_function_warns_when_filter_excludes_everything(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("orders", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("orders", "openai:gpt-4.1", True)])
+
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    diff(a, b, model="anthropic:claude-sonnet-4-5")
+
+    assert any("No matching rows" in line for line in captured)

--- a/cli/tests/nao_core/commands/test_diff.py
+++ b/cli/tests/nao_core/commands/test_diff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 
@@ -21,6 +22,15 @@ from nao_core.commands.test.diff import (
     compute_diff,
     diff,
 )
+
+# `nao_core.commands.test` is shadowed by the cyclopts App at the package
+# level, so dotted imports of the submodule fail. Load the file directly
+# to reach the `_resolve_last_two` helper.
+_DIFF_FILE = Path(__file__).resolve().parents[3] / "nao_core" / "commands" / "test" / "diff.py"
+_diff_spec = importlib.util.spec_from_file_location("nao_core.commands.test.diff", _DIFF_FILE)
+assert _diff_spec is not None and _diff_spec.loader is not None
+diff_module = importlib.util.module_from_spec(_diff_spec)
+_diff_spec.loader.exec_module(diff_module)
 
 
 def _row(name: str, model: str, passed: bool) -> dict:
@@ -459,3 +469,121 @@ def test_diff_function_warns_when_filter_excludes_everything(tmp_path: Path, mon
     diff(a, b, model="anthropic:claude-sonnet-4-5")
 
     assert any("No matching rows" in line for line in captured)
+
+
+# ---------------------------------------------------------------------------
+# --last flag: file resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_last_two_returns_none_when_outputs_dir_missing(tmp_path: Path):
+    assert diff_module._resolve_last_two(tmp_path) is None
+
+
+def test_resolve_last_two_returns_none_with_fewer_than_two_files(tmp_path: Path):
+    (tmp_path / "tests" / "outputs").mkdir(parents=True)
+    assert diff_module._resolve_last_two(tmp_path) is None
+    _write_results(tmp_path / "tests" / "outputs" / "results_20260801_000000.json", [_row("x", "openai:gpt-4.1", True)])
+    assert diff_module._resolve_last_two(tmp_path) is None
+
+
+def test_resolve_last_two_picks_two_most_recent(tmp_path: Path):
+    outputs = tmp_path / "tests" / "outputs"
+    outputs.mkdir(parents=True)
+    _write_results(outputs / "results_20260101_000000.json", [_row("a", "openai:gpt-4.1", True)])
+    _write_results(outputs / "results_20260615_120000.json", [_row("b", "openai:gpt-4.1", True)])
+    _write_results(outputs / "results_20260301_000000.json", [_row("c", "openai:gpt-4.1", True)])
+
+    resolved = diff_module._resolve_last_two(tmp_path)
+
+    assert resolved is not None
+    assert [p.name for p in resolved] == ["results_20260301_000000.json", "results_20260615_120000.json"]
+
+
+def test_diff_last_picks_two_most_recent(tmp_path: Path, monkeypatch):
+    outputs = tmp_path / "tests" / "outputs"
+    outputs.mkdir(parents=True)
+    _write_results(
+        outputs / "results_20260601_000000.json",
+        [_row("orders", "openai:gpt-4.1", True)],
+    )
+    _write_results(
+        outputs / "results_20260615_120000.json",
+        [_row("orders", "openai:gpt-4.1", False)],
+    )
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui(monkeypatch)
+
+    diff(last=True, no_fail=True)
+
+    assert any("1 regression" in line for line in captured)
+
+
+def test_diff_last_errors_when_outputs_dir_missing(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(last=True)
+
+    assert excinfo.value.code == 1
+    assert any("at least two results" in line for line in captured)
+
+
+def test_diff_last_errors_when_only_one_file_exists(tmp_path: Path, monkeypatch):
+    outputs = tmp_path / "tests" / "outputs"
+    outputs.mkdir(parents=True)
+    _write_results(
+        outputs / "results_20260615_120000.json",
+        [_row("orders", "openai:gpt-4.1", True)],
+    )
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(last=True)
+
+    assert excinfo.value.code == 1
+    assert any("at least two results" in line for line in captured)
+
+
+def test_diff_last_rejects_explicit_file_args(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    b = tmp_path / "b.json"
+    _write_results(a, [_row("x", "openai:gpt-4.1", True)])
+    _write_results(b, [_row("x", "openai:gpt-4.1", True)])
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(file1=a, file2=b, last=True)
+
+    assert excinfo.value.code == 1
+    assert any("mutually exclusive" in line for line in captured)
+
+
+def test_diff_with_no_args_errors(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff()
+
+    assert excinfo.value.code == 1
+    assert any("two file paths" in line for line in captured)
+
+
+def test_diff_with_only_one_file_errors(tmp_path: Path, monkeypatch):
+    a = tmp_path / "a.json"
+    _write_results(a, [_row("x", "openai:gpt-4.1", True)])
+    captured = _patch_ui(monkeypatch)
+    monkeypatch.setattr("sys.exit", lambda code=0: (_ for _ in ()).throw(SystemExit(code)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        diff(file1=a)
+
+    assert excinfo.value.code == 1
+    assert any("two file paths" in line for line in captured)


### PR DESCRIPTION
## What

`nao test diff` now has a `--last` flag that picks the two most recent `results_*.json` files in `tests/outputs/` and runs the existing diff logic on them.

```bash
nao test diff --last
```

Output:

```
             Diff: results_20260801_120000.json -> results_20260802_120000.json
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┓
┃ Test         ┃ Model          ┃ Before ┃ After ┃ Change     ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━┩
│ orders_count │ openai:gpt-4.1 │ PASS   │ FAIL  │ regression │
└──────────────┴────────────────┴────────┴───────┴────────────┘

Summary: 1 regression, 0 fixes, 0 unchanged, 0 added, 0 removed
```

The same flags from `nao test diff` are honoured: `--model`, `--test`, `--quiet` / `-q`, `--no-fail`. The flag is mutually exclusive with the two file path arguments: passing both is rejected with a clear error. When `tests/outputs/` has fewer than two files, the subcommand prints a clear error and exits `1`. The two-file-arg form is unchanged.

## Why

The most common use case for `nao test diff` is the one the user has to type the most for: "I just ran tests, then ran them again after a model or prompt change, what changed?". Today that means `ls tests/outputs/` to find the two filenames, then `nao test diff <older> <newer>`. `--last` resolves the "what's the second-newest file" question automatically.

## How

- `cli/nao_core/commands/test/diff.py`: added a `_resolve_last_two(project_path)` helper that globs `tests/outputs/results_*.json`, sorts by name (which is timestamp-prefixed and therefore chronological), and returns the last two files or `None` if there are fewer. Added the `--last` flag to the `diff` function and a small validation block at the top of the function body: `--last` and explicit file args are mutually exclusive, and at least one of the two input modes must be set. The positional `file1` and `file2` arguments are now optional (`Path | None = None`); the existing two-file-arg form still works because callers pass both.
- `cli/tests/nao_core/commands/test_diff.py`: 9 new tests covering `_resolve_last_two` directly (None when outputs dir missing, None when fewer than two files, picks the two most recent by name sort), the end-to-end `--last` happy path with a regression, and the four error paths (no outputs dir, only one file, `--last` with explicit file args, no args at all, only one file arg). All 30 pre-existing diff tests still pass.
- `cli/README.md`: one new bullet on the `--last` flag, two new example lines in the existing "Diff two result files" subsection.

No new dependencies. No changes to `save_results`, `_load_results`, `compute_diff`, or any other call site.

## Verification

- `make lint` clean (ty + ruff check + ruff check --select I + ruff format --check)
- `pytest tests/`: 880 passed, 245 skipped, 0 failed (9 new in `test_diff.py`)
- End-to-end smoke: created two result fixtures in `tests/outputs/` (one passing, one failing on the same test), ran the subcommand via `python -m nao_core.main test diff --last`, `... --last --quiet`, and `... --last --no-fail`. The table renders, the summary prints, the exit code is 1 on regression (verified separately), and `--no-fail` and `--quiet` both work.

## Risks

Low. The new flag is a small file-resolution helper that reuses every existing piece of the diff subcommand. The only edge case is "fewer than two files in `tests/outputs/`", which is the new code path and is covered by the new tests. The change to the positional arg signature (`Path` to `Path | None`) is backward compatible for the existing two-file-arg form.

## Dependency

This PR is based on the `feat/nao-test-diff` branch (the parent PR #1307). The new flag extends the existing `diff` subcommand rather than adding a new one, so the review happens in the context of the diff subcommand as a whole. If the maintainer merges #1307 first, this branch rebases cleanly. If the maintainer merges this branch first, the dependency on #1307 still applies (the `--last` flag references the existing diff logic, which only exists in #1307).

Fixes #1333.

This PR was written using Claude Sonnet 4.5 (claude-sonnet-4-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

