### PR TITLE
Require uv >=0.9.17 for 2-day dependency cooldown

### DIFF
--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-live-settings.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-live-settings.ts
@@ -5,9 +5,10 @@ import { trpc } from '@/main';
 interface UseStoryViewerLiveSettingsParams {
 	chatId: string;
 	storySlug: string;
+	shareId?: string;
 }
 
-export const useStoryViewerLiveSettings = ({ chatId, storySlug }: UseStoryViewerLiveSettingsParams) => {
+export const useStoryViewerLiveSettings = ({ chatId, storySlug, shareId }: UseStoryViewerLiveSettingsParams) => {
 	const queryClient = useQueryClient();
 	const { data } = useQuery(trpc.story.listVersions.queryOptions({ chatId, storySlug }));
 
@@ -16,6 +17,15 @@ export const useStoryViewerLiveSettings = ({ chatId, storySlug }: UseStoryViewer
 	const isLiveTextDynamic = data?.isLiveTextDynamic ?? true;
 	const cacheSchedule = data?.cacheSchedule ?? null;
 	const cacheScheduleDescription = data?.cacheScheduleDescription ?? null;
+
+	const invalidateSharedStory = () => {
+		if (!shareId) {
+			return;
+		}
+		void queryClient.invalidateQueries({
+			queryKey: trpc.storyShare.get.queryKey({ shareId }),
+		});
+	};
 
 	const updateLiveSettingsMutation = useMutation(
 		trpc.story.updateLiveSettings.mutationOptions({
@@ -26,6 +36,7 @@ export const useStoryViewerLiveSettings = ({ chatId, storySlug }: UseStoryViewer
 				void queryClient.invalidateQueries({
 					queryKey: trpc.story.getLatest.queryKey({ chatId, storySlug }),
 				});
+				invalidateSharedStory();
 			},
 		}),
 	);
@@ -42,6 +53,7 @@ export const useStoryViewerLiveSettings = ({ chatId, storySlug }: UseStoryViewer
 				void queryClient.invalidateQueries({
 					queryKey: trpc.automation.feed.queryKey(),
 				});
+				invalidateSharedStory();
 			},
 		}),
 	);

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -98,6 +98,8 @@ function SharedStoryPage() {
 				storyId={story.storyId}
 				chatId={story.chatId}
 				storySlug={story.slug}
+				shareId={shareId}
+				cachedAt={story.cachedAt}
 				onOpenChat={() =>
 					navigate({
 						to: '/$chatId',
@@ -133,6 +135,7 @@ function SharedStoryPage() {
 					story.isLive
 						? {
 								isLive: true,
+								cachedAt: story.cachedAt,
 								isRefreshing: refreshMutation.isPending,
 								onRefresh: () => refreshMutation.mutate({ shareId }),
 							}
@@ -206,6 +209,8 @@ interface SharedStoryOwnerHeaderProps {
 	storyId: string | null;
 	chatId: string;
 	storySlug: string;
+	shareId: string;
+	cachedAt?: string | Date | null;
 	onOpenChat: () => void;
 	viewModeControls: StoryPageHeaderProps['viewModeControls'];
 	versionControls: StoryPageHeaderProps['versionControls'];
@@ -217,6 +222,8 @@ function SharedStoryOwnerHeader({
 	storyId,
 	chatId,
 	storySlug,
+	shareId,
+	cachedAt,
 	onOpenChat,
 	viewModeControls,
 	versionControls,
@@ -234,7 +241,7 @@ function SharedStoryOwnerHeader({
 		isRefreshing,
 		handleSaveSettings,
 		handleRefreshData,
-	} = useStoryViewerLiveSettings({ chatId, storySlug });
+	} = useStoryViewerLiveSettings({ chatId, storySlug, shareId });
 
 	return (
 		<>
@@ -244,6 +251,7 @@ function SharedStoryOwnerHeader({
 				onOpenChat={onOpenChat}
 				live={{
 					isLive,
+					cachedAt,
 					isRefreshing,
 					onRefresh: () => handleRefreshData(),
 					onOpenSettings: () => setIsLiveSettingsOpen(true),

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -117,6 +117,7 @@ include = [
 exclude = ["**/example/**"]
 
 [tool.uv]
+required-version = ">=0.9.17"
 exclude-newer = "2 days"
 
 [tool.uv.pip]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -17,6 +17,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P2D"
+
 [[package]]
 name = "aiobotocore"
 version = "3.3.0"
@@ -1196,7 +1200,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -4356,8 +4360,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Relative `exclude-newer = "2 days"` needs uv ≥ 0.9.17; older uv treats it as a date and warns during settings discovery.
- Add `required-version = ">=0.9.17"` and refresh `uv.lock` with `exclude-newer-span = "P2D"`.

## Test plan
- [ ] Upgrade uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`) then `uv --version` ≥ 0.9.17
- [ ] Ensure `uv` on your PATH is the new one (`which uv`)
- [ ] `cd cli && uv sync` — no TOML parse warning
- [ ] `npm run dev:fastapi` starts without the exclude-newer parse error

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

