### PR TITLE
Let the ClickHouse connector work with a token that cannot read the system database

### DIFF
--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -118,11 +118,14 @@ class _RestrictedDiscoveryBackend:
     def list_databases(self, *args: Any, **kwargs: Any) -> list[str]:
         list_databases = getattr(self._backend, "list_databases", None)
         if list_databases is None:
+            self._warn_unexpandable()
             return list(self._targets)
         try:
             return list_databases(*args, **kwargs)
         except Exception as e:
             logger.warning("Cannot list databases (%s); using the schemas named in include", _brief_reason(e))
+            logger.debug("Full error listing databases", exc_info=True)
+            self._warn_unexpandable()
             return list(self._targets)
 
     def list_tables(self, *args: Any, database: str | None = None, **kwargs: Any) -> list[str]:
@@ -133,14 +136,19 @@ class _RestrictedDiscoveryBackend:
                 "Cannot list tables in %s (%s); using the tables named in include", database, _brief_reason(e)
             )
             logger.debug("Full error listing tables in %s", database, exc_info=True)
-            if self._unexpandable:
-                logger.warning(
-                    "Ignoring include patterns that need a table listing to expand: %s. "
-                    "Name these tables individually to sync them.",
-                    ", ".join(self._unexpandable),
-                )
-                self._unexpandable = []
+            self._warn_unexpandable()
             return list(self._targets.get(database or "", []))
+
+    def _warn_unexpandable(self) -> None:
+        """Name the include patterns being dropped, so an all-wildcard include is not silent."""
+        if not self._unexpandable:
+            return
+        logger.warning(
+            "Ignoring include patterns that need a table listing to expand: %s. "
+            "Name these tables individually to sync them.",
+            ", ".join(self._unexpandable),
+        )
+        self._unexpandable = []
 
 
 # AggregateFunction(type_str) -> first argument is the function name (uniq, sum, etc.)
@@ -463,10 +471,17 @@ def _columns_from_system(conn: BaseBackend, database: str, table_name: str) -> l
         return []
 
 
+def _quote_identifier(name: str) -> str:
+    """Backtick-quote an identifier, doubling any backtick it contains."""
+    escaped = name.replace("`", "``")
+    return f"`{escaped}`"
+
+
 def _columns_from_describe(conn: BaseBackend, database: str, table_name: str) -> list[dict[str, Any]]:
     """Return column metadata from DESCRIBE TABLE, which needs no system database access."""
+    target = f"{_quote_identifier(database)}.{_quote_identifier(table_name)}"
     try:
-        cursor = conn.raw_sql(f"DESCRIBE TABLE `{database}`.`{table_name}`")  # type: ignore[union-attr]
+        cursor = conn.raw_sql(f"DESCRIBE TABLE {target}")  # type: ignore[union-attr]
         rows = _raw_sql_to_rows(cursor)
     except Exception:
         return []
@@ -485,9 +500,14 @@ def _columns_from_describe(conn: BaseBackend, database: str, table_name: str) ->
     ]
 
 
-def _column_metadata(conn: BaseBackend, database: str, table_name: str) -> list[dict[str, Any]]:
-    """Return column metadata, preferring system.columns and falling back to DESCRIBE TABLE."""
-    return _columns_from_system(conn, database, table_name) or _columns_from_describe(conn, database, table_name)
+def _column_metadata(
+    conn: BaseBackend, database: str, table_name: str, describe_fallback: bool = False
+) -> list[dict[str, Any]]:
+    """Return column metadata from system.columns, falling back to DESCRIBE only when allowed."""
+    columns = _columns_from_system(conn, database, table_name)
+    if columns or not describe_fallback:
+        return columns
+    return _columns_from_describe(conn, database, table_name)
 
 
 def _get_table_engine(conn: BaseBackend, database: str, table_name: str) -> str | None:
