### PR TITLE
fix th scroll bug when saving a chart setting in story preview

### DIFF
--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -279,7 +279,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 								queryData={queryData ?? null}
 								chatId={chatId}
 								storySlug={resolvedStorySlug}
-								versionKey={`${currentVersionNumber}-${cachedAt ?? ''}`}
+								versionKey={isViewingLatest ? undefined : currentVersionNumber}
 								filtersEnabled={isViewingLatest && !isAgentRunning}
 							/>
 						)


### PR DESCRIPTION
#1281 worked to fix the scrolling bug for stories in fullscreen.
However, in story preview, in chats, It turns out that this bug was still present.
This fixes that


Follows up on #1281

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

