### PR TITLE
Reserve axis-title width so y-axis label doesn't overlap ticks

### DIFF
--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -70,6 +70,8 @@ const VALUE_AXIS_DEFAULT_WIDTH = 40;
 const VALUE_AXIS_MAX_WIDTH = 120;
 const VALUE_AXIS_CHARACTER_WIDTH = 7;
 const VALUE_AXIS_PADDING = 12;
+/** Reserves horizontal room for a rotated axis title so it does not overlap tick values. */
+const AXIS_LABEL_WIDTH = 20;
 
 export function labelize(key: unknown, dateFormat?: DateFormatSettings | null): string {
 	const str = String(key);
@@ -129,9 +131,14 @@ export function formatYAxisTick(value: number): string {
 	return String(Number(abs < 1 ? value.toPrecision(2) : value.toFixed(2)));
 }
 
-export function computeValueAxisWidth(axisValues: number[], valueFormat?: displayChart.ValueFormat): number {
+export function computeValueAxisWidth(
+	axisValues: number[],
+	valueFormat?: displayChart.ValueFormat,
+	hasLabel = false,
+): number {
+	const labelAllowance = hasLabel ? AXIS_LABEL_WIDTH : 0;
 	if (axisValues.length === 0) {
-		return VALUE_AXIS_DEFAULT_WIDTH;
+		return VALUE_AXIS_DEFAULT_WIDTH + labelAllowance;
 	}
 
 	let minimumValue = axisValues[0];
@@ -150,8 +157,8 @@ export function computeValueAxisWidth(axisValues: number[], valueFormat?: displa
 	}
 
 	const maximumLabelLength = Math.max(...candidates.map((value) => formatValueYAxisTick(value, valueFormat).length));
-	const estimatedWidth = maximumLabelLength * VALUE_AXIS_CHARACTER_WIDTH + VALUE_AXIS_PADDING;
-	return Math.min(VALUE_AXIS_MAX_WIDTH, Math.max(Y_AXIS_WIDTH, estimatedWidth));
+	const estimatedWidth = maximumLabelLength * VALUE_AXIS_CHARACTER_WIDTH + VALUE_AXIS_PADDING + labelAllowance;
+	return Math.min(VALUE_AXIS_MAX_WIDTH + labelAllowance, Math.max(Y_AXIS_WIDTH + labelAllowance, estimatedWidth));
 }
 
 function abbreviate(abs: number, unit: number): string {
@@ -612,7 +619,7 @@ function KpiTrendArrow({ direction }: { direction: KpiComparisonDirection }) {
 function renderValueYAxis(isPercent = false, valueFormatter = formatYAxisTick, yAxisLabel?: string) {
 	return (
 		<YAxis
-			width={Y_AXIS_WIDTH}
+			width={Y_AXIS_WIDTH + (yAxisLabel ? AXIS_LABEL_WIDTH : 0)}
 			tick={AXIS_TICK}
 			tickLine={false}
 			axisLine={false}
@@ -716,7 +723,7 @@ function buildBarChart(props: ResolvedProps) {
 	const seriesKeys = renderedSeries.map((s) => s.data_key);
 	const separatorColor = props.backgroundColor ?? DEFAULT_BACKGROUND_COLOR;
 	const chartLevelFormat = getChartLevelValueFormat(series);
-	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat);
+	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat, Boolean(yAxisLabel));
 
 	return (
 		<BarChart data={data} accessibilityLayer margin={margin} stackOffset={isPercent ? 'expand' : undefined}>
@@ -845,7 +852,7 @@ function buildAreaChart(props: ResolvedProps) {
 	const { renderedSeries, stackTotalLabel, stackTotalLabelIndex } = getDataLabelSetup(props, isStacked);
 	const pointLabelContent = showDataLabels && !isStacked ? buildPointLabelContentBySeries(data, series) : new Map();
 	const chartLevelFormat = getChartLevelValueFormat(series);
-	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat);
+	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat, Boolean(yAxisLabel));
 
 	return (
 		<AreaChart data={data} accessibilityLayer margin={margin} stackOffset={isPercent ? 'expand' : undefined}>
@@ -952,8 +959,8 @@ function buildComboChart(props: ResolvedProps) {
 	const rightFormat = getChartLevelValueFormat(rightSeries);
 	const leftDomain = resolveComboAxisDomain(data, leftSeries, yAxisMin, yAxisMax);
 	const rightDomain = resolveComboAxisDomain(data, rightSeries, yAxisRightMin, yAxisRightMax);
-	const leftAxisWidth = computeComboAxisWidth(data, leftSeries, leftFormat);
-	const rightAxisWidth = computeComboAxisWidth(data, rightSeries, rightFormat);
+	const leftAxisWidth = computeComboAxisWidth(data, leftSeries, leftFormat, Boolean(yAxisLabel));
+	const rightAxisWidth = computeComboAxisWidth(data, rightSeries, rightFormat, Boolean(yAxisRightLabel));
 	const areaSeries = series.filter((s) => comboSeriesType(s, chartType) === 'area');
 	const pointLabelContent = showDataLabels ? buildPointLabelContentBySeries(data, series) : new Map();
 
@@ -1051,12 +1058,13 @@ function computeComboAxisWidth(
 	data: Record<string, unknown>[],
 	axisSeries: displayChart.SeriesConfig[],
 	valueFormat?: displayChart.ValueFormat,
+	hasLabel = false,
 ) {
 	const values = collectAxisValues(
 		data,
 		axisSeries.map((s) => s.data_key),
 	);
-	return computeValueAxisWidth(values, valueFormat);
+	return computeValueAxisWidth(values, valueFormat, hasLabel);
 }
 
 function renderComboSeries(
@@ -1158,7 +1166,7 @@ function buildScatterChart(props: ResolvedProps) {
 		data,
 		series.map((s) => s.data_key),
 	);
-	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat);
+	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat, Boolean(yAxisLabel));
 
 	return (
 		<ScatterChart data={data} accessibilityLayer margin={margin}>

--- a/apps/shared/tests/chart-builder.test.tsx
+++ b/apps/shared/tests/chart-builder.test.tsx
@@ -55,6 +55,14 @@ describe('computeValueAxisWidth', () => {
 		expect(currencyWidth).toBe(82);
 		expect(computeValueAxisWidth([0, Number.MAX_SAFE_INTEGER], valueFormat)).toBe(120);
 	});
+
+	it('reserves extra width for a rotated axis title when hasLabel is set', () => {
+		const currencyFormat = { d3_format: ',.0f', prefix: '$' };
+		expect(computeValueAxisWidth([1, 10], undefined, true)).toBe(56);
+		expect(computeValueAxisWidth([], undefined, true)).toBe(60);
+		expect(computeValueAxisWidth([0, 980_000], currencyFormat, true)).toBe(102);
+		expect(computeValueAxisWidth([0, Number.MAX_SAFE_INTEGER], currencyFormat, true)).toBe(140);
+	});
 });
 
 describe('buildChart', () => {


### PR DESCRIPTION
## Summary
- Fixes the y-axis title overlapping the axis numbers on charts that have a y-axis label.
- The axis was only sized to fit the value labels; it now reserves extra room for the rotated title too.
- Applies to bar, line/area, scatter, 100%-stacked, and combo charts (both left and right titles).

Closes #1337

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

