### PR TITLE
Fixed a keyboard shortcut bug on Azerty

### DIFF
--- a/apps/frontend/src/components/keyboard-shortcuts-dialog.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts-dialog.tsx
@@ -37,9 +37,7 @@ export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcut
 													key={`${entry.id}-alternate-${index}`}
 													className='flex items-center gap-1.5'
 												>
-													<span className='text-muted-foreground' aria-hidden='true'>
-														·
-													</span>
+													<span className='text-muted-foreground'>·</span>
 													<Kbd shortcut={shortcut} />
 												</span>
 											))}

--- a/apps/frontend/src/components/keyboard-shortcuts-dialog.tsx
+++ b/apps/frontend/src/components/keyboard-shortcuts-dialog.tsx
@@ -30,7 +30,20 @@ export function KeyboardShortcutsDialog({ open, onOpenChange }: KeyboardShortcut
 										className='flex items-center justify-between gap-4 py-1 text-sm'
 									>
 										<span>{entry.label}</span>
-										<Kbd shortcut={entry.shortcut} />
+										<div className='flex items-center gap-1.5'>
+											<Kbd shortcut={entry.shortcut} />
+											{entry.alternateShortcuts?.map((shortcut, index) => (
+												<span
+													key={`${entry.id}-alternate-${index}`}
+													className='flex items-center gap-1.5'
+												>
+													<span className='text-muted-foreground' aria-hidden='true'>
+														·
+													</span>
+													<Kbd shortcut={shortcut} />
+												</span>
+											))}
+										</div>
 									</div>
 								))}
 							</div>

--- a/apps/frontend/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/frontend/src/hooks/use-keyboard-shortcuts.ts
@@ -20,7 +20,8 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
 				if (isTypingTarget(event) && !isAllowedWhileTyping(entry)) {
 					continue;
 				}