@@ -520,10 +540,14 @@ class ClickHouseDatabaseContext(DatabaseContext):
     use the no-SELECT path (SHOW CREATE TABLE + system.columns) for all later operations on that table.
     """
 
-    def __init__(self, conn: BaseBackend, schema: str, table_name: str):
+    def __init__(self, conn: BaseBackend, schema: str, table_name: str, describe_fallback: bool = False):
         super().__init__(conn, schema, table_name)
         self._direct_select_disallowed: bool = False
         self._is_dictionary_obj: bool | None = None
+        self._describe_fallback = describe_fallback
+
+    def _column_metadata(self) -> list[dict[str, Any]]:
+        return _column_metadata(self._conn, self._schema, self._table_name, self._describe_fallback)
 
     @staticmethod
     def _format_type(dtype: Any) -> str:
@@ -586,16 +610,16 @@ class ClickHouseDatabaseContext(DatabaseContext):
     def column_count(self) -> int:
         """Return column count; for stream-like engines use system.columns if table.schema() is disallowed."""
         if self._direct_select_disallowed:
-            return len(_column_metadata(self._conn, self._schema, self._table_name))
+            return len(self._column_metadata())
         try:
             return len(self.table.schema())
         except Exception:
-            return len(_column_metadata(self._conn, self._schema, self._table_name))
+            return len(self._column_metadata())
 
     def columns(self) -> list[dict[str, Any]]:
         """Return column metadata; for stream-like engines use system.columns (no SELECT from table)."""
         if self._direct_select_disallowed:
-            return self._filter_excluded_columns(_column_metadata(self._conn, self._schema, self._table_name))
+            return self._filter_excluded_columns(self._column_metadata())
         try:
             schema = self.table.schema()
             cols = [
@@ -607,7 +631,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
                 }
                 for name, dtype in schema.items()
             ]
-            system_columns = _column_metadata(self._conn, self._schema, self._table_name)
+            system_columns = self._column_metadata()
             system_types = {
                 col["name"]: col["type"]
                 for col in system_columns
@@ -641,7 +665,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
                     col["description"] = description
             return self._filter_excluded_columns(cols)
         except Exception:
-            return self._filter_excluded_columns(_column_metadata(self._conn, self._schema, self._table_name))
+            return self._filter_excluded_columns(self._column_metadata())
 
     def _fetchone(self, result) -> tuple | None:
         """Normalise clickhouse-connect QueryResult objects for profiling queries."""
@@ -850,9 +874,12 @@ class ClickHouseConfig(DatabaseConfig):
 
         require_database_backend("clickhouse")
 
-        if not self.tolerate_unreadable_system_tables:
-            return self._connect_http_client()
-        with _server_settings_probe_optional():
+        if self.tolerate_unreadable_system_tables:
+            with _server_settings_probe_optional():
+                return self._connect_http_client()
+        # Hold the same lock so a concurrent opt-in connection's process-wide patch cannot
+        # leak into a connection that did not ask for it.
+        with _SERVER_SETTINGS_PROBE_LOCK:
             return self._connect_http_client()
 
     def _connect_http_client(self) -> BaseBackend:
@@ -935,7 +962,9 @@ class ClickHouseConfig(DatabaseConfig):
 
     def create_context(self, conn: BaseBackend, schema: str, table_name: str) -> ClickHouseDatabaseContext:
         """Use ClickHouse-specific context for resilient preview."""
-        return ClickHouseDatabaseContext(conn, schema, table_name)
+        return ClickHouseDatabaseContext(
+            conn, schema, table_name, describe_fallback=self.tolerate_unreadable_system_tables
+        )
 
     def _connection_error_message(self, error: Exception) -> str:
         """Point at the escape hatch when the connection died on a system database read."""

--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -91,11 +91,11 @@ def _server_settings_probe_optional():
                 logger.debug("Full error reading system.settings", exc_info=True)
                 return _NoServerSettings()
 
-        HttpClient.query = query
+        setattr(HttpClient, "query", query)
         try:
             yield
         finally:
-            HttpClient.query = original_query
+            setattr(HttpClient, "query", original_query)
 
 
 class _RestrictedDiscoveryBackend:

--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import fnmatch
+import functools
 import logging
 import re
+import threading
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
@@ -26,6 +29,118 @@ def _is_direct_select_disallowed(exc: BaseException) -> bool:
     """True if the exception is ClickHouse code 620 / direct select not allowed (e.g. Kafka/RabbitMQ/FileLog)."""
     msg = str(exc)
     return any(s in msg for s in _DIRECT_SELECT_DISALLOWED)
+
+
+# Tinybird serves the system database to ADMIN tokens only, so a token scoped to a few tables
+# cannot read system.settings (read while the client is constructed), system.databases or
+# system.tables (discovery). The remaining system reads already fail soft.
+_SERVER_SETTINGS_PROBE_PATTERN = re.compile(
+    r"^\s*select\s+name\s*,\s*value\s*,.*\breadonly\b.*\bfrom\s+system\.settings\b.*\blimit\s+10000\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_SERVER_SETTINGS_PROBE_LOCK = threading.Lock()
+
+
+def _is_server_settings_probe(sql: Any) -> bool:
+    return isinstance(sql, str) and bool(_SERVER_SETTINGS_PROBE_PATTERN.match(sql))
+
+
+def _brief_reason(error: Exception) -> str:
+    """First sentence of an error, so a repeated fallback does not log a paragraph each time."""
+    first = str(error).strip().split(". ", 1)[0]
+    return first if len(first) <= 160 else f"{first[:160]}…"
+
+
+class _NoServerSettings:
+    """Empty stand-in for the server settings probe result."""
+
+    def named_results(self) -> tuple:
+        return ()
+
+
+@contextmanager
+def _server_settings_probe_optional():
+    """Let the connection survive a server that refuses to serve system.settings.
+
+    The probe only feeds client-side setting validation, and an empty result is already a
+    supported state — Tinybird returns no rows even for an ADMIN token — so a refused probe
+    degrades to that instead of failing the connection. Servers that do serve the table are
+    unaffected: the fallback is reached only when the probe itself errors.
+
+    clickhouse-connect builds the client and runs the probe inside ``__init__``, so there is no
+    client to configure beforehand; the query method is wrapped for the length of the connection
+    instead. The lock keeps concurrent connections from restoring each other's wrapper.
+    """
+    from clickhouse_connect.driver.httpclient import HttpClient
+
+    with _SERVER_SETTINGS_PROBE_LOCK:
+        original_query = HttpClient.query
+
+        @functools.wraps(original_query)
+        def query(self, *args, **kwargs):
+            try:
+                return original_query(self, *args, **kwargs)
+            except Exception as e:
+                sql = args[0] if args else kwargs.get("query")
+                if not _is_server_settings_probe(sql):
+                    raise
+                logger.warning(
+                    "system.settings is not readable, connecting without client-side setting validation: %s",
+                    _brief_reason(e),
+                )
+                logger.debug("Full error reading system.settings", exc_info=True)
+                return _NoServerSettings()
+
+        HttpClient.query = query
+        try:
+            yield
+        finally:
+            HttpClient.query = original_query
+
+
+class _RestrictedDiscoveryBackend:
+    """Ibis backend wrapper for credentials that cannot read the system database.
+
+    Schema and table discovery normally comes from system.databases and system.tables. When a
+    least-privilege token cannot read those, discovery falls back to the tables named outright in
+    ``include``, so nao reads exactly what it was pointed at and nothing more. Everything else is
+    delegated untouched.
+    """
+
+    def __init__(self, backend: BaseBackend, targets: dict[str, list[str]], unexpandable: list[str] | None = None):
+        self._backend = backend
+        self._targets = targets
+        self._unexpandable = unexpandable or []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._backend, name)
+
+    def list_databases(self, *args: Any, **kwargs: Any) -> list[str]:
+        list_databases = getattr(self._backend, "list_databases", None)
+        if list_databases is None:
+            return list(self._targets)
+        try:
+            return list_databases(*args, **kwargs)
+        except Exception as e:
+            logger.warning("Cannot list databases (%s); using the schemas named in include", _brief_reason(e))
+            return list(self._targets)
+
+    def list_tables(self, *args: Any, database: str | None = None, **kwargs: Any) -> list[str]:
+        try:
+            return self._backend.list_tables(*args, database=database, **kwargs)
+        except Exception as e:
+            logger.warning(
+                "Cannot list tables in %s (%s); using the tables named in include", database, _brief_reason(e)
+            )
+            logger.debug("Full error listing tables in %s", database, exc_info=True)
+            if self._unexpandable:
+                logger.warning(
+                    "Ignoring include patterns that need a table listing to expand: %s. "
+                    "Name these tables individually to sync them.",
+                    ", ".join(self._unexpandable),
+                )
+                self._unexpandable = []
+            return list(self._targets.get(database or "", []))
 
 
 # AggregateFunction(type_str) -> first argument is the function name (uniq, sum, etc.)
@@ -348,6 +463,33 @@ def _columns_from_system(conn: BaseBackend, database: str, table_name: str) -> l
         return []
 
 
+def _columns_from_describe(conn: BaseBackend, database: str, table_name: str) -> list[dict[str, Any]]:
+    """Return column metadata from DESCRIBE TABLE, which needs no system database access."""
+    try:
+        cursor = conn.raw_sql(f"DESCRIBE TABLE `{database}`.`{table_name}`")  # type: ignore[union-attr]
+        rows = _raw_sql_to_rows(cursor)
+    except Exception:
+        return []
+    return [
+        {
+            "name": r["name"],
+            "type": str(r.get("type", "")),
+            "nullable": "Nullable" in str(r.get("type", "")),
+            "description": str(r.get("comment", "")).strip() or None,
+            # DESCRIBE calls this default_type; system.columns calls it default_kind.
+            "default_kind": str(r.get("default_type", "")).strip() or None,
+            "default_expression": str(r.get("default_expression", "")).strip() or None,
+        }
+        for r in rows
+        if r.get("name")
+    ]
+
+
+def _column_metadata(conn: BaseBackend, database: str, table_name: str) -> list[dict[str, Any]]:
+    """Return column metadata, preferring system.columns and falling back to DESCRIBE TABLE."""
+    return _columns_from_system(conn, database, table_name) or _columns_from_describe(conn, database, table_name)
+
+
 def _get_table_engine(conn: BaseBackend, database: str, table_name: str) -> str | None:
     """Return the table engine from system.tables, or None on error."""
     try:
@@ -444,16 +586,16 @@ class ClickHouseDatabaseContext(DatabaseContext):
     def column_count(self) -> int:
         """Return column count; for stream-like engines use system.columns if table.schema() is disallowed."""
         if self._direct_select_disallowed:
-            return len(_columns_from_system(self._conn, self._schema, self._table_name))
+            return len(_column_metadata(self._conn, self._schema, self._table_name))
         try:
             return len(self.table.schema())
         except Exception:
-            return len(_columns_from_system(self._conn, self._schema, self._table_name))
+            return len(_column_metadata(self._conn, self._schema, self._table_name))
 
     def columns(self) -> list[dict[str, Any]]:
         """Return column metadata; for stream-like engines use system.columns (no SELECT from table)."""
         if self._direct_select_disallowed:
-            return self._filter_excluded_columns(_columns_from_system(self._conn, self._schema, self._table_name))
+            return self._filter_excluded_columns(_column_metadata(self._conn, self._schema, self._table_name))
         try:
             schema = self.table.schema()
             cols = [
@@ -465,7 +607,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
                 }
                 for name, dtype in schema.items()
             ]
-            system_columns = _columns_from_system(self._conn, self._schema, self._table_name)
+            system_columns = _column_metadata(self._conn, self._schema, self._table_name)
             system_types = {
                 col["name"]: col["type"]
                 for col in system_columns
@@ -499,7 +641,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
                     col["description"] = description
             return self._filter_excluded_columns(cols)
         except Exception:
-            return self._filter_excluded_columns(_columns_from_system(self._conn, self._schema, self._table_name))
+            return self._filter_excluded_columns(_column_metadata(self._conn, self._schema, self._table_name))
 
     def _fetchone(self, result) -> tuple | None:
         """Normalise clickhouse-connect QueryResult objects for profiling queries."""
@@ -614,6 +756,17 @@ class ClickHouseConfig(DatabaseConfig):
         default=True,
         description="Verify TLS certificates when using protocol='native' with secure=True.",
     )
+    tolerate_unreadable_system_tables: bool = Field(
+        default=False,
+        description=(
+            "Work with a credential that cannot read the system database. Needed for Tinybird, "
+            "which serves system tables to ADMIN tokens only, so a token scoped to a few tables "
+            "cannot connect at all. Connection tolerates an unreadable system.settings, and "
+            "schema/table discovery falls back to the tables named outright in `include` — "
+            "wildcard patterns cannot be expanded without a table listing, so list each table. "
+            "Query settings are then validated by the server rather than by the client."
+        ),
+    )
     # System databases are skipped by default unless explicitly included.
     _SYSTEM_DATABASES = frozenset(("INFORMATION_SCHEMA", "information_schema", "system"))
     accessors: list[DatabaseAccessor] = Field(
@@ -674,14 +827,35 @@ class ClickHouseConfig(DatabaseConfig):
         ``clickhouse-driver`` so that nao can talk to ClickHouse instances that
         only expose the native TCP protocol (port 9000 by default).
         """
