### PR TITLE
Fix the scrollbar bug where it used to be stuck, unable to reach bottom

### DIFF
--- a/apps/frontend/src/components/chat-messages/chat-messages.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-messages.tsx
@@ -48,11 +48,9 @@ export function ChatMessages() {
 			key={chatId}
 		>
 			<Conversation>
-				<ConversationContent
-					className='max-w-3xl mx-auto gap-0 pt-15 max-md:pt-0'
-					style={{ paddingBottom: 'var(--chat-input-height, 0px)' }}
-				>
+				<ConversationContent className='max-w-3xl mx-auto gap-0 pt-15 pb-0 md:pb-0 max-md:pt-0'>
 					<ChatMessagesContent />
+					<div className='shrink-0' style={{ height: 'var(--chat-input-height, 0px)' }} aria-hidden />
 				</ConversationContent>
 
 				<ConversationScrollButton className='bottom-[calc(var(--chat-input-height,0px)+1rem)]' />

--- a/apps/frontend/src/contexts/text-selection.tsx
+++ b/apps/frontend/src/contexts/text-selection.tsx
@@ -82,14 +82,16 @@ export const SelectionProvider = ({
 	const [selection, setSelection] = useState<SelectionState | null>(null);
 	const [anchors, setAnchors] = useState<SelectionAnchor[]>([]);
 	const [openAnchorChatId, setOpenAnchorChatId] = useState<string | null>(null);
+	const [prevResetKey, setPrevResetKey] = useState(resetKey);
 	const [containerMounted, setContainerMounted] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 
-	useEffect(() => {
+	if (resetKey !== prevResetKey) {
+		setPrevResetKey(resetKey);
 		setSelection(null);
 		setAnchors([]);
 		setOpenAnchorChatId(null);
-	}, [resetKey]);
+	}
 
 	useEffect(() => {
 		setContainerMounted(true);

--- a/apps/frontend/src/contexts/text-selection.tsx
+++ b/apps/frontend/src/contexts/text-selection.tsx
@@ -73,15 +73,23 @@ export const useOptionalSelection = () => useContext(SelectionContext);
 export const SelectionProvider = ({
 	children,
 	persistenceConfig,
+	resetKey,
 }: {
 	children: React.ReactNode;
 	persistenceConfig?: PersistenceConfig;
+	resetKey?: string;
 }) => {
 	const [selection, setSelection] = useState<SelectionState | null>(null);
 	const [anchors, setAnchors] = useState<SelectionAnchor[]>([]);
 	const [openAnchorChatId, setOpenAnchorChatId] = useState<string | null>(null);
 	const [containerMounted, setContainerMounted] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		setSelection(null);
+		setAnchors([]);
+		setOpenAnchorChatId(null);
+	}, [resetKey]);
 
 	useEffect(() => {
 		setContainerMounted(true);

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -150,7 +150,7 @@ function ChatPage() {
 			open={sidePanel.open}
 			close={sidePanel.close}
 		>
-			<SelectionProvider key={chatId}>
+			<SelectionProvider resetKey={chatId}>
 				<div className='flex-1 flex min-w-0 bg-background' ref={containerRef}>
 					<div
 						className='flex flex-col h-full flex-1 min-w-0 overflow-hidden justify-center relative'
@@ -259,8 +259,11 @@ function ChatPage() {
 								<ChatMessages />
 							</>
 						)}
-						<div ref={inputAreaRef} className='pointer-events-none absolute inset-x-0 bottom-0 z-10 pt-8'>
-							<div className='pointer-events-auto bg-gradient-to-t from-background via-background to-transparent'>
+						<div className='pointer-events-none absolute left-0 right-4 bottom-0 z-10 pt-8'>
+							<div
+								ref={inputAreaRef}
+								className='pointer-events-auto bg-gradient-to-t from-background via-background to-transparent'
+							>
 								<ChatInput />
 							</div>
 						</div>


### PR DESCRIPTION
## Summary
- Fixes chat scroll getting stuck after switching chats, where the last lines sat under the input and you couldn’t reach them.
- Keeps bottom clearance in sync with the real input height, and makes the scroll area notice when that height changes.
- Stops remounting the whole chat chrome on every switch (selection just resets), and leaves the scrollbar visible at the bottom.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

