### PR TITLE
Solve crop data labels bug

### DIFF
--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -508,7 +508,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 		if(/^\\d{4}-\\d{2}-\\d{2}/.test(str)){var d=new Date(str);if(!isNaN(d.getTime()))return escHtml(formatDate(d))}
 		return escHtml(str.replace(/_/g,' ').replace(/\\b\\w/g,function(c){return c.toUpperCase()}))
 	}
-	function formatCompact(v){var a=Math.abs(v);if(a>=1e9)return (v/1e9).toFixed(1).replace(/[.]0$/,'')+'B';if(a>=1e6)return (v/1e6).toFixed(1).replace(/[.]0$/,'')+'M';if(a>=1e4)return (v/1e3).toFixed(1).replace(/[.]0$/,'')+'K';return v.toLocaleString()}
+	function formatCompact(v){var a=Math.abs(v);if(a>=1e9)return (v/1e9).toFixed(1).replace(/[.]0$/,'')+'B';if(a>=1e6)return (v/1e6).toFixed(1).replace(/[.]0$/,'')+'M';if(a>=1e4)return (v/1e3).toFixed(1).replace(/[.]0$/,'')+'K';return v.toLocaleString('en-US')}
 	// Faithful port of d3-format's SI-prefix formatting so exported values match the chart.
 	var SI_PREFIXES=['y','z','a','f','p','n','µ','m','','k','M','G','T','P','E','Z','Y'];
 	var siPrefixExponent=0;
@@ -551,9 +551,9 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 		var fixed=/^(,)?(?:\\.([0-9]+))?f$/.exec(spec);
 		if(fixed){
 			var decimals=fixed[2]===undefined?6:Number(fixed[2]);
-			return fixed[1]?v.toLocaleString(undefined,{minimumFractionDigits:decimals,maximumFractionDigits:decimals}):v.toFixed(decimals);
+			return fixed[1]?v.toLocaleString('en-US',{minimumFractionDigits:decimals,maximumFractionDigits:decimals}):v.toFixed(decimals);
 		}
-		if(spec===',')return v.toLocaleString();
+		if(spec===',')return v.toLocaleString('en-US');
 		var si=/^\\.?([0-9]+)?(~)?s$/.exec(spec);
 		if(si)return formatSi(v,si[1]===undefined?undefined:Number(si[1]),si[2]==='~',compact);
 		return formatCompact(v);

--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -1,4 +1,10 @@
-import { formatChartValue, formatCompactNumber, formatPercentShare, sumPercentStackBase } from '@nao/shared';
+import {
+	CHART_NUMBER_LOCALE,
+	formatChartValue,
+	formatCompactNumber,
+	formatPercentShare,
+	sumPercentStackBase,
+} from '@nao/shared';
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
 import type { Payload } from 'recharts/types/component/DefaultLegendContent';
@@ -252,7 +258,7 @@ function ChartTooltipContent({
 														: formatChartValue(item.value, itemConfig?.valueFormat, {
 																compact: true,
 															})
-													: item.value.toLocaleString()}
+													: item.value.toLocaleString(CHART_NUMBER_LOCALE)}
 											</span>
 										)}
 									</div>

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -32,7 +32,7 @@ import {
 	shouldReserveDataLabelHeadroom,
 	shouldReserveStackTotalFootroom,
 } from './chart-data-labels';
