### PR TITLE
[fix : budget per-user] add provider budget from nao config & add budget config to nao config

### DIFF
--- a/apps/backend/src/queries/budget.queries.ts
+++ b/apps/backend/src/queries/budget.queries.ts
@@ -1,6 +1,6 @@
 import { getCurrentPeriodStart } from '@nao/shared/date';
 import type { LlmProvider } from '@nao/shared/types';
-import { and, eq, notInArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, notInArray, sql } from 'drizzle-orm';
 
 import s, { DBProjectProviderBudget } from '../db/abstractSchema';
 import { db } from '../db/db';
@@ -20,12 +20,15 @@ export const getProviderBudget = async (
 	return row ?? null;
 };
 
+export type ProviderPeriod = { provider: LlmProvider; period: BudgetPeriod };
+
 export const getProviderBudgetSpend = async (
 	projectId: string,
 	provider: LlmProvider,
+	period: BudgetPeriod,
 	userId?: string,
 ): Promise<{ projectSpend: number; userSpend: number }> => {
-	const rows = await queryProviderPeriodCosts(projectId, { provider });
+	const rows = await queryProviderPeriodCosts(projectId, [{ provider, period }]);
 
 	let projectTotal = 0;
 	let userTotal = 0;
@@ -122,14 +125,19 @@ export const setProjectProviderBudgets = async (
 	});
 };
 
