### PR TITLE
Add Command Z & Highlight effect in story editor

### DIFF
--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
@@ -17,12 +17,7 @@ import {
 	STORY_BLOCK_DRAG_TYPE,
 	StoryBlockDragContext,
 } from '../story-editor-drag-context';
-import {
-	applyBlockSelection,
-	blockSelectionPluginKey,
-	blockSelectionFromOrigin,
-	resolveDragSelection,
-} from '../story-block-selection';
+import { blockSelectionPluginKey, blockSelectionFromOrigin, resolveDragSelection } from '../story-block-selection';
 import type { Segment } from '@nao/shared/story-segments';
 import type { ReactNodeViewProps } from '@tiptap/react';
 import type {
@@ -298,14 +293,16 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 			const finalGridPos = transaction.mapping.map(gridPos, -1);
 			transaction.setMeta(
 				blockSelectionPluginKey,
-				blockSelectionFromOrigin({
-					kind: 'gridColumn',
-					gridPos: finalGridPos,
-					columnIndex: clampedIndex,
-				}),
+				blockSelectionFromOrigin(
+					{
+						kind: 'gridColumn',
+						gridPos: finalGridPos,
+						columnIndex: clampedIndex,
+					},
+					[source.markup],
+				),
 			);
 			dispatchDropWithScroll(editor.view, transaction, finalGridPos);
-			storyBlockDrag.rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 			editor.view.focus();
 			clearDrag();
 		},
@@ -324,24 +321,25 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 					const targetIndex = dropColumnIndex > dragColumnIndex ? dropColumnIndex - 1 : dropColumnIndex;
 					const nextRawContent = reorderGridColumns(rawContent, dragColumnIndex, targetIndex);
 					if (nextRawContent !== rawContent) {
+						const movedMarkup = splitGridColumnsRaw(rawContent).columns[dragColumnIndex];
 						const gridPos = getPos();
-						updateAttributes({ rawContent: nextRawContent });
 						if (typeof gridPos === 'number') {
-							storyBlockDrag?.rememberDragUndoSelection(
-								blockSelectionFromOrigin({
-									kind: 'gridColumn',
-									gridPos,
-									columnIndex: dragColumnIndex,
-								}),
+							const transaction = editor.state.tr;
+							transaction.setNodeAttribute(gridPos, 'rawContent', nextRawContent);
+							transaction.setMeta(
+								blockSelectionPluginKey,
+								blockSelectionFromOrigin(
+									{
+										kind: 'gridColumn',
+										gridPos,
+										columnIndex: targetIndex,
+									},
+									movedMarkup === undefined ? [] : [movedMarkup],
+								),
 							);
-							applyBlockSelection(
-								editor.view,
-								blockSelectionFromOrigin({
-									kind: 'gridColumn',
-									gridPos,
-									columnIndex: targetIndex,
-								}),
-							);
+							dispatchDropWithScroll(editor.view, transaction, gridPos);
+						} else {
+							updateAttributes({ rawContent: nextRawContent });
 						}
 						editor.view.focus();
 					}

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
@@ -10,14 +10,19 @@ import {
 	splitGridColumnsRaw,
 } from '@nao/shared/story-segments';
 import { useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { removeCardFromOrigin } from '../story-editor-utils';
+import { dispatchDropWithScroll, removeCardFromOrigin } from '../story-editor-utils';
 import {
 	GRID_COLUMN_DRAG_TYPE,
 	GridDragContext,
 	STORY_BLOCK_DRAG_TYPE,
 	StoryBlockDragContext,
 } from '../story-editor-drag-context';
-import { resolveDragSelection } from '../story-block-selection';
+import {
+	applyBlockSelection,
+	blockSelectionPluginKey,
+	blockSelectionFromOrigin,
+	resolveDragSelection,
+} from '../story-block-selection';
 import type { Segment } from '@nao/shared/story-segments';
 import type { ReactNodeViewProps } from '@tiptap/react';
 import type {
@@ -290,7 +295,17 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 			const transaction = state.tr;
 			transaction.setNodeAttribute(gridPos, 'rawContent', newGrid);
 			removeCardFromOrigin(transaction, state, source.origin);
-			editor.view.dispatch(transaction);
+			const finalGridPos = transaction.mapping.map(gridPos, -1);
+			transaction.setMeta(
+				blockSelectionPluginKey,
+				blockSelectionFromOrigin({
+					kind: 'gridColumn',
+					gridPos: finalGridPos,
+					columnIndex: clampedIndex,
+				}),
+			);
+			dispatchDropWithScroll(editor.view, transaction, finalGridPos);
+			storyBlockDrag.rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 			editor.view.focus();
 			clearDrag();
 		},
@@ -309,7 +324,25 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 					const targetIndex = dropColumnIndex > dragColumnIndex ? dropColumnIndex - 1 : dropColumnIndex;
 					const nextRawContent = reorderGridColumns(rawContent, dragColumnIndex, targetIndex);
 					if (nextRawContent !== rawContent) {
+						const gridPos = getPos();
 						updateAttributes({ rawContent: nextRawContent });
+						if (typeof gridPos === 'number') {
+							storyBlockDrag?.rememberDragUndoSelection(
+								blockSelectionFromOrigin({
+									kind: 'gridColumn',
+									gridPos,
+									columnIndex: dragColumnIndex,
+								}),
+							);
+							applyBlockSelection(
+								editor.view,
+								blockSelectionFromOrigin({
+									kind: 'gridColumn',
+									gridPos,
+									columnIndex: targetIndex,
+								}),
+							);
+						}
 						editor.view.focus();
 					}
 				}
@@ -335,6 +368,7 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 			dropColumnIndex,
 			insertExternalStoryBlock,
 			editor,
+			getPos,
 			rawContent,
 			segments.length,
 			storyBlockDrag,

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor-grid-block.ts
@@ -291,6 +291,7 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 			transaction.setNodeAttribute(gridPos, 'rawContent', newGrid);
 			removeCardFromOrigin(transaction, state, source.origin);
 			editor.view.dispatch(transaction);
+			editor.view.focus();
 			clearDrag();
 		},
 		[clearDrag, editor, getPos, rawContent, segments.length, storyBlockDrag],
@@ -309,6 +310,7 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 					const nextRawContent = reorderGridColumns(rawContent, dragColumnIndex, targetIndex);
 					if (nextRawContent !== rawContent) {
 						updateAttributes({ rawContent: nextRawContent });
+						editor.view.focus();
 					}
 				}
 
