### PR TITLE
Disable DuckDB external file and network access

### DIFF
--- a/cli/nao_core/config/databases/duckdb.py
+++ b/cli/nao_core/config/databases/duckdb.py
@@ -34,16 +34,19 @@ class DuckDBConfig(DatabaseConfig):
         return DuckDBConfig(name=name, path=path)
 
     def connect(self) -> BaseBackend:
-        """Create an Ibis DuckDB connection."""
+        """Create an Ibis DuckDB connection with external file/network access disabled."""
         from nao_core.deps import require_database_backend
 
         require_database_backend("duckdb")
         import ibis
 
-        return ibis.duckdb.connect(
+        conn = ibis.duckdb.connect(
             database=self.path,
             read_only=False if self.path == ":memory:" else True,
         )
+        conn.raw_sql("SET enable_external_access = false")
+        conn.raw_sql("SET lock_configuration = true")
+        return conn
 
     def get_database_name(self) -> str:
         """Get the database name for DuckDB."""

--- a/cli/tests/nao_core/config/test_duckdb.py
+++ b/cli/tests/nao_core/config/test_duckdb.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from typing import Any, cast
+
+import duckdb
+import pytest
+
+from nao_core.config.databases.duckdb import DuckDBConfig
+
+
+@pytest.fixture
+def duckdb_config(tmp_path: Path) -> DuckDBConfig:
+    db_path = tmp_path / "warehouse.duckdb"
+    secret_csv = tmp_path / "secret.csv"
+    secret_csv.write_text("password\nhunter2\n")
+
+    seed = duckdb.connect(str(db_path))
+    seed.execute("CREATE TABLE users AS SELECT 1 AS id, 'alice' AS name")
+    seed.close()
+
+    return DuckDBConfig(name="warehouse", path=str(db_path))
+
+
+def test_connect_can_query_tables_inside_the_database(duckdb_config: DuckDBConfig) -> None:
+    conn = cast(Any, duckdb_config.connect())
+    try:
+        rows = conn.raw_sql("SELECT name FROM users").fetchall()
+        assert rows == [("alice",)]
+    finally:
+        conn.disconnect()
+
+
+def test_connect_blocks_reading_local_files(duckdb_config: DuckDBConfig, tmp_path: Path) -> None:
+    conn = cast(Any, duckdb_config.connect())
+    try:
+        with pytest.raises(Exception, match="file system operations are disabled|Permission Error"):
+            conn.raw_sql(f"SELECT * FROM read_csv('{tmp_path / 'secret.csv'}')")
+    finally:
+        conn.disconnect()
+
+
+def test_connect_blocks_network_reads(duckdb_config: DuckDBConfig) -> None:
+    conn = cast(Any, duckdb_config.connect())
+    try:
+        with pytest.raises(Exception, match="file system operations are disabled|Permission Error|HTTP"):
+            conn.raw_sql("SELECT * FROM read_csv('https://example.com/data.csv')")
+    finally:
+        conn.disconnect()
+
+
+def test_connect_locks_configuration(duckdb_config: DuckDBConfig) -> None:
+    conn = cast(Any, duckdb_config.connect())
+    try:
+        with pytest.raises(Exception, match="locked|Cannot change configuration"):
+            conn.raw_sql("SET enable_external_access = true")
+    finally:
+        conn.disconnect()
+
+
+def test_connect_blocks_attach(duckdb_config: DuckDBConfig, tmp_path: Path) -> None:
+    other_db = tmp_path / "other.duckdb"
+    seed = duckdb.connect(str(other_db))
+    seed.execute("CREATE TABLE leaked AS SELECT 'secret' AS value")
+    seed.close()
+
+    conn = cast(Any, duckdb_config.connect())
+    try:
+        with pytest.raises(Exception, match="external access|Permission Error|Cannot access"):
+            conn.raw_sql(f"ATTACH '{other_db}' AS other")
+    finally:
+        conn.disconnect()


### PR DESCRIPTION
## Summary
- Lock down warehouse DuckDB connections after connect with `enable_external_access = false` and `lock_configuration = true`, matching the backend local DuckDB lockdown
- Prevent agent/user SQL from reading arbitrary local files, fetching remote URLs, attaching other databases, or re-enabling external access
- Add unit tests covering local file reads, network reads, ATTACH, and config lock

## Test plan
- [x] `make lint` in `cli/`
- [x] `pytest tests/nao_core/config/test_duckdb.py`
- [x] `pytest tests/nao_core/commands/sync/integration/test_duckdb.py`
- [ ] Confirm a configured DuckDB warehouse still syncs and answers `SELECT` against in-DB tables
- [ ] Confirm `read_csv('/etc/passwd')` / `https://…` / `ATTACH` fail on that connection

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

