### PR TITLE
[fix : chart edit dialog] restore the edit config chart for series of mixed one

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -512,32 +512,33 @@ export function ChartConfigEditDialog({
 								}
 
 								return (
-									<div
-										key={index}
-										className='flex flex-col gap-2 rounded-md border border-border px-3 pt-2 pb-3'
-									>
-										<SeriesTypeSelect
-											value={series.series_type ?? 'bar'}
-											onChange={(value) => updateSeriesAt(index, { series_type: value })}
-										/>
-										{row}
-										{isOpen && (
-											<SeriesValueFormatFields
-												d3Format={series.value_format?.d3_format ?? ''}
-												unit={unit}
-												placement={placement}
-												onD3FormatChange={(value) =>
-													updateSeriesValueFormatAt(index, 'd3_format', value)
-												}
-												onUnitChange={(nextUnit, nextPlacement) =>
-													setSeriesUnit(index, {
-														unit: nextUnit,
-														placement: nextPlacement,
-													})
-												}
+									<fieldset key={index} className='rounded-md border border-border px-3 pt-1 pb-3'>
+										<legend className='ml-1'>
+											<SeriesTypeSelect
+												value={series.series_type ?? 'bar'}
+												onChange={(value) => updateSeriesAt(index, { series_type: value })}
 											/>
-										)}
-									</div>
+										</legend>
+										<div className='flex flex-col gap-2'>
+											{row}
+											{isOpen && (
+												<SeriesValueFormatFields
+													d3Format={series.value_format?.d3_format ?? ''}
+													unit={unit}
+													placement={placement}
+													onD3FormatChange={(value) =>
+														updateSeriesValueFormatAt(index, 'd3_format', value)
+													}
+													onUnitChange={(nextUnit, nextPlacement) =>
+														setSeriesUnit(index, {
+															unit: nextUnit,
+															placement: nextPlacement,
+														})
+													}
+												/>
+											)}
+										</div>
+									</fieldset>
 								);
 							})}
 						</div>


### PR DESCRIPTION
## Before

<img width="547" height="149" alt="image" src="https://github.com/user-attachments/assets/7f5315be-1357-46e6-9479-08547a49ca17" />

## After

<img width="557" height="129" alt="image" src="https://github.com/user-attachments/assets/6a587d4e-e7ca-4959-8c70-d7f13f9acd92" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

