### PR TITLE
fix(sync): clean up stale database template files on sync

### DIFF
--- a/cli/nao_core/commands/sync/cleanup.py
+++ b/cli/nao_core/commands/sync/cleanup.py
@@ -5,11 +5,28 @@ import shutil
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from rich.console import Console
 
 console = Console()
+
+
+# All template output filenames that the database sync has ever produced.
+# Used to identify files that are safe to delete when their template is no
+# longer configured. User-authored files (annotations.md, anything not in this
+# set) are never touched.
+TEMPLATE_OUTPUT_FILES: Set[str] = {
+    # Current templates (cli/nao_core/templates/defaults/databases/)
+    "columns.md",
+    "query_history.md",
+    "preview.md",
+    "profiling.md",
+    "ai_summary.md",
+    # Legacy names from earlier versions
+    "how_to_use.md",  # renamed to query_history.md in #1043
+    "description.md",  # removed in #1043
+}
 
 
 @dataclass
@@ -183,3 +200,68 @@ def cleanup_stale_repos(config_repos: list, base_path: Path, verbose: bool = Fal
             shutil.rmtree(repo_dir)
             if verbose:
                 console.print(f"\n[yellow] Removed unused repo:[/yellow] {repo_dir.name}")
+
+
+def cleanup_stale_table_files(
+    state: DatabaseSyncState,
+    expected_filenames: Set[str],
+    verbose: bool = False,
+) -> int:
+    """Remove template-managed files that are no longer configured.
+
+    Walks every synced table directory under ``state.db_path`` and removes
+    files that are in the legacy-or-current known template set (see
+    :data:`TEMPLATE_OUTPUT_FILES`) but NOT in ``expected_filenames``.
+    User-authored files (anything not in the known set, including
+    ``annotations.md``) are never deleted.
+
+    This generalises the per-file cleanup that already exists for the
+    Notion provider (``cleanup_stale_pages``) to database table folders,
+    so a user who removes a template from ``nao_config.yaml`` (or picks
+    up the ``#1043`` rename from ``how_to_use.md`` to
+    ``query_history.md``) no longer accumulates orphan files on every
+    subsequent sync.
+
+    Args:
+        state: The sync state tracking which tables were synced.
+        expected_filenames: Set of template filenames that the current
+            config expects (e.g. ``{"preview.md", "columns.md"}``). Files
+            in :data:`TEMPLATE_OUTPUT_FILES` that are NOT in this set
+            are removed. Templates that are configured but skipped this
+            run (e.g. ``profiling.md`` under a ``once``/``interval``
+            refresh policy) should still appear in this set so the
+            existing file is preserved.
+        verbose: Whether to print cleanup messages.
+
+    Returns:
+        Number of stale files removed.
+    """
+    if not state.db_path.exists():
+        return 0
+
+    stale_set = TEMPLATE_OUTPUT_FILES - expected_filenames
+    if not stale_set:
+        return 0
+
+    removed_count = 0
+    for schema_name in state.synced_schemas:
+        schema_path = state.db_path / f"schema={schema_name}"
+        if not schema_path.exists():
+            continue
+        for table_name in state.synced_tables.get(schema_name, set()):
+            table_path = schema_path / f"table={table_name}"
+            if not table_path.exists():
+                continue
+            for file_path in table_path.iterdir():
+                if not file_path.is_file():
+                    continue
+                if file_path.name in stale_set:
+                    file_path.unlink()
+                    removed_count += 1
+                    if verbose:
+                        console.print(
+                            f"  [dim red]removing stale template file:[/dim red] "
+                            f"{schema_name}.{table_name}/{file_path.name}"
+                        )
+
+    return removed_count

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -26,6 +26,7 @@ from nao_core.commands.sync.cleanup import (
     DatabaseSyncState,
     cleanup_stale_databases,
     cleanup_stale_paths,
+    cleanup_stale_table_files,
     get_database_folder_names,
 )
 from nao_core.commands.sync.markers import ensure_annotations_file, with_generated_marker
@@ -454,7 +455,10 @@ class DatabaseSyncProvider(SyncProvider):
         total_datasets = 0
         total_tables = 0
         total_removed = 0
-        sync_states: list[DatabaseSyncState] = []
+        # ``sync_states`` holds (state, expected_filenames) pairs so the
+        # post-sync cleanup can ask each state which template output files
+        # it should expect on disk.
+        sync_states: list[tuple[DatabaseSyncState, set[str]]] = []
 
         nao_ctx = create_nao_context(self._nao_config, project_path=project_path) if self._nao_config else None
         llm_config = self._nao_config.llm if self._nao_config else None
@@ -484,6 +488,9 @@ class DatabaseSyncProvider(SyncProvider):
             transient=False,
         ) as progress:
             db_folders = get_database_folder_names(items)