@@ -332,6 +334,7 @@ export function useStoryEditorGridBlock({ node, updateAttributes, getPos, editor
 			dragColumnIndex,
 			dropColumnIndex,
 			insertExternalStoryBlock,
+			editor,
 			rawContent,
 			segments.length,
 			storyBlockDrag,

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -298,8 +298,16 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 		const onKeyDown = (event: KeyboardEvent) => {
 			const selection = blockSelectionPluginKey.getState(editor.state);
 			const targetInsideEditor = event.target instanceof Node && container.contains(event.target);
+			const targetOutsideEditorUndoContext =
+				!targetInsideEditor &&
+				event.target instanceof Element &&
+				Boolean(
+					event.target.closest(
+						'input, textarea, select, [contenteditable]:not([contenteditable="false"]), dialog, [role="dialog"]',
+					),
+				);
 			const hasBlockSelection = Boolean(selection?.blocks.length || selection?.gridColumns.length);
-			if (!targetInsideEditor && !editor.isFocused && !hasBlockSelection) {
+			if (targetOutsideEditorUndoContext || (!targetInsideEditor && !editor.isFocused && !hasBlockSelection)) {
 				return;
 			}
 			if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== 'z') {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -438,6 +438,16 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			) {
 				return;
 			}
+			const blockSelection = blockSelectionPluginKey.getState(editor.state);
+			const targetInsideEditor = target instanceof Node && storyEditorRef.current?.contains(target);
+			if (
+				!targetInsideEditor &&
+				!blockSelection?.blocks.length &&
+				!blockSelection?.gridColumns.length &&
+				blockSelection?.movedMarkups === undefined
+			) {
+				return;
+			}
 
 			event.preventDefault();
 			event.stopPropagation();

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -6,11 +6,8 @@ import { dropPoint } from '@tiptap/pm/transform';
 import { useEditor } from '@tiptap/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-	applyBlockSelection,
 	blockSelectionPluginKey,
 	blockSelectionForInsertedNodes,
-	blockSelectionFromDragUnits,
-	blockSelectionFromOrigin,
 	buildDragUnitNodes,
 	buildSelectionMoveTransaction,
 	emptySelection,
@@ -27,9 +24,10 @@ import {
 	dispatchDropWithScroll,
 	preprocessForEditor,
 	removeCardFromOrigin,
+	scrollPosIntoView,
 } from '../story-editor-utils';
 import type { GridDragSource, StoryBlockDragSource } from '../story-editor-drag-context';
-import type { BlockSelectionState, DragUnit, GridColumnRef } from '../story-block-selection';
+import type { DragUnit, GridColumnRef } from '../story-block-selection';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
 import type { Editor } from '@tiptap/react';
@@ -52,7 +50,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 	const gridDragSourceRef = useRef<GridDragSource | null>(null);
 	const storyBlockSourceRef = useRef<StoryBlockDragSource | null>(null);
 	const multiSelectionDragRef = useRef<DragUnit[] | null>(null);
-	const dragUndoSelectionRef = useRef<BlockSelectionState | null>(null);
 	const handleNodePosRef = useRef<number | null>(null);
 	const dragPreviewElementsRef = useRef<HTMLElement[] | null>(null);
 	const pendingDropRef = useRef<(() => void) | null>(null);
@@ -62,9 +59,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 	const [handleNodeType, setHandleNodeType] = useState<string | null>(null);
 	const [selectedGridColumns, setSelectedGridColumns] = useState<GridColumnRef[]>([]);
 	const [selectedBlocks, setSelectedBlocks] = useState<number[]>([]);
-	const rememberDragUndoSelection = useCallback((selection: BlockSelectionState) => {
-		dragUndoSelectionRef.current = selection;
-	}, []);
 	const resetDragContexts = useCallback(() => {
 		gridDragSourceRef.current = null;
 		storyBlockSourceRef.current = null;
@@ -145,7 +139,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 				const dataTransfer = event.dataTransfer;
 				if (multiSelectionDragRef.current) {
 					try {
-						const undoSelection = blockSelectionFromDragUnits(multiSelectionDragRef.current);
 						const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
 						if (!coords) {
 							return true;
@@ -159,7 +152,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 							return true;
 						}
 						dispatchDropWithScroll(view, move.transaction, move.insertPos);
-						rememberDragUndoSelection(undoSelection);
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -218,16 +210,9 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						transaction.insert(mappedInsert, poppedNode);
 						transaction.setMeta(
 							blockSelectionPluginKey,
-							blockSelectionForInsertedNodes(mappedInsert, [poppedNode]),
+							blockSelectionForInsertedNodes(mappedInsert, [poppedNode], [result.popped]),
 						);
 						dispatchDropWithScroll(view, transaction, mappedInsert);
-						rememberDragUndoSelection(
-							blockSelectionFromOrigin({
-								kind: 'gridColumn',
-								gridPos: source.gridPos,
-								columnIndex: source.columnIndex,
-							}),
-						);
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -272,10 +257,9 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						const finalInsertPos = transaction.mapping.map(insertPos, -1);
 						transaction.setMeta(
 							blockSelectionPluginKey,
-							blockSelectionForInsertedNodes(finalInsertPos, [node]),
+							blockSelectionForInsertedNodes(finalInsertPos, [node], [source.markup]),
 						);
 						dispatchDropWithScroll(view, transaction, finalInsertPos);
-						rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -288,50 +272,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			},
 		},
 	});
-
-	useEffect(() => {
-		const container = storyEditorRef.current;
-		if (!container || !editor) {
-			return;
-		}
-
-		const onKeyDown = (event: KeyboardEvent) => {
-			const selection = blockSelectionPluginKey.getState(editor.state);
-			const targetInsideEditor = event.target instanceof Node && container.contains(event.target);
-			const targetInExternalUndoContext =
-				!targetInsideEditor &&
-				event.target instanceof Element &&
-				event.target.closest(
-					'input, textarea, select, [contenteditable]:not([contenteditable="false"]), dialog, [role="dialog"]',
-				);
-			const hasBlockSelection = Boolean(selection?.blocks.length || selection?.gridColumns.length);
-			if (targetInExternalUndoContext || (!targetInsideEditor && !editor.isFocused && !hasBlockSelection)) {
-				return;
-			}
-			if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== 'z') {
-				return;
-			}
-
-			event.preventDefault();
-			event.stopPropagation();
-			if (event.shiftKey) {
-				dragUndoSelectionRef.current = null;
-				editor.commands.redo();
-				return;
-			}
-			const selectionToRestore = dragUndoSelectionRef.current;
-			if (!editor.commands.undo()) {
-				return;
-			}
-			if (selectionToRestore) {
-				dragUndoSelectionRef.current = null;
-				applyBlockSelection(editor.view, selectionToRestore);
-			}
-		};
-
-		document.addEventListener('keydown', onKeyDown, true);
-		return () => document.removeEventListener('keydown', onKeyDown, true);
-	}, [editor]);
 
 	useEffect(() => {
 		const container = storyEditorRef.current;
@@ -452,13 +392,6 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 		}
 
 		const syncGridColumns = ({ transaction }: { transaction?: Transaction } = {}) => {
-			if (
-				transaction?.docChanged &&
-				transaction.getMeta('addToHistory') !== false &&
-				!isHistoryTransaction(transaction)
-			) {
-				dragUndoSelectionRef.current = null;
-			}
 			const next = getSelectedGridColumns(editor.state);
 			setSelectedGridColumns((current) => (sameGridColumns(current, next) ? current : next));
 			const nextBlocks = getSelectedBlockPositions(editor.state);
@@ -467,11 +400,58 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 					? current
 					: nextBlocks,
 			);
+			if (transaction?.docChanged && isHistoryTransaction(transaction)) {
+				if (nextBlocks[0] !== undefined) {
+					scrollPosIntoView(editor.view, nextBlocks[0]);
+				} else if (next[0] !== undefined) {
+					scrollPosIntoView(editor.view, next[0].gridPos, next[0].index);
+				}
+			}
 		};
 		syncGridColumns();
 		editor.on('transaction', syncGridColumns);
 		return () => {
 			editor.off('transaction', syncGridColumns);
+		};
+	}, [editor]);
+
+	useEffect(() => {
+		if (!editor) {
+			return;
+		}
+
+		const forwardHistoryShortcut = (event: KeyboardEvent) => {
+			if (
+				editor.isFocused ||
+				event.altKey ||
+				(!event.metaKey && !event.ctrlKey) ||
+				event.key.toLowerCase() !== 'z'
+			) {
+				return;
+			}
+			const target = event.target;
+			if (
+				target instanceof Element &&
+				target.closest(
+					'input, textarea, select, [contenteditable]:not([contenteditable="false"]), dialog, [role="dialog"]',
+				)
+			) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			editor.commands.focus();
+			if (event.shiftKey) {
+				editor.commands.redo();
+			} else {
+				editor.commands.undo();
+			}
+		};
+
+		document.addEventListener('keydown', forwardHistoryShortcut, true);
+		return () => {
+			document.removeEventListener('keydown', forwardHistoryShortcut, true);
 		};
 	}, [editor]);
 
@@ -559,9 +539,8 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			pendingDropRef,
 			beginMultiSelectionDrag,
 			endMultiSelectionDrag,
-			rememberDragUndoSelection,
 		}),
-		[activeDropZone, beginMultiSelectionDrag, endMultiSelectionDrag, isBlockDragging, rememberDragUndoSelection],
+		[activeDropZone, beginMultiSelectionDrag, endMultiSelectionDrag, isBlockDragging],
 	);
 	const onElementDragEnd = endMultiSelectionDrag;
 	const onDragHandleClick = useCallback(() => {
@@ -580,10 +559,10 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			return;
 		}
 		const next = selectBlockFromHandle(editor.state, pos);
-		if (!next) {
-			return;
+		if (next) {
+			editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
 		}
-		editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
+		editor.view.focus();
 	}, [editor]);
 
 	return {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -298,16 +298,14 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 		const onKeyDown = (event: KeyboardEvent) => {
 			const selection = blockSelectionPluginKey.getState(editor.state);
 			const targetInsideEditor = event.target instanceof Node && container.contains(event.target);
-			const targetOutsideEditorUndoContext =
+			const targetInExternalUndoContext =
 				!targetInsideEditor &&
 				event.target instanceof Element &&
-				Boolean(
-					event.target.closest(
-						'input, textarea, select, [contenteditable]:not([contenteditable="false"]), dialog, [role="dialog"]',
-					),
+				event.target.closest(
+					'input, textarea, select, [contenteditable]:not([contenteditable="false"]), dialog, [role="dialog"]',
 				);
 			const hasBlockSelection = Boolean(selection?.blocks.length || selection?.gridColumns.length);
-			if (targetOutsideEditorUndoContext || (!targetInsideEditor && !editor.isFocused && !hasBlockSelection)) {
+			if (targetInExternalUndoContext || (!targetInsideEditor && !editor.isFocused && !hasBlockSelection)) {
 				return;
 			}
 			if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== 'z') {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -149,6 +149,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 							return true;
 						}
 						dispatchDropWithScroll(view, move.transaction, move.insertPos);
+						view.focus();
 						event.preventDefault();
 						return true;
 					} finally {
@@ -204,6 +205,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						const insertAssoc = insertPos >= gridTo ? 1 : -1;
 						transaction.insert(transaction.mapping.map(insertPos, insertAssoc), poppedNode);
 						view.dispatch(transaction);
+						view.focus();
 						event.preventDefault();
 						return true;
 					} finally {
@@ -245,6 +247,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						transaction.insert(insertPos, node);
 						removeCardFromOrigin(transaction, view.state, source.origin);
 						view.dispatch(transaction);
+						view.focus();
 						event.preventDefault();
 						return true;
 					} finally {
@@ -256,6 +259,36 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			},
 		},
 	});
