### PR TITLE
fix(backend): enable Anthropic prompt caching for OpenRouter Claude models

### DIFF
--- a/apps/backend/src/utils/prompt-cache.ts
+++ b/apps/backend/src/utils/prompt-cache.ts
@@ -35,6 +35,9 @@ export function getPromptCacheProvider(modelSelection: LlmSelectedModel): Prompt
 	if (provider === 'vertex' && modelId.toLowerCase().startsWith('claude-')) {
 		return 'anthropic';
 	}
+	if (provider === 'openrouter' && modelId.toLowerCase().startsWith('anthropic/')) {
+		return 'anthropic';
+	}
 	if (provider === 'bedrock' && isBedrockAnthropicModel(modelId)) {
 		return 'bedrock';
 	}

--- a/apps/backend/tests/prompt-cache.test.ts
+++ b/apps/backend/tests/prompt-cache.test.ts
@@ -32,6 +32,21 @@ describe('addPromptCache', () => {
 		});
 	});
 
+	it('uses Anthropic cache control for OpenRouter Claude models', () => {
+		const cached = addPromptCache(messages, modelSelection('openrouter', 'anthropic/claude-haiku-4.5'));
+
+		expect(cached[0].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+		});
+		expect(cached[1].providerOptions).toEqual({
+			anthropic: { cacheControl: { type: 'ephemeral' } },
+		});
+	});
+
+	it('does not cache OpenRouter models that cache server-side', () => {
+		expect(addPromptCache(messages, modelSelection('openrouter', 'openai/gpt-5.2'))).toBe(messages);
+	});
+
 	it('uses Bedrock cache points for Bedrock Anthropic foundation models', () => {
 		const cached = addPromptCache(messages, modelSelection('bedrock', 'us.anthropic.claude-sonnet-4-6'));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1381.

`getPromptCacheProvider` had no branch for the `openrouter` provider, so it fell through to `null` and `addPromptCache` returned messages untouched. Claude models served through OpenRouter therefore never received a `cache_control` breakpoint and re-sent the whole schema context at full price on every round trip.

## Change

One branch in `apps/backend/src/utils/prompt-cache.ts`, mirroring the Vertex case directly above it:

```ts
if (provider === 'openrouter' && modelId.toLowerCase().startsWith('anthropic/')) {
	return 'anthropic';
}
```

No new plumbing: `withAnthropicCache` already writes `providerOptions.anthropic.cacheControl`, and `@openrouter/ai-sdk-provider` resolves `openrouter?.cacheControl ?? openrouter?.cache_control ?? anthropic?.cacheControl ?? anthropic?.cache_control` when building the request body.

Models that cache server-side (`openai/*`, `deepseek/*`) keep returning `null`, so they gain no cache-write premium.

## Verification

Two tests added next to the existing Vertex/Bedrock ones (`anthropic/claude-haiku-4.5` gets breakpoints, `openai/gpt-5.2` is returned unchanged and identical by reference).

Additionally verified end-to-end against the real OpenRouter language model with a stub `fetch` capturing the outgoing request body. `anthropic/claude-haiku-4.5` now emits:

```json
[
  { "role": "system", "content": [{ "type": "text", "text": "...", "cache_control": { "type": "ephemeral", "ttl": "1h" } }] },
  { "role": "user",   "content": [{ "type": "text", "text": "...", "cache_control": { "type": "ephemeral" } }] }
]
```

while `openai/gpt-5.2` emits no `cache_control` at all. That throwaway script was not committed.

`npm run lint`, `npm run format:check`, and `npm run -w @nao/backend test -- tests/prompt-cache.test.ts` all pass. The full backend suite has 7 failing files (`context-explorer-*`, `auth-hooks-oidc`, `app-db-views`, `slack-message-blocks`, `project-llm-config-override`); those fail identically on the unmodified base commit and are unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b036396a-ef38-4e51-abb8-3d04c8c8f4da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b036396a-ef38-4e51-abb8-3d04c8c8f4da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