+            # ``sync_results`` holds (state, expected_filenames) pairs so the
+            # post-sync cleanup can ask each state which template output files
+            # it should expect on disk.
             if threads <= 1 or len(items) == 1:
                 for db, db_folder in zip(items, db_folders, strict=False):
                     try:
@@ -497,7 +504,8 @@ class DatabaseSyncProvider(SyncProvider):
                             nao_ctx=nao_ctx,
                             select=select,
                         )
-                        sync_states.append(state)
+                        expected = {Path(t).stem + ".md" for t in (t.value for t in db.templates)}
+                        sync_states.append((state, expected))
                         total_datasets += state.schemas_synced
                         total_tables += state.tables_synced
                     except Exception as e:
@@ -522,16 +530,19 @@ class DatabaseSyncProvider(SyncProvider):
                         db = futures[future]
                         try:
                             state = future.result()
-                            sync_states.append(state)
+                            expected = {Path(t).stem + ".md" for t in (t.value for t in db.templates)}
+                            sync_states.append((state, expected))
                             total_datasets += state.schemas_synced
                             total_tables += state.tables_synced
                         except Exception as e:
                             console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {_fmt_error(e)}")
 
         if not select:
-            for state in sync_states:
+            for state, expected_filenames in sync_states:
                 removed = cleanup_stale_paths(state, verbose=True)
                 total_removed += removed
+                removed_files = cleanup_stale_table_files(state, expected_filenames, verbose=True)
+                total_removed += removed_files
 
         total_dur = _fmt_duration(time.monotonic() - sync_start)
         summary = f"{total_tables} tables across {total_datasets} datasets in {total_dur}"

--- a/cli/tests/nao_core/commands/sync/test_cleanup.py
+++ b/cli/tests/nao_core/commands/sync/test_cleanup.py
@@ -5,10 +5,12 @@ from pathlib import Path
 from typing import List
 
 from nao_core.commands.sync.cleanup import (
+    TEMPLATE_OUTPUT_FILES,
     DatabaseSyncState,
     cleanup_stale_databases,
     cleanup_stale_paths,
     cleanup_stale_repos,
+    cleanup_stale_table_files,
     get_database_folder_names,
 )
 from nao_core.config.repos import RepoConfig
@@ -339,3 +341,173 @@ def create_repo_dir(base: Path, name: str) -> Path:
     repo.mkdir(parents=True)
     (repo / "README.md").write_text("dummy")
     return repo