-type ProviderPeriodCostRow = { provider: string; userId: string | null; totalCost: number };
+type ProviderPeriodCostRow = { provider: LlmProvider | null; userId: string | null; totalCost: number };
 
 const roundCost = (value: number): number => Math.round(value * 100) / 100;
 
 const queryProviderPeriodCosts = async (
 	projectId: string,
-	options: { provider?: LlmProvider; userId?: string; requirePerUserLimit?: boolean } = {},
+	budgets: ProviderPeriod[],
+	options: { userId?: string } = {},
 ): Promise<ProviderPeriodCostRow[]> => {
+	if (budgets.length === 0) {
+		return [];
+	}
+
 	const costLookup = await createCostLookup(projectId);
 	const isPostgres = dbConfig.dialect === Dialect.Postgres;
 	const dayStart = getCurrentPeriodStart('day');
@@ -145,36 +153,38 @@ const queryProviderPeriodCosts = async (
 
 	return db
 		.select({
-			provider: s.projectProviderBudget.provider,
+			provider: s.chatMessage.llmProvider,
 			userId: s.chat.userId,
 			totalCost: sql<number>`sum(${TOTAL_COST_EXPR})`,
 		})
-		.from(s.projectProviderBudget)
-		.innerJoin(s.chat, eq(s.chat.projectId, s.projectProviderBudget.projectId))
-		.innerJoin(s.chatMessage, eq(s.chatMessage.chatId, s.chat.id))
+		.from(s.chatMessage)
+		.innerJoin(s.chat, eq(s.chat.id, s.chatMessage.chatId))
 		.leftJoin(costLookup.table, costLookup.joinCondition)
 		.where(
 			and(
-				eq(s.projectProviderBudget.projectId, projectId),
-				sql`${s.chatMessage.llmProvider} = ${s.projectProviderBudget.provider}`,
+				eq(s.chat.projectId, projectId),
+				inArray(
+					s.chatMessage.llmProvider,
+					budgets.map((b) => b.provider),
+				),
 				sql`${s.chatMessage.createdAt} >= ${periodStartExpr}`,
-				options.provider ? eq(s.projectProviderBudget.provider, options.provider) : undefined,
 				options.userId ? eq(s.chat.userId, options.userId) : undefined,
-				options.requirePerUserLimit ? sql`${s.projectProviderBudget.perUserLimitUsd} > 0` : undefined,
 			),
 		)
-		.groupBy(s.projectProviderBudget.provider, s.chat.userId);
+		.groupBy(s.chatMessage.llmProvider, s.chat.userId);
 };
 
 export const getProviderPeriodCosts = async (
 	projectId: string,
-	provider?: LlmProvider,
-	userId?: string,
+	budgets: ProviderPeriod[],
 ): Promise<Record<string, number>> => {
-	const rows = await queryProviderPeriodCosts(projectId, { provider, userId });
+	const rows = await queryProviderPeriodCosts(projectId, budgets);
 
 	const totals: Record<string, number> = {};
 	for (const row of rows) {
+		if (!row.provider) {
+			continue;
+		}
 		totals[row.provider] = (totals[row.provider] ?? 0) + Number(row.totalCost ?? 0);
 	}
 
@@ -187,12 +197,13 @@ export const getProviderPeriodCosts = async (
 
 export const getProviderPeriodCostsByUser = async (
 	projectId: string,
+	budgets: ProviderPeriod[],
 ): Promise<Record<string, Record<string, number>>> => {
-	const rows = await queryProviderPeriodCosts(projectId, { requirePerUserLimit: true });
+	const rows = await queryProviderPeriodCosts(projectId, budgets);
 
 	const result: Record<string, Record<string, number>> = {};
 	for (const row of rows) {
-		if (!row.userId) {
+		if (!row.provider || !row.userId) {
 			continue;
 		}
 		const providerCosts = (result[row.provider] ??= {});

--- a/apps/backend/src/queries/budget.queries.ts
+++ b/apps/backend/src/queries/budget.queries.ts
@@ -70,13 +70,15 @@ export const advanceStaleBudgetPeriods = async (projectId: string, provider?: Ll
 export const setProjectProviderBudgets = async (
 	projectId: string,
 	budgets: Array<{ provider: LlmProvider; limitUsd: number; period: BudgetPeriod; perUserLimitUsd?: number | null }>,
+	preserveProviders: LlmProvider[] = [],
 ): Promise<DBProjectProviderBudget[]> => {
 	const activeProviders = budgets.map((b) => b.provider);
+	const retainedProviders = [...activeProviders, ...preserveProviders];
 
 	return db.transaction(async (tx) => {
 		const deleteConditions = [eq(s.projectProviderBudget.projectId, projectId)];
-		if (activeProviders.length > 0) {
-			deleteConditions.push(notInArray(s.projectProviderBudget.provider, activeProviders));
+		if (retainedProviders.length > 0) {
+			deleteConditions.push(notInArray(s.projectProviderBudget.provider, retainedProviders));
 		}
 		await tx
 			.delete(s.projectProviderBudget)
@@ -140,16 +142,12 @@ const queryProviderPeriodCosts = async (
 
 	const costLookup = await createCostLookup(projectId);
 	const isPostgres = dbConfig.dialect === Dialect.Postgres;
-	const dayStart = getCurrentPeriodStart('day');
-	const weekStart = getCurrentPeriodStart('week');
-	const monthStart = getCurrentPeriodStart('month');
 
 	const toParam = (d: Date) => (isPostgres ? sql`${d.toISOString()}::timestamp` : sql`${d.getTime()}`);
-	const periodStartExpr = sql`CASE ${s.projectProviderBudget.period}
-		WHEN 'day' THEN ${toParam(dayStart)}
-		WHEN 'week' THEN ${toParam(weekStart)}
-		WHEN 'month' THEN ${toParam(monthStart)}
-	END`;
+	const periodStartCases = budgets.map(
+		(b) => sql`WHEN ${b.provider} THEN ${toParam(getCurrentPeriodStart(b.period))}`,
+	);
+	const periodStartExpr = sql`CASE ${s.chatMessage.llmProvider} ${sql.join(periodStartCases, sql` `)} END`;
 
 	return db
 		.select({

--- a/apps/backend/src/trpc/budget.routes.ts
+++ b/apps/backend/src/trpc/budget.routes.ts
@@ -6,7 +6,8 @@ import * as budgetQueries from '../queries/budget.queries';
 import { hasFeature, LICENSE_FEATURES } from '../services/license.service';
 import { setBudgetsInputSchema } from '../types/budget';
 import { llmProviderSchema } from '../types/llm';
-import { checkBudgetStatus } from '../utils/budget';
+import { checkBudgetStatus, getEffectiveProviderBudgets } from '../utils/budget';
+import { getProjectConfigLlm } from '../utils/llm';
 import { adminProtectedProcedure, projectProtectedProcedure } from './trpc';
 
 export const budgetRoutes = {
@@ -21,18 +22,20 @@ export const budgetRoutes = {
 
 	getBudgets: projectProtectedProcedure.query(async ({ ctx }) => {
 		await budgetQueries.advanceStaleBudgetPeriods(ctx.project.id);
-		return budgetQueries.getProjectProviderBudgets(ctx.project.id);
+		return getEffectiveProviderBudgets(ctx.project.id);
 	}),
 
 	getProviderCosts: projectProtectedProcedure.query(async ({ ctx }) => {
-		return budgetQueries.getProviderPeriodCosts(ctx.project.id);
+		const budgets = await getEffectiveProviderBudgets(ctx.project.id);
+		return budgetQueries.getProviderPeriodCosts(ctx.project.id, budgets);
 	}),
 
 	getPerUserProviderCosts: adminProtectedProcedure.query(async ({ ctx }) => {
 		if (!(await hasFeature(LICENSE_FEATURES.userBudget))) {
 			return {};
 		}
-		return budgetQueries.getProviderPeriodCostsByUser(ctx.project.id);
+		const budgets = (await getEffectiveProviderBudgets(ctx.project.id)).filter((b) => (b.perUserLimitUsd ?? 0) > 0);
+		return budgetQueries.getProviderPeriodCostsByUser(ctx.project.id, budgets);
 	}),
 
 	checkBudgetStatus: projectProtectedProcedure
@@ -42,10 +45,14 @@ export const budgetRoutes = {
 		}),
 
 	setBudgets: adminProtectedProcedure.input(setBudgetsInputSchema).mutation(async ({ ctx, input }) => {
+		const configLlm = await getProjectConfigLlm(ctx.project.id);
+		const configManaged = new Set((configLlm?.providers ?? []).filter((p) => p.budget).map((p) => p.provider));
+		const editable = input.budgets.filter((b) => !configManaged.has(b.provider));
+
 		const userBudgetEnabled = await hasFeature(LICENSE_FEATURES.userBudget);
 		const budgets = userBudgetEnabled
-			? input.budgets
-			: input.budgets.map(({ provider, limitUsd, period }) => ({ provider, limitUsd, period }));
+			? editable
+			: editable.map(({ provider, limitUsd, period }) => ({ provider, limitUsd, period }));
 		return budgetQueries.setProjectProviderBudgets(ctx.project.id, budgets);
 	}),
 };

--- a/apps/backend/src/trpc/budget.routes.ts
+++ b/apps/backend/src/trpc/budget.routes.ts
@@ -53,6 +53,6 @@ export const budgetRoutes = {
 		const budgets = userBudgetEnabled
 			? editable
 			: editable.map(({ provider, limitUsd, period }) => ({ provider, limitUsd, period }));
-		return budgetQueries.setProjectProviderBudgets(ctx.project.id, budgets);
+		return budgetQueries.setProjectProviderBudgets(ctx.project.id, budgets, [...configManaged]);
 	}),
 };

--- a/apps/backend/src/utils/budget.ts
+++ b/apps/backend/src/utils/budget.ts
@@ -9,9 +9,49 @@ import { hasFeature, LICENSE_FEATURES } from '../services/license.service';
 import type { BudgetPeriod } from '../types/budget';
 import { buildBudgetLimitReachedEmail } from './email-builders';
 import { BudgetExceededError } from './error';
+import { getProjectConfigLlm } from './llm';
 import { logger } from './logger';
+import type { ConfigProviderBudget } from './nao-config-llm';
 
 export type BudgetStatus = { level: 'ok' | 'warning' | 'exceeded'; message: string | null };
+
+export type BudgetSource = 'project' | 'config';
+
+export type EffectiveProviderBudget = ConfigProviderBudget & {
+	provider: LlmProvider;
+	source: BudgetSource;
+};
+
+export async function getEffectiveProviderBudgets(projectId: string): Promise<EffectiveProviderBudget[]> {
+	const [dbBudgets, configLlm] = await Promise.all([
+		budgetQueries.getProjectProviderBudgets(projectId),
+		getProjectConfigLlm(projectId),
+	]);
+
+	const byProvider = new Map<LlmProvider, EffectiveProviderBudget>();
+	for (const budget of dbBudgets) {
+		byProvider.set(budget.provider as LlmProvider, {
+			provider: budget.provider as LlmProvider,
+			limitUsd: budget.limitUsd,
+			perUserLimitUsd: budget.perUserLimitUsd ?? null,
+			period: budget.period as BudgetPeriod,
+			source: 'project',
+		});
+	}
+	for (const configured of configLlm?.providers ?? []) {
+		if (configured.budget) {
+			byProvider.set(configured.provider, {
+				provider: configured.provider,
+				limitUsd: configured.budget.limitUsd,
+				perUserLimitUsd: configured.budget.perUserLimitUsd,
+				period: configured.budget.period,
+				source: 'config',
+			});
+		}
+	}
+
+	return [...byProvider.values()];
+}
 
 export async function checkBudgetStatus(
 	projectId: string,
@@ -41,12 +81,14 @@ export async function assertBudgetNotExceeded(
 	const userUsage = usages.find((u) => u.scope === 'user');
 
 	if (projectUsage && projectUsage.ratio >= 1) {
-		await notifyAdminsOnBudgetLimitReached(
-			projectId,
-			projectUsage.budget,
-			projectUsage.currentSpend,
-			projectUsage.resetLabel,
-		).catch(() => {});
+		if (projectUsage.dbBudget) {
+			await notifyAdminsOnBudgetLimitReached(
+				projectId,
+				projectUsage.dbBudget,
+				projectUsage.currentSpend,
+				projectUsage.resetLabel,
+			).catch(() => {});
+		}
 		throw new BudgetExceededError(
 			buildBudgetMessage(projectUsage.ratio, providerLabel(provider), projectUsage.resetLabel, 'project'),
 		);
@@ -60,11 +102,11 @@ export async function assertBudgetNotExceeded(
 }
 
 type BudgetUsage = {
-	budget: DBProjectProviderBudget;
 	currentSpend: number;
 	ratio: number;
 	resetLabel: string;
 	scope: 'project' | 'user';
+	dbBudget: DBProjectProviderBudget | null;
 };
 
 function buildBudgetMessage(ratio: number, label: string, resetLabel: string, scope: 'project' | 'user'): string {
@@ -78,7 +120,8 @@ async function resolveBudgetUsages(
 	provider: LlmProvider,
 	userId: string | undefined,
 ): Promise<BudgetUsage[]> {
-	const budget = await budgetQueries.getProviderBudget(projectId, provider);
+	const budgets = await getEffectiveProviderBudgets(projectId);
+	const budget = budgets.find((b) => b.provider === provider);
 	if (!budget) {
 		return [];
 	}
@@ -94,31 +137,43 @@ async function resolveBudgetUsages(
 		return [];
 	}
 
-	await budgetQueries.advanceStaleBudgetPeriods(projectId, provider);
-	const { projectSpend, userSpend } = await budgetQueries.getProviderBudgetSpend(projectId, provider, userId);
-	const period = budget.period as BudgetPeriod;
-	const resetLabel = formatResetDate(getNextPeriodStart(period), period);
+	const dbBudget = budget.source === 'project' ? await advanceAndFetchDbBudget(projectId, provider) : null;
+	const { projectSpend, userSpend } = await budgetQueries.getProviderBudgetSpend(
+		projectId,
+		provider,
+		budget.period,
+		userId,
+	);
+	const resetLabel = formatResetDate(getNextPeriodStart(budget.period), budget.period);
 
 	const usages: BudgetUsage[] = [];
 	if (hasProjectLimit) {
 		usages.push({
-			budget,
 			currentSpend: projectSpend,
 			ratio: projectSpend / budget.limitUsd,
 			resetLabel,
 			scope: 'project',
+			dbBudget,
 		});
 	}
 	if (hasUserLimit && budget.perUserLimitUsd) {
 		usages.push({
-			budget,
 			currentSpend: userSpend,
 			ratio: userSpend / budget.perUserLimitUsd,
 			resetLabel,
 			scope: 'user',
+			dbBudget,
 		});
 	}
 	return usages;
+}
+
+async function advanceAndFetchDbBudget(
+	projectId: string,
+	provider: LlmProvider,
+): Promise<DBProjectProviderBudget | null> {
+	await budgetQueries.advanceStaleBudgetPeriods(projectId, provider);
+	return budgetQueries.getProviderBudget(projectId, provider);
 }
 
 async function notifyAdminsOnBudgetLimitReached(

--- a/apps/backend/src/utils/nao-config-llm.ts
+++ b/apps/backend/src/utils/nao-config-llm.ts
@@ -2,9 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
+	BUDGET_PERIODS,
+	type BudgetPeriod,
 	LLM_PROVIDERS as LLM_PROVIDER_NAMES,
 	type LlmProvider,
 	type LlmProviderKind,
+	MAX_BUDGET_LIMIT_USD,
 	NAMED_PROVIDER_KIND,
 	providerKind,
 	toNamedProvider,
@@ -21,6 +24,12 @@ import {
 } from '../types/llm';
 import { logger } from './logger';
 
+export type ConfigProviderBudget = {
+	limitUsd: number;
+	perUserLimitUsd: number | null;
+	period: BudgetPeriod;
+};
+
 /** An `llm` provider entry of nao_config.yaml, shaped like the rows of `project_llm_config`. */
 export type ConfigLlmProvider = {
 	provider: LlmProvider;
@@ -30,6 +39,7 @@ export type ConfigLlmProvider = {
 	enabledModels: string[];
 	customModels: CustomModelMetadata[];
 	modelSettings: ModelSettingsMap;
+	budget: ConfigProviderBudget | null;
 };
 
 export type ConfigLlm = {
@@ -74,11 +84,18 @@ const modelSchema = z.object({
 	settings: z.record(z.string(), z.unknown()).optional(),
 });
 
+const budgetSchema = z.object({
+	limit: z.number().min(0).nullish(),
+	per_user_limit: z.number().min(0).nullish(),
+	period: z.enum(BUDGET_PERIODS).nullish(),
+});
+
 const providerSchema = z.looseObject({
 	provider: z.string(),
 	api_key: z.string().nullish(),
 	base_url: z.string().nullish(),
 	models: z.array(modelSchema).nullish(),
+	budget: budgetSchema.nullish(),
 });
 
 const llmSchema = z.looseObject({
@@ -180,7 +197,34 @@ function toConfigProvider(raw: RawProvider, extraEnv: Record<string, string>): C
 		enabledModels: ordered.map((model) => model.id),
 		customModels: ordered.flatMap((model) => toCustomModel(model)),
 		modelSettings: toModelSettings(ordered),
+		budget: toBudget(raw.budget),
 	};
+}
+
+/** Read the `budget` block of a provider, keeping only the limits that actually cap spending. */
+function toBudget(raw: RawProvider['budget']): ConfigProviderBudget | null {
+	if (!raw) {
+		return null;
+	}
+
+	const limitUsd = clampBudget(raw.limit);
+	const perUserLimitUsd = clampBudget(raw.per_user_limit);
+	if (limitUsd <= 0 && perUserLimitUsd <= 0) {
+		return null;
+	}
+
+	return {
+		limitUsd,
+		perUserLimitUsd: perUserLimitUsd > 0 ? perUserLimitUsd : null,
+		period: raw.period ?? 'month',
+	};
+}
+
+function clampBudget(value: number | null | undefined): number {
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+		return 0;
+	}
+	return Math.min(value, MAX_BUDGET_LIMIT_USD);
 }
 
 function toCredentials(

--- a/apps/backend/tests/nao-config-llm.test.ts
+++ b/apps/backend/tests/nao-config-llm.test.ts
@@ -65,6 +65,7 @@ describe('readProjectConfigLlm', () => {
 						},
 					],
 					modelSettings: { 'gpt-4.1': { reasoningEffort: 'high' } },
+					budget: null,
 				},
 			],
 		});
@@ -91,8 +92,53 @@ describe('readProjectConfigLlm', () => {
 				enabledModels: [],
 				customModels: [],
 				modelSettings: {},
+				budget: null,
 			},
 		]);
+	});
+
+	it('reads a provider budget with its limits and period', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: openai',
+			'    api_key: sk-openai',
+			'    budget:',
+			'      limit: 100',
+			'      per_user_limit: 20',
+			'      period: week',
+			'  - provider: anthropic',
+			'    api_key: sk-ant',
+			'    budget:',
+			'      per_user_limit: 5',
+		]);
+
+		const config = readProjectConfigLlm(dir);
+
+		expect(findConfigLlmProvider(config, 'openai')?.budget).toEqual({
+			limitUsd: 100,
+			perUserLimitUsd: 20,
+			period: 'week',
+		});
+		expect(findConfigLlmProvider(config, 'anthropic')?.budget).toEqual({
+			limitUsd: 0,
+			perUserLimitUsd: 5,
+			period: 'month',
+		});
+	});
+
+	it('drops a budget that sets no positive limit', () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: openai',
+			'    api_key: sk-openai',
+			'    budget:',
+			'      limit: 0',
+			'      period: month',
+		]);
+
+		expect(findConfigLlmProvider(readProjectConfigLlm(dir), 'openai')?.budget).toBeNull();
 	});
 
 	it('resolves env placeholders from the project env vars then the process env', () => {

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
@@ -98,14 +98,24 @@ function RouteComponent() {
 	const licenseFeatures = useLicenseFeatures();
 	const hasUserBudget = licenseFeatures.data?.['user-budget'] === true;
 
-	const { projectConfigs, envProviders } = useLlmProviders();
+	const { projectConfigs, configProviders, envProviders } = useLlmProviders();
 	const allConfiguredProviders = useMemo(
-		() => [...new Set([...projectConfigs.map((config) => config.provider), ...envProviders])],
-		[projectConfigs, envProviders],
+		() => [
+			...new Set([
+				...projectConfigs.map((config) => config.provider),
+				...configProviders.map((config) => config.provider),
+				...envProviders,
+			]),
+		],
+		[projectConfigs, configProviders, envProviders],
 	);
 	const costSupport = useQuery(trpc.budget.getProvidersCostSupport.queryOptions());
 
 	const savedBudgets = useQuery(trpc.budget.getBudgets.queryOptions());
+	const configManagedProviders = useMemo(
+		() => new Set((savedBudgets.data ?? []).filter((row) => row.source === 'config').map((row) => row.provider)),
+		[savedBudgets.data],
+	);
 	const queryClient = useQueryClient();
 	const setBudgetsMutation = useMutation(
 		trpc.budget.setBudgets.mutationOptions({
@@ -152,6 +162,9 @@ function RouteComponent() {
 		}
 		const saved = buildFormState(savedBudgets.data);
 		for (const provider of allConfiguredProviders) {
+			if (configManagedProviders.has(provider)) {
+				continue;
+			}
 			if (
 				(saved.budgets[provider] ?? 0) !== (budgets[provider] ?? 0) ||
 				(saved.perUserBudgets[provider] ?? 0) !== (perUserBudgets[provider] ?? 0) ||
@@ -161,7 +174,7 @@ function RouteComponent() {
 			}
 		}
 		return false;
-	}, [savedBudgets.data, budgets, perUserBudgets, periods, allConfiguredProviders]);
+	}, [savedBudgets.data, budgets, perUserBudgets, periods, allConfiguredProviders, configManagedProviders]);
 
 	function resetForm() {
 		const state = buildFormState(savedBudgets.data ?? []);
@@ -198,6 +211,9 @@ function RouteComponent() {
 	async function handleSave() {
 		const entries = allConfiguredProviders
 			.filter((provider) => {
+				if (configManagedProviders.has(provider)) {
+					return false;
+				}
 				const hasCost = costSupport.data?.[providerKind(provider)] ?? false;
 				const budget = budgets[provider] ?? 0;
 				const perUserBudget = perUserBudgets[provider] ?? 0;
@@ -251,14 +267,27 @@ function RouteComponent() {
 							const perUserBudget = perUserBudgets[provider] ?? 0;
 							const period = periods[provider] ?? 'none';
 							const hasAnyBudget = budget > 0 || perUserBudget > 0;
+							const isConfigManaged = configManagedProviders.has(provider);
 
 							return (
 								<TableRow key={provider}>
-									<TableCell>{providerLabel(provider)}</TableCell>
+									<TableCell>
+										<span className='flex items-center gap-2'>
+											{providerLabel(provider)}
+											{isConfigManaged && (
+												<span
+													className='px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground'
+													title='This budget is set in nao_config.yaml'
+												>
+													nao_config.yaml
+												</span>
+											)}
+										</span>
+									</TableCell>
 									<TableCell>
 										<BudgetInput
 											value={budget}
-											disabled={!isAdmin}
+											disabled={!isAdmin || isConfigManaged}
 											onChange={(v) => updateBudget(provider, v)}
 											onBlur={() => clearPeriodIfNoBudget(provider)}
 										/>
@@ -267,7 +296,7 @@ function RouteComponent() {
 										<TableCell>
 											<BudgetInput
 												value={perUserBudget}
-												disabled={!isAdmin}
+												disabled={!isAdmin || isConfigManaged}
 												onChange={(v) => updatePerUserBudget(provider, v)}
 												onBlur={() => clearPeriodIfNoBudget(provider)}
 											/>
@@ -279,7 +308,7 @@ function RouteComponent() {
 											onValueChange={(val) =>
 												setPeriods((prev) => ({ ...prev, [provider]: val as Period }))
 											}
-											disabled={!isAdmin || !hasAnyBudget}
+											disabled={!isAdmin || !hasAnyBudget || isConfigManaged}
 										>
 											<SelectTrigger size='sm' className='w-24'>
 												<SelectValue />

--- a/cli/nao_core/config/llm/__init__.py
+++ b/cli/nao_core/config/llm/__init__.py
@@ -190,6 +190,30 @@ class ModelCosts(BaseModel):
     output: float | None = Field(default=None, ge=0, description="Price of an output token")
 
 
+class BudgetPeriod(str, Enum):
+    """How often a provider's spend limit resets."""
+
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+class BudgetConfig(BaseModel):
+    """A spend limit for a provider, enforced by the chat app and shown in its budgets page."""
+
+    limit: float | None = Field(default=None, ge=0, description="Project-wide spend limit in US dollars for the period")
+    per_user_limit: float | None = Field(
+        default=None, ge=0, description="Spend limit in US dollars per user for the period"
+    )
+    period: BudgetPeriod = Field(default=BudgetPeriod.MONTH, description="How often the limit resets")
+
+    @model_validator(mode="after")
+    def validate_limits(self) -> "BudgetConfig":
+        if not self.limit and not self.per_user_limit:
+            raise ValueError("budget requires a limit or a per_user_limit")
+        return self
+
+
 class LLMConfigMeta(BaseModel):
     costs: ModelCosts
 
@@ -229,6 +253,9 @@ class ProviderConfig(BaseModel):
     key_file: str | None = Field(default=None, description="Path to service account key file (only for Vertex)")
     models: list[ModelConfig] = Field(
         default_factory=list, description="The models to expose for this provider, in display order"
+    )
+    budget: BudgetConfig | None = Field(
+        default=None, description="Spend limit for this provider, enforced by the chat app"
     )
 
     @property

--- a/cli/tests/nao_core/config/test_llm.py
+++ b/cli/tests/nao_core/config/test_llm.py
@@ -7,6 +7,8 @@ import pytest
 from nao_core.config.llm import (
     DEFAULT_ANNOTATION_MODELS,
     PROVIDER_AUTH,
+    BudgetConfig,
+    BudgetPeriod,
     LLMConfig,
     LLMProvider,
     ModelConfig,
@@ -153,6 +155,34 @@ def test_default_model_falls_back_to_the_first_one():
     )
     assert provider.default_model is not None
     assert provider.default_model.id == "gpt-4.1"
+
+
+def test_budget_reads_limits_and_period():
+    config = LLMConfig(
+        providers=[
+            ProviderConfig(
+                provider=LLMProvider.OPENAI,
+                api_key="sk-test",
+                budget=BudgetConfig(limit=100, per_user_limit=20, period=BudgetPeriod.WEEK),
+            )
+        ]
+    )
+
+    budget = config.providers[0].budget
+    assert budget is not None
+    assert budget.limit == 100
+    assert budget.per_user_limit == 20
+    assert budget.period is BudgetPeriod.WEEK
+
+
+def test_budget_period_defaults_to_month():
+    budget = BudgetConfig(limit=50)
+    assert budget.period is BudgetPeriod.MONTH
+
+
+def test_budget_requires_a_positive_limit():
+    with pytest.raises(ValueError, match="budget requires a limit or a per_user_limit"):
+        BudgetConfig(period=BudgetPeriod.MONTH)
 
 
 def test_costs_are_resolved_per_model():


### PR DESCRIPTION
## Summary

- [x] Add providers defined in nao_config.yaml into the budget panel
<img width="978" height="792" alt="image" src="https://github.com/user-attachments/assets/804c2a52-4d56-4a10-bce7-9257fb361b05" />

- [x] Add capabilities to setup the limit budget of providers into nao_config.yaml
<img width="348" height="147" alt="image" src="https://github.com/user-attachments/assets/7b075d63-f1e4-4f48-be37-18c87610b198" />

## Related issue

Fix #1375 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