-				if (matchesShortcut(event, entry.shortcut)) {
+				const shortcuts = [entry.shortcut, ...(entry.alternateShortcuts ?? [])];
+				if (shortcuts.some((shortcut) => matchesShortcut(event, shortcut))) {
 					event.preventDefault();
 					if (!event.repeat) {
 						handler();

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -16,6 +16,7 @@ export type ShortcutDefinition = {
 	label: string;
 	group: ShortcutGroup;
 	shortcut: Shortcut;
+	alternateShortcuts?: readonly Shortcut[];
 	allowInInput?: boolean;
 };
 
@@ -37,6 +38,7 @@ export const SHORTCUTS: readonly ShortcutDefinition[] = [
 		label: 'Keyboard shortcuts',
 		group: 'General',
 		shortcut: { mod: true, key: '/' },
+		alternateShortcuts: [{ mod: true, key: ':' }],
 	},
 	{
 		id: 'new-chat',
@@ -78,7 +80,8 @@ export function getShortcutTokens(id: ShortcutId): string[] {
 }
 
 export function getShortcutLabel(id: ShortcutId): string {
-	return formatShortcutLabel(getShortcut(id).shortcut);
+	const { shortcut, alternateShortcuts = [] } = getShortcut(id);
+	return [shortcut, ...alternateShortcuts].map(formatShortcutLabel).join(' · ');
 }
 
 export function isTypingTarget(event: KeyboardEvent): boolean {

--- a/apps/frontend/src/lib/platform.test.ts
+++ b/apps/frontend/src/lib/platform.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMac, matchesShortcut } from './platform';
+
+describe('matchesShortcut', () => {
+	it('matches mod+/ without shift', () => {
+		expect(matchesShortcut(createModEvent('/'), { mod: true, key: '/' })).toBe(true);
+	});
+
+	it('matches mod+/ with shift', () => {
+		expect(matchesShortcut(createModEvent('/', true), { mod: true, key: '/' })).toBe(true);
+	});
+
+	it('matches mod+: without shift', () => {
+		expect(matchesShortcut(createModEvent(':'), { mod: true, key: ':' })).toBe(true);
+	});
+
+	it('matches mod+: with shift', () => {
+		expect(matchesShortcut(createModEvent(':', true), { mod: true, key: ':' })).toBe(true);
+	});
+
+	it('rejects shift for mod+k', () => {
+		expect(matchesShortcut(createModEvent('k', true), { mod: true, key: 'k' })).toBe(false);
+	});
+
+	it('requires shift for mod+shift+o', () => {
+		const shortcut = { mod: true, shift: true, key: 'o' };
+
+		expect(matchesShortcut(createModEvent('o'), shortcut)).toBe(false);
+		expect(matchesShortcut(createModEvent('O', true), shortcut)).toBe(true);
+	});
+
+	it('keeps ctrl shortcuts shift-exact', () => {
+		const shortcut = { ctrl: true, key: 'c' };
+
+		expect(matchesShortcut(createKeyboardEvent('c', { ctrlKey: true }), shortcut)).toBe(true);
+		expect(matchesShortcut(createKeyboardEvent('C', { ctrlKey: true, shiftKey: true }), shortcut)).toBe(false);
+	});
+});
+
+function createModEvent(key: string, shiftKey = false): KeyboardEvent {
+	return createKeyboardEvent(key, {
+		metaKey: isMac,
+		ctrlKey: !isMac,
+		shiftKey,
+	});
+}
+
+function createKeyboardEvent(
+	key: string,
+	overrides: Partial<Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'shiftKey' | 'altKey'>> = {},
+): KeyboardEvent {
+	return {
+		key,
+		ctrlKey: false,
+		metaKey: false,
+		shiftKey: false,
+		altKey: false,
+		...overrides,
+	} as KeyboardEvent;
+}

--- a/apps/frontend/src/lib/platform.ts
+++ b/apps/frontend/src/lib/platform.ts
@@ -66,12 +66,14 @@ export function matchesShortcut(event: KeyboardEvent, shortcut: Shortcut): boole
 	if (modPressed !== Boolean(shortcut.mod) || otherModPressed) {
 		return false;
 	}
-	if (event.shiftKey !== Boolean(shortcut.shift) || event.altKey !== Boolean(shortcut.alt)) {
+	if (event.altKey !== Boolean(shortcut.alt)) {
 		return false;
 	}
-
 	if (shortcut.key === '/') {
-		return event.code === 'Slash' || event.key === '/';
+		return event.key === '/' || event.key === ':';
+	}
+	if (event.shiftKey !== Boolean(shortcut.shift)) {
+		return false;
 	}
 
 	return event.key.toLowerCase() === shortcut.key.toLowerCase();

--- a/apps/frontend/src/lib/platform.ts
+++ b/apps/frontend/src/lib/platform.ts
@@ -69,14 +69,17 @@ export function matchesShortcut(event: KeyboardEvent, shortcut: Shortcut): boole
 	if (event.altKey !== Boolean(shortcut.alt)) {
 		return false;
 	}
-	if (shortcut.key === '/') {
-		return event.key === '/' || event.key === ':';
+	if (event.key.toLowerCase() !== shortcut.key.toLowerCase()) {
+		return false;
 	}
-	if (event.shiftKey !== Boolean(shortcut.shift)) {
+	if (shortcut.shift) {
+		return event.shiftKey;
+	}
+	if (isLetterKey(shortcut.key) && event.shiftKey) {
 		return false;
 	}
 
-	return event.key.toLowerCase() === shortcut.key.toLowerCase();
+	return true;
 }
 
 function formatKey(key: string): string {
@@ -84,4 +87,8 @@ function formatKey(key: string): string {
 		return 'Esc';
 	}
 	return key.length === 1 ? key.toUpperCase() : key;
+}
+
+function isLetterKey(key: string): boolean {
+	return /^[a-z]$/i.test(key);
 }


### PR DESCRIPTION
### Summary

- There was a problem on `platform.ts`, we were listening to keys code instead of the character, which means that except for Qwerty keyboards, shortcuts didn't work as they were supposed to.

- Fixed that by listening only to actual characters, and adding `command + :` as a shortcut to open the keyboard helper, since `command + /` is not possible on Azerty, it conflicts with a Mac system shortcut.

- Note that `Command + :` doesn't work on Qwerty and that's on purpose, so that each keyboard type has their shortcut for opening the keyboard helper.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

