### PR TITLE
hotfix(licenses): refresh the expiresAt from online retrieval

### DIFF
--- a/apps/backend/src/services/license.service.ts
+++ b/apps/backend/src/services/license.service.ts
@@ -148,6 +148,7 @@ export async function refreshLicenseOnline(): Promise<void> {
 interface ValidateVerdict {
 	valid: boolean;
 	isActive: boolean;
+	expiresAt?: Date;
 	features?: LicenseFeature[];
 	reason?: string;
 }
@@ -168,6 +169,7 @@ async function verifyValidateToken(token: string, expectedSubscriptionId: string
 		return {
 			valid: payload.valid === true,
 			isActive: payload.isActive === true,
+			expiresAt: parseOptionalExpiresAt(payload.expiresAt),
 			features: parseOptionalFeatures(payload.features),
 			reason: typeof payload.reason === 'string' ? payload.reason : undefined,
 		};
@@ -178,15 +180,30 @@ async function verifyValidateToken(token: string, expectedSubscriptionId: string
 	}
 }
 
+/**
+ * Fold a positive verdict back into the cached license so a subscription renewed
+ * on the licenses server takes effect without re-issuing the license file. The
+ * expiry is only ever pushed further out — shortening it is left to the
+ * `isActive` flag, so a replayed stale verdict can never cut a license short.
+ */
 function updateCachedLicenseFromOnlineVerdict(license: NaoLicense, verdict: ValidateVerdict): void {
-	if (!verdict.features) {
-		return;
+	const expiresAt = pickLatestExpiry(license.expiresAt, verdict.expiresAt);
+	if (expiresAt !== license.expiresAt) {
+		console.log(`[license] ${license.subscriptionId} renewed online until ${expiresAt.toISOString()}`);
 	}
 
 	licensePromise = Promise.resolve({
 		...license,
-		features: verdict.features,
+		expiresAt,
+		features: verdict.features ?? license.features,
 	});
+}
+
+function pickLatestExpiry(current: Date, renewed: Date | undefined): Date {
+	if (!renewed || renewed.getTime() <= current.getTime()) {
+		return current;
+	}
+	return renewed;
 }
 
 async function loadAndVerifyLicense(): Promise<NaoLicense | null> {
@@ -284,6 +301,14 @@ function parseFeatures(value: unknown): LicenseFeature[] {
 	}
 	const known = new Set<string>(Object.values(LICENSE_FEATURES));
 	return value.filter((item): item is LicenseFeature => typeof item === 'string' && known.has(item));
+}
+
+function parseOptionalExpiresAt(value: unknown): Date | undefined {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 }
 
 function parseOptionalFeatures(value: unknown): LicenseFeature[] | undefined {

--- a/apps/backend/tests/license.test.ts
+++ b/apps/backend/tests/license.test.ts
@@ -118,18 +118,12 @@ describe('license.service', () => {
 			features: [],
 		});
 		setLicenseEnv({ licensePath, publicKeyPem });
-		vi.stubGlobal(
-			'fetch',
-			vi.fn(async () => {
-				const token = await createSignedValidateToken(privateKey, {
-					subscriptionId: DEFAULT_CLAIMS.subscriptionId,
-					valid: true,
-					isActive: true,
-					features: [LICENSE_FEATURES.sso],
-				});
-				return new Response(JSON.stringify({ token }));
-			}),
-		);
+		stubValidateResponse(privateKey, {
+			subscriptionId: DEFAULT_CLAIMS.subscriptionId,
+			valid: true,
+			isActive: true,
+			features: [LICENSE_FEATURES.sso],
+		});
 
 		expect(await hasFeature(LICENSE_FEATURES.sso)).toBe(false);
 
@@ -137,6 +131,47 @@ describe('license.service', () => {
 
 		expect(await hasFeature(LICENSE_FEATURES.sso)).toBe(true);
 		expect((await getLicense())?.features).toEqual([LICENSE_FEATURES.sso]);
+	});
+
+	it('extends an expired license when the renewal is verified online', async () => {
+		const eightDaysAgoSeconds = -8 * 24 * 60 * 60;
+		const { licensePath, privateKey, publicKeyPem } = await createSignedLicenseFile(DEFAULT_CLAIMS, {
+			expiresInSeconds: eightDaysAgoSeconds,
+		});
+		const renewedExpiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+		setLicenseEnv({ licensePath, publicKeyPem });
+		stubValidateResponse(privateKey, {
+			subscriptionId: DEFAULT_CLAIMS.subscriptionId,
+			valid: true,
+			isActive: true,
+			expiresAt: renewedExpiry.toISOString(),
+			features: [LICENSE_FEATURES.sso],
+		});
+
+		expect(await hasFeature(LICENSE_FEATURES.sso)).toBe(false);
+
+		await refreshLicenseOnline();
+
+		expect(await hasFeature(LICENSE_FEATURES.sso)).toBe(true);
+		expect((await getLicense())?.expiresAt).toEqual(renewedExpiry);
+	});
+
+	it('never shortens the license expiry from an online verdict', async () => {
+		const { licensePath, privateKey, publicKeyPem } = await createSignedLicenseFile(DEFAULT_CLAIMS);
+		setLicenseEnv({ licensePath, publicKeyPem });
+		const originalExpiry = (await getLicense())?.expiresAt;
+		stubValidateResponse(privateKey, {
+			subscriptionId: DEFAULT_CLAIMS.subscriptionId,
+			valid: true,
+			isActive: true,
+			expiresAt: new Date(Date.now() - 60_000).toISOString(),
+			features: [LICENSE_FEATURES.sso],
+		});
+
+		await refreshLicenseOnline();
+
+		expect((await getLicense())?.expiresAt).toEqual(originalExpiry);
+		expect(await hasFeature(LICENSE_FEATURES.sso)).toBe(true);
 	});
 
 	it('never checks online for offline licenses', async () => {
@@ -281,17 +316,27 @@ async function createSignedLicenseFile(
 	return { licensePath, privateKey, publicKeyPem };
 }
 
-async function createSignedValidateToken(
-	privateKey: CryptoKey,
-	claims: {
-		subscriptionId: string;
-		valid: boolean;
-		isActive: boolean;
-		features: string[];
-	},
-): Promise<string> {
+interface ValidateClaims {
+	subscriptionId: string;
+	valid: boolean;
+	isActive: boolean;
+	expiresAt?: string;
+	features: string[];
+}
+
+function stubValidateResponse(privateKey: CryptoKey, claims: ValidateClaims): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async () => {
+			const token = await createSignedValidateToken(privateKey, claims);
+			return new Response(JSON.stringify({ token }));
+		}),
+	);
+}
+
+async function createSignedValidateToken(privateKey: CryptoKey, claims: ValidateClaims): Promise<string> {
 	const now = Math.floor(Date.now() / 1000);
-	return new SignJWT(claims)
+	return new SignJWT({ ...claims })
 		.setProtectedHeader({ alg: 'EdDSA' })
 		.setIssuer('getnao')
 		.setIssuedAt(now)


### PR DESCRIPTION
Entire-Checkpoint: 01KZNHK8W22ABA3A2PQQPDX675

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

