### PR TITLE
[fix : Slack & `display_map`] resolving bugs & add `/new` command on Slack private conversation

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -57,6 +57,7 @@ import { slackService } from './services/slack';
 import { TrpcRouter, trpcRouter } from './trpc/router';
 import { createContext } from './trpc/trpc';
 import { BudgetExceededError, HandlerError } from './utils/error';
+import { closeBrowser } from './utils/headless-browser';
 import { logger } from './utils/logger';
 
 // Get the directory of the current module (works in both dev and compiled)
@@ -398,6 +399,7 @@ export const startServer = async (opts: { port: number; host: string }) => {
 	posthog.capture(undefined, PostHogEvent.ServerStarted, { ...opts, address });
 
 	const handleShutdown = async () => {
+		await closeBrowser();
 		await flushTelemetry();
 		await posthog.shutdown();
 		process.exit(0);

--- a/apps/backend/src/components/generate-map.tsx
+++ b/apps/backend/src/components/generate-map.tsx
@@ -11,14 +11,11 @@ import {
 	DEFAULT_MARKER_RADIUS,
 	formatCompactNumber,
 	indexBoundaries,
-	MAP_BOUNDARY_URLS,
-	type MapFeatureCollection,
 	type MapGeometry,
 	MAX_MAP_POINTS,
 	type NumericDomain,
 	numericDomain,
 	parseNumericValue,
-	resolveBoundary,
 	resolveMapConfig,
 	scaleBubbleRadius,
 	withOpacity,
@@ -28,8 +25,8 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { svgToPng } from '../utils/generate-chart';
-import { getCachedBoundary, setCachedBoundary } from '../utils/map-boundary-cache';
-import { parseAndValidateGeoJson, safeFetch } from '../utils/safe-fetch';
+import { builtinBoundaryUrl, fetchBoundary, resolveChoroplethBoundary } from '../utils/map-boundary-resolve';
+import { renderMapWithBrowser } from '../utils/render-map-browser';
 import { type Basemap, buildBasemapTiles } from '../utils/static-map-basemap';
 import {
 	buildChoroplethSvg,
@@ -51,8 +48,16 @@ export interface RenderMapInput {
 
 /** Renders a `display_map` tool call to a PNG for surfaces that cannot run the interactive map (Slack, Teams, Telegram, WhatsApp). Returns null when there is nothing to draw. */
 export async function generateMapImage(input: RenderMapInput): Promise<Buffer | null> {
+	const browserImage = await renderMapWithBrowser({
+		config: input.config,
+		rows: input.rows,
+		customBoundaries: input.customBoundaries,
+	});
+	if (browserImage) {
+		return browserImage;
+	}
 	const svg = await renderMapToSvg(input);
-	return svg ? svgToPng(svg) : null;
+	return svg ? svgToPng(svg, 3) : null;
 }
 
 async function renderMapToSvg({ config, rows, customBoundaries = [] }: RenderMapInput): Promise<string | null> {
@@ -100,7 +105,6 @@ async function renderChoroplethSvg(
 	}
 
 	return renderSvgMarkup({
-		viewBox: svg.viewBox,
 		basemap,
 		backdrop: svg.backdrop,
 		title: config.title,
@@ -154,7 +158,6 @@ async function renderPointsSvg(config: displayMap.Input, rows: Record<string, un
 	}
 
 	return renderSvgMarkup({
-		viewBox: svg.viewBox,
 		basemap,
 		backdrop: svg.backdrop,
 		title: config.title,
@@ -175,70 +178,79 @@ async function renderPointsSvg(config: displayMap.Input, rows: Record<string, un
 	});
 }
 
+const TITLE_BAND_HEIGHT = 34;
+
 function renderSvgMarkup(args: {
-	viewBox: string;
 	basemap?: Basemap | null;
 	backdrop: string[];
 	title?: string;
 	legend: React.ReactNode;
 	children: React.ReactNode;
 }): string {
+	const bandHeight = args.title ? TITLE_BAND_HEIGHT : 0;
+	const totalHeight = VIEW_HEIGHT + bandHeight;
 	const markup = renderToStaticMarkup(
 		<svg
 			xmlns='http://www.w3.org/2000/svg'
 			width={VIEW_WIDTH}
-			height={VIEW_HEIGHT}
-			viewBox={args.viewBox}
+			height={totalHeight}
+			viewBox={`0 0 ${VIEW_WIDTH} ${totalHeight}`}
 			preserveAspectRatio='xMidYMid meet'
 		>
-			<rect x={0} y={0} width={VIEW_WIDTH} height={VIEW_HEIGHT} fill='#eef1f5' />
-			{args.basemap?.tiles.map((tile, index) => (
-				<image
-					key={`tile-${index}`}
-					href={tile.href}
-					x={tile.x}
-					y={tile.y}
-					width={tile.size}
-					height={tile.size}
-					preserveAspectRatio='none'
-				/>
-			))}
-			{args.backdrop.map((path, index) => (
-				<path
-					key={`backdrop-${index}`}
-					d={path}
-					fill='#d8dee8'
-					stroke='#eef1f5'
-					strokeWidth={0.5}
-					fillRule='evenodd'
-				/>
-			))}
-			{args.children}
-			{args.title && <TitleOverlay title={args.title} />}
-			{args.legend}
-			{args.basemap && <Attribution text={args.basemap.attribution} />}
+			<rect x={0} y={0} width={VIEW_WIDTH} height={totalHeight} fill='#ffffff' />
+			{args.title && <TitleHeader title={args.title} bandHeight={bandHeight} />}
+			<svg
+				x={0}
+				y={bandHeight}
+				width={VIEW_WIDTH}
+				height={VIEW_HEIGHT}
+				viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+			>
+				<rect x={0} y={0} width={VIEW_WIDTH} height={VIEW_HEIGHT} fill='#eef1f5' />
+				{args.basemap?.tiles.map((tile, index) => (
+					<image
+						key={`tile-${index}`}
+						href={tile.href}
+						x={tile.x}
+						y={tile.y}
+						width={tile.size}
+						height={tile.size}
+						preserveAspectRatio='none'
+					/>
+				))}
+				{args.backdrop.map((path, index) => (
+					<path
+						key={`backdrop-${index}`}
+						d={path}
+						fill='#d8dee8'
+						stroke='#eef1f5'
+						strokeWidth={0.5}
+						fillRule='evenodd'
+					/>
+				))}
+				{args.children}
+				{args.legend}
+				{args.basemap && <Attribution text={args.basemap.attribution} />}
+			</svg>
 		</svg>,
 	);
 	return markup;
 }
 
-function TitleOverlay({ title }: { title: string }) {
-	const width = Math.min(VIEW_WIDTH - 24, title.length * 7 + 16);
+function TitleHeader({ title, bandHeight }: { title: string; bandHeight: number }) {
 	return (
-		<g>
-			<rect
-				x={12}
-				y={12}
-				width={width}
-				height={22}
-				rx={4}
-				fill='rgba(255,255,255,0.9)'
-				stroke='rgba(0,0,0,0.08)'
-			/>
-			<text x={20} y={27} fontSize={12} fontWeight={500} fontFamily='system-ui, sans-serif' fill='#111827'>
-				{title}
-			</text>
-		</g>
+		<text
+			x={VIEW_WIDTH / 2}
+			y={bandHeight / 2}
+			fontSize={15}
+			fontWeight={300}
+			fontFamily='system-ui, -apple-system, "Segoe UI", Roboto, sans-serif'
+			fill='#0a0a0a'
+			textAnchor='middle'
+			dominantBaseline='middle'
+		>
+			{title}
+		</text>
 	);
 }
 
@@ -329,58 +341,4 @@ function Attribution({ text }: { text: string }) {
 			</text>
 		</g>
 	);
-}
-
-async function resolveChoroplethBoundary(
-	config: displayMap.Input,
-	customBoundaries: CustomBoundarySet[],
-): Promise<{ geojson: MapFeatureCollection; joinProps: string[] | null } | null> {
-	if (config.geometry_key) {
-		return null;
-	}
-	if (config.boundaries_url) {
-		const geojson = await fetchBoundary(config.boundaries_url);
-		return geojson
-			? { geojson, joinProps: config.boundaries_join_property ? [config.boundaries_join_property] : null }
-			: null;
-	}
-	if (config.region_boundaries) {
-		const boundary = resolveBoundary(config.region_boundaries, customBoundaries);
-		if (!boundary) {
-			return null;
-		}
-		const isCustom = customBoundaries.some((set) => set.key === config.region_boundaries);
-		const url = isCustom ? boundary.url : builtinBoundaryUrl(config.region_boundaries);
-		const geojson = await fetchBoundary(url);
-		return geojson ? { geojson, joinProps: boundary.joinProps } : null;
-	}
-	return null;
-}
-
-async function fetchBoundary(url: string): Promise<MapFeatureCollection | null> {
-	if (!url) {
-		return null;
-	}
-	const cached = getCachedBoundary(url);
-	if (cached) {
-		return cached;
-	}
-	try {
-		const text = await safeFetch(url);
-		const { geojson } = parseAndValidateGeoJson(text);
-		setCachedBoundary(url, geojson);
-		return geojson;
-	} catch {
-		return null;
-	}
-}
-
-function builtinBoundaryUrl(set: string): string {
-	if (set === 'world_countries') {
-		return process.env.NAO_STORY_MAP_BOUNDARIES_WORLD_URL || MAP_BOUNDARY_URLS.world_countries;
-	}
-	if (set === 'france_regions') {
-		return process.env.NAO_STORY_MAP_BOUNDARIES_FRANCE_URL || MAP_BOUNDARY_URLS.france_regions;
-	}
-	return resolveBoundary(set)?.url ?? '';
 }

--- a/apps/backend/src/queries/chat.queries.ts
+++ b/apps/backend/src/queries/chat.queries.ts
@@ -781,6 +781,17 @@ export const clearWhatsappThread = async (threadId: string): Promise<boolean> =>
 	return result.length > 0;
 };
 
+/** Clears the slack thread mapping for the main conversation of a DM, identified by the raw Slack channel ID (e.g. `D123ABC`). The main conversation is the chat with an empty thread timestamp (`slack:<channelId>:`); explicitly opened threads are left untouched. Returns the affected chat IDs so running agents can be stopped. */
+export const clearSlackMainThread = async (slackChannelId: string): Promise<string[]> => {
+	const result = await db
+		.update(s.chat)
+		.set({ slackThreadId: null })
+		.where(eq(s.chat.slackThreadId, `slack:${slackChannelId}:`))
+		.returning({ id: s.chat.id })
+		.execute();
+	return result.map((r) => r.id);
+};
+
 export type SearchChatResult = {
 	id: string;
 	title: string;

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -483,9 +483,7 @@ class ProjectSlackBot {
 
 	private _newChatConfirmation(hadActiveChat: boolean, hasQuestion: boolean): string {
 		if (hasQuestion) {
-			return hadActiveChat
-				? '✅ Started a new chat with a fresh context.'
-				: '✅ Started a fresh chat.';
+			return hadActiveChat ? '✅ Started a new chat with a fresh context.' : '✅ Started a fresh chat.';
 		}
 		return hadActiveChat
 			? '✅ Started a new chat. Send your next message to continue with a fresh context.'

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -474,16 +474,6 @@ class ProjectSlackBot {
 			return;
 		}
 
-		const authorized = await this._authorizeSlackUser(event.user.userId);
-		if (!authorized) {
-			await event.channel.postEphemeral(
-				event.user,
-				"❌ You don't have permission to use nao in this project. Please contact an administrator.",
-				ephemeralOpts,
-			);
-			return;
-		}
-
 		const question = event.text.trim();
 
 		if (question && !(await this._isPrivateChannel(event))) {
@@ -492,6 +482,11 @@ class ProjectSlackBot {
 				'❌ `/new <question>` is only available in direct messages and private channels. Send `/new` on its own here, or ask your question in a private conversation with nao.',
 				ephemeralOpts,
 			);
+			return;
+		}
+
+		const authorized = await this._authorizeSlashCommandUser(event, ephemeralOpts);
+		if (!authorized) {
 			return;
 		}
 
@@ -526,9 +521,36 @@ class ProjectSlackBot {
 		);
 	}
 
-	private async _authorizeSlackUser(slackUserId: string): Promise<User | null> {
-		const result = await this._resolveAuthorizedUser(slackUserId);
-		return result.status === 'authorized' ? result.user : null;
+	private async _authorizeSlashCommandUser(
+		event: SlashCommandEvent,
+		ephemeralOpts: { fallbackToDM: boolean },
+	): Promise<User | null> {
+		const result = await this._resolveAuthorizedUser(event.user.userId);
+		switch (result.status) {
+			case 'authorized':
+				return result.user;
+			case 'no-email':
+				await event.channel.postEphemeral(
+					event.user,
+					'❌ Could not retrieve your email from Slack.',
+					ephemeralOpts,
+				);
+				return null;
+			case 'user-not-found':
+				await event.channel.postEphemeral(
+					event.user,
+					`❌ No user found. Create an account with \`${result.email}\` on ${this._redirectUrl} to sign up.`,
+					ephemeralOpts,
+				);
+				return null;
+			case 'no-permission':
+				await event.channel.postEphemeral(
+					event.user,
+					"❌ You don't have permission to use nao in this project. Please contact an administrator.",
+					ephemeralOpts,
+				);
+				return null;
+		}
 	}
 
 	private async _resolveAuthorizedUser(slackUserId: string): Promise<SlackUserAuthorization> {

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -7,7 +7,17 @@ import { displayChart } from '@nao/shared/tools';
 import type { LlmSelectedModel } from '@nao/shared/types';
 import { type ChatPostMessageArguments, WebClient } from '@slack/web-api';
 import { InferUIMessageChunk, readUIMessageStream } from 'ai';
-import { Card, Chat, deriveChannelId, Message, SentMessage, Thread, ThreadImpl } from 'chat';
+import {
+	Card,
+	Chat,
+	deriveChannelId,
+	Message,
+	parseMarkdown,
+	SentMessage,
+	SlashCommandEvent,
+	Thread,
+	ThreadImpl,
+} from 'chat';
 
 import { generateChartImage } from '../components/generate-chart';
 import * as chartImageQueries from '../queries/chart-image';
@@ -284,6 +294,10 @@ class ProjectSlackBot {
 	}
 
 	private _registerHandlers(): void {
+		this._bot.onSlashCommand('/new', async (event) => {
+			await this._handleNewCommand(event);
+		});
+
 		this._bot.onNewMention(async (thread, message) => {
 			const startsThread = await this._isThreadStarter(thread.id);
 			if (startsThread && this._config.replyMode === 'thread') {
@@ -442,6 +456,76 @@ class ProjectSlackBot {
 				await ctx.thread.post(errorMessage);
 			}
 		}
+	}
+
+	private async _handleNewCommand(event: SlashCommandEvent): Promise<void> {
+		const channelJson = event.channel.toJSON();
+		const [, slackChannelId] = channelJson.id.split(':');
+		const ephemeralOpts = { fallbackToDM: true };
+		if (!slackChannelId) {
+			await event.channel.postEphemeral(event.user, '❌ Could not determine the channel.', ephemeralOpts);
+			return;
+		}
+
+		const chatIds = await chatQueries.clearSlackMainThread(slackChannelId);
+		for (const chatId of chatIds) {
+			agentService.get(chatId)?.stop();
+		}
+
+		const question = event.text.trim();
+		const confirmation = this._newChatConfirmation(chatIds.length > 0, !!question);
+		await event.channel.postEphemeral(event.user, confirmation, ephemeralOpts);
+
+		if (question) {
+			await this._startNewChatFromCommand(event, slackChannelId, question);
+		}
+	}
+
+	private _newChatConfirmation(hadActiveChat: boolean, hasQuestion: boolean): string {
+		if (hasQuestion) {
+			return hadActiveChat
+				? '✅ Started a new chat with a fresh context.'
+				: '✅ Started a fresh chat.';
+		}
+		return hadActiveChat
+			? '✅ Started a new chat. Send your next message to continue with a fresh context.'
+			: '✅ No active chat to reset. Send your next message to start a fresh conversation.';
+	}
+
+	private async _startNewChatFromCommand(
+		event: SlashCommandEvent,
+		slackChannelId: string,
+		question: string,
+	): Promise<void> {
+		const rootMessage = await event.channel.post(`<@${event.user.userId}>: ${question}`);
+		const threadId = getSlackThreadId(slackChannelId, rootMessage.id);
+
+		await this._bot.initialize();
+		const adapter = this._bot.getAdapter('slack');
+		const thread = new ThreadImpl({
+			adapter,
+			stateAdapter: this._bot.getState(),
+			id: threadId,
+			channelId: deriveChannelId(adapter, threadId),
+			isDM: false,
+		});
+
+		if (this._config.replyMode === 'thread') {
+			await thread.subscribe();
+		}
+
+		const userMessage = new Message({
+			id: rootMessage.id,
+			threadId,
+			text: question,
+			formatted: parseMarkdown(question),
+			raw: {},
+			author: event.user,
+			metadata: { dateSent: new Date(), edited: false },
+			attachments: [],
+		});
+
+		await this._handleWorkFlow(thread, userMessage, { fetchUnseenMessages: false });
 	}
 
 	private async _validateUserAccess(ctx: ConversationContext): Promise<void> {

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -38,6 +38,7 @@ import {
 	createTextBlocks,
 	EXCLUDED_TOOLS,
 	FEEDBACK_MODAL_CALLBACK_ID,
+	formatClarificationText,
 	formatMessagingError,
 	formatSlackMessageText,
 	renderMapImage,
@@ -697,11 +698,24 @@ class ProjectSlackBot {
 				await this._handleChartPart(part, state, ctx);
 			} else if (part.type === 'tool-display_map') {
 				await this._handleMapPart(part, state, ctx);
+			} else if (part.type === 'tool-clarification') {
+				this._handleClarificationPart(part, ctx);
 			}
 		}
 
 		await this._sendFinalText(ctx);
 		return state;
+	}
+
+	private _handleClarificationPart(
+		part: Extract<UIMessagePart, { type: 'tool-clarification' }>,
+		ctx: ConversationContext,
+	): void {
+		if (part.state === 'input-streaming' || !part.input) {
+			return;
+		}
+		const text = formatClarificationText(part.input.question, part.input.options);
+		this._updateTextBlock(text, ctx);
 	}
 
 	private async _handleTextPart(

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -20,6 +20,7 @@ import {
 } from 'chat';
 
 import { generateChartImage } from '../components/generate-chart';
+import type { User } from '../db/abstractSchema';
 import * as chartImageQueries from '../queries/chart-image';
 import * as chatQueries from '../queries/chat.queries';
 import * as feedbackQueries from '../queries/feedback.queries';
@@ -86,6 +87,12 @@ export type SlackFileUpload = {
 	content: Buffer;
 	title?: string;
 };
+
+type SlackUserAuthorization =
+	| { status: 'authorized'; user: User; timezone: string | undefined }
+	| { status: 'no-email' }
+	| { status: 'user-not-found'; email: string }
+	| { status: 'no-permission' };
 
 class ProjectSlackBot {
 	public readonly projectId: string;
@@ -467,17 +474,107 @@ class ProjectSlackBot {
 			return;
 		}
 
+		const authorized = await this._authorizeSlackUser(event.user.userId);
+		if (!authorized) {
+			await event.channel.postEphemeral(
+				event.user,
+				"❌ You don't have permission to use nao in this project. Please contact an administrator.",
+				ephemeralOpts,
+			);
+			return;
+		}
+
+		const question = event.text.trim();
+
+		if (question && !(await this._isPrivateChannel(event))) {
+			await event.channel.postEphemeral(
+				event.user,
+				'❌ `/new <question>` is only available in direct messages and private channels. Send `/new` on its own here, or ask your question in a private conversation with nao.',
+				ephemeralOpts,
+			);
+			return;
+		}
+
 		const chatIds = await chatQueries.clearSlackMainThread(slackChannelId);
 		for (const chatId of chatIds) {
 			agentService.get(chatId)?.stop();
 		}
 
-		const question = event.text.trim();
-		const confirmation = this._newChatConfirmation(chatIds.length > 0, !!question);
-		await event.channel.postEphemeral(event.user, confirmation, ephemeralOpts);
+		if (!question) {
+			await event.channel.postEphemeral(
+				event.user,
+				this._newChatConfirmation(chatIds.length > 0, false),
+				ephemeralOpts,
+			);
+			return;
+		}
 
-		if (question) {
+		try {
 			await this._startNewChatFromCommand(event, slackChannelId, question);
+		} catch (error) {
+			logger.error(`Failed to start new chat from /new command: ${String(error)}`, {
+				source: 'system',
+				context: { projectId: this.projectId, slackChannelId },
+			});
+			await event.channel.postEphemeral(event.user, formatMessagingError(error), ephemeralOpts);
+			return;
+		}
+		await event.channel.postEphemeral(
+			event.user,
+			this._newChatConfirmation(chatIds.length > 0, true),
+			ephemeralOpts,
+		);
+	}
+
+	private async _authorizeSlackUser(slackUserId: string): Promise<User | null> {
+		const result = await this._resolveAuthorizedUser(slackUserId);
+		return result.status === 'authorized' ? result.user : null;
+	}
+
+	private async _resolveAuthorizedUser(slackUserId: string): Promise<SlackUserAuthorization> {
+		const slackUser = await this._getSlackUser(slackUserId);
+		const email = slackUser?.profile?.email?.toLowerCase() || null;
+		if (!email) {
+			return { status: 'no-email' };
+		}
+
+		const timezone = slackUser?.tz || undefined;
+
+		if (this._canAutoProvision(email)) {
+			const project = await projectQueries.getProjectById(this.projectId);
+			const projectName = project?.name ?? 'nao';
+			const displayName = slackUser?.real_name || slackUser?.name || email.split('@')[0];
+			const user = await ensureMessagingProviderUser({
+				email,
+				name: displayName,
+				projectId: this.projectId,
+				buildEmail: (user, temporaryPassword) =>
+					buildUserAddedEmail(user, projectName, 'project', temporaryPassword),
+			});
+			return { status: 'authorized', user, timezone };
+		}
+
+		const user = await getUser({ email });
+		if (!user) {
+			return { status: 'user-not-found', email };
+		}
+		const role = await projectQueries.getUserRoleInProject(this.projectId, user.id);
+		if (role !== 'admin' && role !== 'user' && role !== 'context_admin') {
+			return { status: 'no-permission' };
+		}
+		return { status: 'authorized', user, timezone };
+	}
+
+	private async _isPrivateChannel(event: SlashCommandEvent): Promise<boolean> {
+		try {
+			const info = await event.channel.fetchMetadata();
+			return info.channelVisibility === 'private';
+		} catch (error) {
+			logger.warn(`Failed to resolve Slack channel visibility: ${String(error)}`, {
+				source: 'system',
+				context: { projectId: this.projectId },
+			});
+			return false;
 		}
 	}
 
@@ -527,32 +624,26 @@ class ProjectSlackBot {
 	}
 
 	private async _validateUserAccess(ctx: ConversationContext): Promise<void> {
-		const slackUserId = ctx.userMessage.author.userId;
-		const slackUser = await this._getSlackUser(slackUserId);
-		const email = slackUser?.profile?.email?.toLowerCase() || null;
+		const result = await this._resolveAuthorizedUser(ctx.userMessage.author.userId);
 
-		if (!email) {
-			throw new Error('Could not retrieve user email from Slack');
+		switch (result.status) {
+			case 'authorized':
+				ctx.user = result.user;
+				ctx.timezone = result.timezone;
+				return;
+			case 'no-email':
+				throw new Error('Could not retrieve user email from Slack');
+			case 'user-not-found':
+				await ctx.thread.post(
+					`❌ No user found. Create an account with \`${result.email}\` on ${this._redirectUrl} to sign up.`,
+				);
+				throw new Error('User not found');
+			case 'no-permission':
+				await ctx.thread.post(
+					"❌ You don't have permission to use nao in this project. Please contact an administrator.",
+				);
+				throw new Error('User does not have permission to access this project');
 		}
-
-		ctx.timezone = slackUser?.tz || undefined;
-
-		if (this._canAutoProvision(email)) {
-			const project = await projectQueries.getProjectById(this.projectId);
-			const projectName = project?.name ?? 'nao';
-			const displayName = slackUser?.real_name || slackUser?.name || email.split('@')[0];
-			ctx.user = await ensureMessagingProviderUser({
-				email,
-				name: displayName,
-				projectId: this.projectId,
-				buildEmail: (user, temporaryPassword) =>
-					buildUserAddedEmail(user, projectName, 'project', temporaryPassword),
-			});
-			return;
-		}
-
-		await this._resolveExistingUser(ctx, email);
-		await this._checkUserBelongsToProject(ctx);
 	}
 
 	private _canAutoProvision(email: string): boolean {
@@ -562,30 +653,9 @@ class ProjectSlackBot {
 		return isEmailDomainAllowed(email, this._autoCreateUsersDomains.join(','));
 	}
 
-	private async _resolveExistingUser(ctx: ConversationContext, email: string): Promise<void> {
-		const user = await getUser({ email });
-		if (!user) {
-			await ctx.thread.post(
-				`❌ No user found. Create an account with \`${email}\` on ${this._redirectUrl} to sign up.`,
-			);
-			throw new Error('User not found');
-		}
-		ctx.user = user;
-	}
-
 	private async _getSlackUser(userId: string) {
 		const response = await this._slackClient.users.info({ user: userId });
 		return response?.user || null;
-	}
-
-	private async _checkUserBelongsToProject(ctx: ConversationContext): Promise<void> {
-		const role = await projectQueries.getUserRoleInProject(this.projectId, ctx.user!.id);
-		if (role !== 'admin' && role !== 'user' && role !== 'context_admin') {
-			await ctx.thread.post(
-				"❌ You don't have permission to use nao in this project. Please contact an administrator.",
-			);
-			throw new Error('User does not have permission to access this project');
-		}
 	}
 
 	private async _saveOrUpdateUserMessage(ctx: ConversationContext, fetchUnseenMessages: boolean): Promise<void> {

--- a/apps/backend/src/services/teams.ts
+++ b/apps/backend/src/services/teams.ts
@@ -29,6 +29,7 @@ import {
 	createSummaryToolCalls,
 	createTextBlock,
 	EXCLUDED_TOOLS,
+	formatClarificationText,
 	formatMessagingError,
 	renderMapImage,
 } from '../utils/messaging-provider';
@@ -325,12 +326,25 @@ class TeamsService {
 				await this._handleChartPart(part, state, ctx);
 			} else if (part.type === 'tool-display_map') {
 				await this._handleMapPart(part, state, ctx);
+			} else if (part.type === 'tool-clarification') {
+				this._handleClarificationPart(part, ctx);
 			}
 			lastMessage = uiMessage;
 		}
 
 		await this._sendFinalText(ctx);
 		return { ...state, lastMessage };
+	}
+
+	private _handleClarificationPart(
+		part: Extract<UIMessagePart, { type: 'tool-clarification' }>,
+		ctx: ConversationContext,
+	): void {
+		if (part.state === 'input-streaming' || !part.input) {
+			return;
+		}
+		const text = formatClarificationText(part.input.question, part.input.options);
+		this._updateTextBlock(text, ctx);
 	}
 
 	private async _handleTextPart(

--- a/apps/backend/src/services/telegram.ts
+++ b/apps/backend/src/services/telegram.ts
@@ -324,7 +324,7 @@ class TelegramService {
 			} else if (part.type === 'tool-display_map') {
 				await this._handleMapPart(part, state, ctx);
 			} else if (part.type === 'tool-clarification') {
-				this._handleClarificationPart(part, ctx);
+				this._handleClarificationPart(part, state, ctx);
 			}
 			lastMessage = uiMessage;
 		}
@@ -349,11 +349,13 @@ class TelegramService {
 
 	private _handleClarificationPart(
 		part: Extract<UIMessagePart, { type: 'tool-clarification' }>,
+		state: StreamState,
 		ctx: ConversationContext,
 	): void {
 		if (part.state === 'input-streaming' || !part.input) {
 			return;
 		}
+		this._flushToolGroup(state, ctx);
 		const text = formatClarificationText(part.input.question, part.input.options);
 		this._updateTextBlock(text, ctx);
 	}

--- a/apps/backend/src/services/telegram.ts
+++ b/apps/backend/src/services/telegram.ts
@@ -23,6 +23,7 @@ import {
 	createTelegramMapLinkCard,
 	createTelegramStopButtonCard,
 	EXCLUDED_TOOLS,
+	formatClarificationText,
 	formatMessagingError,
 	renderMapImage,
 } from '../utils/messaging-provider';
@@ -322,6 +323,8 @@ class TelegramService {
 				await this._handleChartPart(part, state, ctx);
 			} else if (part.type === 'tool-display_map') {
 				await this._handleMapPart(part, state, ctx);
+			} else if (part.type === 'tool-clarification') {
+				this._handleClarificationPart(part, ctx);
 			}
 			lastMessage = uiMessage;
 		}
@@ -342,6 +345,17 @@ class TelegramService {
 				throw error;
 			}
 		}
+	}
+
+	private _handleClarificationPart(
+		part: Extract<UIMessagePart, { type: 'tool-clarification' }>,
+		ctx: ConversationContext,
+	): void {
+		if (part.state === 'input-streaming' || !part.input) {
+			return;
+		}
+		const text = formatClarificationText(part.input.question, part.input.options);
+		this._updateTextBlock(text, ctx);
 	}
 
 	private async _handleTextPart(

--- a/apps/backend/src/services/whatsapp.ts
+++ b/apps/backend/src/services/whatsapp.ts
@@ -529,7 +529,9 @@ class WhatsappService {
 			(lastMessage?.parts ?? [])
 				.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
 				.map((p) => p.text.replace(CITATION_TAG_REGEX, ''))
-				.join('\n\n') || clarificationText || '';
+				.join('\n\n') ||
+			clarificationText ||
+			'';
 
 		return { finalText, chartUrls, mapLinks };
 	}

--- a/apps/backend/src/services/whatsapp.ts
+++ b/apps/backend/src/services/whatsapp.ts
@@ -24,6 +24,7 @@ import { logger } from '../utils/logger';
 import {
 	createWhatsappMapLink,
 	EXCLUDED_TOOLS,
+	formatClarificationText,
 	formatMessagingError,
 	renderMapImage,
 } from '../utils/messaging-provider';
@@ -494,6 +495,7 @@ class WhatsappService {
 		const chartUrls: string[] = [];
 		const mapLinks: string[] = [];
 		let lastMessage: UIMessage | null = null;
+		let clarificationText: string | null = null;
 
 		for await (const uiMessage of readUIMessageStream<UIMessage>({ stream })) {
 			lastMessage = uiMessage;
@@ -518,13 +520,16 @@ class WhatsappService {
 				} else if (result?.link) {
 					mapLinks.push(result.link);
 				}
+			} else if (part.type === 'tool-clarification' && part.state !== 'input-streaming' && part.input) {
+				clarificationText = formatClarificationText(part.input.question, part.input.options);
 			}
 		}
 
-		const finalText = (lastMessage?.parts ?? [])
-			.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
-			.map((p) => p.text.replace(CITATION_TAG_REGEX, ''))
-			.join('\n\n');
+		const finalText =
+			(lastMessage?.parts ?? [])
+				.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
+				.map((p) => p.text.replace(CITATION_TAG_REGEX, ''))
+				.join('\n\n') || clarificationText || '';
 
 		return { finalText, chartUrls, mapLinks };
 	}

--- a/apps/backend/src/services/whatsapp.ts
+++ b/apps/backend/src/services/whatsapp.ts
@@ -521,17 +521,21 @@ class WhatsappService {
 					mapLinks.push(result.link);
 				}
 			} else if (part.type === 'tool-clarification' && part.state !== 'input-streaming' && part.input) {
-				clarificationText = formatClarificationText(part.input.question, part.input.options);
+				clarificationText = formatClarificationText(part.input.question, part.input.options).replace(
+					CITATION_TAG_REGEX,
+					'',
+				);
 			}
 		}
 
-		const finalText =
-			(lastMessage?.parts ?? [])
-				.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
-				.map((p) => p.text.replace(CITATION_TAG_REGEX, ''))
-				.join('\n\n') ||
-			clarificationText ||
-			'';
+		const textContent = (lastMessage?.parts ?? [])
+			.filter((p): p is Extract<UIMessagePart, { type: 'text' }> => p.type === 'text')
+			.map((p) => p.text.replace(CITATION_TAG_REGEX, ''))
+			.join('\n\n');
+
+		const finalText = [textContent, clarificationText]
+			.filter((part): part is string => Boolean(part && part.trim()))
+			.join('\n\n');
 
 		return { finalText, chartUrls, mapLinks };
 	}

--- a/apps/backend/src/utils/generate-chart.ts
+++ b/apps/backend/src/utils/generate-chart.ts
@@ -158,9 +158,9 @@ export function truncateLabel(label: string, maxChars: number): string {
 	return `${codePoints.slice(0, maxChars - 1).join('')}…`;
 }
 
-export function svgToPng(svg: string): Buffer {
+export function svgToPng(svg: string, zoom = 2): Buffer {
 	const resvg = new Resvg(svg, {
-		fitTo: { mode: 'zoom' as const, value: 2 },
+		fitTo: { mode: 'zoom' as const, value: zoom },
 		font: { loadSystemFonts: true },
 	});
 	return Buffer.from(resvg.render().asPng());

--- a/apps/backend/src/utils/headless-browser.ts
+++ b/apps/backend/src/utils/headless-browser.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import type { Browser } from 'puppeteer-core';
 
 let browserPromise: Promise<Browser> | null = null;
+let activeBrowser: Browser | null = null;
 
 async function loadPuppeteer() {
 	try {
@@ -17,34 +18,54 @@ async function loadPuppeteer() {
 /** Shared, lazily-launched headless Chromium used for server-side rendering (PDF export, static map images). */
 export async function getBrowser(): Promise<Browser> {
 	if (browserPromise) {
-		const browser = await browserPromise;
-		if (browser.connected) {
+		const browser = await browserPromise.catch(() => null);
+		if (browser?.connected) {
 			return browser;
 		}
-		await browser.close().catch(() => {});
+		await closeBrowser();
 	}
-	const puppeteer = await loadPuppeteer();
-	browserPromise = puppeteer.default
-		.launch({
+	if (!browserPromise) {
+		browserPromise = launchBrowser();
+	}
+	return browserPromise;
+}
+
+async function launchBrowser(): Promise<Browser> {
+	try {
+		const puppeteer = await loadPuppeteer();
+		const browser = await puppeteer.default.launch({
 			headless: true,
 			executablePath: findChromePath(),
-			args: [
-				'--no-sandbox',
-				'--disable-setuid-sandbox',
-				'--disable-gpu',
-				'--disable-dev-shm-usage',
-				'--enable-unsafe-swiftshader',
-			],
-		})
-		.catch((error) => {
-			browserPromise = null;
-			throw error;
+			args: browserLaunchArgs(),
 		});
-	return browserPromise;
+		activeBrowser = browser;
+		browser.on('disconnected', () => {
+			if (activeBrowser === browser) {
+				activeBrowser = null;
+			}
+		});
+		return browser;
+	} catch (error) {
+		browserPromise = null;
+		throw error;
+	}
+}
+
+function browserLaunchArgs(): string[] {
+	const args = ['--disable-gpu', '--disable-dev-shm-usage', '--enable-unsafe-swiftshader'];
+	if (isSandboxDisabled()) {
+		args.unshift('--no-sandbox', '--disable-setuid-sandbox');
+	}
+	return args;
+}
+
+function isSandboxDisabled(): boolean {
+	return process.env.DOCKER === '1';
 }
 
 function findChromePath(): string {
 	const candidates = [
+		process.env.PUPPETEER_EXECUTABLE_PATH,
 		process.env.CHROME_PATH,
 		'/usr/bin/chromium',
 		'/usr/bin/chromium-browser',
@@ -62,19 +83,23 @@ function findChromePath(): string {
 			encoding: 'utf-8',
 		}).trim();
 	} catch {
-		throw new Error('Chrome/Chromium not found. Install chromium or set the CHROME_PATH environment variable.');
+		throw new Error(
+			'Chrome/Chromium not found. Install chromium or set the PUPPETEER_EXECUTABLE_PATH (or CHROME_PATH) environment variable.',
+		);
 	}
 }
 
-async function closeBrowser() {
-	if (!browserPromise) {
+export async function closeBrowser(): Promise<void> {
+	const promise = browserPromise;
+	browserPromise = null;
+	activeBrowser = null;
+	if (!promise) {
 		return;
 	}
-	const browser = await browserPromise.catch(() => null);
-	browserPromise = null;
+	const browser = await promise.catch(() => null);
 	await browser?.close().catch(() => {});
 }
 
-for (const signal of ['SIGINT', 'SIGTERM', 'exit'] as const) {
-	process.on(signal, () => void closeBrowser());
-}
+process.once('exit', () => {
+	activeBrowser?.process()?.kill('SIGKILL');
+});

--- a/apps/backend/src/utils/headless-browser.ts
+++ b/apps/backend/src/utils/headless-browser.ts
@@ -1,0 +1,80 @@
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import type { Browser } from 'puppeteer-core';
+
+let browserPromise: Promise<Browser> | null = null;
+
+async function loadPuppeteer() {
+	try {
+		return await import('puppeteer-core');
+	} catch {
+		throw new Error(
+			'puppeteer-core is not available. Headless rendering requires puppeteer-core and a Chrome/Chromium installation.',
+		);
+	}
+}
+
+/** Shared, lazily-launched headless Chromium used for server-side rendering (PDF export, static map images). */
+export async function getBrowser(): Promise<Browser> {
+	if (browserPromise) {
+		const browser = await browserPromise;
+		if (browser.connected) {
+			return browser;
+		}
+		await browser.close().catch(() => {});
+	}
+	const puppeteer = await loadPuppeteer();
+	browserPromise = puppeteer.default
+		.launch({
+			headless: true,
+			executablePath: findChromePath(),
+			args: [
+				'--no-sandbox',
+				'--disable-setuid-sandbox',
+				'--disable-gpu',
+				'--disable-dev-shm-usage',
+				'--enable-unsafe-swiftshader',
+			],
+		})
+		.catch((error) => {
+			browserPromise = null;
+			throw error;
+		});
+	return browserPromise;
+}
+
+function findChromePath(): string {
+	const candidates = [
+		process.env.CHROME_PATH,
+		'/usr/bin/chromium',
+		'/usr/bin/chromium-browser',
+		'/usr/bin/google-chrome',
+	];
+
+	for (const candidate of candidates) {
+		if (candidate && existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	try {
+		return execSync('which chromium || which chromium-browser || which google-chrome', {
+			encoding: 'utf-8',
+		}).trim();
+	} catch {
+		throw new Error('Chrome/Chromium not found. Install chromium or set the CHROME_PATH environment variable.');
+	}
+}
+
+async function closeBrowser() {
+	if (!browserPromise) {
+		return;
+	}
+	const browser = await browserPromise.catch(() => null);
+	browserPromise = null;
+	await browser?.close().catch(() => {});
+}
+
+for (const signal of ['SIGINT', 'SIGTERM', 'exit'] as const) {
+	process.on(signal, () => void closeBrowser());
+}

--- a/apps/backend/src/utils/headless-browser.ts
+++ b/apps/backend/src/utils/headless-browser.ts
@@ -60,7 +60,14 @@ function browserLaunchArgs(): string[] {
 }
 
 function isSandboxDisabled(): boolean {
-	return process.env.DOCKER === '1';
+	if (process.env.PUPPETEER_DISABLE_SANDBOX === '1' || process.env.DOCKER === '1') {
+		return true;
+	}
+	return isRunningAsRoot();
+}
+
+function isRunningAsRoot(): boolean {
+	return typeof process.getuid === 'function' && process.getuid() === 0;
 }
 
 function findChromePath(): string {

--- a/apps/backend/src/utils/map-boundary-resolve.ts
+++ b/apps/backend/src/utils/map-boundary-resolve.ts
@@ -1,0 +1,65 @@
+import { type CustomBoundarySet, MAP_BOUNDARY_URLS, type MapFeatureCollection, resolveBoundary } from '@nao/shared';
+import type { displayMap } from '@nao/shared/tools';
+
+import { getCachedBoundary, setCachedBoundary } from './map-boundary-cache';
+import { parseAndValidateGeoJson, safeFetch } from './safe-fetch';
+
+export interface ResolvedBoundary {
+	geojson: MapFeatureCollection;
+	joinProps: string[] | null;
+}
+
+/** Resolves the boundary GeoJSON (and join properties) for a choropleth config, or null when geometry is inline or unavailable. */
+export async function resolveChoroplethBoundary(
+	config: displayMap.Input,
+	customBoundaries: CustomBoundarySet[],
+): Promise<ResolvedBoundary | null> {
+	if (config.geometry_key) {
+		return null;
+	}
+	if (config.boundaries_url) {
+		const geojson = await fetchBoundary(config.boundaries_url);
+		return geojson
+			? { geojson, joinProps: config.boundaries_join_property ? [config.boundaries_join_property] : null }
+			: null;
+	}
+	if (config.region_boundaries) {
+		const boundary = resolveBoundary(config.region_boundaries, customBoundaries);
+		if (!boundary) {
+			return null;
+		}
+		const isCustom = customBoundaries.some((set) => set.key === config.region_boundaries);
+		const url = isCustom ? boundary.url : builtinBoundaryUrl(config.region_boundaries);
+		const geojson = await fetchBoundary(url);
+		return geojson ? { geojson, joinProps: boundary.joinProps } : null;
+	}
+	return null;
+}
+
+export async function fetchBoundary(url: string): Promise<MapFeatureCollection | null> {
+	if (!url) {
+		return null;
+	}
+	const cached = getCachedBoundary(url);
+	if (cached) {
+		return cached;
+	}
+	try {
+		const text = await safeFetch(url);
+		const { geojson } = parseAndValidateGeoJson(text);
+		setCachedBoundary(url, geojson);
+		return geojson;
+	} catch {
+		return null;
+	}
+}
+
+export function builtinBoundaryUrl(set: string): string {
+	if (set === 'world_countries') {
+		return process.env.NAO_STORY_MAP_BOUNDARIES_WORLD_URL || MAP_BOUNDARY_URLS.world_countries;
+	}
+	if (set === 'france_regions') {
+		return process.env.NAO_STORY_MAP_BOUNDARIES_FRANCE_URL || MAP_BOUNDARY_URLS.france_regions;
+	}
+	return resolveBoundary(set)?.url ?? '';
+}

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -148,6 +148,14 @@ export const createImageBlock = (url: string): CardChild => {
 	return Image({ url, alt: 'image' });
 };
 
+export function formatClarificationText(question: string, options?: string[]): string {
+	if (!options || options.length === 0) {
+		return question;
+	}
+	const optionLines = options.map((opt, i) => `${i + 1}. ${opt}`).join('\n');
+	return `${question}\n${optionLines}`;
+}
+
 /** Interactive maps cannot be rendered by messaging providers, so they degrade to a link to the nao chat. */
 export const createMapLinkCard = (title: string, chatUrl: string): CardChild[] => [
 	CardText(`🗺️ **${title}**`),

--- a/apps/backend/src/utils/render-map-browser.ts
+++ b/apps/backend/src/utils/render-map-browser.ts
@@ -5,6 +5,7 @@ import {
 	buildMapPoints,
 	CHOROPLETH_MIN_OPACITY,
 	choroplethValueDomain,
+	computeMapBounds,
 	type CustomBoundarySet,
 	DEFAULT_MARKER_COLOR,
 	DEFAULT_MARKER_RADIUS,
@@ -99,8 +100,21 @@ function buildPointsMap(config: displayMap.Input, rows: Record<string, unknown>[
 			: defaultRadius,
 	}));
 
+	const bounds = computeMapBounds(points);
+
 	return {
-		dataMap: { type: config.map_type, color, radius: defaultRadius, points: mapPoints },
+		dataMap: {
+			type: config.map_type,
+			color,
+			radius: defaultRadius,
+			points: mapPoints,
+			bounds: bounds
+				? [
+						[bounds.west, bounds.south],
+						[bounds.east, bounds.north],
+					]
+				: null,
+		},
 		legendHtml: isBubble && sizeDomain ? bubbleLegendHtml(color, sizeDomain, maxRadius) : '',
 	};
 }
@@ -156,6 +170,12 @@ async function captureHtml(html: string, hasTitle: boolean): Promise<Buffer | nu
 		await page.setContent(html, { waitUntil: 'load', timeout: 30000 });
 		await page.waitForFunction('window.__naoMapsReady === true', { timeout: READY_TIMEOUT_MS }).catch(() => {});
 		await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+		const rendered = await page
+			.evaluate(() => (window as unknown as { __naoMapsRendered?: number }).__naoMapsRendered ?? 0)
+			.catch(() => 0);
+		if (rendered < 1) {
+			return null;
+		}
 		const element = await page.$('#nao-map-wrap');
 		if (!element) {
 			return null;
@@ -175,6 +195,7 @@ interface PointsDataMap {
 	color: string;
 	radius: number;
 	points: MapPointConfig[];
+	bounds: [[number, number], [number, number]] | null;
 }
 
 interface ChoroplethRegionConfig {
@@ -240,7 +261,11 @@ function bubbleLegendHtml(color: string, domain: NumericDomain, maxRadius: numbe
 		.map((value) => {
 			const radius = scaleBubbleRadius(value, domain, maxRadius);
 			const size = radius * 2;
-			return `<div class="nao-map-legend-item"><div class="nao-map-legend-circle-wrap" style="height:${maxRadius * 2}px"><span class="nao-map-legend-circle" style="width:${size}px;height:${size}px;background:${withOpacity(color, 0.9)}"></span></div><span>${escapeHtml(formatCompactNumber(value))}</span></div>`;
+			const wrapStyle = escapeAttribute(`height:${maxRadius * 2}px`);
+			const circleStyle = escapeAttribute(
+				`width:${size}px;height:${size}px;background:${withOpacity(color, 0.9)}`,
+			);
+			return `<div class="nao-map-legend-item"><div class="nao-map-legend-circle-wrap" style="${wrapStyle}"><span class="nao-map-legend-circle" style="${circleStyle}"></span></div><span>${escapeHtml(formatCompactNumber(value))}</span></div>`;
 		})
 		.join('');
 	return `<div class="nao-map-legend">${items}</div>`;
@@ -248,7 +273,8 @@ function bubbleLegendHtml(color: string, domain: NumericDomain, maxRadius: numbe
 
 function choroplethLegendHtml(color: string, domain: NumericDomain): string {
 	const gradient = `linear-gradient(to right, ${withOpacity(color, CHOROPLETH_MIN_OPACITY)}, ${color})`;
-	return `<div class="nao-map-legend"><div class="nao-map-legend-scale"><span class="nao-map-legend-bar" style="background:${gradient}"></span><span class="nao-map-legend-scale-labels"><span>${escapeHtml(formatCompactNumber(domain.min))}</span><span>${escapeHtml(formatCompactNumber(domain.max))}</span></span></div></div>`;
+	const barStyle = escapeAttribute(`background:${gradient}`);
+	return `<div class="nao-map-legend"><div class="nao-map-legend-scale"><span class="nao-map-legend-bar" style="${barStyle}"></span><span class="nao-map-legend-scale-labels"><span>${escapeHtml(formatCompactNumber(domain.min))}</span><span>${escapeHtml(formatCompactNumber(domain.max))}</span></span></div></div>`;
 }
 
 function escapeHtml(value: string): string {

--- a/apps/backend/src/utils/render-map-browser.ts
+++ b/apps/backend/src/utils/render-map-browser.ts
@@ -1,0 +1,260 @@
+import {
+	BUBBLE_MAX_RADIUS,
+	bubbleLegendValues,
+	buildChoroplethEntries,
+	buildMapPoints,
+	CHOROPLETH_MIN_OPACITY,
+	choroplethValueDomain,
+	type CustomBoundarySet,
+	DEFAULT_MARKER_COLOR,
+	DEFAULT_MARKER_RADIUS,
+	formatCompactNumber,
+	indexBoundaries,
+	type MapGeometry,
+	MAX_MAP_POINTS,
+	type NumericDomain,
+	numericDomain,
+	parseNumericValue,
+	resolveMapConfig,
+	scaleBubbleRadius,
+	withOpacity,
+} from '@nao/shared';
+import type { displayMap } from '@nao/shared/tools';
+
+import { getBrowser } from './headless-browser';
+import { logger } from './logger';
+import { resolveChoroplethBoundary } from './map-boundary-resolve';
+import { VIEW_HEIGHT, VIEW_WIDTH } from './static-map-svg';
+import { MAPLIBRE_CSS_URL, MAPLIBRE_JS_URL, renderMapScript } from './story-html';
+
+const TITLE_BAND_HEIGHT = 40;
+const MAP_PADDING = 8;
+const MAP_CORNER_RADIUS = 12;
+const READY_TIMEOUT_MS = 20000;
+const SETTLE_MS = 300;
+
+export interface BrowserMapInput {
+	config: displayMap.Input;
+	rows: Record<string, unknown>[];
+	customBoundaries?: CustomBoundarySet[];
+}
+
+interface MapPointConfig {
+	lng: number;
+	lat: number;
+	radius: number;
+}
+
+/**
+ * Renders a `display_map` to a PNG by loading the same MapLibre + Positron vector style the interactive UI uses
+ * inside headless Chromium and screenshotting it, so messaging surfaces match the UI download. Returns null when
+ * there is nothing to draw or no headless browser is available — callers fall back to the inline-SVG raster pipeline.
+ */
+export async function renderMapWithBrowser({
+	config,
+	rows,
+	customBoundaries = [],
+}: BrowserMapInput): Promise<Buffer | null> {
+	if (process.env.NAO_MAP_BROWSER_RENDER === 'false') {
+		return null;
+	}
+	const resolved = resolveMapConfig(rows, config);
+	const built =
+		resolved.map_type === 'choropleth'
+			? await buildChoroplethMap(resolved, rows, customBoundaries)
+			: buildPointsMap(resolved, rows);
+	if (!built) {
+		return null;
+	}
+
+	const html = buildMapHtml({ title: config.title, dataMap: built.dataMap, legendHtml: built.legendHtml });
+	return captureHtml(html, Boolean(config.title));
+}
+
+interface BuiltMap {
+	dataMap: DataMap;
+	legendHtml: string;
+}
+
+function buildPointsMap(config: displayMap.Input, rows: Record<string, unknown>[]): BuiltMap | null {
+	const points = buildMapPoints(rows, config).slice(0, MAX_MAP_POINTS);
+	if (points.length === 0) {
+		return null;
+	}
+
+	const isBubble = config.map_type === 'scatter_bubble';
+	const color = config.color?.trim() || DEFAULT_MARKER_COLOR;
+	const maxRadius = config.radius ?? BUBBLE_MAX_RADIUS;
+	const defaultRadius = config.radius ?? DEFAULT_MARKER_RADIUS;
+	const sizeDomain =
+		isBubble && config.size_key
+			? numericDomain(points.map((point) => parseNumericValue(point.row[config.size_key ?? ''])))
+			: null;
+
+	const mapPoints: MapPointConfig[] = points.map((point) => ({
+		lng: point.longitude,
+		lat: point.latitude,
+		radius: isBubble
+			? scaleBubbleRadius(parseNumericValue(point.row[config.size_key ?? '']), sizeDomain, maxRadius)
+			: defaultRadius,
+	}));
+
+	return {
+		dataMap: { type: config.map_type, color, radius: defaultRadius, points: mapPoints },
+		legendHtml: isBubble && sizeDomain ? bubbleLegendHtml(color, sizeDomain, maxRadius) : '',
+	};
+}
+
+async function buildChoroplethMap(
+	config: displayMap.Input,
+	rows: Record<string, unknown>[],
+	customBoundaries: CustomBoundarySet[],
+): Promise<BuiltMap | null> {
+	const entries = buildChoroplethEntries(rows, config);
+	const domain = choroplethValueDomain(entries);
+	const color = config.color?.trim() || DEFAULT_MARKER_COLOR;
+
+	const boundary = await resolveChoroplethBoundary(config, customBoundaries);
+	const index = boundary ? indexBoundaries(boundary.geojson, boundary.joinProps ?? undefined) : null;
+
+	const regions: ChoroplethRegionConfig[] = [];
+	for (const entry of entries) {
+		if (entry.value === null) {
+			continue;
+		}
+		const geometry = entry.geometry ?? (index && entry.region ? index.get(entry.region) : undefined);
+		if (!geometry) {
+			continue;
+		}
+		regions.push({ geometry, value: entry.value });
+	}
+	if (regions.length === 0) {
+		return null;
+	}
+
+	return {
+		dataMap: {
+			type: 'choropleth',
+			color,
+			regions,
+			domain: domain ? { min: domain.min, max: domain.max } : null,
+		},
+		legendHtml: domain ? choroplethLegendHtml(color, domain) : '',
+	};
+}
+
+async function captureHtml(html: string, hasTitle: boolean): Promise<Buffer | null> {
+	let page: Awaited<ReturnType<Awaited<ReturnType<typeof getBrowser>>['newPage']>> | null = null;
+	try {
+		const browser = await getBrowser();
+		page = await browser.newPage();
+		await page.setViewport({
+			width: VIEW_WIDTH + MAP_PADDING * 2,
+			height: VIEW_HEIGHT + MAP_PADDING * 2 + (hasTitle ? TITLE_BAND_HEIGHT : 0),
+			deviceScaleFactor: 2,
+		});
+		await page.setContent(html, { waitUntil: 'load', timeout: 30000 });
+		await page.waitForFunction('window.__naoMapsReady === true', { timeout: READY_TIMEOUT_MS }).catch(() => {});
+		await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+		const element = await page.$('#nao-map-wrap');
+		if (!element) {
+			return null;
+		}
+		const screenshot = await element.screenshot({ type: 'png' });
+		return Buffer.from(screenshot);
+	} catch (error) {
+		logger.warn(`Browser map render failed, falling back to static image: ${String(error)}`, { source: 'system' });
+		return null;
+	} finally {
+		await page?.close().catch(() => {});
+	}
+}
+
+interface PointsDataMap {
+	type: displayMap.MapType;
+	color: string;
+	radius: number;
+	points: MapPointConfig[];
+}
+
+interface ChoroplethRegionConfig {
+	geometry: MapGeometry;
+	value: number;
+}
+
+interface ChoroplethDataMap {
+	type: 'choropleth';
+	color: string;
+	regions: ChoroplethRegionConfig[];
+	domain: { min: number; max: number } | null;
+}
+
+type DataMap = PointsDataMap | ChoroplethDataMap;
+
+function buildMapHtml({
+	title,
+	dataMap,
+	legendHtml,
+}: {
+	title?: string;
+	dataMap: DataMap;
+	legendHtml: string;
+}): string {
+	const dataAttr = escapeAttribute(JSON.stringify(dataMap));
+	const titleBar = title ? `<div id="nao-map-title">${escapeHtml(title)}</div>` : '';
+	return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<link rel="stylesheet" href="${MAPLIBRE_CSS_URL}" />
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{background:#ffffff}
+#nao-map-wrap{width:${VIEW_WIDTH + MAP_PADDING * 2}px;background:#ffffff;padding:${MAP_PADDING}px}
+#nao-map-title{height:${TITLE_BAND_HEIGHT}px;display:flex;align-items:center;justify-content:center;background:#ffffff;color:#0a0a0a;font:300 15px system-ui,-apple-system,"Segoe UI",Roboto,sans-serif}
+.nao-map{width:${VIEW_WIDTH}px;height:${VIEW_HEIGHT}px;position:relative;overflow:hidden;border-radius:${MAP_CORNER_RADIUS}px}
+.nao-map canvas{display:block}
+.maplibregl-ctrl-group{display:none!important}
+.nao-map-legend{position:absolute;left:8px;bottom:8px;z-index:2;display:flex;align-items:flex-end;gap:8px;background:rgba(255,255,255,0.9);border:1px solid rgba(0,0,0,0.08);border-radius:6px;padding:6px 8px;font:10px ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;color:#6b7280}
+.nao-map-legend-item{display:flex;flex-direction:column;align-items:center;gap:4px}
+.nao-map-legend-circle-wrap{display:flex;align-items:flex-end}
+.nao-map-legend-circle{display:block;border-radius:9999px}
+.nao-map-legend-scale{display:flex;flex-direction:column;gap:4px}
+.nao-map-legend-bar{width:96px;height:8px;border-radius:4px}
+.nao-map-legend-scale-labels{display:flex;justify-content:space-between}
+</style>
+</head>
+<body>
+<div id="nao-map-wrap">
+${titleBar}
+<div class="nao-map" data-map="${dataAttr}">${legendHtml}</div>
+</div>
+<script src="${MAPLIBRE_JS_URL}"></script>
+<script>${renderMapScript()}</script>
+</body>
+</html>`;
+}
+
+function bubbleLegendHtml(color: string, domain: NumericDomain, maxRadius: number): string {
+	const items = bubbleLegendValues(domain)
+		.map((value) => {
+			const radius = scaleBubbleRadius(value, domain, maxRadius);
+			const size = radius * 2;
+			return `<div class="nao-map-legend-item"><div class="nao-map-legend-circle-wrap" style="height:${maxRadius * 2}px"><span class="nao-map-legend-circle" style="width:${size}px;height:${size}px;background:${withOpacity(color, 0.9)}"></span></div><span>${escapeHtml(formatCompactNumber(value))}</span></div>`;
+		})
+		.join('');
+	return `<div class="nao-map-legend">${items}</div>`;
+}
+
+function choroplethLegendHtml(color: string, domain: NumericDomain): string {
+	const gradient = `linear-gradient(to right, ${withOpacity(color, CHOROPLETH_MIN_OPACITY)}, ${color})`;
+	return `<div class="nao-map-legend"><div class="nao-map-legend-scale"><span class="nao-map-legend-bar" style="background:${gradient}"></span><span class="nao-map-legend-scale-labels"><span>${escapeHtml(formatCompactNumber(domain.min))}</span><span>${escapeHtml(formatCompactNumber(domain.max))}</span></span></div></div>`;
+}
+
+function escapeHtml(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeAttribute(value: string): string {
+	return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/apps/backend/src/utils/static-map-basemap.ts
+++ b/apps/backend/src/utils/static-map-basemap.ts
@@ -1,10 +1,11 @@
+import { logger } from './logger';
 import { type Fit, VIEW_HEIGHT, VIEW_WIDTH } from './static-map-svg';
 
 const TILE_SIZE = 256;
-const MAX_ZOOM = 8;
+const MAX_ZOOM = 10;
 const MAX_TILES = 24;
-export const TILE_BYTE_BUDGET = 95 * 1024;
-export const TOTAL_BASEMAP_BYTE_BUDGET = 95 * 1024;
+export const TILE_BYTE_BUDGET = 400 * 1024;
+export const TOTAL_BASEMAP_BYTE_BUDGET = 400 * 1024;
 
 export function basemapByteBudgetForCount(mapCount: number): number {
 	return Math.min(TILE_BYTE_BUDGET, Math.floor(TOTAL_BASEMAP_BYTE_BUDGET / Math.max(1, mapCount)));
@@ -13,7 +14,7 @@ const FETCH_TIMEOUT_MS = 4000;
 const TILE_CACHE_MAX = 512;
 
 export const BASEMAP_TILE_URL =
-	process.env.NAO_STORY_MAP_RASTER_URL || 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
+	process.env.NAO_STORY_MAP_RASTER_URL || 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
 export const BASEMAP_ATTRIBUTION = process.env.NAO_STORY_MAP_RASTER_ATTRIBUTION || '\u00a9 OpenStreetMap \u00a9 CARTO';
 const BASEMAP_SUBDOMAINS = (process.env.NAO_STORY_MAP_RASTER_SUBDOMAINS || 'abcd').split('');
 
@@ -41,20 +42,35 @@ export async function buildBasemapTiles(fit: Fit, byteBudget: number = TILE_BYTE
 	if (!fetchEnabled) {
 		return null;
 	}
+	let reason = 'no zoom level produced any tiles';
 	for (let zoom = pickZoom(fit); zoom >= 0; zoom--) {
 		const coords = tileCoords(fit, zoom);
-		if (coords.length === 0 || coords.length > MAX_TILES) {
+		if (coords.length === 0) {
 			continue;
 		}
-		const tiles = await fetchTiles(coords, zoom, fit, byteBudget);
-		if (tiles === null) {
+		if (coords.length > MAX_TILES) {
+			reason = `too many tiles at zoom ${zoom} (${coords.length} > ${MAX_TILES})`;
 			continue;
 		}
-		if (tiles.length > 0) {
-			return { tiles, attribution: BASEMAP_ATTRIBUTION };
+		const result = await fetchTiles(coords, zoom, fit, byteBudget);
+		if (result.tiles.length > 0) {
+			return { tiles: result.tiles, attribution: BASEMAP_ATTRIBUTION };
 		}
+		reason = result.budgetExceeded
+			? `tile payload exceeded the ${byteBudget}-byte budget at zoom ${zoom}`
+			: `all ${result.requested} tile request(s) failed at zoom ${zoom} (network/timeout or non-image response)`;
 	}
+	logger.warn(`Static map basemap unavailable, falling back to plain backdrop: ${reason}`, {
+		source: 'system',
+		context: { tileUrl: BASEMAP_TILE_URL.replace(/\?.*$/, ''), byteBudget },
+	});
 	return null;
+}
+
+interface TileFetchResult {
+	tiles: BasemapTile[];
+	requested: number;
+	budgetExceeded: boolean;
 }
 
 interface TileCoord {
@@ -90,12 +106,7 @@ function clampTile(value: number, tiles: number): number {
 	return Math.max(0, Math.min(tiles - 1, value));
 }
 
-async function fetchTiles(
-	coords: TileCoord[],
-	zoom: number,
-	fit: Fit,
-	byteBudget: number,
-): Promise<BasemapTile[] | null> {
+async function fetchTiles(coords: TileCoord[], zoom: number, fit: Fit, byteBudget: number): Promise<TileFetchResult> {
 	const tiles = 2 ** zoom;
 	const svgSize = (1 / tiles) * fit.scale;
 	const results = await Promise.all(
@@ -124,12 +135,12 @@ async function fetchTiles(
 			seen.add(tile.href);
 			bytes += tile.href.length;
 			if (bytes > byteBudget) {
-				return null;
+				return { tiles: [], requested: coords.length, budgetExceeded: true };
 			}
 		}
 		tilesOut.push(tile);
 	}
-	return tilesOut;
+	return { tiles: tilesOut, requested: coords.length, budgetExceeded: false };
 }
 
 function wrapTile(value: number, tiles: number): number {
@@ -172,7 +183,8 @@ function tileUrl(tx: number, ty: number, zoom: number): string {
 	return BASEMAP_TILE_URL.replace('{s}', subdomain)
 		.replace('{z}', String(zoom))
 		.replace('{x}', String(tx))
-		.replace('{y}', String(ty));
+		.replace('{y}', String(ty))
+		.replace('{r}', '@2x');
 }
 
 function rememberTile(url: string, value: string | null): void {

--- a/apps/backend/src/utils/static-map-basemap.ts
+++ b/apps/backend/src/utils/static-map-basemap.ts
@@ -62,9 +62,14 @@ export async function buildBasemapTiles(fit: Fit, byteBudget: number = TILE_BYTE
 	}
 	logger.warn(`Static map basemap unavailable, falling back to plain backdrop: ${reason}`, {
 		source: 'system',
-		context: { tileUrl: BASEMAP_TILE_URL.replace(/\?.*$/, ''), byteBudget },
+		context: { tileUrl: sanitizeTileUrlForLog(BASEMAP_TILE_URL), byteBudget },
 	});
 	return null;
+}
+
+function sanitizeTileUrlForLog(url: string): string {
+	const match = url.match(/^([a-zA-Z][\w+.-]*:\/\/)(?:[^@/]*@)?([^/?#]*)/);
+	return match ? `${match[1]}${match[2]}` : '[redacted]';
 }
 
 interface TileFetchResult {

--- a/apps/backend/src/utils/static-map-basemap.ts
+++ b/apps/backend/src/utils/static-map-basemap.ts
@@ -68,7 +68,7 @@ export async function buildBasemapTiles(fit: Fit, byteBudget: number = TILE_BYTE
 }
 
 function sanitizeTileUrlForLog(url: string): string {
-	const match = url.match(/^([a-zA-Z][\w+.-]*:\/\/)(?:[^@/]*@)?([^/?#]*)/);
+	const match = url.match(/^([a-zA-Z][\w+.-]*:\/\/)(?:[^/?#]*@)?([^/?#]*)/);
 	return match ? `${match[1]}${match[2]}` : '[redacted]';
 }
 

--- a/apps/backend/src/utils/static-map-svg.ts
+++ b/apps/backend/src/utils/static-map-svg.ts
@@ -1,7 +1,7 @@
 import { computeMapBounds, type MapGeometry, MERCATOR_MAX_LATITUDE } from '@nao/shared';
 
 export const VIEW_WIDTH = 852;
-export const VIEW_HEIGHT = 360;
+export const VIEW_HEIGHT = 568;
 const PADDING = 12;
 const DATA_BOUNDS_PAD_RATIO = 0.08;
 const MIN_NORMALIZED_SPAN = 0.02;

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -1763,18 +1763,19 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 		var map;
 		try{map=newMap(container);}catch(e){done();return;}
 		var loaded=false;
-		var failed=false;
+		var settled=false;
+		function settle(ok){if(settled)return;settled=true;if(ok){markRendered();}done();}
 		map.addControl(new maplibregl.NavigationControl({showCompass:false}),'top-right');
-		map.on('error',function(){if(!loaded){done();}else{failed=true;}});
+		map.on('error',function(){if(!loaded){settle(false);}});
 		map.on('load',function(){
 			loaded=true;
 			clampMinZoom(map,container);
 		if(cfg.type==='choropleth'){
 			var ready=cfg.inlineGeoJson?Promise.resolve(cfg.inlineGeoJson):cfg.boundaryUrl?fetch(cfg.boundaryUrl).then(function(r){return r.ok?r.json():null;}).catch(function(){return null;}):Promise.resolve(null);
-				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){if(!failed){markRendered();}done();});});
+				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){settle(true);});});
 			}else{
 				renderPoints(map,cfg);
-				map.once('idle',function(){if(!failed){markRendered();}done();});
+				map.once('idle',function(){settle(true);});
 			}
 		});
 	});

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -75,10 +75,10 @@ const CHART_WIDTH = DOC_MAX_WIDTH - DOC_HORIZ_PADDING * 2;
 const CHART_HEIGHT = Math.round((CHART_WIDTH * 9) / 16);
 
 const MAPLIBRE_VERSION = '5.24.0';
-const MAPLIBRE_JS_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js`;
-const MAPLIBRE_CSS_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css`;
-const MAP_STYLE_URL = process.env.NAO_STORY_MAP_STYLE_URL || 'https://tiles.openfreemap.org/styles/positron';
-const MAP_HEIGHT = 360;
+export const MAPLIBRE_JS_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js`;
+export const MAPLIBRE_CSS_URL = `https://unpkg.com/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css`;
+export const MAP_STYLE_URL = process.env.NAO_STORY_MAP_STYLE_URL || 'https://tiles.openfreemap.org/styles/positron';
+const MAP_HEIGHT = 568;
 
 // Static (sandbox) maps enhance the inline SVG with Leaflet — a DOM/raster tile map that needs no
 // WebGL or web-workers, so it renders where MapLibre is blocked. Raster tiles (OpenFreeMap is vector-only).
@@ -1307,7 +1307,7 @@ function renderTooltipScript(datePattern: string): string {
 	return TOOLTIP_SCRIPT_TEMPLATE.replace('__DATE_PATTERN__', escapedPattern);
 }
 
-function renderMapScript(): string {
+export function renderMapScript(): string {
 	return MAP_INIT_SCRIPT_TEMPLATE.replace('__MAP_STYLE_URL__', JSON.stringify(MAP_STYLE_URL));
 }
 
@@ -1355,7 +1355,7 @@ const STATIC_SVG_SCRIPT_TEMPLATE = `
 			el.addEventListener('mousemove',moveTip);
 			el.addEventListener('mouseleave',hideTip);
 		});
-		var base=(svg.getAttribute('viewBox')||'0 0 852 360').split(/\\s+/).map(Number);
+		var base=(svg.getAttribute('viewBox')||'0 0 852 568').split(/\\s+/).map(Number);
 		var baseX=base[0],baseY=base[1],baseW=base[2],baseH=base[3];
 		var view={x:baseX,y:baseY,w:baseW,h:baseH};
 		function apply(){svg.setAttribute('viewBox',view.x+' '+view.y+' '+view.w+' '+view.h);}

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -1763,17 +1763,18 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 		var map;
 		try{map=newMap(container);}catch(e){done();return;}
 		var loaded=false;
+		var failed=false;
 		map.addControl(new maplibregl.NavigationControl({showCompass:false}),'top-right');
-		map.on('error',function(){if(!loaded)done();});
+		map.on('error',function(){if(!loaded){done();}else{failed=true;}});
 		map.on('load',function(){
 			loaded=true;
 			clampMinZoom(map,container);
 		if(cfg.type==='choropleth'){
 			var ready=cfg.inlineGeoJson?Promise.resolve(cfg.inlineGeoJson):cfg.boundaryUrl?fetch(cfg.boundaryUrl).then(function(r){return r.ok?r.json():null;}).catch(function(){return null;}):Promise.resolve(null);
-				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){markRendered();done();});});
+				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){if(!failed){markRendered();}done();});});
 			}else{
 				renderPoints(map,cfg);
-				map.once('idle',function(){markRendered();done();});
+				map.once('idle',function(){if(!failed){markRendered();}done();});
 			}
 		});
 	});

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -1675,8 +1675,11 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 		return ['interpolate',['linear'],['coalesce',['get','value'],domain.min],domain.min,MIN_OPACITY,domain.max,MAX_OPACITY];
 	}
 	var containers=document.querySelectorAll('.nao-map');
-	if(!containers.length||typeof maplibregl==='undefined'){window.__naoMapsReady=true;return;}
+	if(!containers.length||typeof maplibregl==='undefined'){window.__naoMapsReady=true;window.__naoMapsRendered=0;return;}
 	var pending=containers.length;
+	var rendered=0;
+	window.__naoMapsRendered=0;
+	function markRendered(){rendered++;window.__naoMapsRendered=rendered;}
 	function done(){pending--;if(pending<=0){window.__naoMapsReady=true;}}
 	function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 	function norm(v){return v==null?null:String(v).trim().toLowerCase()||null;}
@@ -1706,9 +1709,10 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 		});
 		map.addSource('query-points',{type:'geojson',data:{type:'FeatureCollection',features:features}});
 		map.addLayer({id:'query-points-circles',type:'circle',source:'query-points',paint:{'circle-radius':isBubble?['get','radius']:cfg.radius,'circle-color':cfg.color,'circle-opacity':0.9,'circle-stroke-width':1,'circle-stroke-color':'#ffffff'}});
-		var bounds=new maplibregl.LngLatBounds();
-		cfg.points.forEach(function(point){bounds.extend([point.lng,point.lat]);});
-		try{map.fitBounds(bounds,{padding:40,maxZoom:14,duration:0});}catch(e){}
+		try{
+			if(cfg.bounds){map.fitBounds(cfg.bounds,{padding:40,maxZoom:14,duration:0});}
+			else{var bounds=new maplibregl.LngLatBounds();cfg.points.forEach(function(point){bounds.extend([point.lng,point.lat]);});map.fitBounds(bounds,{padding:40,maxZoom:14,duration:0});}
+		}catch(e){}
 		var popup=new maplibregl.Popup({closeButton:false,closeOnClick:false,className:'map-tooltip',offset:12,maxWidth:'280px'});
 		map.on('mousemove','query-points-circles',function(e){
 			var feature=e.features&&e.features[0];if(!feature)return;
@@ -1758,16 +1762,18 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 		var cfg;try{cfg=JSON.parse(raw);}catch(e){done();return;}
 		var map;
 		try{map=newMap(container);}catch(e){done();return;}
+		var loaded=false;
 		map.addControl(new maplibregl.NavigationControl({showCompass:false}),'top-right');
-		map.on('error',function(){done();});
+		map.on('error',function(){if(!loaded)done();});
 		map.on('load',function(){
+			loaded=true;
 			clampMinZoom(map,container);
 		if(cfg.type==='choropleth'){
 			var ready=cfg.inlineGeoJson?Promise.resolve(cfg.inlineGeoJson):cfg.boundaryUrl?fetch(cfg.boundaryUrl).then(function(r){return r.ok?r.json():null;}).catch(function(){return null;}):Promise.resolve(null);
-				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',done);});
+				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){markRendered();done();});});
 			}else{
 				renderPoints(map,cfg);
-				map.once('idle',done);
+				map.once('idle',function(){markRendered();done();});
 			}
 		});
 	});

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -1723,6 +1723,7 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 			popup.setLngLat([point.lng,point.lat]).setHTML(html).addTo(map);
 		});
 		map.on('mouseleave','query-points-circles',function(){map.getCanvas().style.cursor='';popup.remove();});
+		return features.length;
 	}
 	function renderChoropleth(map,cfg,boundaries){
 		var index=null;
@@ -1756,6 +1757,7 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 			popup.setLngLat(e.lngLat).setHTML(html).addTo(map);
 		});
 		map.on('mouseleave','query-regions-fill',function(){map.getCanvas().style.cursor='';popup.remove();});
+		return features.length;
 	}
 	containers.forEach(function(container){
 		var raw=container.getAttribute('data-map');
@@ -1772,10 +1774,10 @@ const MAP_INIT_SCRIPT_TEMPLATE = `
 			clampMinZoom(map,container);
 		if(cfg.type==='choropleth'){
 			var ready=cfg.inlineGeoJson?Promise.resolve(cfg.inlineGeoJson):cfg.boundaryUrl?fetch(cfg.boundaryUrl).then(function(r){return r.ok?r.json():null;}).catch(function(){return null;}):Promise.resolve(null);
-				ready.then(function(boundaries){renderChoropleth(map,cfg,boundaries);map.once('idle',function(){settle(true);});});
+				ready.then(function(boundaries){var count=renderChoropleth(map,cfg,boundaries);map.once('idle',function(){settle(count>0);});});
 			}else{
-				renderPoints(map,cfg);
-				map.once('idle',function(){settle(true);});
+				var count=renderPoints(map,cfg);
+				map.once('idle',function(){settle(count>0);});
 			}
 		});
 	});

--- a/apps/backend/src/utils/story-pdf.ts
+++ b/apps/backend/src/utils/story-pdf.ts
@@ -1,25 +1,11 @@
 import type { DateFormatSettings } from '@nao/shared/date';
-import { execSync } from 'child_process';
-import { existsSync } from 'fs';
-import type { Browser } from 'puppeteer-core';
 
+import { getBrowser } from './headless-browser';
 import type { QueryDataMap, StoryInput } from './story-download';
 import { generateStoryHtml } from './story-html';
 
-let browserPromise: Promise<Browser> | null = null;
-
 const A4_PRINTABLE_WIDTH_PX = 714;
 const A4_PRINTABLE_HEIGHT_PX = 1043;
-
-async function loadPuppeteer() {
-	try {
-		return await import('puppeteer-core');
-	} catch {
-		throw new Error(
-			'puppeteer-core is not available. PDF export requires puppeteer-core and a Chrome/Chromium installation.',
-		);
-	}
-}
 
 export async function generateStoryPdf(
 	story: StoryInput,
@@ -55,68 +41,4 @@ export async function generateStoryPdf(
 	} finally {
 		await page.close();
 	}
-}
-
-async function getBrowser(): Promise<Browser> {
-	if (browserPromise) {
-		const browser = await browserPromise;
-		if (browser.connected) {
-			return browser;
-		}
-		await browser.close().catch(() => {});
-	}
-	const puppeteer = await loadPuppeteer();
-	browserPromise = puppeteer.default
-		.launch({
-			headless: true,
-			executablePath: findChromePath(),
-			args: [
-				'--no-sandbox',
-				'--disable-setuid-sandbox',
-				'--disable-gpu',
-				'--disable-dev-shm-usage',
-				'--enable-unsafe-swiftshader',
-			],
-		})
-		.catch((error) => {
-			browserPromise = null;
-			throw error;
-		});
-	return browserPromise;
-}
-
-function findChromePath(): string {
-	const candidates = [
-		process.env.CHROME_PATH,
-		'/usr/bin/chromium',
-		'/usr/bin/chromium-browser',
-		'/usr/bin/google-chrome',
-	];
-
-	for (const candidate of candidates) {
-		if (candidate && existsSync(candidate)) {
-			return candidate;
-		}
-	}
-
-	try {
-		return execSync('which chromium || which chromium-browser || which google-chrome', {
-			encoding: 'utf-8',
-		}).trim();
-	} catch {
-		throw new Error('Chrome/Chromium not found. Install chromium or set the CHROME_PATH environment variable.');
-	}
-}
-
-async function closeBrowser() {
-	if (!browserPromise) {
-		return;
-	}
-	const browser = await browserPromise.catch(() => null);
-	browserPromise = null;
-	await browser?.close().catch(() => {});
-}
-
-for (const signal of ['SIGINT', 'SIGTERM', 'exit'] as const) {
-	process.on(signal, () => void closeBrowser());
 }

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -440,6 +440,13 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 			'xapp',
 		],
 	},
+	{
+		page: '/settings/project/slack',
+		pageLabel: 'Slack',
+		title: '/new slash command',
+		description: 'Users can type /new in Slack to start a fresh chat in private conversation and clear the previous main context.',
+		keywords: ['slack new chat', 'slack reset', 'slack fresh session', 'slash command', '/new'],
+	},
 
 	// ── Project > Microsoft Teams ────────────────────────────
 	{

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -444,7 +444,8 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		page: '/settings/project/slack',
 		pageLabel: 'Slack',
 		title: '/new slash command',
-		description: 'Users can type /new in Slack to start a fresh chat in private conversation and clear the previous main context.',
+		description:
+			'Users can type /new in Slack to start a fresh chat in private conversation and clear the previous main context.',
 		keywords: ['slack new chat', 'slack reset', 'slack fresh session', 'slash command', '/new'],
 	},
 

--- a/apps/frontend/src/components/settings/slack-form.tsx
+++ b/apps/frontend/src/components/settings/slack-form.tsx
@@ -201,7 +201,8 @@ export function SlackForm({ webhookUrl, hasProjectConfig, onSubmit, onCancel, is
 						</a>
 					</Button>
 					<p className='text-[11px] text-muted-foreground leading-relaxed'>
-						The manifest includes a <code>/new</code> slash command so users can start a fresh chat in private conversation at any time.
+						The manifest includes a <code>/new</code> slash command so users can start a fresh chat in
+						private conversation at any time.
 					</p>
 				</div>
 

--- a/apps/frontend/src/components/settings/slack-form.tsx
+++ b/apps/frontend/src/components/settings/slack-form.tsx
@@ -39,12 +39,21 @@ function buildSlackManifest(webhookUrl: string, mentionName: string, transportMo
 				display_name: name,
 				always_online: true,
 			},
+			slash_commands: [
+				{
+					command: '/new',
+					description: 'Start a fresh conversation with nao',
+					should_escape: false,
+					...(isSocket ? {} : { url: webhookUrl }),
+				},
+			],
 		},
 		oauth_config: {
 			scopes: {
 				bot: [
 					'channels:history',
 					'channels:read',
+					'commands',
 					'groups:history',
 					'groups:read',
 					'im:history',
@@ -191,6 +200,9 @@ export function SlackForm({ webhookUrl, hasProjectConfig, onSubmit, onCancel, is
 							Create Slack App
 						</a>
 					</Button>
+					<p className='text-[11px] text-muted-foreground leading-relaxed'>
+						The manifest includes a <code>/new</code> slash command so users can start a fresh chat in private conversation at any time.
+					</p>
 				</div>
 
 				{/* Step 3 */}

--- a/apps/frontend/src/components/tool-calls/display-chart-table.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-table.tsx
@@ -57,6 +57,12 @@ export function DisplayChartTable({ config, outputError, toolCallId }: DisplayCh
 					}),
 				});
 				queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+				queryClient.invalidateQueries({
+					queryKey: trpc.story.getLatest.queryKey({
+						chatId: variables.chatId,
+						storySlug: variables.storySlug,
+					}),
+				});
 			},
 		}),
 	);

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -93,6 +93,12 @@ export const DisplayChartToolCall = ({ toolPart }: ToolCallComponentProps<'displ
 					}),
 				});
 				queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+				queryClient.invalidateQueries({
+					queryKey: trpc.story.getLatest.queryKey({
+						chatId: variables.chatId,
+						storySlug: variables.storySlug,
+					}),
+				});
 			},
 		}),
 	);

--- a/apps/frontend/src/components/tool-calls/display-map-view.tsx
+++ b/apps/frontend/src/components/tool-calls/display-map-view.tsx
@@ -52,6 +52,7 @@ const POINT_STROKE_WIDTH = 1;
 
 export interface MapViewHandle {
 	captureImage: (type?: string) => Promise<string | null>;
+	resize: () => void;
 }
 
 interface MapViewProps {
@@ -185,6 +186,9 @@ export default memo(function MapView({
 					regions: regionsRef.current,
 					type,
 				});
+			},
+			resize: () => {
+				mapRef.current?.resize();
 			},
 		}),
 		[],

--- a/apps/frontend/src/components/tool-calls/display-map.tsx
+++ b/apps/frontend/src/components/tool-calls/display-map.tsx
@@ -95,6 +95,12 @@ export const DisplayMapToolCall = ({
 					}),
 				});
 				queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+				queryClient.invalidateQueries({
+					queryKey: trpc.story.getLatest.queryKey({
+						chatId: variables.chatId,
+						storySlug: variables.storySlug,
+					}),
+				});
 			},
 		}),
 	);

--- a/apps/frontend/src/components/tool-calls/display-map.tsx
+++ b/apps/frontend/src/components/tool-calls/display-map.tsx
@@ -74,9 +74,11 @@ export const DisplayMapToolCall = ({
 	const slotRef = useRef<HTMLDivElement>(null);
 	const breakoutStyle = useBreakoutStyle(slotRef, isExpanded && viewMode === 'map');
 	const mapViewRef = useRef<MapViewHandle>(null);
+	const [hasShownMap, setHasShownMap] = useState(false);
 
 	useEffect(() => {
 		if (viewMode === 'map') {
+			setHasShownMap(true);
 			mapViewRef.current?.resize();
 		}
 	}, [viewMode]);
@@ -364,14 +366,16 @@ export const DisplayMapToolCall = ({
 					)}
 
 					<div className={cn('px-3 pb-3', viewMode !== 'map' && 'hidden')}>
-						<Suspense fallback={<Skeleton className='w-full aspect-3/2 rounded-lg' />}>
-							<MapView
-								ref={mapViewRef}
-								points={visiblePoints}
-								rows={sourceData.data as Record<string, unknown>[]}
-								config={mapConfig}
-							/>
-						</Suspense>
+						{(viewMode === 'map' || hasShownMap) && (
+							<Suspense fallback={<Skeleton className='w-full aspect-3/2 rounded-lg' />}>
+								<MapView
+									ref={mapViewRef}
+									points={visiblePoints}
+									rows={sourceData.data as Record<string, unknown>[]}
+									config={mapConfig}
+								/>
+							</Suspense>
+						)}
 					</div>
 
 					{viewMode === 'table' && (

--- a/apps/frontend/src/components/tool-calls/display-map.tsx
+++ b/apps/frontend/src/components/tool-calls/display-map.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
 	Code,
@@ -74,6 +74,12 @@ export const DisplayMapToolCall = ({
 	const slotRef = useRef<HTMLDivElement>(null);
 	const breakoutStyle = useBreakoutStyle(slotRef, isExpanded && viewMode === 'map');
 	const mapViewRef = useRef<MapViewHandle>(null);
+
+	useEffect(() => {
+		if (viewMode === 'map') {
+			mapViewRef.current?.resize();
+		}
+	}, [viewMode]);
 	const isEditable = Boolean(agent && !agent.isReadonly && !agent.isRunning);
 	const storyIds = useStoryIds();
 	const { mutate: logDownload } = useMutation(trpc.analyticsEvent.logChatDownload.mutationOptions());
@@ -351,18 +357,16 @@ export const DisplayMapToolCall = ({
 						/>
 					)}
 
-					{viewMode === 'map' && (
-						<div className='px-3 pb-3'>
-							<Suspense fallback={<Skeleton className='w-full aspect-3/2 rounded-lg' />}>
-								<MapView
-									ref={mapViewRef}
-									points={visiblePoints}
-									rows={sourceData.data as Record<string, unknown>[]}
-									config={mapConfig}
-								/>
-							</Suspense>
-						</div>
-					)}
+					<div className={cn('px-3 pb-3', viewMode !== 'map' && 'hidden')}>
+						<Suspense fallback={<Skeleton className='w-full aspect-3/2 rounded-lg' />}>
+							<MapView
+								ref={mapViewRef}
+								points={visiblePoints}
+								rows={sourceData.data as Record<string, unknown>[]}
+								config={mapConfig}
+							/>
+						</Suspense>
+					</div>
 
 					{viewMode === 'table' && (
 						<TableDisplay

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -262,7 +262,7 @@ function ChatPage() {
 						<div className='pointer-events-none absolute left-0 right-4 bottom-0 z-10 pt-8'>
 							<div
 								ref={inputAreaRef}
-								className='pointer-events-auto bg-gradient-to-t from-background via-background to-transparent'
+								className='pointer-events-auto bg-gradient-to-t from-background via-background via-70% to-transparent'
 							>
 								<ChatInput />
 							</div>

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -781,6 +781,21 @@ code.dollar:before {
 	opacity: 0.9;
 }
 
+/* Reduce the(⌘+scroll) overlay so that it doesn't get over the chat input. */
+.maplibregl-cooperative-gesture-screen {
+	background: rgb(0 0 0 / 0.25);
+	z-index: 2;
+}
+
+.maplibregl-cooperative-gesture-screen.maplibregl-show {
+	transition: opacity 0.05s;
+}
+
+/* Snap the hide-fade so the overlay clears quickly instead of lingering 2 s */
+.maplibregl-cooperative-gesture-screen:not(.maplibregl-show) {
+	transition: opacity 0.3s ease 0.2s;
+}
+
 /* MapLibre hover tooltip: strip default popup chrome so the inner box matches the chart tooltip */
 .maplibregl-popup.map-tooltip {
 	pointer-events: none;


### PR DESCRIPTION
## Summary

- [x] fix clarification handler in connected app like Slack, Teams, Whatsapp and Telegram
<img width="402" height="384" alt="image" src="https://github.com/user-attachments/assets/6693145b-032c-4c4c-a889-86f87fdee0de" />

- [x] add `/new` command in Slack to start a fresh chat in a private conversation
	- `/new` just indicates that what you’re gonna send after will start a fresh main chat session
	- `/new message/question` indicate a new fresh chat with the openning of a thread started by `@your_username: your_message/question` and then the agent put his response is the thread -> this way you can simultanously chat with the bot in the main chat and the different opened threads
<img width="688" height="467" alt="image" src="https://github.com/user-attachments/assets/66c5565c-3a45-41cf-8efc-3ed117dc4e3e" />

- [x] make the `display_map` tool mirroring the map UI so the rendering matches on Slack, by screenshotting an headless browser via puppeteer library fallback to svgToPng instead of making the fallback the only render
<img width="1050" height="758" alt="image" src="https://github.com/user-attachments/assets/cbc373ea-7a58-4743-92b8-af31d29b1aa0" />

- [x] fix the view switching between `map | data | SQL` of the `display_map` tool that caused an mismatched render
- [x] reduce the(⌘+scroll) overlay that sometimes get over the chat input when the map of `display_map` is extend
- [x] "Map data unavailable" after `Add to story` button

## Related issue

Fix #754 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

