### PR TITLE
[fix : skill] skill content is now added to user message

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -902,16 +902,9 @@ class AgentManager {
 
 	private _expandSkillMention(text: string, mention: Mention, skill: string): string {
 		const tokens = [`${mention.trigger}[${mention.label}]`, `${mention.trigger}[${mention.id}]`];
-		let expanded = text;
-		let didExpand = false;
-		for (const token of tokens) {
-			if (expanded.includes(token)) {
-				expanded = expanded.replaceAll(token, () => skill);
-				didExpand = true;
-			}
-		}
-		if (didExpand) {
-			return expanded.trim();
+		const matchedToken = tokens.find((token) => text.includes(token));
+		if (matchedToken) {
+			return text.replaceAll(matchedToken, () => skill).trim();
 		}
 		const rest = text.trim();
 		return rest ? `${skill}\n\n${rest}` : skill;

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -901,10 +901,17 @@ class AgentManager {
 	}
 
 	private _expandSkillMention(text: string, mention: Mention, skill: string): string {
-		for (const token of [`${mention.trigger}[${mention.label}]`, `${mention.trigger}[${mention.id}]`]) {
-			if (text.includes(token)) {
-				return text.replace(token, skill).trim();
+		const tokens = [`${mention.trigger}[${mention.label}]`, `${mention.trigger}[${mention.id}]`];
+		let expanded = text;
+		let didExpand = false;
+		for (const token of tokens) {
+			if (expanded.includes(token)) {
+				expanded = expanded.replaceAll(token, () => skill);
+				didExpand = true;
 			}
+		}
+		if (didExpand) {
+			return expanded.trim();
 		}
 		const rest = text.trim();
 		return rest ? `${skill}\n\n${rest}` : skill;

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -891,10 +891,23 @@ class AgentManager {
 		const skillContent = skillMention
 			? skillService.getSkillContent(this.chat.projectId, skillMention.id)
 			: undefined;
-		if (!skillContent) {
+		if (!skillMention || !skillContent) {
 			return messages;
 		}
-		return this._transformLastUserMessageText(messages, () => truncateMiddle(skillContent, 16_000));
+		const skill = truncateMiddle(skillContent, 16_000);
+		return this._transformLastUserMessageText(messages, (text) =>
+			this._expandSkillMention(text, skillMention, skill),
+		);
+	}
+
+	private _expandSkillMention(text: string, mention: Mention, skill: string): string {
+		for (const token of [`${mention.trigger}[${mention.label}]`, `${mention.trigger}[${mention.id}]`]) {
+			if (text.includes(token)) {
+				return text.replace(token, skill).trim();
+			}
+		}
+		const rest = text.trim();
+		return rest ? `${skill}\n\n${rest}` : skill;
 	}
 
 	private _addDatabaseContext(messages: UIMessage[], mentions?: Mention[]): UIMessage[] {


### PR DESCRIPTION
## Summary

Instead of giving the skill content to the agent when the mention was detected, the content is now injected at the mention place so no part of the user message is deleted.

## Overview

<img width="860" height="652" alt="image" src="https://github.com/user-attachments/assets/7b3f7cee-d3c4-480d-95fb-8403f7625b24" />


## Related issue

Fix #1356 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