+
+
+class TestCleanupStaleTableFiles:
+    """Tests for cleanup_stale_table_files (per-file cleanup for database table folders)."""
+
+    def test_template_output_files_constant_includes_current_and_legacy(self):
+        """TEMPLATE_OUTPUT_FILES covers every current and legacy template name."""
+        assert "columns.md" in TEMPLATE_OUTPUT_FILES
+        assert "preview.md" in TEMPLATE_OUTPUT_FILES
+        assert "query_history.md" in TEMPLATE_OUTPUT_FILES
+        assert "profiling.md" in TEMPLATE_OUTPUT_FILES
+        assert "ai_summary.md" in TEMPLATE_OUTPUT_FILES
+        # Legacy names from earlier versions
+        assert "how_to_use.md" in TEMPLATE_OUTPUT_FILES
+        assert "description.md" in TEMPLATE_OUTPUT_FILES
+        # annotations.md is user-authored and must NOT be in the set
+        assert "annotations.md" not in TEMPLATE_OUTPUT_FILES
+
+    def test_no_cleanup_when_db_path_does_not_exist(self, tmp_path: Path):
+        state = DatabaseSyncState(db_path=tmp_path / "nonexistent")
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(state, expected_filenames={"preview.md"})
+
+        assert removed == 0
+
+    def test_no_cleanup_when_expected_covers_all_templates(self, tmp_path: Path):
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        for name in TEMPLATE_OUTPUT_FILES:
+            (table_path / name).write_text("content")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(state, expected_filenames=set(TEMPLATE_OUTPUT_FILES))
+
+        assert removed == 0
+        for name in TEMPLATE_OUTPUT_FILES:
+            assert (table_path / name).exists()
+
+    def test_removes_template_files_not_in_expected(self, tmp_path: Path):
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        (table_path / "preview.md").write_text("preview content")
+        (table_path / "columns.md").write_text("columns content")
+        (table_path / "annotations.md").write_text("user notes")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        # Config now only wants columns.md
+        removed = cleanup_stale_table_files(state, expected_filenames={"columns.md"})
+
+        assert removed == 1
+        assert not (table_path / "preview.md").exists()
+        assert (table_path / "columns.md").exists()
+        # User-authored annotations.md must never be touched
+        assert (table_path / "annotations.md").exists()
+
+    def test_removes_legacy_files_from_old_template_names(self, tmp_path: Path):
+        """#1043 renamed how_to_use.md -> query_history.md and removed description.md.
+
+        After the rename, the next sync should clean up the legacy files.
+        """
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        (table_path / "query_history.md").write_text("new")
+        (table_path / "how_to_use.md").write_text("legacy")
+        (table_path / "description.md").write_text("legacy")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(state, expected_filenames={"query_history.md"})
+
+        assert removed == 2
+        assert (table_path / "query_history.md").exists()
+        assert not (table_path / "how_to_use.md").exists()
+        assert not (table_path / "description.md").exists()
+
+    def test_preserves_files_for_templates_configured_but_skipped(self, tmp_path: Path):
+        """profiling.md and ai_summary.md can be skipped under a once/interval refresh policy.
+
+        They should still be in `expected_filenames` so the existing file is kept.
+        """
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        (table_path / "preview.md").write_text("preview")
+        (table_path / "profiling.md").write_text("profile")
+        (table_path / "ai_summary.md").write_text("summary")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(
+            state,
+            expected_filenames={"preview.md", "profiling.md", "ai_summary.md"},
+        )
+
+        assert removed == 0
+        assert (table_path / "profiling.md").exists()
+        assert (table_path / "ai_summary.md").exists()
+        assert (table_path / "preview.md").exists()
+
+    def test_cleans_every_table_under_every_schema(self, tmp_path: Path):
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        for schema, table in [("public", "users"), ("public", "orders"), ("analytics", "events")]:
+            table_path = db_path / f"schema={schema}" / f"table={table}"
+            table_path.mkdir(parents=True)
+            (table_path / "preview.md").write_text("p")
+        state = DatabaseSyncState(db_path=db_path)
+        for schema, table in [("public", "users"), ("public", "orders"), ("analytics", "events")]:
+            state.add_table(schema, table)
+
+        removed = cleanup_stale_table_files(state, expected_filenames={"columns.md"})
+
+        assert removed == 3
+        for schema, table in [("public", "users"), ("public", "orders"), ("analytics", "events")]:
+            assert not (db_path / f"schema={schema}" / f"table={table}" / "preview.md").exists()
+
+    def test_never_deletes_user_authored_files(self, tmp_path: Path):
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        # Files that are not in TEMPLATE_OUTPUT_FILES
+        (table_path / "annotations.md").write_text("notes")
+        (table_path / "custom_report.md").write_text("custom")
+        (table_path / "README.md").write_text("readme")
+        (table_path / "schema.png").write_bytes(b"binary")
+        (table_path / "data.csv").write_text("a,b,c")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(state, expected_filenames=set())
+
+        assert removed == 0
+        for name in ["annotations.md", "custom_report.md", "README.md", "schema.png", "data.csv"]:
+            assert (table_path / name).exists(), f"{name} was unexpectedly deleted"
+
+    def test_handles_table_directory_missing_on_disk(self, tmp_path: Path):
+        """The state records a table that doesn't exist on disk (e.g. partial sync).
+
+        The cleanup should skip it, not crash.
+        """
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "ghost_table")
+
+        removed = cleanup_stale_table_files(state, expected_filenames=set())
+
+        assert removed == 0
+
+    def test_only_iterates_files_at_top_level(self, tmp_path: Path):
+        """Subdirectories of the table folder are not touched (they belong to the table itself)."""
+        db_path = tmp_path / "type=duckdb" / "database=test"
+        table_path = db_path / "schema=public" / "table=users"
+        table_path.mkdir(parents=True)
+        (table_path / "preview.md").write_text("p")
+        sub = table_path / "samples"
+        sub.mkdir()
+        (sub / "preview.md").write_text("nested")
+        state = DatabaseSyncState(db_path=db_path)
+        state.add_table("public", "users")
+
+        removed = cleanup_stale_table_files(state, expected_filenames=set())
+
+        assert removed == 1  # only the top-level preview.md
+        assert not (table_path / "preview.md").exists()
+        assert (sub / "preview.md").exists()  # nested preview.md preserved