-        if self.protocol == "native":
-            return self._connect_native()
-        return self._connect_http()
+        backend = self._connect_native() if self.protocol == "native" else self._connect_http()
+        if not self.tolerate_unreadable_system_tables:
+            return backend
+        targets, unexpandable = self._include_targets()
+        return _RestrictedDiscoveryBackend(backend, targets, unexpandable)  # type: ignore[return-value]
+
+    def _include_targets(self) -> tuple[dict[str, list[str]], list[str]]:
+        """Split include into tables named outright and patterns that need a listing to expand."""
+        targets: dict[str, list[str]] = {}
+        unexpandable: list[str] = []
+        for pattern in self.include:
+            schema, separator, table = pattern.partition(".")
+            if any(char in pattern for char in "*?[") or not separator or not table:
+                unexpandable.append(pattern)
+                continue
+            targets.setdefault(schema, []).append(table)
+        return targets, unexpandable
 
     def _connect_http(self) -> BaseBackend:
         from nao_core.deps import require_database_backend
 
         require_database_backend("clickhouse")
+
+        if not self.tolerate_unreadable_system_tables:
+            return self._connect_http_client()
+        with _server_settings_probe_optional():
+            return self._connect_http_client()
+
+    def _connect_http_client(self) -> BaseBackend:
         import ibis
 
         kwargs: dict = {
@@ -763,6 +937,19 @@ class ClickHouseConfig(DatabaseConfig):
         """Use ClickHouse-specific context for resilient preview."""
         return ClickHouseDatabaseContext(conn, schema, table_name)
 
+    def _connection_error_message(self, error: Exception) -> str:
+        """Point at the escape hatch when the connection died on a system database read."""
+        message = str(error)
+        if "system." in message and not self.tolerate_unreadable_system_tables:
+            return (
+                f"{message}\n"
+                "This credential cannot read the system database, which the ClickHouse client "
+                "reads when connecting and when discovering tables. Set "
+                "tolerate_unreadable_system_tables: true on this connection and list the tables "
+                "you want in `include`."
+            )
+        return message
+
     def check_connection(self) -> tuple[bool, str]:
         """Test connectivity to ClickHouse."""
         conn = None
@@ -773,7 +960,7 @@ class ClickHouseConfig(DatabaseConfig):
                 return True, f"Connected successfully ({len(schemas)} databases found)"
             return True, "Connected successfully"
         except Exception as e:
-            return False, str(e)
+            return False, self._connection_error_message(e)
         finally:
             if conn is not None:
                 conn.disconnect()

--- a/cli/tests/nao_core/config/test_clickhouse.py
+++ b/cli/tests/nao_core/config/test_clickhouse.py
@@ -183,6 +183,15 @@ class TestRestrictedDiscovery:
             wrapped.list_tables(database="analytics")
         assert sum("analytics.*" in record.getMessage() for record in caplog.records) == 1
 
+    def test_all_wildcard_include_is_reported_when_databases_are_denied(self, caplog: pytest.LogCaptureFixture) -> None:
+        """With no explicit targets, list_tables is never reached, so list_databases must warn."""
+        backend = MagicMock(name="backend")
+        backend.list_databases.side_effect = RuntimeError(TINYBIRD_FORBIDDEN)
+        wrapped = _RestrictedDiscoveryBackend(backend, {}, ["analytics.*"])
+        with caplog.at_level(logging.WARNING):
+            assert wrapped.list_databases() == []
+        assert any("analytics.*" in record.getMessage() for record in caplog.records)
+
     def test_listings_pass_through_when_the_server_allows_them(self) -> None:
         backend = MagicMock(name="backend")
         backend.list_databases.return_value = ["analytics"]
@@ -289,12 +298,18 @@ class TestColumnMetadata:
         conn = self._conn(RuntimeError("nope"))
         assert _columns_from_describe(conn, "analytics", "users") == []
 
+    def test_backticks_in_identifiers_are_escaped(self) -> None:
+        conn = MagicMock(name="conn")
+        conn.raw_sql.return_value = MagicMock(result_rows=[], column_names=["name"])
+        _columns_from_describe(conn, "we`ird", "ta`ble")
+        assert conn.raw_sql.call_args.args[0] == "DESCRIBE TABLE `we``ird`.`ta``ble`"
+
     def test_system_columns_win_when_available(self) -> None:
         conn = MagicMock(name="conn")
         system_columns = [{"name": "from_system", "type": "String"}]
         with patch("nao_core.config.databases.clickhouse._columns_from_system", return_value=system_columns):
             with patch("nao_core.config.databases.clickhouse._columns_from_describe") as mock_describe:
-                assert _column_metadata(conn, "analytics", "users") == system_columns
+                assert _column_metadata(conn, "analytics", "users", describe_fallback=True) == system_columns
         mock_describe.assert_not_called()
 
     def test_describe_is_used_when_system_columns_is_empty(self) -> None:
@@ -302,7 +317,21 @@ class TestColumnMetadata:
         described = [{"name": "from_describe", "type": "String"}]
         with patch("nao_core.config.databases.clickhouse._columns_from_system", return_value=[]):
             with patch("nao_core.config.databases.clickhouse._columns_from_describe", return_value=described):
-                assert _column_metadata(conn, "analytics", "users") == described
+                assert _column_metadata(conn, "analytics", "users", describe_fallback=True) == described
+
+    def test_describe_is_not_used_unless_opted_in(self) -> None:
+        """With the field off, an empty system.columns must stay empty, as it was before."""
+        conn = MagicMock(name="conn")
+        with patch("nao_core.config.databases.clickhouse._columns_from_system", return_value=[]):
+            with patch("nao_core.config.databases.clickhouse._columns_from_describe") as mock_describe:
+                assert _column_metadata(conn, "analytics", "users") == []
+        mock_describe.assert_not_called()
+
+    def test_context_inherits_the_opt_in_from_config(self) -> None:
+        conn = MagicMock(name="conn")
+        assert _base_config().create_context(conn, "analytics", "users")._describe_fallback is False
+        opted_in = _base_config(tolerate_unreadable_system_tables=True)
+        assert opted_in.create_context(conn, "analytics", "users")._describe_fallback is True
 
 
 def _module(**attributes: Any) -> ModuleType:

--- a/cli/tests/nao_core/config/test_clickhouse.py
+++ b/cli/tests/nao_core/config/test_clickhouse.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import logging
+from types import ModuleType
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from nao_core.config.databases.clickhouse import ClickHouseConfig
+from nao_core.config.databases.clickhouse import (
+    ClickHouseConfig,
+    _column_metadata,
+    _columns_from_describe,
+    _is_server_settings_probe,
+    _RestrictedDiscoveryBackend,
+    _server_settings_probe_optional,
+)
 
 
 def _base_config(**overrides: Any) -> ClickHouseConfig:
@@ -82,3 +91,237 @@ class TestConnectDispatch:
         assert kwargs["send_receive_timeout"] == 60
         assert kwargs["secure"] is True
         assert kwargs["verify"] is False
+
+
+# The query clickhouse-connect runs while constructing a client, unchanged from 0.14 to 1.6.
+SERVER_SETTINGS_PROBE = "SELECT name, value, readonly as readonly FROM system.settings LIMIT 10000"
+
+# Tinybird's response when a non-ADMIN token reads a Service Data Source.
+TINYBIRD_FORBIDDEN = (
+    "HTTP driver received HTTP status 403, server response: Services Data Sources like "
+    "'system.settings' can't be directly accessed without an ADMIN token."
+)
+
+
+class TestServerSettingsProbe:
+    """Servers that refuse system.settings (Tinybird) must still be connectable."""
+
+    def test_probe_is_recognised(self) -> None:
+        assert _is_server_settings_probe(SERVER_SETTINGS_PROBE)
+
+    def test_probe_is_recognised_with_literal_readonly_value(self) -> None:
+        """Pre-19.17 servers get the readonly value inlined instead of the column name."""
+        assert _is_server_settings_probe("SELECT name, value, 0 as readonly FROM system.settings LIMIT 10000")
+
+    def test_user_query_on_system_settings_is_not_the_probe(self) -> None:
+        """A user's own system.settings query must keep raising rather than come back empty."""
+        assert not _is_server_settings_probe("SELECT name, value FROM system.settings WHERE name = 'max_threads'")
+        assert not _is_server_settings_probe("SELECT * FROM system.settings")
+
+    def test_forbidden_probe_falls_back_to_no_settings(self) -> None:
+        client_cls = _fake_http_client_class(raise_on=SERVER_SETTINGS_PROBE)
+        with patch.dict("sys.modules", {"clickhouse_connect.driver.httpclient": _module(HttpClient=client_cls)}):
+            with _server_settings_probe_optional():
+                result = client_cls().query(SERVER_SETTINGS_PROBE)
+        assert list(result.named_results()) == []
+
+    def test_other_failures_still_raise(self) -> None:
+        client_cls = _fake_http_client_class(raise_on="SELECT 1")
+        with patch.dict("sys.modules", {"clickhouse_connect.driver.httpclient": _module(HttpClient=client_cls)}):
+            with _server_settings_probe_optional():
+                with pytest.raises(RuntimeError):
+                    client_cls().query("SELECT 1")
+
+    def test_original_query_method_is_restored(self) -> None:
+        client_cls = _fake_http_client_class(raise_on=SERVER_SETTINGS_PROBE)
+        original = client_cls.query
+        with patch.dict("sys.modules", {"clickhouse_connect.driver.httpclient": _module(HttpClient=client_cls)}):
+            with _server_settings_probe_optional():
+                assert client_cls.query is not original
+        assert client_cls.query is original
+
+    def test_probe_is_not_tolerated_by_default(self) -> None:
+        assert _base_config().tolerate_unreadable_system_tables is False
+
+    def test_error_message_names_the_option(self) -> None:
+        config = _base_config()
+        message = config._connection_error_message(RuntimeError(TINYBIRD_FORBIDDEN))
+        assert "tolerate_unreadable_system_tables" in message
+
+    def test_error_message_is_untouched_once_enabled(self) -> None:
+        config = _base_config(tolerate_unreadable_system_tables=True)
+        message = config._connection_error_message(RuntimeError(TINYBIRD_FORBIDDEN))
+        assert message == TINYBIRD_FORBIDDEN
+
+    def test_unrelated_error_is_untouched(self) -> None:
+        config = _base_config()
+        assert config._connection_error_message(RuntimeError("connection refused")) == "connection refused"
+
+
+class TestRestrictedDiscovery:
+    """When the system database is unreadable, discovery comes from `include`."""
+
+    def test_include_targets_group_tables_by_schema(self) -> None:
+        config = _base_config(include=["analytics.users", "analytics.orders", "telemetry.events"])
+        targets, unexpandable = config._include_targets()
+        assert targets == {"analytics": ["users", "orders"], "telemetry": ["events"]}
+        assert unexpandable == []
+
+    def test_wildcards_and_bare_schemas_are_reported_not_silently_dropped(self) -> None:
+        """A pattern cannot be expanded without the listing that is unavailable."""
+        config = _base_config(include=["analytics.*", "analytics", "analytics.users", "logs.evt_?"])
+        targets, unexpandable = config._include_targets()
+        assert targets == {"analytics": ["users"]}
+        assert unexpandable == ["analytics.*", "analytics", "logs.evt_?"]
+
+    def test_unexpandable_patterns_are_logged_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        backend = MagicMock(name="backend")
+        backend.list_tables.side_effect = RuntimeError(TINYBIRD_FORBIDDEN)
+        wrapped = _RestrictedDiscoveryBackend(backend, {"analytics": ["users"]}, ["analytics.*"])
+        with caplog.at_level(logging.WARNING):
+            wrapped.list_tables(database="analytics")
+            wrapped.list_tables(database="analytics")
+        assert sum("analytics.*" in record.getMessage() for record in caplog.records) == 1
+
+    def test_listings_pass_through_when_the_server_allows_them(self) -> None:
+        backend = MagicMock(name="backend")
+        backend.list_databases.return_value = ["analytics"]
+        backend.list_tables.return_value = ["users", "orders", "audit"]
+        wrapped = _RestrictedDiscoveryBackend(backend, {"analytics": ["users"]})
+        assert wrapped.list_databases() == ["analytics"]
+        assert wrapped.list_tables(database="analytics") == ["users", "orders", "audit"]
+
+    def test_blocked_listings_fall_back_to_include(self) -> None:
+        backend = MagicMock(name="backend")
+        backend.list_databases.side_effect = RuntimeError(TINYBIRD_FORBIDDEN)
+        backend.list_tables.side_effect = RuntimeError(TINYBIRD_FORBIDDEN)
+        wrapped = _RestrictedDiscoveryBackend(backend, {"analytics": ["users", "orders"]})
+        assert wrapped.list_databases() == ["analytics"]
+        assert wrapped.list_tables(database="analytics") == ["users", "orders"]
+
+    def test_blocked_listing_for_unknown_schema_is_empty(self) -> None:
+        backend = MagicMock(name="backend")
+        backend.list_tables.side_effect = RuntimeError(TINYBIRD_FORBIDDEN)
+        wrapped = _RestrictedDiscoveryBackend(backend, {"analytics": ["users"]})
+        assert wrapped.list_tables(database="somewhere_else") == []
+
+    def test_everything_else_is_delegated(self) -> None:
+        backend = MagicMock(name="backend")
+        wrapped = _RestrictedDiscoveryBackend(backend, {})
+        wrapped.raw_sql("SELECT 1")
+        wrapped.disconnect()
+        backend.raw_sql.assert_called_once_with("SELECT 1")
+        backend.disconnect.assert_called_once()
+
+    def test_connection_is_not_wrapped_by_default(self) -> None:
+        config = _base_config()
+        mock_backend = MagicMock(name="ibis_backend")
+        with patch("nao_core.deps.require_database_backend"):
+            with patch.object(ClickHouseConfig, "_connect_http_client", return_value=mock_backend):
+                assert config.connect() is mock_backend
+
+    def test_connection_is_wrapped_when_enabled(self) -> None:
+        config = _base_config(tolerate_unreadable_system_tables=True, include=["analytics.users"])
+        mock_backend = MagicMock(name="ibis_backend")
+        stub = _module(HttpClient=_fake_http_client_class(raise_on=SERVER_SETTINGS_PROBE))
+        with patch.dict("sys.modules", {"clickhouse_connect.driver.httpclient": stub}):
+            with patch("nao_core.deps.require_database_backend"):
+                with patch.object(ClickHouseConfig, "_connect_http_client", return_value=mock_backend):
+                    conn = config.connect()
+        assert isinstance(conn, _RestrictedDiscoveryBackend)
+        assert conn.raw_sql is mock_backend.raw_sql
+
+
+class TestColumnMetadata:
+    """DESCRIBE TABLE covers the same fields as system.columns and needs no system access."""
+
+    def _conn(self, rows: list[dict[str, Any]] | Exception) -> MagicMock:
+        conn = MagicMock(name="conn")
+        cursor = MagicMock(name="cursor")
+        cursor.column_names = ["name", "type", "default_type", "default_expression", "comment"]
+        if isinstance(rows, Exception):
+            conn.raw_sql.side_effect = rows
+        else:
+            cursor.result_rows = [tuple(r[c] for c in cursor.column_names) for r in rows]
+            conn.raw_sql.return_value = cursor
+        return conn
+
+    def test_describe_rows_are_mapped_to_column_metadata(self) -> None:
+        conn = self._conn(
+            [
+                {
+                    "name": "id",
+                    "type": "String",
+                    "default_type": "",
+                    "default_expression": "",
+                    "comment": "primary id",
+                },
+                {
+                    "name": "score",
+                    "type": "Nullable(Float64)",
+                    "default_type": "DEFAULT",
+                    "default_expression": "0",
+                    "comment": "",
+                },
+            ]
+        )
+        columns = _columns_from_describe(conn, "analytics", "users")
+        assert columns == [
+            {
+                "name": "id",
+                "type": "String",
+                "nullable": False,
+                "description": "primary id",
+                "default_kind": None,
+                "default_expression": None,
+            },
+            {
+                "name": "score",
+                "type": "Nullable(Float64)",
+                "nullable": True,
+                "description": None,
+                "default_kind": "DEFAULT",
+                "default_expression": "0",
+            },
+        ]
+
+    def test_describe_failure_is_empty(self) -> None:
+        conn = self._conn(RuntimeError("nope"))
+        assert _columns_from_describe(conn, "analytics", "users") == []
+
+    def test_system_columns_win_when_available(self) -> None:
+        conn = MagicMock(name="conn")
+        system_columns = [{"name": "from_system", "type": "String"}]
+        with patch("nao_core.config.databases.clickhouse._columns_from_system", return_value=system_columns):
+            with patch("nao_core.config.databases.clickhouse._columns_from_describe") as mock_describe:
+                assert _column_metadata(conn, "analytics", "users") == system_columns
+        mock_describe.assert_not_called()
+
+    def test_describe_is_used_when_system_columns_is_empty(self) -> None:
+        conn = MagicMock(name="conn")
+        described = [{"name": "from_describe", "type": "String"}]
+        with patch("nao_core.config.databases.clickhouse._columns_from_system", return_value=[]):
+            with patch("nao_core.config.databases.clickhouse._columns_from_describe", return_value=described):
+                assert _column_metadata(conn, "analytics", "users") == described
+
+
+def _module(**attributes: Any) -> ModuleType:
+    module = ModuleType("stub")
+    for name, value in attributes.items():
+        setattr(module, name, value)
+    return module
+
+
+class _FakeHttpClient:
+    """Stands in for clickhouse-connect's HttpClient, failing on one nominated query."""
+
+    raise_on = ""
+
+    def query(self, sql: str | None = None, *args: Any, **kwargs: Any) -> Any:
+        if sql == self.raise_on:
+            raise RuntimeError(TINYBIRD_FORBIDDEN)
+        return MagicMock(name="query_result")
+
+
+def _fake_http_client_class(raise_on: str) -> type[_FakeHttpClient]:
+    return type("FakeHttpClient", (_FakeHttpClient,), {"raise_on": raise_on})


### PR DESCRIPTION
Closes #1319.

Tinybird serves the `system` database to ADMIN tokens only, so a token scoped to a few tables
can't be used with nao at all. `system.settings` was just the first wall — `system.databases`
and `system.tables` are blocked too, so fixing the connect-time read alone only moves the
failure one step.

The practical effect is that the only credential that can connect is a workspace admin token, meaning that if a guardrail was not fully realised, then a create, update, or delete statement would be actioned on a production database. 

This adds one opt-in field, `tolerate_unreadable_system_tables` (default `false`), which does
three things when the system database is unreadable:

1. **Connect** survives an unreadable `system.settings`. clickhouse-connect reads it inside
   `Client.__init__` to validate query settings, so there's no client to configure beforehand —
   the query method is wrapped for the length of the connection, matching that one query and
   nothing else. A query *you* write against `system.settings` still fails as it should.
2. **Discovery** falls back to the tables named outright in `include`, via a thin wrapper around
   the Ibis backend. No change to the shared sync path, so no other backend is affected.
   Wildcards can't be expanded without a listing, so restricted-token users must name each
   table; any pattern that gets skipped is logged rather than silently dropped.
3. **Column metadata** falls back to `DESCRIBE TABLE`, which returns the same name, type,
   comment and default fields as `system.columns` and needs no system access.

Nothing changes with the flag off, and nothing is lost with it on: the fallbacks are only
reached when the underlying call actually fails, so a server that serves the system database
still gets full listings and `system.columns` metadata.

What a Tinybird token actually needs

This is the second half of #1319 — the minimum-privilege set, established by testing rather than
by reading docs. With the field enabled, nao needs only:

- `SELECT` on each datasource named in `include`
- `DESCRIBE TABLE` on those datasources (column names, types, comments, defaults)

No system-database access at all. `SELECT version(), timezone()` is permitted to any token.
`system.projections` doesn't exist on Tinybird, and every other system read nao attempts already
degrades to `None`, costing only the table comment and the engine/index metadata.

Why not just scope the token instead

Tinybird's error suggests adding the resource to a token with `DATASOURCES:READ`. That doesn't
work for `system.settings` — it can't be granted to a non-ADMIN token, so an ADMIN token
belonging to a named individual is currently the only credential that can connect. That's the
blast radius the issue is about.

Testing

Against a real Tinybird workspace with a read-only token, and a local ClickHouse for regression:

- `nao sync` from the CLI: 15/15 tables across 2 datasets, no errors
- All four templates generated — `columns`, `preview`, `profiling`, `ai_summary`. Profiling
  produced real per-column stats (min/max/distinct/nulls/stddev, top values for
  `LowCardinality`) over a 242k-row table
- `/execute_sql` on the FastAPI sidecar (the chat path): real aggregates returned, dialect
  detected as `clickhouse`
- ClickHouse sync integration suite: identical before and after — 23 passed, 3 skipped — on
  clickhouse-connect 1.6.0 and 0.14.1
- Full `cli` unit suite: same 25 pre-existing env-related failures before and after, +23 new
  tests passing
- New unit tests pass on Python 3.13 and 3.12, and without the `clickhouse` extra installed
- `ruff check`, `ruff check --select I`, `ruff format --check` clean apart from pre-existing
  findings

Notes for review

- The connect-time wrapper is a workaround for a third-party constraint. clickhouse-connect
  already tolerates the adjacent `client_protocol_version` probe failing
  (`_backend/orchestration.py`); the same treatment for the settings probe would remove the need
  for that piece. Happy to send that upstream separately — parts 2 and 3 belong here regardless.
- ClickHouse isn't in `DATABASE_CONFIGS` in `scripts/generate-config-docs.py` (nor MySQL, Fabric
  or StarRocks), so no ClickHouse option appears in the generated config reference and this new
  one won't either. Left alone here since it's pre-existing and unrelated — happy to raise it
  separately if useful.
- One behaviour change worth knowing: with a live listing, an `include` entry naming a table that
  doesn't exist is silently filtered out. When discovery falls back to `include`, the name is
  trusted, so it surfaces as a logged per-table error and a `columns.md` containing that error
  instead. Louder rather than silent, which seems right when `include` is the source of truth,
  but it is a difference.
- Two new `BLE001` blind-excepts, consistent with the 13 already in this file. `ty` wants
  `setattr` where ruff's B010 wants direct assignment; I went with ruff, since that's what CI
  runs.

This PR was written using Claude Opus 5 (claude-opus-5).