-import { collectAxisValues, collectStackedAxisValues, resolveYAxisDomain } from './chart-domain';
+import { collectAxisValues, collectStackedAxisValues, resolveBarYAxisDomain, resolveYAxisDomain } from './chart-domain';
 import {
 	attachValueAffixes,
 	formatChartValue,
@@ -623,7 +623,11 @@ function buildBarChart(props: ResolvedProps) {
 	const separatorColor = props.backgroundColor ?? DEFAULT_BACKGROUND;
 	const labelFootroom = shouldReserveStackTotalFootroom(props) ? DATA_LABEL_X_AXIS_FOOTROOM : 0;
 	const chartLevelFormat = getChartLevelValueFormat(series);
-	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat, Boolean(yAxisLabel));
+	const yAxisDomain = isPercent
+		? undefined
+		: resolveBarYAxisDomain(yAxisMin, yAxisMax, axisValues, showDataLabels === true);
+	const valueAxisValues = typeof yAxisDomain?.[1] === 'number' ? [...axisValues, yAxisDomain[1]] : axisValues;
+	const valueAxisWidth = computeValueAxisWidth(valueAxisValues, chartLevelFormat, Boolean(yAxisLabel));
 	const dataLabelsLayer = showDataLabels && !isStacked ? renderDataLabelsLayer(series) : undefined;
 
 	return (
@@ -639,7 +643,7 @@ function buildBarChart(props: ResolvedProps) {
 					axisLine={false}
 					minTickGap={12}
 					tickFormatter={(value: number) => formatValueYAxisTick(value, chartLevelFormat)}
-					domain={resolveYAxisDomain(yAxisMin, yAxisMax, axisValues, true)}
+					domain={yAxisDomain}
 					allowDataOverflow={yAxisMin !== undefined || yAxisMax !== undefined}
 					label={axisLabel(yAxisLabel, 'left')}
 				/>

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -616,9 +616,9 @@ function buildBarChart(props: ResolvedProps) {
 	} = props;
 	const isStacked = displayChart.isStackedChartType(chartType);
 	const isPercent = displayChart.isPercentStackedChartType(chartType);
-	const dataKeys = series.map((s) => s.data_key);
-	const axisValues = isStacked ? collectStackedAxisValues(data, dataKeys) : collectAxisValues(data, dataKeys);
 	const { renderedSeries, stackTotalLayer } = getDataLabelSetup(props, isStacked);
+	const dataKeys = renderedSeries.map((s) => s.data_key);
+	const axisValues = isStacked ? collectStackedAxisValues(data, dataKeys) : collectAxisValues(data, dataKeys);
 	const seriesKeys = renderedSeries.map((s) => s.data_key);
 	const separatorColor = props.backgroundColor ?? DEFAULT_BACKGROUND;
 	const labelFootroom = shouldReserveStackTotalFootroom(props) ? DATA_LABEL_X_AXIS_FOOTROOM : 0;
@@ -746,9 +746,9 @@ function buildAreaChart(props: ResolvedProps) {
 	const isStacked = displayChart.isStackedChartType(chartType);
 	const isPercent = displayChart.isPercentStackedChartType(chartType);
 	const zeroBaseline = chartType !== 'line';
-	const dataKeys = series.map((s) => s.data_key);
-	const axisValues = isStacked ? collectStackedAxisValues(data, dataKeys) : collectAxisValues(data, dataKeys);
 	const { renderedSeries, stackTotalLayer } = getDataLabelSetup(props, isStacked);
+	const dataKeys = renderedSeries.map((s) => s.data_key);
+	const axisValues = isStacked ? collectStackedAxisValues(data, dataKeys) : collectAxisValues(data, dataKeys);
 	const labelFootroom = shouldReserveStackTotalFootroom(props) ? DATA_LABEL_X_AXIS_FOOTROOM : 0;
 	const chartLevelFormat = getChartLevelValueFormat(series);
 	const valueAxisWidth = computeValueAxisWidth(axisValues, chartLevelFormat, Boolean(yAxisLabel));

--- a/apps/shared/src/chart-data-labels.tsx
+++ b/apps/shared/src/chart-data-labels.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { barYAxisDomainIsPadded, collectAxisValues, collectStackedAxisValues } from './chart-domain';
 import { formatChartValue, getChartLevelValueFormat, niceAxisMax, toFiniteNumber } from './chart-values';
 import * as displayChart from './tools/display-chart';
 
@@ -30,6 +31,8 @@ interface DataLabelChartProps {
 	series: displayChart.SeriesConfig[];
 	chartType: displayChart.ChartType;
 	showDataLabels?: boolean;
+	yAxisMin?: number;
+	yAxisMax?: number;
 }
 
 interface PlotRect {
@@ -107,8 +110,9 @@ export function shouldReserveDataLabelHeadroom<Props extends DataLabelChartProps
 	if (props.showDataLabels !== true || !isCartesianLabelChart(props.chartType)) {
 		return false;
 	}
-	// Stacked charts label the running total at the very top of the stack, which can sit flush against
-	// the axis top, so always keep room for that label rather than relying on the axis-headroom ratio.
+	if (barChartUsesPaddedDomain(props)) {
+		return false;
+	}
 	if (displayChart.isStackedChartType(props.chartType)) {
 		return true;
 	}
@@ -134,19 +138,21 @@ export function shouldReserveStackTotalFootroom<Props extends DataLabelChartProp
 
 /** Coordinates cartesian labels across series so conflicts can be dropped without moving labels. */
 export function renderDataLabelsLayer(series: displayChart.SeriesConfig[]) {
-	return createLabelsLayer('DataLabelsLayer', ({ formattedGraphicalItems, offset }) =>
-		collectLabelCandidates(formattedGraphicalItems ?? [], offset ?? {}, series),
+	return createLabelsLayer('DataLabelsLayer', ({ formattedGraphicalItems, offset, width, height }) =>
+		collectLabelCandidates(formattedGraphicalItems ?? [], offset ?? {}, width, height, series),
 	);
 }
 
 export function renderStackTotalLabelsLayer(data: Record<string, unknown>[], series: displayChart.SeriesConfig[]) {
 	const valueFormat = getChartLevelValueFormat(series);
-	return createLabelsLayer('StackTotalLabelsLayer', ({ formattedGraphicalItems, offset }) => {
+	return createLabelsLayer('StackTotalLabelsLayer', ({ formattedGraphicalItems, offset, width, height }) => {
 		const items = (formattedGraphicalItems ?? []).filter((entry) =>
 			LABELLED_SERIES_KINDS.has(entry.item?.type?.displayName ?? ''),
 		);
 		const kind = items[0]?.item?.type?.displayName;
-		return kind ? stackTotalCandidates(items, data, series, kind === 'Bar', offset ?? {}, valueFormat) : [];
+		return kind
+			? stackTotalCandidates(items, data, series, kind === 'Bar', offset ?? {}, width, height, valueFormat)
+			: [];
 	});
 }
 
@@ -209,6 +215,18 @@ function isCartesianLabelChart(chartType: displayChart.ChartType): boolean {
 	);
 }
 
+function barChartUsesPaddedDomain(props: DataLabelChartProps): boolean {
+	if (props.chartType !== 'bar' && props.chartType !== 'stacked_bar') {
+		return false;
+	}
+	const dataKeys = props.series.map((series) => series.data_key);
+	const axisValues =
+		props.chartType === 'stacked_bar'
+			? collectStackedAxisValues(props.data, dataKeys)
+			: collectAxisValues(props.data, dataKeys);
+	return barYAxisDomainIsPadded(props.yAxisMax, axisValues, props.showDataLabels === true);
+}
+
 function getMaxPlottedValue(props: DataLabelChartProps): number | null {
 	const isStacked = displayChart.isStackedChartType(props.chartType);
 	let max: number | null = null;
@@ -259,6 +277,8 @@ function stackTotalCandidates(
 	series: displayChart.SeriesConfig[],
 	isBar: boolean,
 	plot: PlotRect,
+	chartWidth: number | undefined,
+	chartHeight: number | undefined,
 	valueFormat?: displayChart.ValueFormat,
 ): LabelCandidate[] {
 	const totals = data.map((row) => sumStackValue(row, series));
@@ -281,7 +301,12 @@ function stackTotalCandidates(
 			formatDataLabel(total, valueFormat),
 			cartesianLabelRank(isLocalExtremum(totals, dataIndex), 0, anchor.cx),
 			{
-				bounds: cartesianLabelBounds(plot, isPositive ? 0 : DATA_LABEL_X_AXIS_FOOTROOM),
+				bounds: cartesianLabelBounds(
+					plot,
+					chartWidth,
+					chartHeight,
+					isPositive ? 0 : DATA_LABEL_X_AXIS_FOOTROOM,
+				),
 			},
 		);
 		return candidate ? [candidate] : [];
@@ -346,6 +371,8 @@ function collectPieLabelCandidates(
 function collectLabelCandidates(
 	items: GraphicalItem[],
 	plot: PlotRect,
+	chartWidth: number | undefined,
+	chartHeight: number | undefined,
 	series: displayChart.SeriesConfig[],
 ): LabelCandidate[] {
 	const graphicalItems = items.filter((entry) => LABELLED_SERIES_KINDS.has(entry.item?.type?.displayName ?? ''));
@@ -367,6 +394,8 @@ function collectLabelCandidates(
 			kind === 'Bar',
 			seriesIndex,
 			plot,
+			chartWidth,
+			chartHeight,
 			seriesConfig?.value_format,
 		);
 	});
@@ -378,6 +407,8 @@ function seriesCandidates(
 	isBar: boolean,
 	seriesIndex: number,
 	plot: PlotRect,
+	chartWidth: number | undefined,
+	chartHeight: number | undefined,
 	valueFormat?: displayChart.ValueFormat,
 ): LabelCandidate[] {
 	const candidates = points.flatMap((point, index): IndexedLabelCandidate[] => {
@@ -398,7 +429,7 @@ function seriesCandidates(
 			anchor.baselineY,
 			text,
 			cartesianLabelRank(isLocalExtremum(values, index), seriesIndex, anchor.cx),
-			{ bounds: cartesianLabelBounds(plot) },
+			{ bounds: cartesianLabelBounds(plot, chartWidth, chartHeight) },
 		);
 		return candidate ? [{ candidate, index, value }] : [];
 	});
@@ -470,8 +501,9 @@ function buildLabelCandidate(
 	rank: number[],
 	options: LabelCandidateOptions,
 ): LabelCandidate | null {
-	const textAnchor = options.textAnchor ?? 'middle';
 	const halfWidth = (text.length * DATA_LABEL_FONT_SIZE * DATA_LABEL_CHAR_WIDTH_RATIO) / 2;
+	const middleBox = labelBox(cx, baselineY, halfWidth);
+	const textAnchor = options.textAnchor ?? selectTextAnchor(middleBox, options.bounds);
 	const box = labelBox(cx, baselineY, halfWidth, textAnchor);
 	if (!boxFitsBounds(box, options.bounds)) {
 		return null;
@@ -558,15 +590,27 @@ function cartesianLabelRank(isExtremum: boolean, seriesIndex: number, x: number)
 	return [isExtremum ? 1 : 0, -seriesIndex, -x];
 }
 
-function cartesianLabelBounds(plot: PlotRect, bottomAllowance = 0): LabelBox {
+function selectTextAnchor(middleBox: LabelBox, bounds: LabelBox): LabelCandidate['textAnchor'] {
+	if (middleBox.right > bounds.right) {
+		return 'end';
+	}
+	if (middleBox.left < bounds.left) {
+		return 'start';
+	}
+	return 'middle';
+}
+
+function cartesianLabelBounds(
+	plot: PlotRect,
+	chartWidth: number | undefined,
+	chartHeight: number | undefined,
+	bottomAllowance = 0,
+): LabelBox {
 	return {
-		left: plot.left ?? Number.NEGATIVE_INFINITY,
-		right: plot.left != null && plot.width != null ? plot.left + plot.width : Number.POSITIVE_INFINITY,
-		top: plot.top != null ? Math.max(0, plot.top - DATA_LABEL_MARGIN_TOP) : Number.NEGATIVE_INFINITY,
-		bottom:
-			plot.top != null && plot.height != null
-				? plot.top + plot.height + bottomAllowance
-				: Number.POSITIVE_INFINITY,
+		left: plot.left ?? 0,
+		right: plot.left != null && plot.width != null ? plot.left + plot.width : (chartWidth ?? 0),
+		top: plot.top != null ? Math.max(0, plot.top - DATA_LABEL_MARGIN_TOP) : 0,
+		bottom: plot.top != null && plot.height != null ? plot.top + plot.height + bottomAllowance : (chartHeight ?? 0),
 	};
 }
 
@@ -583,8 +627,8 @@ function labelBox(
 	const left = textAnchor === 'start' ? cx : textAnchor === 'end' ? cx - halfWidth * 2 : cx - halfWidth;
 	const right = textAnchor === 'start' ? cx + halfWidth * 2 : textAnchor === 'end' ? cx : cx + halfWidth;
 	return {
-		left: left - DATA_LABEL_BOX_PADDING,
-		right: right + DATA_LABEL_BOX_PADDING,
+		left: left - (textAnchor === 'start' ? 0 : DATA_LABEL_BOX_PADDING),
+		right: right + (textAnchor === 'end' ? 0 : DATA_LABEL_BOX_PADDING),
 		top: baselineY - DATA_LABEL_FONT_SIZE - DATA_LABEL_BOX_PADDING,
 		bottom: baselineY + DATA_LABEL_BOX_PADDING,
 	};

--- a/apps/shared/src/chart-data-labels.tsx
+++ b/apps/shared/src/chart-data-labels.tsx
@@ -167,12 +167,16 @@ export function getDataLabelSetup<Props extends Pick<DataLabelChartProps, 'data'
 	props: Props,
 	isStacked: boolean,
 ) {
-	const renderedSeries = isStacked ? props.series.filter((item) => !item.is_total) : props.series;
+	const renderedSeries = getRenderedSeries(props.series, isStacked);
 	const stackTotalLayer =
 		props.showDataLabels && isStacked && renderedSeries.length > 0
 			? renderStackTotalLabelsLayer(props.data, props.series)
 			: undefined;
 	return { renderedSeries, stackTotalLayer };
+}
+
+export function getRenderedSeries(series: displayChart.SeriesConfig[], isStacked: boolean) {
+	return isStacked ? series.filter((item) => !item.is_total) : series;
 }
 
 function createLabelsLayer(displayName: string, collect: LabelsCollector) {
@@ -219,11 +223,11 @@ function barChartUsesPaddedDomain(props: DataLabelChartProps): boolean {
 	if (props.chartType !== 'bar' && props.chartType !== 'stacked_bar') {
 		return false;
 	}
-	const dataKeys = props.series.map((series) => series.data_key);
-	const axisValues =
-		props.chartType === 'stacked_bar'
-			? collectStackedAxisValues(props.data, dataKeys)
-			: collectAxisValues(props.data, dataKeys);
+	const isStacked = props.chartType === 'stacked_bar';
+	const dataKeys = getRenderedSeries(props.series, isStacked).map((series) => series.data_key);
+	const axisValues = isStacked
+		? collectStackedAxisValues(props.data, dataKeys)
+		: collectAxisValues(props.data, dataKeys);
 	return barYAxisDomainIsPadded(props.yAxisMax, axisValues, props.showDataLabels === true);
 }
 

--- a/apps/shared/src/chart-domain.ts
+++ b/apps/shared/src/chart-domain.ts
@@ -102,7 +102,8 @@ export function resolveBarYAxisDomain(
 
 	const dataMax = maxOf(values);
 	const paddedTop = niceAxisMax(dataMax / (1 - DATA_LABEL_HEADROOM_FRACTION));
-	return [explicitMin ?? 0, paddedTop];
+	const lower = explicitMin ?? 0;
+	return paddedTop > lower ? [lower, paddedTop] : domain;
 }
 
 export function barYAxisDomainIsPadded(

--- a/apps/shared/src/chart-domain.ts
+++ b/apps/shared/src/chart-domain.ts
@@ -1,3 +1,7 @@
+import { niceAxisMax } from './chart-values';
+
+export const DATA_LABEL_HEADROOM_FRACTION = 0.15;
+
 export function niceNumber(range: number, round: boolean): number {
 	if (range <= 0 || !Number.isFinite(range)) {
 		return 1;
@@ -83,6 +87,36 @@ export function resolveYAxisDomain(
 	}
 
 	return [lowerValue, upperValue];
+}
+
+export function resolveBarYAxisDomain(
+	explicitMin: number | undefined,
+	explicitMax: number | undefined,
+	values: number[],
+	showDataLabels: boolean,
+): [number | 'auto', number | 'auto'] | undefined {
+	const domain = resolveYAxisDomain(explicitMin, explicitMax, values, true);
+	if (!barYAxisDomainIsPadded(explicitMax, values, showDataLabels)) {
+		return domain;
+	}
+
+	const dataMax = maxOf(values);
+	const paddedTop = niceAxisMax(dataMax / (1 - DATA_LABEL_HEADROOM_FRACTION));
+	return [explicitMin ?? 0, paddedTop];
+}
+
+export function barYAxisDomainIsPadded(
+	explicitMax: number | undefined,
+	values: number[],
+	showDataLabels: boolean,
+): boolean {
+	return (
+		showDataLabels &&
+		explicitMax === undefined &&
+		values.length > 0 &&
+		values.every((value) => value >= 0) &&
+		maxOf(values) > 0
+	);
 }
 
 function computeNiceDomainFromValues(values: number[]): [number, number] {

--- a/apps/shared/src/chart-values.ts
+++ b/apps/shared/src/chart-values.ts
@@ -2,6 +2,8 @@ import { format as d3Format, formatSpecifier } from 'd3-format';
 
 import type { ValueFormat } from './tools/display-chart';
 
+export const CHART_NUMBER_LOCALE = 'en-US';
+
 const COMPACT_UNITS = [
 	{ value: 1_000_000_000_000, suffix: 'T' },
 	{ value: 1_000_000_000, suffix: 'B' },
@@ -14,7 +16,7 @@ export function formatCompactNumber(value: number): string {
 	if (abs >= 10_000) {
 		return formatCompactUnit(value, 1);
 	}
-	return value.toLocaleString();
+	return value.toLocaleString(CHART_NUMBER_LOCALE);
 }
 
 export function formatCompactUnit(value: number, fractionDigits: number): string {
@@ -36,7 +38,7 @@ export function formatCompactUnit(value: number, fractionDigits: number): string
 
 export function formatChartValue(value: number, valueFormat?: ValueFormat, opts?: { compact?: boolean }): string {
 	const formatted = formatWithD3(value, valueFormat);
-	const body = formatted ?? (opts?.compact ? formatCompactNumber(value) : value.toLocaleString());
+	const body = formatted ?? (opts?.compact ? formatCompactNumber(value) : value.toLocaleString(CHART_NUMBER_LOCALE));
 	return attachValueAffixes(body, valueFormat);
 }
 

--- a/apps/shared/tests/chart-builder-data-labels.test.tsx
+++ b/apps/shared/tests/chart-builder-data-labels.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildChart } from '../src/chart-builder';
 import { shouldReserveDataLabelHeadroom } from '../src/chart-data-labels';
+import { resolveBarYAxisDomain } from '../src/chart-domain';
 import { niceAxisMax } from '../src/chart-values';
 
 function renderChart(element: React.ReactElement) {
@@ -43,8 +44,8 @@ function parseDataLabels(html: string): RenderedLabel[] {
 			y,
 			text,
 			textAnchor,
-			left: left - 2,
-			right: right + 2,
+			left: left - (textAnchor === 'start' ? 0 : 2),
+			right: right + (textAnchor === 'end' ? 0 : 2),
 			top: y - 11 - 2,
 			bottom: y + 2,
 		});
@@ -116,18 +117,82 @@ function expectLabelsInsideSvg(labels: RenderedLabel[], width: number, height: n
 	}
 }
 
+function expectLabelsInsidePlot(labels: RenderedLabel[], plot: ReturnType<typeof parsePlotRect>) {
+	for (const label of labels) {
+		expect(label.left).toBeGreaterThanOrEqual(plot.left - 0.5);
+		expect(label.right).toBeLessThanOrEqual(plot.right + 0.5);
+		expect(label.top).toBeGreaterThanOrEqual(plot.top - 0.5);
+		expect(label.bottom).toBeLessThanOrEqual(plot.bottom + 0.5);
+	}
+}
+
+const EDGE_LABEL_DATA = [79, 604, 769, 1057, 1220, 1349, 1449].map((value, index) => ({
+	month: `2026-${String(index + 1).padStart(2, '0')}`,
+	value,
+}));
+
+function renderEdgeLabelChart(chartType: 'area' | 'line', width = 980, height = 260) {
+	return renderChartAtSize(
+		buildChart({
+			data: EDGE_LABEL_DATA,
+			chartType,
+			xAxisKey: 'month',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+			showDataLabels: true,
+			margin: { top: 0, right: 0, bottom: 0, left: 0 },
+		}),
+		width,
+		height,
+	);
+}
+
 describe('buildChart data labels', () => {
+	it('keeps the full last area label inside the chart', () => {
+		const width = 980;
+		const height = 260;
+		const labels = parseDataLabels(renderEdgeLabelChart('area', width, height));
+		const lastLabel = labels.find((label) => label.text === '1,449');
+
+		expect(lastLabel).toBeDefined();
+		expect(lastLabel!.textAnchor).toBe('end');
+		expectLabelsInsideSvg(labels, width, height);
+		expect(hasOverlap(labels)).toBe(false);
+	});
+
+	it('keeps the full last line label inside the chart', () => {
+		const width = 980;
+		const height = 260;
+		const labels = parseDataLabels(renderEdgeLabelChart('line', width, height));
+		const lastLabel = labels.find((label) => label.text === '1,449');
+
+		expect(lastLabel).toBeDefined();
+		expect(lastLabel!.textAnchor).toBe('end');
+		expectLabelsInsideSvg(labels, width, height);
+	});
+
+	it('keeps the first point label inside the left edge', () => {
+		const width = 980;
+		const height = 260;
+		const labels = parseDataLabels(renderEdgeLabelChart('area', width, height));
+		const firstLabel = labels.find((label) => label.text === '79');
+
+		expect(firstLabel).toBeDefined();
+		expect(firstLabel!.textAnchor).toBe('start');
+		expectLabelsInsideSvg([firstLabel!], width, height);
+	});
+
 	it('rounds axis max using nice tick steps', () => {
 		expect(niceAxisMax(622)).toBe(800);
 		expect(niceAxisMax(780)).toBe(800);
 		expect(niceAxisMax(460)).toBe(600);
 	});
 
-	it('does not reserve headroom when labels fit below the nice axis top', () => {
+	it('does not reserve area headroom when labels fit below the nice axis top', () => {
 		expect(
 			shouldReserveDataLabelHeadroom({
 				data: [{ m: 'a', v: 460 }],
-				chartType: 'bar',
+				chartType: 'area',
 				xAxisKey: 'm',
 				series: [{ data_key: 'v' }],
 				showDataLabels: true,
@@ -135,7 +200,7 @@ describe('buildChart data labels', () => {
 		).toBe(false);
 	});
 
-	it('reserves headroom when labels are close to the nice axis top', () => {
+	it('does not reserve margin headroom for bar charts', () => {
 		expect(
 			shouldReserveDataLabelHeadroom({
 				data: [{ m: 'a', v: 780 }],
@@ -144,7 +209,7 @@ describe('buildChart data labels', () => {
 				series: [{ data_key: 'v' }],
 				showDataLabels: true,
 			}),
-		).toBe(true);
+		).toBe(false);
 	});
 
 	it('does not reserve headroom when data labels are disabled', () => {
@@ -174,6 +239,135 @@ describe('buildChart data labels', () => {
 			expect(parseDataLabels(renderChart(buildChart(props))).some((label) => label.text === '100')).toBe(true);
 		},
 	);
+
+	it.each(['line', 'area', 'mixed'] as const)('keeps margin headroom behavior for %s charts', (chartType) => {
+		expect(
+			shouldReserveDataLabelHeadroom({
+				data: [{ m: 'a', v: 780 }],
+				chartType,
+				xAxisKey: 'm',
+				series: [{ data_key: 'v' }],
+				showDataLabels: true,
+			}),
+		).toBe(true);
+	});
+
+	it('renders the tallest bar label inside a short plot', () => {
+		const width = 600;
+		const height = 200;
+		expect(resolveBarYAxisDomain(undefined, undefined, [250, 500], true)).toEqual([0, 600]);
+		const html = renderChartAtSize(
+			buildChart({
+				data: [
+					{ month: 'Jan', sales: 250 },
+					{ month: 'Feb', sales: 500 },
+				],
+				chartType: 'bar',
+				xAxisKey: 'month',
+				xAxisType: 'category',
+				series: [{ data_key: 'sales' }],
+				showDataLabels: true,
+			}),
+			width,
+			height,
+		);
+		const labels = parseDataLabels(html);
+		const plot = parsePlotRect(html);
+
+		expect(labels.some((label) => label.text === '500')).toBe(true);
+		expect(labels.every((label) => label.textAnchor === 'middle')).toBe(true);
+		expectLabelsInsideSvg(labels, width, height);
+		expectLabelsInsidePlot(labels, plot);
+	});
+
+	it('keeps an explicit y-axis maximum instead of padding it', () => {
+		expect(resolveBarYAxisDomain(undefined, 500, [250, 500], true)).toEqual([0, 500]);
+	});
+
+	it('falls back to margin headroom when an explicit maximum disables padding', () => {
+		expect(
+			shouldReserveDataLabelHeadroom({
+				data: [{ month: 'Jan', sales: 780 }],
+				chartType: 'bar',
+				xAxisKey: 'month',
+				series: [{ data_key: 'sales' }],
+				showDataLabels: true,
+				yAxisMax: 780,
+			}),
+		).toBe(true);
+		expect(
+			shouldReserveDataLabelHeadroom({
+				data: [{ month: 'Jan', direct: 200, partner: 300 }],
+				chartType: 'stacked_bar',
+				xAxisKey: 'month',
+				series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+				showDataLabels: true,
+				yAxisMax: 500,
+			}),
+		).toBe(true);
+	});
+
+	it('keeps bar plot geometry independent of data labels', () => {
+		const props = {
+			data: [
+				{ month: 'Jan', sales: 250 },
+				{ month: 'Feb', sales: 500 },
+			],
+			chartType: 'bar' as const,
+			xAxisKey: 'month',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'sales' }],
+		};
+		const labelsOn = renderChartAtSize(buildChart({ ...props, showDataLabels: true }), 600, 200);
+		const labelsOff = renderChartAtSize(buildChart({ ...props, showDataLabels: false }), 600, 200);
+
+		expect(parsePlotRect(labelsOn)).toEqual(parsePlotRect(labelsOff));
+	});
+
+	it('does not pad a bar domain containing negative values', () => {
+		expect(resolveBarYAxisDomain(undefined, undefined, [-50, 500], true)).toBeUndefined();
+	});
+
+	it('keeps the top label for a bar chart containing negative values', () => {
+		const width = 600;
+		const height = 200;
+		const props = {
+			data: [
+				{ month: 'Jan', sales: -50 },
+				{ month: 'Feb', sales: 780 },
+			],
+			chartType: 'bar' as const,
+			xAxisKey: 'month',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'sales' }],
+			showDataLabels: true,
+		};
+		const html = renderChartAtSize(buildChart(props), width, height);
+		const topLabel = parseDataLabels(html).find((label) => label.text === '780');
+
+		expect(shouldReserveDataLabelHeadroom(props)).toBe(true);
+		expect(topLabel).toBeDefined();
+		expectLabelsInsideSvg([topLabel!], width, height);
+	});
+
+	it('renders a stacked bar total without changing plot geometry', () => {
+		const props = {
+			data: [
+				{ month: 'Jan', direct: 100, partner: 150 },
+				{ month: 'Feb', direct: 200, partner: 300 },
+			],
+			chartType: 'stacked_bar' as const,
+			xAxisKey: 'month',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+		};
+		const labelsOn = renderChartAtSize(buildChart({ ...props, showDataLabels: true }), 600, 200);
+		const labelsOff = renderChartAtSize(buildChart({ ...props, showDataLabels: false }), 600, 200);
+
+		expect(parseDataLabels(labelsOn).some((label) => label.text === '500')).toBe(true);
+		expect(parsePlotRect(labelsOn)).toEqual(parsePlotRect(labelsOff));
+		expect(shouldReserveDataLabelHeadroom({ ...props, showDataLabels: true })).toBe(false);
+	});
 
 	it('renders x and y axes for cartesian charts', () => {
 		const html = renderChart(
@@ -561,6 +755,7 @@ describe('buildChart data labels', () => {
 
 			expect(positive).toBeDefined();
 			expect(negative).toBeDefined();
+			expectLabelsInsideSvg([positive!], 600, 400);
 			expect(positive!.y).toBeLessThan(plot.top);
 			expect(negative!.y).toBeGreaterThan(plot.bottom);
 			expect(negative!.bottom).toBeLessThan(parseXAxisTickY(html));

--- a/apps/shared/tests/chart-builder-data-labels.test.tsx
+++ b/apps/shared/tests/chart-builder-data-labels.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { buildChart } from '../src/chart-builder';
 import { shouldReserveDataLabelHeadroom } from '../src/chart-data-labels';
 import { resolveBarYAxisDomain } from '../src/chart-domain';
-import { niceAxisMax } from '../src/chart-values';
+import { CHART_NUMBER_LOCALE, niceAxisMax } from '../src/chart-values';
 
 function renderChart(element: React.ReactElement) {
 	return renderToString(React.cloneElement(element, { width: 600, height: 400 }));
@@ -13,6 +13,20 @@ function renderChart(element: React.ReactElement) {
 
 function renderChartAtSize(element: React.ReactElement, width: number, height: number) {
 	return renderToString(React.cloneElement(element, { width, height }));
+}
+
+function getYAxis(chart: React.ReactElement): React.ReactElement | undefined {
+	return flattenChildren(chart.props.children).find((child) => child.type.displayName === 'YAxis');
+}
+
+function flattenChildren(children: unknown): React.ReactElement[] {
+	if (Array.isArray(children)) {
+		return children.flatMap(flattenChildren);
+	}
+	if (React.isValidElement(children)) {
+		return [children];
+	}
+	return [];
 }
 
 interface RenderedLabel {
@@ -284,6 +298,61 @@ describe('buildChart data labels', () => {
 		expect(resolveBarYAxisDomain(undefined, 500, [250, 500], true)).toEqual([0, 500]);
 	});
 
+	it('does not let a total series inflate the stacked bar domain', () => {
+		const props = {
+			data: [{ month: 'Jan', direct: 100, partner: 200, total: 300 }],
+			chartType: 'stacked_bar' as const,
+			xAxisKey: 'month',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+			showDataLabels: true,
+		};
+		const domainWithoutTotal = getYAxis(buildChart(props))?.props.domain;
+		const domainWithTotal = getYAxis(
+			buildChart({
+				...props,
+				series: [...props.series, { data_key: 'total', is_total: true }],
+			}),
+		)?.props.domain;
+
+		expect(domainWithoutTotal).toEqual([0, 400]);
+		expect(domainWithTotal?.[1]).toBe(domainWithoutTotal?.[1]);
+	});
+
+	it('ignores hidden total values when deciding stacked bar headroom', () => {
+		expect(
+			shouldReserveDataLabelHeadroom({
+				data: [{ month: 'Jan', direct: 100, partner: 200, total: -999 }],
+				chartType: 'stacked_bar',
+				xAxisKey: 'month',
+				series: [{ data_key: 'direct' }, { data_key: 'partner' }, { data_key: 'total', is_total: true }],
+				showDataLabels: true,
+			}),
+		).toBe(false);
+	});
+
+	it('does not let a total series inflate the stacked area domain', () => {
+		const props = {
+			data: [{ month: 'Jan', direct: 100, partner: 200, total: 300 }],
+			chartType: 'stacked_area' as const,
+			xAxisKey: 'month',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+			yAxisMin: 0,
+			showDataLabels: true,
+		};
+		const domainWithoutTotal = getYAxis(buildChart(props))?.props.domain;
+		const domainWithTotal = getYAxis(
+			buildChart({
+				...props,
+				series: [...props.series, { data_key: 'total', is_total: true }],
+			}),
+		)?.props.domain;
+
+		expect(domainWithoutTotal).toEqual([0, 300]);
+		expect(domainWithTotal?.[1]).toBe(domainWithoutTotal?.[1]);
+	});
+
 	it('falls back to margin headroom when an explicit maximum disables padding', () => {
 		expect(
 			shouldReserveDataLabelHeadroom({
@@ -528,7 +597,7 @@ describe('buildChart data labels', () => {
 		const labels = parseDataLabels(html);
 		const sectors = parsePieSectors(
 			html,
-			data.map((entry) => entry.value.toLocaleString()),
+			data.map((entry) => entry.value.toLocaleString(CHART_NUMBER_LOCALE)),
 		);
 
 		expect(labels.some((label) => label.text === '6,000')).toBe(true);

--- a/apps/shared/tests/chart-builder.test.tsx
+++ b/apps/shared/tests/chart-builder.test.tsx
@@ -5,7 +5,7 @@ import { buildChart, computeKpiComparison, computeValueAxisWidth, describePrevio
 import { formatChartValue } from '../src/chart-values';
 
 describe('formatChartValue', () => {
-	it('uses locale formatting by default', () => {
+	it('uses en-US formatting by default', () => {
 		expect(formatChartValue(1234)).toBe('1,234');
 	});
 

--- a/apps/shared/tests/chart-domain.test.ts
+++ b/apps/shared/tests/chart-domain.test.ts
@@ -5,6 +5,7 @@ import {
 	collectStackedAxisValues,
 	computeNiceDomain,
 	niceNumber,
+	resolveBarYAxisDomain,
 	resolveYAxisDomain,
 } from '../src/chart-domain';
 
@@ -87,6 +88,16 @@ describe('chart domain helpers', () => {
 
 		it('keeps valid explicit bounds', () => {
 			expect(resolveYAxisDomain(1300, 1600, [1203, 1672], false)).toEqual([1300, 1600]);
+		});
+	});
+
+	describe('resolveBarYAxisDomain', () => {
+		it('keeps a padded bar domain ordered when the explicit minimum exceeds the data', () => {
+			const values = [500];
+			const domain = resolveBarYAxisDomain(2000, undefined, values, true);
+
+			expect(domain).toEqual(resolveYAxisDomain(2000, undefined, values, true));
+			expect(Number(domain?.[0])).toBeLessThan(Number(domain?.[1]));
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Bar charts with data labels now keep 15% of empty space at the top of the y-axis, so the label on the tallest bar always has room instead of disappearing. The space comes from the axis scale, not from shrinking the chart, so **chart heights stay identical and still line up in a story grid.**
- Labels on the first and last points of line and area charts are no longer cut off at the chart edges: they get slightly shifted so the whole number stays visible.
- If you set your own y-axis max though, you might cause labels to get cropped again

Fix #1339

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