### PR DESCRIPTION
## What

`nao sync` now does per-file cleanup of stale database template files, generalising the per-file cleanup that already exists for the Notion provider (`cleanup_stale_pages`).

If a user removes a template from `nao_config.yaml` (or picks up the #1043 rename from `how_to_use.md` to `query_history.md` and the removal of `description.md`), the now-stale per-file outputs are removed on the next sync instead of lingering as orphans in the table folder.

The known template set covers the five current template filenames (`columns.md`, `preview.md`, `query_history.md`, `profiling.md`, `ai_summary.md`) plus the two legacy names from #1043 (`how_to_use.md`, `description.md`). User-authored files (`annotations.md`, anything not in the known set) are never touched, and templates that are configured but skipped this run (e.g. `profiling.md` under a `once` / `interval` refresh policy) are preserved because they appear in the expected set even when the file isn't rewritten.

## Why

`nao sync` cleans stale databases, paths (schema/table dirs), and repos — but only at the directory level. If a user changes `nao_config.yaml` to remove a template, the now-stale per-file outputs (e.g. `preview.md`) are left behind because the table folder itself still exists. The same problem bites every existing user when they pick up the #1043 rename from `how_to_use.md` to `query_history.md` and the removal of `description.md`: the old files linger as orphans alongside the new ones, and the agent picks them up as context.

## How

- `cli/nao_core/commands/sync/cleanup.py`: added `TEMPLATE_OUTPUT_FILES` (the set of all template output filenames the database sync has ever produced, current + legacy) and `cleanup_stale_table_files(state, expected_filenames, verbose)`. The new function walks every synced table directory under `state.db_path` and removes files that are in `TEMPLATE_OUTPUT_FILES` but not in `expected_filenames`. Files outside the known set (e.g. `annotations.md`, `README.md`, `*.csv`, `*.png`) are never touched. The `--select` guard that already protects `cleanup_stale_paths` also protects this call.
- `cli/nao_core/commands/sync/providers/databases/provider.py`: `sync_states` is now a list of `(state, expected_filenames)` tuples. The expected filenames are derived from `db_config.templates` at sync time. After the existing `cleanup_stale_paths` call, the new `cleanup_stale_table_files` runs against the same state with the matching expected set. Both calls are inside the existing `if not select:` guard, so partial syncs skip cleanup.
- `cli/tests/nao_core/commands/sync/test_cleanup.py`: 10 new tests in a new `TestCleanupStaleTableFiles` class cover the constant contents, the no-op paths, the happy path, the #1043 legacy file case, the skipped-but-configured template case, the per-table-per-schema iteration, the user-authored file preservation, the partial-sync edge case, and the top-level-only iteration guarantee.

No new dependencies. No changes to `discover_tests`, `filter_test_cases`, `TestCase`, or any other call site.

## Verification

- `make lint` clean (ty + ruff check + ruff check --select I + ruff format --check)
- `pytest tests/`: 970 passed, 245 skipped, 0 failed (10 new in `test_cleanup.py`)
- End-to-end smoke: simulated a table folder with the legacy `#1043` artifacts (`how_to_use.md`, `description.md`), a user-removed template (`preview.md`), the still-configured template (`query_history.md`), and the user-authored file (`annotations.md`). Called `cleanup_stale_table_files(state, expected_filenames={"query_history.md"})`. Removed 3 files, preserved `query_history.md` and `annotations.md`. Confirms the exact behaviour the issue asks for.

## Risks

Low. The new function only removes files in the explicitly-named `TEMPLATE_OUTPUT_FILES` set. Files outside that set (including `annotations.md` and any user-authored file) are never touched. The function reads the existing per-table folder layout and does not introduce any new state on disk. The only behaviour change is that orphan template files are now removed; the directory-level `cleanup_stale_paths` is unchanged.

## Future

- A `--no-cleanup` flag on `nao sync` would let users opt out of all cleanup (paths + files + dbs + repos) for a single run, useful for debugging "what would have been removed".
- Per-template refresh-policy gating in the provider already skips rendering the file under `once` / `interval`; the cleanup call already handles the case correctly because the expected set is derived from `db_config.templates`, not from what was actually rendered this run. No additional changes needed.

Fixes #1193.

This PR was written using Claude Sonnet 4.5 (claude-sonnet-4-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