+
+	useEffect(() => {
+		const container = storyEditorRef.current;
+		if (!container || !editor) {
+			return;
+		}
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			const selection = blockSelectionPluginKey.getState(editor.state);
+			const targetInsideEditor = event.target instanceof Node && container.contains(event.target);
+			const hasBlockSelection = Boolean(selection?.blocks.length || selection?.gridColumns.length);
+			if (!targetInsideEditor && !editor.isFocused && !hasBlockSelection) {
+				return;
+			}
+			if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== 'z') {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			if (event.shiftKey) {
+				editor.commands.redo();
+				return;
+			}
+			editor.commands.undo();
+		};
+
+		document.addEventListener('keydown', onKeyDown, true);
+		return () => document.removeEventListener('keydown', onKeyDown, true);
+	}, [editor]);
 
 	useEffect(() => {
 		const container = storyEditorRef.current;

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -1,11 +1,16 @@
 import { popGridColumn } from '@nao/shared/story-segments';
 import { Extension } from '@tiptap/core';
+import { isHistoryTransaction } from '@tiptap/pm/history';
 import { Fragment, Slice } from '@tiptap/pm/model';
 import { dropPoint } from '@tiptap/pm/transform';
 import { useEditor } from '@tiptap/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+	applyBlockSelection,
 	blockSelectionPluginKey,
+	blockSelectionForInsertedNodes,
+	blockSelectionFromDragUnits,
+	blockSelectionFromOrigin,
 	buildDragUnitNodes,
 	buildSelectionMoveTransaction,
 	emptySelection,
@@ -24,9 +29,9 @@ import {
 	removeCardFromOrigin,
 } from '../story-editor-utils';
 import type { GridDragSource, StoryBlockDragSource } from '../story-editor-drag-context';
-import type { DragUnit, GridColumnRef } from '../story-block-selection';
+import type { BlockSelectionState, DragUnit, GridColumnRef } from '../story-block-selection';
 import type { Node as PMNode } from '@tiptap/pm/model';
-import type { EditorState } from '@tiptap/pm/state';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
 import type { Editor } from '@tiptap/react';
 import type { MutableRefObject } from 'react';
 
@@ -47,6 +52,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 	const gridDragSourceRef = useRef<GridDragSource | null>(null);
 	const storyBlockSourceRef = useRef<StoryBlockDragSource | null>(null);
 	const multiSelectionDragRef = useRef<DragUnit[] | null>(null);
+	const dragUndoSelectionRef = useRef<BlockSelectionState | null>(null);
 	const handleNodePosRef = useRef<number | null>(null);
 	const dragPreviewElementsRef = useRef<HTMLElement[] | null>(null);
 	const pendingDropRef = useRef<(() => void) | null>(null);
@@ -56,6 +62,9 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 	const [handleNodeType, setHandleNodeType] = useState<string | null>(null);
 	const [selectedGridColumns, setSelectedGridColumns] = useState<GridColumnRef[]>([]);
 	const [selectedBlocks, setSelectedBlocks] = useState<number[]>([]);
+	const rememberDragUndoSelection = useCallback((selection: BlockSelectionState) => {
+		dragUndoSelectionRef.current = selection;
+	}, []);
 	const resetDragContexts = useCallback(() => {
 		gridDragSourceRef.current = null;
 		storyBlockSourceRef.current = null;
@@ -136,6 +145,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 				const dataTransfer = event.dataTransfer;
 				if (multiSelectionDragRef.current) {
 					try {
+						const undoSelection = blockSelectionFromDragUnits(multiSelectionDragRef.current);
 						const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
 						if (!coords) {
 							return true;
@@ -149,6 +159,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 							return true;
 						}
 						dispatchDropWithScroll(view, move.transaction, move.insertPos);
+						rememberDragUndoSelection(undoSelection);
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -203,8 +214,20 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						// Bias mapping to the right for drops at/after the grid so the popped
 						// column lands after the remaining grid, left otherwise.
 						const insertAssoc = insertPos >= gridTo ? 1 : -1;
-						transaction.insert(transaction.mapping.map(insertPos, insertAssoc), poppedNode);
-						view.dispatch(transaction);
+						const mappedInsert = transaction.mapping.map(insertPos, insertAssoc);
+						transaction.insert(mappedInsert, poppedNode);
+						transaction.setMeta(
+							blockSelectionPluginKey,
+							blockSelectionForInsertedNodes(mappedInsert, [poppedNode]),
+						);
+						dispatchDropWithScroll(view, transaction, mappedInsert);
+						rememberDragUndoSelection(
+							blockSelectionFromOrigin({
+								kind: 'gridColumn',
+								gridPos: source.gridPos,
+								columnIndex: source.columnIndex,
+							}),
+						);
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -246,7 +269,13 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 						const transaction = view.state.tr;
 						transaction.insert(insertPos, node);
 						removeCardFromOrigin(transaction, view.state, source.origin);
-						view.dispatch(transaction);
+						const finalInsertPos = transaction.mapping.map(insertPos, -1);
+						transaction.setMeta(
+							blockSelectionPluginKey,
+							blockSelectionForInsertedNodes(finalInsertPos, [node]),
+						);
+						dispatchDropWithScroll(view, transaction, finalInsertPos);
+						rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 						view.focus();
 						event.preventDefault();
 						return true;
@@ -280,10 +309,18 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			event.preventDefault();
 			event.stopPropagation();
 			if (event.shiftKey) {
+				dragUndoSelectionRef.current = null;
 				editor.commands.redo();
 				return;
 			}
-			editor.commands.undo();
+			const selectionToRestore = dragUndoSelectionRef.current;
+			if (!editor.commands.undo()) {
+				return;
+			}
+			if (selectionToRestore) {
+				dragUndoSelectionRef.current = null;
+				applyBlockSelection(editor.view, selectionToRestore);
+			}
 		};
 
 		document.addEventListener('keydown', onKeyDown, true);
@@ -408,7 +445,14 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			return;
 		}
 
-		const syncGridColumns = () => {
+		const syncGridColumns = ({ transaction }: { transaction?: Transaction } = {}) => {
+			if (
+				transaction?.docChanged &&
+				transaction.getMeta('addToHistory') !== false &&
+				!isHistoryTransaction(transaction)
+			) {
+				dragUndoSelectionRef.current = null;
+			}
 			const next = getSelectedGridColumns(editor.state);
 			setSelectedGridColumns((current) => (sameGridColumns(current, next) ? current : next));
 			const nextBlocks = getSelectedBlockPositions(editor.state);
@@ -470,7 +514,8 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 					event.dataTransfer.effectAllowed = 'move';
 				}
 			} else {
-				multiSelectionDragRef.current = null;
+				multiSelectionDragRef.current =
+					hoveredPosition == null ? null : [{ kind: 'block', pos: hoveredPosition }];
 				dragPreviewElementsRef.current =
 					hoveredPosition == null
 						? null
@@ -508,8 +553,9 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			pendingDropRef,
 			beginMultiSelectionDrag,
 			endMultiSelectionDrag,
+			rememberDragUndoSelection,
 		}),
-		[activeDropZone, beginMultiSelectionDrag, endMultiSelectionDrag, isBlockDragging],
+		[activeDropZone, beginMultiSelectionDrag, endMultiSelectionDrag, isBlockDragging, rememberDragUndoSelection],
 	);
 	const onElementDragEnd = endMultiSelectionDrag;
 	const onDragHandleClick = useCallback(() => {

--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -750,7 +750,7 @@ function rawMarkupForBlock(node: PMNode): string | null {
 	if (node.type.name === 'chartBlock' || node.type.name === 'tableBlock') {
 		return node.attrs.rawTag as string;
 	}
-	return null;
+	return node.isTextblock ? `text:${node.type.name}:${node.textContent}` : null;
 }
 
 function rawMarkupsForNode(node: PMNode): string[] {

--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -1,7 +1,7 @@
 import { popGridColumns, splitGridColumnsRaw } from '@nao/shared/story-segments';
 import { Extension } from '@tiptap/core';
 import { Fragment, Slice } from '@tiptap/pm/model';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
 import { dropPoint } from '@tiptap/pm/transform';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { createBlockNode } from './story-editor-utils';
@@ -9,6 +9,7 @@ import { createBlockNode } from './story-editor-utils';
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
+import type { CardOrigin } from './story-editor-drag-context';
 
 export interface GridColumnRef {
 	gridPos: number;
@@ -44,6 +45,75 @@ export function getSelectedGridColumns(state: EditorState): GridColumnRef[] {
 
 export function emptySelection(): BlockSelectionState {
 	return { blocks: [], gridColumns: [], anchor: null, columnAnchor: null };
+}
+
+export function blockSelectionFromDragUnits(units: DragUnit[]): BlockSelectionState {
+	const blocks: number[] = [];
+	const gridColumns: GridColumnRef[] = [];
+	for (const unit of units) {
+		if (unit.kind === 'block') {
+			blocks.push(unit.pos);
+			continue;
+		}
+		for (const index of unit.indices) {
+			gridColumns.push({ gridPos: unit.gridPos, index });
+		}
+	}
+	blocks.sort((first, second) => first - second);
+	gridColumns.sort((first, second) => first.gridPos - second.gridPos || first.index - second.index);
+	return {
+		blocks,
+		gridColumns,
+		anchor: blocks[0] ?? null,
+		columnAnchor: gridColumns[0] ?? null,
+	};
+}
+
+export function blockSelectionFromOrigin(origin: CardOrigin): BlockSelectionState {
+	if (origin.kind === 'block') {
+		return {
+			blocks: [origin.pos],
+			gridColumns: [],
+			anchor: origin.pos,
+			columnAnchor: null,
+		};
+	}
+	const column = { gridPos: origin.gridPos, index: origin.columnIndex };
+	return {
+		blocks: [],
+		gridColumns: [column],
+		anchor: null,
+		columnAnchor: column,
+	};
+}
+
+export function blockSelectionForInsertedNodes(insertPos: number, nodes: PMNode[]): BlockSelectionState {
+	const blocks: number[] = [];
+	let position = insertPos;
+	for (const node of nodes) {
+		blocks.push(position);
+		position += node.nodeSize;
+	}
+	return {
+		blocks,
+		gridColumns: [],
+		anchor: blocks[0] ?? null,
+		columnAnchor: null,
+	};
+}
+
+export function applyBlockSelection(view: EditorView, selection: BlockSelectionState): void {
+	const transaction = view.state.tr;
+	const selectedPositions = [...selection.blocks, ...selection.gridColumns.map((column) => column.gridPos)].sort(
+		(first, second) => first - second,
+	);
+	const selectionPosition = selectedPositions[0];
+	if (selectionPosition !== undefined) {
+		setCollapsedTextSelection(transaction, selectionPosition);
+	}
+	transaction.setMeta(blockSelectionPluginKey, selection);
+	transaction.setMeta('addToHistory', false);
+	view.dispatch(transaction);
 }
 
 export function resolveDragSelection(
@@ -470,7 +540,8 @@ export function buildSelectionMoveTransaction(
 	}
 	const mappedInsert = transaction.mapping.map(insertPos);
 	transaction.insert(mappedInsert, Fragment.fromArray(nodes));
-	transaction.setMeta(blockSelectionPluginKey, emptySelection());
+	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes));
+	setCollapsedTextSelection(transaction, mappedInsert);
 	return { transaction, insertPos: mappedInsert };
 }
 
@@ -497,8 +568,17 @@ export function buildBlockMoveTransaction(
 
 	const mappedInsert = transaction.mapping.map(insertPos);
 	transaction.insert(mappedInsert, Fragment.fromArray(nodes));
-	transaction.setMeta(blockSelectionPluginKey, emptySelection());
+	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes));
+	setCollapsedTextSelection(transaction, mappedInsert);
 	return { transaction, insertPos: mappedInsert };
+}
+
+function setCollapsedTextSelection(transaction: Transaction, position: number): void {
+	const clampedPosition = Math.max(0, Math.min(position, transaction.doc.content.size));
+	const $position = transaction.doc.resolve(clampedPosition);
+	const nearbySelection =
+		Selection.findFrom($position, 1, true) ?? Selection.findFrom($position, -1, true) ?? Selection.near($position);
+	transaction.setSelection(TextSelection.create(transaction.doc, nearbySelection.from));
 }
 
 function buildDragUnitOperations(state: EditorState, units: DragUnit[]): DragUnitOperation[] | null {

--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -1,5 +1,6 @@
 import { popGridColumns, splitGridColumnsRaw } from '@nao/shared/story-segments';
 import { Extension } from '@tiptap/core';
+import { isHistoryTransaction } from '@tiptap/pm/history';
 import { Fragment, Slice } from '@tiptap/pm/model';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { dropPoint } from '@tiptap/pm/transform';
@@ -21,6 +22,7 @@ export interface BlockSelectionState {
 	gridColumns: GridColumnRef[];
 	anchor: number | null;
 	columnAnchor: GridColumnRef | null;
+	movedMarkups?: string[];
 }
 
 export type DragUnit = { kind: 'block'; pos: number } | { kind: 'gridColumns'; gridPos: number; indices: number[] };
@@ -47,7 +49,7 @@ export function emptySelection(): BlockSelectionState {
 	return { blocks: [], gridColumns: [], anchor: null, columnAnchor: null };
 }
 
-export function blockSelectionFromDragUnits(units: DragUnit[]): BlockSelectionState {
+export function blockSelectionFromDragUnits(units: DragUnit[], movedMarkups?: string[]): BlockSelectionState {
 	const blocks: number[] = [];
 	const gridColumns: GridColumnRef[] = [];
 	for (const unit of units) {
@@ -61,45 +63,61 @@ export function blockSelectionFromDragUnits(units: DragUnit[]): BlockSelectionSt
 	}
 	blocks.sort((first, second) => first - second);
 	gridColumns.sort((first, second) => first.gridPos - second.gridPos || first.index - second.index);
-	return {
-		blocks,
-		gridColumns,
-		anchor: blocks[0] ?? null,
-		columnAnchor: gridColumns[0] ?? null,
-	};
+	return withMovedMarkups(
+		{
+			blocks,
+			gridColumns,
+			anchor: blocks[0] ?? null,
+			columnAnchor: gridColumns[0] ?? null,
+		},
+		movedMarkups,
+	);
 }
 
-export function blockSelectionFromOrigin(origin: CardOrigin): BlockSelectionState {
+export function blockSelectionFromOrigin(origin: CardOrigin, movedMarkups?: string[]): BlockSelectionState {
 	if (origin.kind === 'block') {
-		return {
-			blocks: [origin.pos],
-			gridColumns: [],
-			anchor: origin.pos,
-			columnAnchor: null,
-		};
+		return withMovedMarkups(
+			{
+				blocks: [origin.pos],
+				gridColumns: [],
+				anchor: origin.pos,
+				columnAnchor: null,
+			},
+			movedMarkups,
+		);
 	}
 	const column = { gridPos: origin.gridPos, index: origin.columnIndex };
-	return {
-		blocks: [],
-		gridColumns: [column],
-		anchor: null,
-		columnAnchor: column,
-	};
+	return withMovedMarkups(
+		{
+			blocks: [],
+			gridColumns: [column],
+			anchor: null,
+			columnAnchor: column,
+		},
+		movedMarkups,
+	);
 }
 
-export function blockSelectionForInsertedNodes(insertPos: number, nodes: PMNode[]): BlockSelectionState {
+export function blockSelectionForInsertedNodes(
+	insertPos: number,
+	nodes: PMNode[],
+	movedMarkups?: string[],
+): BlockSelectionState {
 	const blocks: number[] = [];
 	let position = insertPos;
 	for (const node of nodes) {
 		blocks.push(position);
 		position += node.nodeSize;
 	}
-	return {
-		blocks,
-		gridColumns: [],
-		anchor: blocks[0] ?? null,
-		columnAnchor: null,
-	};
+	return withMovedMarkups(
+		{
+			blocks,
+			gridColumns: [],
+			anchor: blocks[0] ?? null,
+			columnAnchor: null,
+		},
+		movedMarkups,
+	);
 }
 
 export function applyBlockSelection(view: EditorView, selection: BlockSelectionState): void {
@@ -193,10 +211,22 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 			apply(tr, value) {
 				const meta = tr.getMeta(blockSelectionPluginKey) as BlockSelectionState | undefined;
 				if (meta !== undefined) {
+					if (
+						meta.blocks.length === 0 &&
+						meta.gridColumns.length === 0 &&
+						!Object.hasOwn(meta, 'movedMarkups')
+					) {
+						return withMovedMarkups(meta, value.movedMarkups);
+					}
 					return meta;
 				}
 				if (!tr.docChanged) {
 					return value;
+				}
+				if (isHistoryTransaction(tr)) {
+					return value.movedMarkups === undefined
+						? emptySelection()
+						: selectionFromMovedMarkups(tr.doc, value.movedMarkups);
 				}
 
 				const valid = new Set(topLevelBlockPositions(tr.doc));
@@ -222,7 +252,15 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 					isValidGridColumn(tr.doc, mappedColumnAnchor)
 						? mappedColumnAnchor
 						: null;
-				return { blocks, gridColumns, anchor, columnAnchor };
+				return withMovedMarkups(
+					{
+						blocks,
+						gridColumns,
+						anchor,
+						columnAnchor,
+					},
+					tr.getMeta('appendedTransaction') === undefined ? undefined : value.movedMarkups,
+				);
 			},
 		},
 		props: {
@@ -285,8 +323,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 									(selected) => selected.gridPos === gridPos && selected.index === index,
 								);
 								if (alreadySelected) {
-									// Already selected (alone or within a multi-selection): let the native
-									// drag start so the column can be dragged directly from its body.
+									view.focus();
 									return false;
 								}
 								event.preventDefault();
@@ -294,6 +331,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 								if (next) {
 									view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, next));
 								}
+								view.focus();
 								return true;
 							}
 
@@ -315,6 +353,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 										columnAnchor: column,
 									}),
 								);
+								view.focus();
 								return true;
 							}
 
