### PR TITLE
fix(export): apply the project date format when exporting data

### DIFF
--- a/apps/backend/src/trpc/shared-chat.routes.ts
+++ b/apps/backend/src/trpc/shared-chat.routes.ts
@@ -207,6 +207,14 @@ export const sharedChatRoutes = {
 				},
 			});
 
-			return buildDownloadResponse(input.format, version.title, version.code, queryData);
+			const displaySettings = await projectQueries.getDisplaySettings(share.projectId);
+
+			return buildDownloadResponse(
+				input.format,
+				version.title,
+				version.code,
+				queryData,
+				displaySettings.dateFormat,
+			);
 		}),
 };

--- a/apps/frontend/src/components/data-table-card.tsx
+++ b/apps/frontend/src/components/data-table-card.tsx
@@ -8,6 +8,7 @@ import { ExportDataMenu } from '@/components/export-data-menu';
 import { TableDisplay } from '@/components/tool-calls/display-table';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { useDateFormat } from '@/hooks/use-date-format';
 import { tableToTsv } from '@/lib/table-export';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
@@ -41,6 +42,7 @@ export const DataTableCard = memo(
 	}: DataTableCardProps) => {
 		const [isFullscreen, setIsFullscreen] = useState(false);
 		const logDownload = useMutation(trpc.analyticsEvent.logChatDownload.mutationOptions());
+		const dateFormat = useDateFormat();
 
 		const resolvedColumns = columns.length > 0 ? columns : inferColumns(data);
 
@@ -48,7 +50,7 @@ export const DataTableCard = memo(
 			return null;
 		}
 
-		const handleCopy = () => navigator.clipboard.writeText(tableToTsv(resolvedColumns, data));
+		const handleCopy = () => navigator.clipboard.writeText(tableToTsv(resolvedColumns, data, dateFormat));
 		const handleExport = (format: DataExportFormat) => {
 			if (chatId) {
 				logDownload.mutate({ chatId, format, title });

--- a/apps/frontend/src/components/export-data-menu.tsx
+++ b/apps/frontend/src/components/export-data-menu.tsx
@@ -8,6 +8,7 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useToolCallActions } from '@/contexts/tool-call-actions';
+import { useDateFormat } from '@/hooks/use-date-format';
 import { downloadCsv, downloadXlsx, tableToCsv } from '@/lib/table-export';
 
 export type DataExportFormat = 'csv' | 'xlsx';
@@ -24,6 +25,7 @@ interface ExportDataMenuProps {
 export function ExportDataMenu({ columns, data, filename, onExport, align = 'end', children }: ExportDataMenuProps) {
 	const [open, setOpen] = useState(false);
 	const toolCallActions = useToolCallActions();
+	const dateFormat = useDateFormat();
 
 	const handleOpenChange = (next: boolean) => {
 		setOpen(next);
@@ -32,9 +34,9 @@ export function ExportDataMenu({ columns, data, filename, onExport, align = 'end
 
 	const handleExport = async (format: DataExportFormat) => {
 		if (format === 'csv') {
-			downloadCsv(`${filename}.csv`, tableToCsv(columns, data));
+			downloadCsv(`${filename}.csv`, tableToCsv(columns, data, dateFormat));
 		} else {
-			await downloadXlsx(`${filename}.xlsx`, columns, data);
+			await downloadXlsx(`${filename}.xlsx`, columns, data, dateFormat);
 		}
 		onExport?.(format);
 	};

--- a/apps/frontend/src/lib/table-export.ts
+++ b/apps/frontend/src/lib/table-export.ts
@@ -1,5 +1,6 @@
 import writeXlsxFile from 'write-excel-file/universal';
 import { formatCellValue } from '@nao/shared/story-table-utils';
+import type { DateFormatSettings } from '@nao/shared/date';
 import type { Cell, Row } from 'write-excel-file/universal';
 
 type TableRow = Record<string, unknown>;
@@ -11,28 +12,30 @@ const escapeCsvCell = (value: string) => {
 	return /[",\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
 };
 
-export function tableToCsv(columns: string[], rows: TableRow[]): string {
+export function tableToCsv(columns: string[], rows: TableRow[], dateFormat: DateFormatSettings | null): string {
 	return [
 		columns.map(escapeCsvCell).join(','),
-		...rows.map((row) => columns.map((column) => escapeCsvCell(formatCellValue(row[column]))).join(',')),
+		...rows.map((row) =>
+			columns.map((column) => escapeCsvCell(formatCellValue(row[column], dateFormat))).join(','),
+		),
 	].join('\n');
 }
 
-export function tableToTsv(columns: string[], rows: TableRow[]): string {
+export function tableToTsv(columns: string[], rows: TableRow[], dateFormat: DateFormatSettings | null): string {
 	const clean = (value: string) => neutralizeFormula(value).replace(/[\t\n]/g, ' ');
 	return [
 		columns.map(clean).join('\t'),
-		...rows.map((row) => columns.map((column) => clean(formatCellValue(row[column]))).join('\t')),
+		...rows.map((row) => columns.map((column) => clean(formatCellValue(row[column], dateFormat))).join('\t')),
 	].join('\n');
 }
 
-function tableToXlsxBlob(columns: string[], rows: TableRow[]): Promise<Blob> {
+function tableToXlsxBlob(columns: string[], rows: TableRow[], dateFormat: DateFormatSettings | null): Promise<Blob> {
 	const header: Row = columns.map((column) => ({ value: column, fontWeight: 'bold' }));
-	const body: Row[] = rows.map((row) => columns.map((column) => toXlsxCell(row[column])));
+	const body: Row[] = rows.map((row) => columns.map((column) => toXlsxCell(row[column], dateFormat)));
 	return writeXlsxFile([header, ...body]).toBlob();
 }
 
-function toXlsxCell(value: unknown): Cell {
+function toXlsxCell(value: unknown, dateFormat: DateFormatSettings | null): Cell {
 	if (value === null || value === undefined) {
 		return null;
 	}
@@ -42,15 +45,20 @@ function toXlsxCell(value: unknown): Cell {
 	if (typeof value === 'boolean') {
 		return { type: Boolean, value };
 	}
-	return { type: String, value: formatCellValue(value) };
+	return { type: String, value: formatCellValue(value, dateFormat) };
 }
 
 export function downloadCsv(filename: string, csv: string): void {
 	triggerDownload(filename, new Blob([csv], { type: 'text/csv;charset=utf-8;' }));
 }
 
-export async function downloadXlsx(filename: string, columns: string[], rows: TableRow[]): Promise<void> {
-	triggerDownload(filename, await tableToXlsxBlob(columns, rows));
+export async function downloadXlsx(
+	filename: string,
+	columns: string[],
+	rows: TableRow[],
+	dateFormat: DateFormatSettings | null,
+): Promise<void> {
+	triggerDownload(filename, await tableToXlsxBlob(columns, rows, dateFormat));
 }
 
 function triggerDownload(filename: string, blob: Blob): void {

--- a/apps/frontend/tests/export-data-menu.test.tsx
+++ b/apps/frontend/tests/export-data-menu.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as TableExport from '@/lib/table-export';
+import { ExportDataMenu } from '@/components/export-data-menu';
+
+vi.mock('@/hooks/use-date-format', () => ({
+	useDateFormat: () => ({ preset: 'american' }),
+}));
+
+const { downloadCsv, downloadXlsx } = vi.hoisted(() => ({ downloadCsv: vi.fn(), downloadXlsx: vi.fn() }));
+
+vi.mock('@/lib/table-export', async (importOriginal) => ({
+	...(await importOriginal<typeof TableExport>()),
+	downloadCsv,
+	downloadXlsx,
+}));
+
+const columns = ['day', 'label'];
+const data = [{ day: '2024-03-15', label: 'launch' }];
+
+describe('ExportDataMenu', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('exports CSV using the project date format', async () => {
+		renderMenu();
+		await selectMenuItem('CSV');
+
+		expect(downloadCsv).toHaveBeenCalledWith('sales.csv', 'day,label\n03/15/2024,launch');
+	});
+
+	it('exports XLSX using the project date format', async () => {
+		renderMenu();
+		await selectMenuItem('Excel (XLSX)');
+
+		expect(downloadXlsx).toHaveBeenCalledWith('sales.xlsx', columns, data, { preset: 'american' });
+	});
+});
+
+function renderMenu() {
+	render(
+		<ExportDataMenu columns={columns} data={data} filename='sales'>
+			<button type='button'>Export</button>
+		</ExportDataMenu>,
+	);
+}
+
+async function selectMenuItem(label: string) {
+	fireEvent.pointerDown(screen.getByRole('button', { name: 'Export' }), { button: 0, ctrlKey: false });
+	fireEvent.click(await screen.findByText(label));
+}

--- a/apps/frontend/tests/table-export.test.ts
+++ b/apps/frontend/tests/table-export.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import JSZip from 'jszip';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadXlsx, tableToCsv, tableToTsv } from '@/lib/table-export';
+
+const columns = ['day', 'label'];
+const rows = [{ day: '2024-03-15', label: 'launch' }];
+
+describe('tableToCsv', () => {
+	it('formats ISO dates with the provided date format settings', () => {
+		expect(tableToCsv(columns, rows, { preset: 'american' })).toBe('day,label\n03/15/2024,launch');
+		expect(tableToCsv(columns, rows, { preset: 'iso' })).toBe('day,label\n2024-03-15,launch');
+		expect(tableToCsv(columns, rows, { preset: 'custom', customFormat: 'D MMM YYYY' })).toBe(
+			'day,label\n15 Mar 2024,launch',
+		);
+	});
+
+	it('falls back to the European default when no settings are known', () => {
+		expect(tableToCsv(columns, rows, null)).toBe('day,label\n15/03/2024,launch');
+	});
+
+	it('quotes formatted dates that contain a comma', () => {
+		expect(tableToCsv(columns, rows, { preset: 'custom', customFormat: 'MMMM D, YYYY' })).toBe(
+			'day,label\n"March 15, 2024",launch',
+		);
+	});
+});
+
+describe('tableToTsv', () => {
+	it('formats ISO dates with the provided date format settings', () => {
+		expect(tableToTsv(columns, rows, { preset: 'american' })).toBe('day\tlabel\n03/15/2024\tlaunch');
+	});
+});
+
+describe('downloadXlsx', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('writes ISO dates using the provided date format settings', async () => {
+		const blob = await captureDownloadedBlob(() =>
+			downloadXlsx('table.xlsx', columns, rows, { preset: 'american' }),
+		);
+
+		const content = await readXlsxText(blob);
+		expect(content).toContain('03/15/2024');
+		expect(content).not.toContain('15/03/2024');
+	});
+});
+
+async function captureDownloadedBlob(download: () => Promise<void>): Promise<Blob> {
+	let captured: Blob | undefined;
+	vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+	vi.stubGlobal('URL', {
+		...URL,
+		createObjectURL: (blob: Blob) => {
+			captured = blob;
+			return 'blob:mock';
+		},
+		revokeObjectURL: () => undefined,
+	});
+
+	await download();
+
+	if (!captured) {
+		throw new Error('No blob was downloaded');
+	}
+	return captured;
+}
+
+async function readXlsxText(blob: Blob): Promise<string> {
+	const zip = await JSZip.loadAsync(blob);
+	const sheets = zip.file(/xl\/(worksheets\/.*|sharedStrings)\.xml/);
+	const contents = await Promise.all(sheets.map((file) => file.async('string')));
+	return contents.join('\n');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1390.

## Problem

Tables rendered in the UI format ISO date values with the project's **Date format** setting (`/settings/project`), but every data export ignored it: `tableToCsv`, `tableToTsv` and `toXlsxCell` called `formatCellValue(value)` without the settings argument, so `formatDateValue` silently fell back to the European default. With the project set to `american`, a cell shown as `03/15/2024` in the table was written as `15/03/2024` in the downloaded CSV/XLSX and in the clipboard copy.

The same argument was missing on the shared-chat story download route, so story PDF/HTML files downloaded from a shared chat also used the European default while the owner's download used the project setting.

## Changes

- `apps/frontend/src/lib/table-export.ts` — `tableToCsv`, `tableToTsv`, `downloadXlsx` (and the private `tableToXlsxBlob`/`toXlsxCell`) now take the date format settings and pass them to `formatCellValue`. The argument is required so new call sites cannot silently skip it.
- `apps/frontend/src/components/export-data-menu.tsx` — resolves the project setting with `useDateFormat()` for CSV and XLSX downloads.
- `apps/frontend/src/components/data-table-card.tsx` — resolves the project setting for the "Copy rows" clipboard action.
- `apps/backend/src/trpc/shared-chat.routes.ts` — `downloadStory` now loads `getDisplaySettings` and passes `dateFormat` to `buildDownloadResponse`, matching `story.routes.ts`.

This covers every table export surface, since they all funnel through `ExportDataMenu` / `DataTableCard`: markdown tables, `execute_sql` results, chart and map data views, story table embeds and the fullscreen table dialog.

## Tests

New `apps/frontend/tests/table-export.test.ts` covers CSV, TSV and XLSX serialization per preset (the XLSX case unzips the generated workbook and asserts the formatted string), and new `apps/frontend/tests/export-data-menu.test.tsx` covers the wiring by driving the export menu with the project format mocked to `american`. Both files fail on `main` and pass with the fix.

`npm run lint`, `npm run format:check` and `npm run -w @nao/frontend test` (167 tests) all pass. Backend and shared suites show only failures that already exist on `main` (git/OIDC/Slack/app-db-view tests and `chart-domain.test.ts`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44e5b9cb-c710-4bcf-a037-93e0f5323357?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44e5b9cb-c710-4bcf-a037-93e0f5323357&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

