### PR TITLE
fix(cli): preserve provider extra in debug pip install recommendation

### DIFF
--- a/cli/nao_core/commands/debug.py
+++ b/cli/nao_core/commands/debug.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, Tuple
 
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from nao_core.config import NaoConfig, resolve_project_path
@@ -258,7 +259,7 @@ def debug():
                     db.name,
                     db.type,
                     "[green]Connected[/green]",
-                    message,
+                    escape(message),
                 )
             else:
                 console.print("[bold red]✗[/bold red]")
@@ -266,7 +267,7 @@ def debug():
                     db.name,
                     db.type,
                     "[red]Failed[/red]",
-                    f"[red]{message}[/red]",
+                    f"[red]{escape(message)}[/red]",
                 )
 
         console.print()
@@ -295,19 +296,21 @@ def debug():
 
             if success and has_model_warning:
                 console.print("[bold yellow]⚠[/bold yellow]")
-                llm_table.add_row(provider_name, models, "[yellow]Connected[/yellow]", f"[yellow]{message}[/yellow]")
+                llm_table.add_row(
+                    provider_name, models, "[yellow]Connected[/yellow]", f"[yellow]{escape(message)}[/yellow]"
+                )
                 model_warnings.append(f"{provider_name}: {message.split('Warning: ', 1)[1]}")
             elif success:
                 console.print("[bold green]✓[/bold green]")
-                llm_table.add_row(provider_name, models, "[green]Connected[/green]", message)
+                llm_table.add_row(provider_name, models, "[green]Connected[/green]", escape(message))
             else:
                 console.print("[bold red]✗[/bold red]")
-                llm_table.add_row(provider_name, models, "[red]Failed[/red]", f"[red]{message}[/red]")
+                llm_table.add_row(provider_name, models, "[red]Failed[/red]", f"[red]{escape(message)}[/red]")
 
         console.print()
         console.print(llm_table)
         for warning in model_warnings:
-            console.print(f"[yellow]⚠[/yellow] {warning}")
+            console.print(f"[yellow]⚠[/yellow] {escape(warning)}")
     else:
         console.print("[dim]No LLM configured[/dim]")
 

--- a/cli/tests/nao_core/commands/test_debug.py
+++ b/cli/tests/nao_core/commands/test_debug.py
@@ -817,3 +817,35 @@ llm:
         assert any("[bold red]✗[/bold red]" in call for call in calls)
 
         mock_check.assert_called_once()
+
+    def test_debug_preserves_provider_extra_in_missing_dependency_message(self, create_config):
+        """MissingDependencyError pip extras like [anthropic] must survive Rich table rendering."""
+        from io import StringIO
+
+        from rich.console import Console
+
+        from nao_core.deps import MissingDependencyError
+
+        create_config("""\
+project_name: test-project
+llm:
+  provider: anthropic
+  api_key: sk-test-key
+""")
+
+        missing_message = str(MissingDependencyError("anthropic", "anthropic", "for Anthropic LLM provider"))
+        assert "pip install 'nao-core[anthropic]'" in missing_message
+
+        buffer = StringIO()
+        real_console = Console(file=buffer, force_terminal=True, width=200, color_system=None)
+
+        with patch(
+            "nao_core.commands.debug.check_llm_connection",
+            return_value=(False, missing_message),
+        ):
+            with patch("nao_core.commands.debug.console", real_console):
+                debug()
+
+        output = buffer.getvalue()
+        assert "pip install 'nao-core[anthropic]'" in output
+        assert "uv pip install 'nao-core[anthropic]'" in output

--- a/cli/tests/nao_core/test_deps.py
+++ b/cli/tests/nao_core/test_deps.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nao_core.deps import MissingDependencyError, require_database_backend
+from nao_core.deps import MissingDependencyError, require_database_backend, require_dependency
 
 
 def test_require_database_backend_uses_public_extra_for_shared_ibis_backend(monkeypatch):
@@ -17,3 +17,22 @@ def test_require_database_backend_uses_public_extra_for_shared_ibis_backend(monk
     assert "to connect to redshift databases" in message
     assert "pip install 'nao-core[redshift]'" in message
     assert "uv pip install 'nao-core[redshift]'" in message
+
+
+def test_missing_dependency_error_keeps_extra_brackets_in_pip_command():
+    """Provider extras must keep [name] brackets — callers escape only at render time."""
+    message = str(MissingDependencyError("anthropic", "anthropic", "for Anthropic LLM provider"))
+    assert "pip install 'nao-core[anthropic]'" in message
+    assert "uv pip install 'nao-core[anthropic]'" in message
+
+
+def test_require_dependency_raises_missing_dependency_with_extra(monkeypatch):
+    def raise_import_error(module_name: str):
+        raise ImportError(module_name)
+
+    monkeypatch.setattr("nao_core.deps.importlib.import_module", raise_import_error)
+
+    with pytest.raises(MissingDependencyError) as exc_info:
+        require_dependency("anthropic", "anthropic", "for Anthropic LLM provider")
+
+    assert "pip install 'nao-core[anthropic]'" in str(exc_info.value)


### PR DESCRIPTION
## Description
**Related Issue: #1298**

`nao debug` silently dropped the LLM provider name from its pip install recommendation whenever a required LLM SDK (e.g. `anthropic`, `openai`, `mistralai`, `google.genai`, `ollama`) was missing. Instead of the actionable command `pip install 'nao-core[anthropic]'`, users saw `pip install 'nao-core'` — a command that installs nothing extra and leaves them stuck without knowing which extra to add.

The root cause was that `check_llm_connection`'s error message (raised as `MissingDependencyError` in `deps.py`) was interpolated directly into a Rich `Table` cell using Rich markup syntax (e.g. `f"[red]{message}[/red]"`). Rich's markup parser treats any `[word]` as a style tag, so `[anthropic]` inside the pip command was parsed away as an unrecognized style instead of being rendered as text; silently stripping the provider extra from the on-screen recommendation.

The fix escapes dynamic message text with `rich.markup.escape()` before it's embedded in any markup string, so literal brackets in error messages (pip extras, model IDs, etc.) always render as-is.

## Changes made
- **Escape dynamic messages before Rich markup rendering**: Updated `cli/nao_core/commands/debug.py` to wrap all dynamic DB/LLM message strings in `rich.markup.escape()` before interpolating them into `console.print()` / `Table.add_row()` calls, for both the database table rows and the LLM provider table rows (including the yellow "warning" and red "failed" states).
- **Regression test for the exact failure mode**: Added `test_debug_preserves_provider_extra_in_missing_dependency_message` in `cli/tests/nao_core/commands/test_debug.py`, which renders a real Rich `Console` into a buffer (not just mocked `print` calls) and asserts the full `pip install 'nao-core[anthropic]'` command survives table rendering intact.
- **Dependency error coverage**: Extended `cli/tests/nao_core/test_deps.py` to confirm `MissingDependencyError` continues to produce a message containing the bracketed extra name, guarding against a future regression in the message format itself.

## Validation
- Manual repro comparing unescaped vs. escaped rendering confirms the fix: before → `pip install 'nao-core'`, after → `pip install 'nao-core[anthropic]'`.
- `uv run pytest tests/nao_core/commands/test_debug.py tests/nao_core/test_deps.py -v` — all tests pass, including the new regression test.
- `uv run ruff check .` and the project's type checker pass with no new issues.

## Screenshots
<img width="1068" height="579" alt="Screenshot From 2026-08-07 15-56-37" src="https://github.com/user-attachments/assets/b0fcbfea-0119-427b-99c5-62ba2a7dd399" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