@@ -330,6 +369,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 									columnAnchor: columnAnchor?.gridPos === gridPos ? columnAnchor : column,
 								}),
 							);
+							view.focus();
 							return true;
 						}
 					}
@@ -348,12 +388,12 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 						) {
 							const next = selectBlockFromHandle(view.state, clickedBlockPos);
 							if (!next) {
-								// Already selected: allow the native drag to start so the block can
-								// be dragged directly from its body.
+								view.focus();
 								return false;
 							}
 							event.preventDefault();
 							view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, next));
+							view.focus();
 							return true;
 						}
 						if (clickedNode != null && clickedNode.type.name === 'gridBlock') {
@@ -399,6 +439,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 								anchor: blockPosition,
 							}),
 						);
+						view.focus();
 						return true;
 					}
 
@@ -410,6 +451,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 							anchor,
 						}),
 					);
+					view.focus();
 					return true;
 				},
 			},
@@ -488,6 +530,7 @@ interface DragUnitOperation {
 	from: number;
 	to: number;
 	remainingNode: PMNode | null;
+	movedMarkups: string[];
 }
 
 export function buildDragUnitNodes(state: EditorState, units: DragUnit[]): PMNode[] | null {
@@ -540,7 +583,8 @@ export function buildSelectionMoveTransaction(
 	}
 	const mappedInsert = transaction.mapping.map(insertPos);
 	transaction.insert(mappedInsert, Fragment.fromArray(nodes));
-	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes));
+	const movedMarkups = operations.flatMap((operation) => operation.movedMarkups);
+	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes, movedMarkups));
 	setCollapsedTextSelection(transaction, mappedInsert);
 	return { transaction, insertPos: mappedInsert };
 }
@@ -568,7 +612,10 @@ export function buildBlockMoveTransaction(
 
 	const mappedInsert = transaction.mapping.map(insertPos);
 	transaction.insert(mappedInsert, Fragment.fromArray(nodes));
-	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes));
+	transaction.setMeta(
+		blockSelectionPluginKey,
+		blockSelectionForInsertedNodes(mappedInsert, nodes, nodes.flatMap(rawMarkupsForNode)),
+	);
 	setCollapsedTextSelection(transaction, mappedInsert);
 	return { transaction, insertPos: mappedInsert };
 }
@@ -587,6 +634,7 @@ function buildDragUnitOperations(state: EditorState, units: DragUnit[]): DragUni
 				from: unit.pos,
 				to: unit.pos + node.nodeSize,
 				remainingNode: null,
+				movedMarkups: rawMarkupsForNode(node),
 			});
 			continue;
 		}
@@ -606,6 +654,9 @@ function buildDragUnitOperations(state: EditorState, units: DragUnit[]): DragUni
 			from: unit.gridPos,
 			to: unit.gridPos + grid.nodeSize,
 			remainingNode,
+			movedMarkups: unit.indices
+				.map((index) => splitGridColumnsRaw(grid.attrs.rawContent as string).columns[index])
+				.filter((markup): markup is string => markup !== undefined),
 		});
 	}
 	return operations;
@@ -647,6 +698,79 @@ export function rangeBetween(doc: PMNode, first: number, second: number): number
 	const start = Math.min(first, second);
 	const end = Math.max(first, second);
 	return topLevelBlockPositions(doc).filter((position) => position >= start && position <= end);
