### PR TITLE
Move light/dark mode to last in cmd+k and add ⌘⇧L shortcut

### DIFF
--- a/apps/frontend/src/components/command-menu.tsx
+++ b/apps/frontend/src/components/command-menu.tsx
@@ -96,16 +96,6 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				group: 'Jump to',
 			},
 			{
-				id: 'switch-mode',
-				label: `Switch ${theme === 'light' ? 'Dark' : 'Light'} Mode`,
-				keywords: ['switch light mode', 'switch dark mode', 'light mode', 'dark mode', 'theme', 'appearance'],
-				icon: theme === 'light' ? MoonIcon : SunIcon,
-				action: () => {
-					setTheme(theme === 'light' ? 'dark' : 'light');
-				},
-				group: 'Actions',
-			},
-			{
 				id: 'search-settings',
 				label: 'Search settings',
 				keywords: ['settings', 'preferences'],
@@ -123,6 +113,16 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				icon: KeyboardIcon,
 				action: onOpenKeyboardShortcuts,
 				shortcut: getShortcutLabel('keyboard-help'),
+				group: 'Actions',
+			},
+			{
+				id: 'switch-mode',
+				label: `Switch ${theme === 'light' ? 'Dark' : 'Light'} Mode`,
+				keywords: ['switch light mode', 'switch dark mode', 'light mode', 'dark mode', 'theme', 'appearance'],
+				icon: theme === 'light' ? MoonIcon : SunIcon,
+				action: () => {
+					setTheme(theme === 'light' ? 'dark' : 'light');
+				},
 				group: 'Actions',
 			},
 		],

--- a/apps/frontend/src/components/command-menu.tsx
+++ b/apps/frontend/src/components/command-menu.tsx
@@ -123,6 +123,7 @@ export function CommandMenu({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcu
 				action: () => {
 					setTheme(theme === 'light' ? 'dark' : 'light');
 				},
+				shortcut: getShortcutLabel('toggle-theme'),
 				group: 'Actions',
 			},
 		],

--- a/apps/frontend/src/lib/keyboard-shortcuts.ts
+++ b/apps/frontend/src/lib/keyboard-shortcuts.ts
@@ -4,6 +4,7 @@ import { formatShortcut, formatShortcutLabel } from '@/lib/platform';
 export type ShortcutId =
 	| 'toggle-sidebar'
 	| 'command-menu'
+	| 'toggle-theme'
 	| 'new-chat'
 	| 'go-to-stories'
 	| 'keyboard-help'
@@ -32,6 +33,12 @@ export const SHORTCUTS: readonly ShortcutDefinition[] = [
 		label: 'Command menu',
 		group: 'General',
 		shortcut: { mod: true, key: 'k' },
+	},
+	{
+		id: 'toggle-theme',
+		label: 'Toggle light/dark mode',
+		group: 'General',
+		shortcut: { mod: true, shift: true, key: 'l' },
 	},
 	{
 		id: 'keyboard-help',

--- a/apps/frontend/src/routes/_sidebar-layout.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.tsx
@@ -6,6 +6,7 @@ import { KeyboardShortcutsDialog } from '@/components/keyboard-shortcuts-dialog'
 import { Sidebar } from '@/components/sidebar';
 import { CommandMenuCallbackProvider, useCommandMenuCallback } from '@/contexts/command-menu-callback';
 import { SidebarProvider, useSidebar } from '@/contexts/sidebar';
+import { useTheme } from '@/contexts/theme.provider';
 import { useKeyboardShortcuts } from '@/hooks/use-keyboard-shortcuts';
 import { usePermissions } from '@/hooks/use-permissions';
 
@@ -40,15 +41,20 @@ function SidebarLayoutContent() {
 function GlobalShortcuts({ onOpenKeyboardShortcuts }: { onOpenKeyboardShortcuts: () => void }) {
 	const navigate = useNavigate();
 	const { toggle } = useSidebar();
+	const { theme, setTheme } = useTheme();
 	const { fire: openCommandMenu } = useCommandMenuCallback();
 	const { canStartNewChat } = usePermissions();
 
 	const navigateHome = useCallback(() => navigate({ to: '/' }), [navigate]);
 	const navigateStories = useCallback(() => navigate({ to: '/stories', search: { folderId: null } }), [navigate]);
+	const toggleTheme = useCallback(() => {
+		setTheme(theme === 'light' ? 'dark' : 'light');
+	}, [theme, setTheme]);
 
 	useKeyboardShortcuts({
 		'toggle-sidebar': toggle,
 		'command-menu': openCommandMenu,
+		'toggle-theme': toggleTheme,
 		'new-chat': canStartNewChat ? navigateHome : undefined,
 		'go-to-stories': navigateStories,
 		'keyboard-help': onOpenKeyboardShortcuts,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Moves Switch Light/Dark Mode to the end of the Actions group in the command menu, and adds a Notion-style `⌘⇧L` / `Ctrl+Shift+L` shortcut to toggle theme.

## Changes
- Command menu: theme toggle is last so `⌘K` → `↑` → `Enter` selects it
- Global shortcut: `⌘⇧L` / `Ctrl+Shift+L` toggles light/dark mode
- Shortcut appears in the command menu item and the keyboard shortcuts help dialog

## Test plan
- [ ] Open command menu with `⌘K` / `Ctrl+K`
- [ ] Confirm Switch Light/Dark Mode is the last item
- [ ] Press `↑` then `Enter` and confirm the theme toggles
- [ ] Press `⌘⇧L` / `Ctrl+Shift+L` and confirm the theme toggles
- [ ] Open keyboard shortcuts help (`⌘/`) and confirm the new shortcut is listed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-246b8e57-42ce-4f84-9b8d-99fd8cf565d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-246b8e57-42ce-4f84-9b8d-99fd8cf565d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