+}
+
+function selectionFromMovedMarkups(doc: PMNode, movedMarkups: string[]): BlockSelectionState {
+	const blocks: number[] = [];
+	const gridColumns: GridColumnRef[] = [];
+	const usedBlocks = new Set<number>();
+	const usedGridColumns = new Set<string>();
+	const normalizedMarkups = normalizeMovedMarkups(movedMarkups);
+	for (const markup of normalizedMarkups) {
+		const matches: Array<{ block: number } | { gridColumn: GridColumnRef }> = [];
+		doc.forEach((node, position) => {
+			const blockMarkup = rawMarkupForBlock(node);
+			if (blockMarkup?.trim() === markup && !usedBlocks.has(position)) {
+				matches.push({ block: position });
+			}
+			if (node.type.name !== 'gridBlock') {
+				return;
+			}
+			for (const [index, column] of splitGridColumnsRaw(node.attrs.rawContent as string).columns.entries()) {
+				if (column.trim() === markup && !usedGridColumns.has(gridColumnKey(position, index))) {
+					matches.push({ gridColumn: { gridPos: position, index } });
+				}
+			}
+		});
+		if (matches.length !== 1) {
+			continue;
+		}
+		const [match] = matches;
+		if ('block' in match) {
+			blocks.push(match.block);
+			usedBlocks.add(match.block);
+		} else {
+			gridColumns.push(match.gridColumn);
+			usedGridColumns.add(gridColumnKey(match.gridColumn.gridPos, match.gridColumn.index));
+		}
+	}
+
+	blocks.sort((first, second) => first - second);
+	gridColumns.sort((first, second) => first.gridPos - second.gridPos || first.index - second.index);
+	return {
+		blocks,
+		gridColumns,
+		anchor: blocks[0] ?? null,
+		columnAnchor: gridColumns[0] ?? null,
+		movedMarkups: normalizedMarkups,
+	};
+}
+
+function rawMarkupForBlock(node: PMNode): string | null {
+	if (node.type.name === 'chartBlock' || node.type.name === 'tableBlock') {
+		return node.attrs.rawTag as string;
+	}
+	return null;
+}
+
+function rawMarkupsForNode(node: PMNode): string[] {
+	const blockMarkup = rawMarkupForBlock(node);
+	if (blockMarkup !== null) {
+		return [blockMarkup];
+	}
+	return node.type.name === 'gridBlock' ? splitGridColumnsRaw(node.attrs.rawContent as string).columns : [];
+}
+
+function withMovedMarkups(selection: BlockSelectionState, movedMarkups?: string[]): BlockSelectionState {
+	return movedMarkups === undefined ? selection : { ...selection, movedMarkups: normalizeMovedMarkups(movedMarkups) };
+}
+
+function normalizeMovedMarkups(markups: string[]): string[] {
+	return markups.map((markup) => markup.trim()).filter(Boolean);
+}
+
+function gridColumnKey(gridPos: number, index: number): string {
+	return `${gridPos}:${index}`;
 }
 
 function getChangedGridPositions(tr: Transaction, selection: BlockSelectionState): Set<number> {

--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -1,10 +1,10 @@
 import { popGridColumns, splitGridColumnsRaw } from '@nao/shared/story-segments';
 import { Extension } from '@tiptap/core';
 import { Fragment, Slice } from '@tiptap/pm/model';
-import { Plugin, PluginKey, Selection, TextSelection } from '@tiptap/pm/state';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { dropPoint } from '@tiptap/pm/transform';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
-import { createBlockNode } from './story-editor-utils';
+import { createBlockNode, setCollapsedTextSelection } from './story-editor-utils';
 
 import type { Node as PMNode } from '@tiptap/pm/model';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
@@ -571,14 +571,6 @@ export function buildBlockMoveTransaction(
 	transaction.setMeta(blockSelectionPluginKey, blockSelectionForInsertedNodes(mappedInsert, nodes));
 	setCollapsedTextSelection(transaction, mappedInsert);
 	return { transaction, insertPos: mappedInsert };
-}
-
-function setCollapsedTextSelection(transaction: Transaction, position: number): void {
-	const clampedPosition = Math.max(0, Math.min(position, transaction.doc.content.size));
-	const $position = transaction.doc.resolve(clampedPosition);
-	const nearbySelection =
-		Selection.findFrom($position, 1, true) ?? Selection.findFrom($position, -1, true) ?? Selection.near($position);
-	transaction.setSelection(TextSelection.create(transaction.doc, nearbySelection.from));
 }
 
 function buildDragUnitOperations(state: EditorState, units: DragUnit[]): DragUnitOperation[] | null {

--- a/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
@@ -79,10 +79,10 @@ export function StoryBlockDragGrip({ node, editor, getPos }: Pick<ReactNodeViewP
 					return;
 				}
 				const next = selectBlockFromHandle(editor.state, pos);
-				if (!next) {
-					return;
+				if (next) {
+					editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
 				}
-				editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
+				editor.view.focus();
 			}}
 			onPointerDown={(event) => {
 				event.stopPropagation();
@@ -150,14 +150,16 @@ export function StoryBlockDropZones({ node, editor, getPos }: Pick<ReactNodeView
 			const finalGridPos = transaction.mapping.map(targetPos, -1);
 			transaction.setMeta(
 				blockSelectionPluginKey,
-				blockSelectionFromOrigin({
-					kind: 'gridColumn',
-					gridPos: finalGridPos,
-					columnIndex: side === 'left' ? 0 : 1,
-				}),
+				blockSelectionFromOrigin(
+					{
+						kind: 'gridColumn',
+						gridPos: finalGridPos,
+						columnIndex: side === 'left' ? 0 : 1,
+					},
+					[source.markup],
+				),
 			);
 			dispatchDropWithScroll(editor.view, transaction, finalGridPos);
-			dragContext.rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 			editor.view.focus();
 			resetDrag();
 		},

--- a/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
@@ -147,6 +147,7 @@ export function StoryBlockDropZones({ node, editor, getPos }: Pick<ReactNodeView
 			transaction.replaceWith(targetPos, targetPos + node.nodeSize, gridNode);
 			removeCardFromOrigin(transaction, state, source.origin);
 			editor.view.dispatch(transaction);
+			editor.view.focus();
 			resetDrag();
 		},
 		[dragContext, editor, getPos, node, resetDrag],

--- a/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
@@ -3,11 +3,12 @@ import { GripVertical } from 'lucide-react';
 import { useCallback, useContext } from 'react';
 import {
 	blockSelectionPluginKey,
+	blockSelectionFromOrigin,
 	emptySelection,
 	resolveDragSelection,
 	selectBlockFromHandle,
 } from './story-block-selection';
-import { createBlockNode, removeCardFromOrigin } from './story-editor-utils';
+import { createBlockNode, dispatchDropWithScroll, removeCardFromOrigin } from './story-editor-utils';
 import { GridDragContext, STORY_BLOCK_DRAG_TYPE, StoryBlockDragContext } from './story-editor-drag-context';
 import type { ReactNodeViewProps } from '@tiptap/react';
 import type { DragEvent as ReactDragEvent } from 'react';
@@ -146,7 +147,17 @@ export function StoryBlockDropZones({ node, editor, getPos }: Pick<ReactNodeView
 			const transaction = state.tr;
 			transaction.replaceWith(targetPos, targetPos + node.nodeSize, gridNode);
 			removeCardFromOrigin(transaction, state, source.origin);
-			editor.view.dispatch(transaction);
+			const finalGridPos = transaction.mapping.map(targetPos, -1);
+			transaction.setMeta(
+				blockSelectionPluginKey,
+				blockSelectionFromOrigin({
+					kind: 'gridColumn',
+					gridPos: finalGridPos,
+					columnIndex: side === 'left' ? 0 : 1,
+				}),
+			);
+			dispatchDropWithScroll(editor.view, transaction, finalGridPos);
+			dragContext.rememberDragUndoSelection(blockSelectionFromOrigin(source.origin));
 			editor.view.focus();
 			resetDrag();
 		},

--- a/apps/frontend/src/components/side-panel/story-editor-drag-context.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-drag-context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import type { BlockSelectionState, DragUnit } from './story-block-selection';
+import type { DragUnit } from './story-block-selection';
 
 export const STORY_BLOCK_DRAG_TYPE = 'application/x-nao-story-block';
 export const GRID_COLUMN_DRAG_TYPE = 'application/x-nao-grid-column';
@@ -28,7 +28,6 @@ export const StoryBlockDragContext = createContext<{
 	pendingDropRef: MutableRefObject<(() => void) | null>;
 	beginMultiSelectionDrag: (units: DragUnit[], event: DragEvent) => void;
 	endMultiSelectionDrag: () => void;
-	rememberDragUndoSelection: (selection: BlockSelectionState) => void;
 } | null>(null);
 
 export const GridDragContext = createContext<MutableRefObject<GridDragSource | null> | null>(null);

--- a/apps/frontend/src/components/side-panel/story-editor-drag-context.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-drag-context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import type { DragUnit } from './story-block-selection';
+import type { BlockSelectionState, DragUnit } from './story-block-selection';
 
 export const STORY_BLOCK_DRAG_TYPE = 'application/x-nao-story-block';
 export const GRID_COLUMN_DRAG_TYPE = 'application/x-nao-grid-column';
@@ -28,6 +28,7 @@ export const StoryBlockDragContext = createContext<{
 	pendingDropRef: MutableRefObject<(() => void) | null>;
 	beginMultiSelectionDrag: (units: DragUnit[], event: DragEvent) => void;
 	endMultiSelectionDrag: () => void;
+	rememberDragUndoSelection: (selection: BlockSelectionState) => void;
 } | null>(null);
 
 export const GridDragContext = createContext<MutableRefObject<GridDragSource | null> | null>(null);

--- a/apps/frontend/src/components/side-panel/story-editor-grid-block.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-grid-block.tsx
@@ -141,12 +141,12 @@ function GridBlockView(props: ReactNodeViewProps) {
 											return;
 										}
 										const next = selectColumnFromHandle(props.editor.state, gridPos, i);
-										if (!next) {
-											return;
+										if (next) {
+											props.editor.view.dispatch(
+												props.editor.state.tr.setMeta(blockSelectionPluginKey, next),
+											);
 										}
-										props.editor.view.dispatch(
-											props.editor.state.tr.setMeta(blockSelectionPluginKey, next),
-										);
+										props.editor.view.focus();
 									}}
 									onPointerDown={(event) => {
 										event.stopPropagation();

--- a/apps/frontend/src/components/side-panel/story-editor-utils.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-utils.ts
@@ -114,10 +114,55 @@ export function setCollapsedTextSelection(transaction: Transaction, position: nu
 export function dispatchDropWithScroll(view: EditorView, transaction: Transaction, pos: number): void {
 	setCollapsedTextSelection(transaction, pos);
 	view.dispatch(transaction);
+	scrollPosIntoView(view, pos);
+}
+
+export function scrollPosIntoView(view: EditorView, pos: number, gridColumnIndex?: number): void {
 	requestAnimationFrame(() => {
 		const clamped = Math.max(0, Math.min(pos, view.state.doc.content.size));
-		const dom = view.nodeDOM(clamped);
+		const gridColumn =
+			gridColumnIndex === undefined
+				? null
+				: view.dom.querySelector<HTMLElement>(
+						`[data-grid-pos="${clamped}"][data-col-index="${gridColumnIndex}"]`,
+					);
+		const dom = gridColumn ?? view.nodeDOM(clamped);
 		const element = dom instanceof HTMLElement ? dom : (dom?.parentElement ?? null);
-		element?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+		if (!element || isReasonablyVisible(element)) {
+			return;
+		}
+		element.scrollIntoView({ block: 'center', behavior: 'smooth' });
 	});
+}
+
+const SCROLL_VISIBILITY_MARGIN = 24;
+
+function isReasonablyVisible(element: HTMLElement): boolean {
+	const scrollContainer = findVerticalScrollContainer(element);
+	if (!scrollContainer) {
+		return false;
+	}
+
+	const elementRect = element.getBoundingClientRect();
+	const scrollportRect = scrollContainer.getBoundingClientRect();
+	if (elementRect.bottom <= elementRect.top || scrollportRect.bottom <= scrollportRect.top) {
+		return false;
+	}
+
+	return (
+		elementRect.top >= scrollportRect.top - SCROLL_VISIBILITY_MARGIN &&
+		elementRect.bottom <= scrollportRect.bottom + SCROLL_VISIBILITY_MARGIN
+	);
+}
+
+function findVerticalScrollContainer(element: HTMLElement): HTMLElement | null {
+	let ancestor = element.parentElement;
+	while (ancestor) {
+		const overflowY = window.getComputedStyle(ancestor).overflowY;
+		if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+			return ancestor;
+		}
+		ancestor = ancestor.parentElement;
+	}
+	return null;
 }

--- a/apps/frontend/src/components/side-panel/story-editor-utils.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-utils.ts
@@ -1,5 +1,5 @@
 import { popGridColumn, TAG_ATTRS } from '@nao/shared/story-segments';
-import { Selection } from '@tiptap/pm/state';
+import { Selection, TextSelection } from '@tiptap/pm/state';
 import type { Node as PMNode, Schema } from '@tiptap/pm/model';
 import type { EditorState, Transaction } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
@@ -105,7 +105,10 @@ export function cloneElementWithStyles(node: HTMLElement): HTMLElement {
 
 export function dispatchDropWithScroll(view: EditorView, transaction: Transaction, pos: number): void {
 	const target = Math.max(0, Math.min(pos, transaction.doc.content.size));
-	transaction.setSelection(Selection.near(transaction.doc.resolve(target)));
+	const $target = transaction.doc.resolve(target);
+	const nearbySelection =
+		Selection.findFrom($target, 1, true) ?? Selection.findFrom($target, -1, true) ?? Selection.near($target);
+	transaction.setSelection(TextSelection.create(transaction.doc, nearbySelection.from));
 	view.dispatch(transaction);
 	requestAnimationFrame(() => {
 		const clamped = Math.max(0, Math.min(pos, view.state.doc.content.size));

--- a/apps/frontend/src/components/side-panel/story-editor-utils.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-utils.ts
@@ -138,7 +138,7 @@ export function scrollPosIntoView(view: EditorView, pos: number, gridColumnIndex
 const SCROLL_VISIBILITY_MARGIN = 24;
 
 function isReasonablyVisible(element: HTMLElement): boolean {
-	const scrollContainer = findScrollContainer(element);
+	const scrollContainer = findVerticalScrollContainer(element);
 	if (!scrollContainer) {
 		return false;
 	}
@@ -162,11 +162,11 @@ function isReasonablyVisible(element: HTMLElement): boolean {
 	);
 }
 
-function findScrollContainer(element: HTMLElement): HTMLElement | null {
+function findVerticalScrollContainer(element: HTMLElement): HTMLElement | null {
 	let ancestor = element.parentElement;
 	while (ancestor) {
-		const { overflowX, overflowY } = window.getComputedStyle(ancestor);
-		if ([overflowX, overflowY].some((overflow) => ['auto', 'scroll', 'overlay'].includes(overflow))) {
+		const { overflowY } = window.getComputedStyle(ancestor);
+		if (['auto', 'scroll', 'overlay'].includes(overflowY) && ancestor.scrollHeight - ancestor.clientHeight > 1) {
 			return ancestor;
 		}
 		ancestor = ancestor.parentElement;

--- a/apps/frontend/src/components/side-panel/story-editor-utils.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-utils.ts
@@ -138,28 +138,35 @@ export function scrollPosIntoView(view: EditorView, pos: number, gridColumnIndex
 const SCROLL_VISIBILITY_MARGIN = 24;
 
 function isReasonablyVisible(element: HTMLElement): boolean {
-	const scrollContainer = findVerticalScrollContainer(element);
+	const scrollContainer = findScrollContainer(element);
 	if (!scrollContainer) {
 		return false;
 	}
 
 	const elementRect = element.getBoundingClientRect();
 	const scrollportRect = scrollContainer.getBoundingClientRect();
-	if (elementRect.bottom <= elementRect.top || scrollportRect.bottom <= scrollportRect.top) {
+	if (
+		elementRect.bottom <= elementRect.top ||
+		elementRect.right <= elementRect.left ||
+		scrollportRect.bottom <= scrollportRect.top ||
+		scrollportRect.right <= scrollportRect.left
+	) {
 		return false;
 	}
 
 	return (
 		elementRect.top >= scrollportRect.top - SCROLL_VISIBILITY_MARGIN &&
-		elementRect.bottom <= scrollportRect.bottom + SCROLL_VISIBILITY_MARGIN
+		elementRect.bottom <= scrollportRect.bottom + SCROLL_VISIBILITY_MARGIN &&
+		elementRect.left >= scrollportRect.left - SCROLL_VISIBILITY_MARGIN &&
+		elementRect.right <= scrollportRect.right + SCROLL_VISIBILITY_MARGIN
 	);
 }
 
-function findVerticalScrollContainer(element: HTMLElement): HTMLElement | null {
+function findScrollContainer(element: HTMLElement): HTMLElement | null {
 	let ancestor = element.parentElement;
 	while (ancestor) {
-		const overflowY = window.getComputedStyle(ancestor).overflowY;
-		if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+		const { overflowX, overflowY } = window.getComputedStyle(ancestor);
+		if ([overflowX, overflowY].some((overflow) => ['auto', 'scroll', 'overlay'].includes(overflow))) {
 			return ancestor;
 		}
 		ancestor = ancestor.parentElement;

--- a/apps/frontend/src/components/side-panel/story-editor-utils.ts
+++ b/apps/frontend/src/components/side-panel/story-editor-utils.ts
@@ -103,12 +103,16 @@ export function cloneElementWithStyles(node: HTMLElement): HTMLElement {
 	return clone;
 }
 
-export function dispatchDropWithScroll(view: EditorView, transaction: Transaction, pos: number): void {
-	const target = Math.max(0, Math.min(pos, transaction.doc.content.size));
-	const $target = transaction.doc.resolve(target);
+export function setCollapsedTextSelection(transaction: Transaction, position: number): void {
+	const clampedPosition = Math.max(0, Math.min(position, transaction.doc.content.size));
+	const $position = transaction.doc.resolve(clampedPosition);
 	const nearbySelection =
-		Selection.findFrom($target, 1, true) ?? Selection.findFrom($target, -1, true) ?? Selection.near($target);
+		Selection.findFrom($position, 1, true) ?? Selection.findFrom($position, -1, true) ?? Selection.near($position);
 	transaction.setSelection(TextSelection.create(transaction.doc, nearbySelection.from));
+}
+
+export function dispatchDropWithScroll(view: EditorView, transaction: Transaction, pos: number): void {
+	setCollapsedTextSelection(transaction, pos);
 	view.dispatch(transaction);
 	requestAnimationFrame(() => {
 		const clamped = Math.max(0, Math.min(pos, view.state.doc.content.size));

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -357,6 +357,10 @@ describe('story block selection', () => {
 		const column = createColumnElement(gridPos, 0, 'chart');
 		gridEditor.view.dom.appendChild(column);
 		gridEditor.view.dom.style.overflowY = 'auto';
+		Object.defineProperties(gridEditor.view.dom, {
+			scrollHeight: { configurable: true, value: 1000 },
+			clientHeight: { configurable: true, value: 500 },
+		});
 		gridEditor.view.dom.getBoundingClientRect = () => new DOMRect(0, 0, 600, 500);
 		column.getBoundingClientRect = () => new DOMRect(0, 100, 300, 200);
 		const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
@@ -372,6 +376,46 @@ describe('story block selection', () => {
 		try {
 			scrollPosIntoView(gridEditor.view, gridPos, 0);
 			expect(didScroll).toBe(false);
+		} finally {
+			globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+			gridEditor.destroy();
+		}
+	});
+
+	it('scrolls when a horizontal wrapper hides the vertical scroll container', () => {
+		const gridEditor = createGridEditor();
+		const [, gridPos] = topLevelBlockPositions(gridEditor.state.doc);
+		const column = createColumnElement(gridPos, 0, 'chart');
+		const horizontalWrapper = document.createElement('div');
+		horizontalWrapper.style.overflowX = 'auto';
+		horizontalWrapper.style.overflowY = 'auto';
+		horizontalWrapper.appendChild(column);
+		gridEditor.view.dom.appendChild(horizontalWrapper);
+		gridEditor.view.dom.style.overflowY = 'auto';
+		Object.defineProperties(horizontalWrapper, {
+			scrollHeight: { configurable: true, value: 1000 },
+			clientHeight: { configurable: true, value: 1000 },
+		});
+		Object.defineProperties(gridEditor.view.dom, {
+			scrollHeight: { configurable: true, value: 1000 },
+			clientHeight: { configurable: true, value: 300 },
+		});
+		horizontalWrapper.getBoundingClientRect = () => new DOMRect(0, 0, 600, 1000);
+		gridEditor.view.dom.getBoundingClientRect = () => new DOMRect(0, 0, 600, 300);
+		column.getBoundingClientRect = () => new DOMRect(0, 400, 300, 100);
+		const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+		let didScroll = false;
+		column.scrollIntoView = () => {
+			didScroll = true;
+		};
+		globalThis.requestAnimationFrame = (callback) => {
+			callback(0);
+			return 1;
+		};
+
+		try {
+			scrollPosIntoView(gridEditor.view, gridPos, 0);
+			expect(didScroll).toBe(true);
 		} finally {
 			globalThis.requestAnimationFrame = originalRequestAnimationFrame;
 			gridEditor.destroy();

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -4,7 +4,12 @@ import { Editor, Node } from '@tiptap/core';
 import { TextSelection } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { splitGridColumnsRaw } from '@nao/shared/story-segments';
+import {
+	groupBlocksIntoGrid,
+	popGridColumn,
+	reorderGridColumns,
+	splitGridColumnsRaw,
+} from '@nao/shared/story-segments';
 import type { Transaction } from '@tiptap/pm/state';
 
 import {
@@ -26,6 +31,7 @@ import {
 	selectColumnFromHandle,
 	topLevelBlockPositions,
 } from '@/components/side-panel/story-block-selection';
+import { createBlockNode, removeCardFromOrigin, scrollPosIntoView } from '@/components/side-panel/story-editor-utils';
 
 function createEditor(): Editor {
 	return new Editor({
@@ -85,6 +91,10 @@ const TestTableBlock = Node.create({
 const FIRST_GRID = '<grid><chart query_id="q1" chart_type="line" x_axis_key="month" /></grid>';
 const FIRST_GRID_REORDERED = '<grid><chart query_id="q1" chart_type="bar" x_axis_key="month" /></grid>';
 const SECOND_GRID = '<grid><chart query_id="q2" chart_type="bar" x_axis_key="month" /></grid>';
+const FIRST_TWO_COLUMN_GRID = `<grid widths="1,1">
+<chart query_id="q1" chart_type="line" x_axis_key="month" />
+<chart query_id="q2" chart_type="bar" x_axis_key="month" />
+</grid>`;
 const FIRST_THREE_COLUMN_GRID = `<grid widths="1,1,1">
 <chart query_id="q1" chart_type="line" x_axis_key="month" />
 <chart query_id="q2" chart_type="bar" x_axis_key="month" />
@@ -134,6 +144,63 @@ function selectMixed(editor: Editor, blocks: number[], gridColumns: { gridPos: n
 			columnAnchor: gridColumns[0] ?? null,
 		}),
 	);
+}
+
+function joinFirstChartIntoLast(editor: Editor): void {
+	const [sourcePos, , targetPos] = topLevelBlockPositions(editor.state.doc);
+	const sourceNode = editor.state.doc.nodeAt(sourcePos);
+	const targetNode = editor.state.doc.nodeAt(targetPos);
+	if (!sourceNode || !targetNode) {
+		throw new Error('Expected source and target chart blocks');
+	}
+	const gridNode = createBlockNode(
+		editor.state.schema,
+		groupBlocksIntoGrid(targetNode.attrs.rawTag as string, sourceNode.attrs.rawTag as string),
+	);
+	if (!gridNode) {
+		throw new Error('Expected grid block');
+	}
+
+	const transaction = editor.state.tr;
+	transaction.replaceWith(targetPos, targetPos + targetNode.nodeSize, gridNode);
+	removeCardFromOrigin(transaction, editor.state, { kind: 'block', pos: sourcePos });
+	const finalGridPos = transaction.mapping.map(targetPos, -1);
+	transaction.setMeta(
+		blockSelectionPluginKey,
+		blockSelectionFromOrigin({ kind: 'gridColumn', gridPos: finalGridPos, columnIndex: 1 }, [
+			sourceNode.attrs.rawTag as string,
+		]),
+	);
+	editor.view.dispatch(transaction);
+}
+
+function popFirstGridColumn(editor: Editor): void {
+	const [gridPos] = topLevelBlockPositions(editor.state.doc);
+	const gridNode = editor.state.doc.nodeAt(gridPos);
+	if (!gridNode || gridNode.type.name !== 'gridBlock') {
+		throw new Error('Expected grid block');
+	}
+	const result = popGridColumn(gridNode.attrs.rawContent as string, 0);
+	if (!result) {
+		throw new Error('Expected popped grid column');
+	}
+	const poppedNode = createBlockNode(editor.state.schema, result.popped);
+	const remainingNode = createBlockNode(editor.state.schema, result.remaining);
+	if (!poppedNode || !remainingNode) {
+		throw new Error('Expected grid column nodes');
+	}
+
+	const gridTo = gridPos + gridNode.nodeSize;
+	const insertPos = editor.state.doc.content.size;
+	const transaction = editor.state.tr;
+	transaction.replaceWith(gridPos, gridTo, remainingNode);
+	const mappedInsert = transaction.mapping.map(insertPos, insertPos >= gridTo ? 1 : -1);
+	transaction.insert(mappedInsert, poppedNode);
+	transaction.setMeta(
+		blockSelectionPluginKey,
+		blockSelectionForInsertedNodes(mappedInsert, [poppedNode], [result.popped]),
+	);
+	editor.view.dispatch(transaction);
 }
 
 function dispatchEditorMouseDown(target: Element, init?: MouseEventInit): void {
@@ -258,6 +325,57 @@ describe('story block selection', () => {
 			anchor: 10,
 			columnAnchor: null,
 		});
+	});
+
+	it('scrolls a selected grid column into view', () => {
+		const gridEditor = createGridEditor();
+		const [, gridPos] = topLevelBlockPositions(gridEditor.state.doc);
+		const column = createColumnElement(gridPos, 0, 'chart');
+		gridEditor.view.dom.appendChild(column);
+		const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+		let scrollOptions: boolean | ScrollIntoViewOptions | undefined;
+		column.scrollIntoView = (options) => {
+			scrollOptions = options;
+		};
+		globalThis.requestAnimationFrame = (callback) => {
+			callback(0);
+			return 1;
+		};
+
+		try {
+			scrollPosIntoView(gridEditor.view, gridPos, 0);
+			expect(scrollOptions).toEqual({ block: 'center', behavior: 'smooth' });
+		} finally {
+			globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+			gridEditor.destroy();
+		}
+	});
+
+	it('does not scroll a grid column that is already visible', () => {
+		const gridEditor = createGridEditor();
+		const [, gridPos] = topLevelBlockPositions(gridEditor.state.doc);
+		const column = createColumnElement(gridPos, 0, 'chart');
+		gridEditor.view.dom.appendChild(column);
+		gridEditor.view.dom.style.overflowY = 'auto';
+		gridEditor.view.dom.getBoundingClientRect = () => new DOMRect(0, 0, 600, 500);
+		column.getBoundingClientRect = () => new DOMRect(0, 100, 300, 200);
+		const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+		let didScroll = false;
+		column.scrollIntoView = () => {
+			didScroll = true;
+		};
+		globalThis.requestAnimationFrame = (callback) => {
+			callback(0);
+			return 1;
+		};
+
+		try {
+			scrollPosIntoView(gridEditor.view, gridPos, 0);
+			expect(didScroll).toBe(false);
+		} finally {
+			globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+			gridEditor.destroy();
+		}
 	});
 
 	it('applies block chrome with a collapsed selection outside history', () => {
@@ -654,6 +772,105 @@ describe('story block selection', () => {
 				index: 0,
 			});
 		});
+
+		it('restores a reordered column selection on undo', () => {
+			const reorderEditor = createDocumentEditor([
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_THREE_COLUMN_GRID } },
+			]);
+			const [gridPos] = topLevelBlockPositions(reorderEditor.state.doc);
+			const transaction = reorderEditor.state.tr;
+			transaction.setNodeAttribute(gridPos, 'rawContent', reorderGridColumns(FIRST_THREE_COLUMN_GRID, 0, 2));
+			transaction.setMeta(
+				blockSelectionPluginKey,
+				blockSelectionFromOrigin({ kind: 'gridColumn', gridPos, columnIndex: 2 }, [
+					splitGridColumnsRaw(FIRST_THREE_COLUMN_GRID).columns[0],
+				]),
+			);
+			reorderEditor.view.dispatch(transaction);
+
+			expect(getSelectedGridColumns(reorderEditor.state)).toEqual([{ gridPos, index: 2 }]);
+			expect(reorderEditor.commands.undo()).toBe(true);
+			expect(getSelectedGridColumns(reorderEditor.state)).toEqual([{ gridPos, index: 0 }]);
+			reorderEditor.destroy();
+		});
+	});
+
+	describe('grid column pop history selection', () => {
+		function createPopEditor(): Editor {
+			return createDocumentEditor([
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_TWO_COLUMN_GRID } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Target' }] },
+			]);
+		}
+
+		it('restores only the popped column on undo after selection was cleared', () => {
+			const popEditor = createPopEditor();
+			popFirstGridColumn(popEditor);
+			popEditor.view.dispatch(popEditor.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
+
+			expect(popEditor.commands.undo()).toBe(true);
+
+			const [gridPos] = topLevelBlockPositions(popEditor.state.doc);
+			expect(getSelectedBlockPositions(popEditor.state)).toEqual([]);
+			expect(getSelectedGridColumns(popEditor.state)).toEqual([{ gridPos, index: 0 }]);
+
+			popEditor.view.dispatch(popEditor.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
+			expect(popEditor.commands.redo()).toBe(true);
+			const [selectedBlockPos] = getSelectedBlockPositions(popEditor.state);
+			expect(getSelectedBlockPositions(popEditor.state)).toHaveLength(1);
+			expect(popEditor.state.doc.nodeAt(selectedBlockPos)?.attrs.rawTag).toContain('query_id="q1"');
+			expect(getSelectedGridColumns(popEditor.state)).toEqual([]);
+			popEditor.destroy();
+		});
+
+		it('restores only the popped column on undo while selection is active', () => {
+			const popEditor = createPopEditor();
+			popFirstGridColumn(popEditor);
+
+			expect(popEditor.commands.undo()).toBe(true);
+
+			const [gridPos] = topLevelBlockPositions(popEditor.state.doc);
+			expect(getSelectedBlockPositions(popEditor.state)).toEqual([]);
+			expect(getSelectedGridColumns(popEditor.state)).toEqual([{ gridPos, index: 0 }]);
+			popEditor.destroy();
+		});
+	});
+
+	describe('join into grid history selection', () => {
+		function createJoinEditor(): Editor {
+			return createDocumentEditor([
+				{ type: 'chartBlock', attrs: { rawTag: '<chart query_id="moved" />' } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Between' }] },
+				{ type: 'chartBlock', attrs: { rawTag: '<chart query_id="neighbor" />' } },
+			]);
+		}
+
+		it('selects only the restored moved chart on undo', () => {
+			const joinEditor = createJoinEditor();
+			joinFirstChartIntoLast(joinEditor);
+
+			expect(joinEditor.commands.undo()).toBe(true);
+
+			const [movedPos, , neighborPos] = topLevelBlockPositions(joinEditor.state.doc);
+			expect(getSelectedBlockPositions(joinEditor.state)).toEqual([movedPos]);
+			expect(getSelectedBlockPositions(joinEditor.state)).not.toContain(neighborPos);
+			expect(getSelectedGridColumns(joinEditor.state)).toEqual([]);
+			joinEditor.destroy();
+		});
+
+		it('selects only the restored moved chart on undo after selection was cleared', () => {
+			const joinEditor = createJoinEditor();
+			joinFirstChartIntoLast(joinEditor);
+			selectBlocks(joinEditor, [], null);
+
+			expect(joinEditor.commands.undo()).toBe(true);
+
+			const [movedPos, , neighborPos] = topLevelBlockPositions(joinEditor.state.doc);
+			expect(getSelectedBlockPositions(joinEditor.state)).toEqual([movedPos]);
+			expect(getSelectedBlockPositions(joinEditor.state)).not.toContain(neighborPos);
+			expect(getSelectedGridColumns(joinEditor.state)).toEqual([]);
+			joinEditor.destroy();
+		});
 	});
 
 	describe('isDropInsideSelection', () => {
@@ -688,6 +905,26 @@ describe('story block selection', () => {
 			expect(editor.state.doc.textContent).toBe('BBAACC');
 			expect(getSelectedBlockPositions(editor.state)).toEqual(topLevelBlockPositions(editor.state.doc).slice(1));
 			expect(editor.state.selection.empty).toBe(true);
+		});
+
+		it('reselects moved chart and table blocks after selection was cleared', () => {
+			const embedEditor = createDocumentEditor([
+				{ type: 'chartBlock', attrs: { rawTag: '<chart query_id="q1" />' } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Target' }] },
+				{ type: 'tableBlock', attrs: { rawTag: '<table query_id="q2" />' } },
+			]);
+			const [chartPos, , tablePos] = topLevelBlockPositions(embedEditor.state.doc);
+			const move = buildBlockMoveTransaction(embedEditor.state, [chartPos, tablePos], tablePos);
+			expect(move).not.toBeNull();
+			if (move) {
+				embedEditor.view.dispatch(move.transaction);
+			}
+			selectBlocks(embedEditor, [], null);
+
+			expect(embedEditor.commands.undo()).toBe(true);
+			const [restoredChartPos, , restoredTablePos] = topLevelBlockPositions(embedEditor.state.doc);
+			expect(getSelectedBlockPositions(embedEditor.state)).toEqual([restoredChartPos, restoredTablePos]);
+			embedEditor.destroy();
 		});
 
 		it('moves a contiguous selection past a later block without dropping blocks', () => {
@@ -810,6 +1047,14 @@ describe('story block selection', () => {
 			);
 			expect(getSelectedBlockPositions(moveEditor.state)).toEqual([
 				topLevelBlockPositions(moveEditor.state.doc)[1],
+			]);
+			expect(moveEditor.commands.undo()).toBe(true);
+			const [restoredGridPos] = topLevelBlockPositions(moveEditor.state.doc);
+			expect(getSelectedBlockPositions(moveEditor.state)).toEqual([]);
+			expect(getSelectedGridColumns(moveEditor.state)).toEqual([
+				{ gridPos: restoredGridPos, index: 0 },
+				{ gridPos: restoredGridPos, index: 1 },
+				{ gridPos: restoredGridPos, index: 2 },
 			]);
 			moveEditor.destroy();
 		});

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -927,6 +927,19 @@ describe('story block selection', () => {
 			embedEditor.destroy();
 		});
 
+		it('reselects a moved paragraph on undo after selection was cleared', () => {
+			const [paragraphPos] = topLevelBlockPositions(editor.state.doc);
+			const move = buildBlockMoveTransaction(editor.state, [paragraphPos], editor.state.doc.content.size);
+			expect(move).not.toBeNull();
+			if (move) {
+				editor.view.dispatch(move.transaction);
+			}
+			selectBlocks(editor, [], null);
+
+			expect(editor.commands.undo()).toBe(true);
+			expect(getSelectedBlockPositions(editor.state)).toEqual([topLevelBlockPositions(editor.state.doc)[0]]);
+		});
+
 		it('moves a contiguous selection past a later block without dropping blocks', () => {
 			const [a, b, c] = topLevelBlockPositions(editor.state.doc);
 			const move = buildBlockMoveTransaction(editor.state, [a, b], c);

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 
 import { Editor, Node } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { splitGridColumnsRaw } from '@nao/shared/story-segments';
+import type { Transaction } from '@tiptap/pm/state';
 
 import {
 	BlockSelection,
+	applyBlockSelection,
 	blockSelectionPluginKey,
+	blockSelectionForInsertedNodes,
+	blockSelectionFromDragUnits,
+	blockSelectionFromOrigin,
 	buildBlockMoveTransaction,
 	buildSelectionMoveTransaction,
 	emptySelection,
@@ -207,6 +213,76 @@ describe('story block selection', () => {
 
 		selectBlocks(editor, [], null);
 		expect(getSelectedBlockPositions(editor.state)).toEqual([]);
+	});
+
+	it('builds a block selection from mixed drag units', () => {
+		expect(
+			blockSelectionFromDragUnits([
+				{ kind: 'block', pos: 8 },
+				{ kind: 'gridColumns', gridPos: 3, indices: [2, 0] },
+				{ kind: 'block', pos: 1 },
+			]),
+		).toEqual({
+			blocks: [1, 8],
+			gridColumns: [
+				{ gridPos: 3, index: 0 },
+				{ gridPos: 3, index: 2 },
+			],
+			anchor: 1,
+			columnAnchor: { gridPos: 3, index: 0 },
+		});
+	});
+
+	it('builds a block selection from a card origin', () => {
+		expect(blockSelectionFromOrigin({ kind: 'block', pos: 8 })).toEqual({
+			blocks: [8],
+			gridColumns: [],
+			anchor: 8,
+			columnAnchor: null,
+		});
+		expect(blockSelectionFromOrigin({ kind: 'gridColumn', gridPos: 3, columnIndex: 2 })).toEqual({
+			blocks: [],
+			gridColumns: [{ gridPos: 3, index: 2 }],
+			anchor: null,
+			columnAnchor: { gridPos: 3, index: 2 },
+		});
+	});
+
+	it('builds a block selection for consecutive inserted nodes', () => {
+		const first = editor.state.doc.child(0);
+		const second = editor.state.doc.child(1);
+
+		expect(blockSelectionForInsertedNodes(10, [first, second])).toEqual({
+			blocks: [10, 10 + first.nodeSize],
+			gridColumns: [],
+			anchor: 10,
+			columnAnchor: null,
+		});
+	});
+
+	it('applies block chrome with a collapsed selection outside history', () => {
+		const [first, , third] = topLevelBlockPositions(editor.state.doc);
+		editor.view.dispatch(
+			editor.state.tr.setSelection(TextSelection.create(editor.state.doc, first + 1, third + 1)),
+		);
+		const transactions: Transaction[] = [];
+		const captureTransaction = ({ transaction }: { transaction: Transaction }) => {
+			transactions.push(transaction);
+		};
+		editor.on('transaction', captureTransaction);
+
+		applyBlockSelection(
+			editor.view,
+			blockSelectionFromDragUnits([
+				{ kind: 'block', pos: first },
+				{ kind: 'block', pos: third },
+			]),
+		);
+
+		expect(getSelectedBlockPositions(editor.state)).toEqual([first, third]);
+		expect(editor.state.selection.empty).toBe(true);
+		expect(transactions.at(-1)?.getMeta('addToHistory')).toBe(false);
+		editor.off('transaction', captureTransaction);
 	});
 
 	describe('mousedown handling', () => {
@@ -610,6 +686,8 @@ describe('story block selection', () => {
 			editor.view.dispatch(move.transaction);
 			expect(editor.state.doc.childCount).toBe(3);
 			expect(editor.state.doc.textContent).toBe('BBAACC');
+			expect(getSelectedBlockPositions(editor.state)).toEqual(topLevelBlockPositions(editor.state.doc).slice(1));
+			expect(editor.state.selection.empty).toBe(true);
 		});
 
 		it('moves a contiguous selection past a later block without dropping blocks', () => {
@@ -622,6 +700,9 @@ describe('story block selection', () => {
 			editor.view.dispatch(move.transaction);
 			expect(editor.state.doc.childCount).toBe(3);
 			expect(editor.state.doc.textContent).toBe('AABBCC');
+			expect(getSelectedBlockPositions(editor.state)).toEqual(
+				topLevelBlockPositions(editor.state.doc).slice(0, 2),
+			);
 		});
 
 		it('returns null when dropping between two adjacent selected blocks', () => {
@@ -659,6 +740,10 @@ describe('story block selection', () => {
 			expect(splitGridColumnsRaw(moveEditor.state.doc.child(3).attrs.rawContent as string).columns).toHaveLength(
 				2,
 			);
+			expect(getSelectedBlockPositions(moveEditor.state)).toEqual(
+				topLevelBlockPositions(moveEditor.state.doc).slice(2, 4),
+			);
+			expect(moveEditor.state.selection.empty).toBe(true);
 			moveEditor.destroy();
 		});
 
@@ -695,6 +780,9 @@ describe('story block selection', () => {
 			expect(firstMovedColumns[0]).toContain('query_id="q1"');
 			expect(secondMovedColumns).toHaveLength(2);
 			expect(secondMovedColumns[0]).toContain('query_id="q4"');
+			expect(getSelectedBlockPositions(moveEditor.state)).toEqual(
+				topLevelBlockPositions(moveEditor.state.doc).slice(3, 5),
+			);
 			moveEditor.destroy();
 		});
 
@@ -720,6 +808,9 @@ describe('story block selection', () => {
 			expect(splitGridColumnsRaw(moveEditor.state.doc.child(1).attrs.rawContent as string).columns).toHaveLength(
 				3,
 			);
+			expect(getSelectedBlockPositions(moveEditor.state)).toEqual([
+				topLevelBlockPositions(moveEditor.state.doc)[1],
+			]);
 			moveEditor.destroy();
 		});
 


### PR DESCRIPTION
## Summary

- added a Command + Z shortcut which cancels the last block drag
- To help users keep tracks of their blocks' movements, the highlighting of selected blocks remains on even after dropping the blocks or hitting Command Z to put them back in where they were. This makes it much easier to actually see what changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

