### PR TITLE
Add possibility to delete selection in story editor using Backspace

### DIFF
--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -26,6 +26,17 @@ export type DragUnit = { kind: 'block'; pos: number } | { kind: 'gridColumns'; g
 
 export const blockSelectionPluginKey = new PluginKey<BlockSelectionState>('blockSelection');
 
+const CARET_MOVEMENT_KEYS = new Set([
+	'ArrowLeft',
+	'ArrowRight',
+	'ArrowUp',
+	'ArrowDown',
+	'Home',
+	'End',
+	'PageUp',
+	'PageDown',
+]);
+
 export const BlockSelection = Extension.create({
 	name: 'blockSelection',
 	priority: 200,
@@ -390,6 +401,10 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 				if (event.key === 'Escape') {
 					view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
 					return true;
+				}
+				if (CARET_MOVEMENT_KEYS.has(event.key)) {
+					view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
+					return false;
 				}
 				if (event.key === 'Backspace' || event.key === 'Delete') {
 					event.preventDefault();

--- a/apps/frontend/src/components/side-panel/story-block-selection.ts
+++ b/apps/frontend/src/components/side-panel/story-block-selection.ts
@@ -1,7 +1,7 @@
 import { popGridColumns, splitGridColumnsRaw } from '@nao/shared/story-segments';
 import { Extension } from '@tiptap/core';
 import { Fragment, Slice } from '@tiptap/pm/model';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import { dropPoint } from '@tiptap/pm/transform';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { createBlockNode } from './story-editor-utils';
@@ -28,6 +28,7 @@ export const blockSelectionPluginKey = new PluginKey<BlockSelectionState>('block
 
 export const BlockSelection = Extension.create({
 	name: 'blockSelection',
+	priority: 200,
 
 	addProseMirrorPlugins() {
 		return [buildBlockSelectionPlugin()];
@@ -46,6 +47,31 @@ export function emptySelection(): BlockSelectionState {
 	return { blocks: [], gridColumns: [], anchor: null, columnAnchor: null };
 }
 
+export function deleteSelectedBlocks(view: EditorView): boolean {
+	const selection = blockSelectionPluginKey.getState(view.state) ?? emptySelection();
+	if (!selection.blocks.length && !selection.gridColumns.length) {
+		return false;
+	}
+
+	const operations = buildDragUnitOperations(view.state, dragUnitsFromSelection(selection));
+	if (!operations?.length) {
+		view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
+		return true;
+	}
+
+	const transaction = view.state.tr;
+	const selectionPosition = Math.min(...operations.map((operation) => operation.from));
+	applyDragUnitRemovals(transaction, operations);
+	const mappedSelectionPosition = Math.min(
+		transaction.mapping.map(selectionPosition, -1),
+		transaction.doc.content.size,
+	);
+	transaction.setSelection(TextSelection.near(transaction.doc.resolve(mappedSelectionPosition)));
+	transaction.setMeta(blockSelectionPluginKey, emptySelection());
+	view.dispatch(transaction);
+	return true;
+}
+
 export function resolveDragSelection(
 	state: EditorState,
 	origin: { kind: 'block'; pos: number } | { kind: 'gridColumn'; gridPos: number; index: number },
@@ -61,14 +87,28 @@ export function resolveDragSelection(
 		return null;
 	}
 
+	const units = dragUnitsFromSelection(selection);
+	if (
+		units.length === 1 &&
+		(units[0].kind === 'block' || (units[0].kind === 'gridColumns' && units[0].indices.length === 1))
+	) {
+		return null;
+	}
+	return units;
+}
+
+function dragUnitsFromSelection(selection: BlockSelectionState): DragUnit[] {
 	const columnsByGrid = new Map<number, number[]>();
 	for (const column of selection.gridColumns) {
+		if (selection.blocks.includes(column.gridPos)) {
+			continue;
+		}
 		const indices = columnsByGrid.get(column.gridPos) ?? [];
 		indices.push(column.index);
 		columnsByGrid.set(column.gridPos, indices);
 	}
 
-	const units: DragUnit[] = [
+	return [
 		...selection.blocks.map((pos): DragUnit => ({ kind: 'block', pos })),
 		...Array.from(
 			columnsByGrid,
@@ -79,14 +119,6 @@ export function resolveDragSelection(
 			}),
 		),
 	].sort((first, second) => dragUnitPosition(first) - dragUnitPosition(second));
-
-	if (
-		units.length === 1 &&
-		(units[0].kind === 'block' || (units[0].kind === 'gridColumns' && units[0].indices.length === 1))
-	) {
-		return null;
-	}
-	return units;
 }
 
 /**
@@ -223,6 +255,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 								const next = selectColumnFromHandle(view.state, gridPos, index);
 								if (next) {
 									view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, next));
+									view.focus();
 								}
 								return true;
 							}
@@ -245,6 +278,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 										columnAnchor: column,
 									}),
 								);
+								view.focus();
 								return true;
 							}
 
@@ -260,6 +294,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 									columnAnchor: columnAnchor?.gridPos === gridPos ? columnAnchor : column,
 								}),
 							);
+							view.focus();
 							return true;
 						}
 					}
@@ -284,6 +319,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 							}
 							event.preventDefault();
 							view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, next));
+							view.focus();
 							return true;
 						}
 						if (clickedNode != null && clickedNode.type.name === 'gridBlock') {
@@ -329,6 +365,7 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 								anchor: blockPosition,
 							}),
 						);
+						view.focus();
 						return true;
 					}
 
@@ -340,17 +377,25 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 							anchor,
 						}),
 					);
+					view.focus();
 					return true;
 				},
 			},
 			handleKeyDown(view, event) {
 				const selection = blockSelectionPluginKey.getState(view.state);
-				if (event.key !== 'Escape' || (!selection?.blocks.length && !selection?.gridColumns.length)) {
+				if (!selection?.blocks.length && !selection?.gridColumns.length) {
 					return false;
 				}
 
-				view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
-				return true;
+				if (event.key === 'Escape') {
+					view.dispatch(view.state.tr.setMeta(blockSelectionPluginKey, emptySelection()));
+					return true;
+				}
+				if (event.key === 'Backspace' || event.key === 'Delete') {
+					event.preventDefault();
+					return deleteSelectedBlocks(view);
+				}
+				return false;
 			},
 		},
 		view(editorView) {
@@ -376,6 +421,22 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 			const onKeyDown = (event: KeyboardEvent) => {
 				if (event.key === 'Escape') {
 					clearSelection();
+					return;
+				}
+				if (
+					(event.key !== 'Backspace' && event.key !== 'Delete') ||
+					event.defaultPrevented ||
+					isEditableTarget(event.target)
+				) {
+					return;
+				}
+				const target = event.target;
+				if (target instanceof globalThis.Node && editorView.dom.contains(target)) {
+					return;
+				}
+				if (deleteSelectedBlocks(editorView)) {
+					event.preventDefault();
+					event.stopPropagation();
 				}
 			};
 
@@ -390,6 +451,13 @@ function buildBlockSelectionPlugin(): Plugin<BlockSelectionState> {
 			};
 		},
 	});
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+	if (!(target instanceof HTMLElement)) {
+		return false;
+	}
+	return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 }
 
 export function topLevelBlockPositions(doc: PMNode): number[] {
@@ -461,13 +529,7 @@ export function buildSelectionMoveTransaction(
 	}
 
 	const transaction = state.tr;
-	for (const operation of [...operations].sort((first, second) => second.from - first.from)) {
-		if (operation.remainingNode) {
-			transaction.replaceWith(operation.from, operation.to, operation.remainingNode);
-		} else {
-			transaction.delete(operation.from, operation.to);
-		}
-	}
+	applyDragUnitRemovals(transaction, operations);
 	const mappedInsert = transaction.mapping.map(insertPos);
 	transaction.insert(mappedInsert, Fragment.fromArray(nodes));
 	transaction.setMeta(blockSelectionPluginKey, emptySelection());
@@ -537,6 +599,16 @@ function buildDragUnitOperations(state: EditorState, units: DragUnit[]): DragUni
 		});
 	}
 	return operations;
+}
+
+function applyDragUnitRemovals(transaction: Transaction, operations: DragUnitOperation[]): void {
+	for (const operation of [...operations].sort((first, second) => second.from - first.from)) {
+		if (operation.remainingNode) {
+			transaction.replaceWith(operation.from, operation.to, operation.remainingNode);
+		} else {
+			transaction.delete(operation.from, operation.to);
+		}
+	}
 }
 
 function dragUnitPosition(unit: DragUnit): number {

--- a/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-block-drag.tsx
@@ -78,10 +78,10 @@ export function StoryBlockDragGrip({ node, editor, getPos }: Pick<ReactNodeViewP
 					return;
 				}
 				const next = selectBlockFromHandle(editor.state, pos);
-				if (!next) {
-					return;
+				if (next) {
+					editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
 				}
-				editor.view.dispatch(editor.state.tr.setMeta(blockSelectionPluginKey, next));
+				editor.view.focus();
 			}}
 			onPointerDown={(event) => {
 				event.stopPropagation();

--- a/apps/frontend/src/components/side-panel/story-editor-grid-block.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor-grid-block.tsx
@@ -149,12 +149,12 @@ function GridBlockView(props: ReactNodeViewProps) {
 											return;
 										}
 										const next = selectColumnFromHandle(props.editor.state, gridPos, i);
-										if (!next) {
-											return;
+										if (next) {
+											props.editor.view.dispatch(
+												props.editor.state.tr.setMeta(blockSelectionPluginKey, next),
+											);
 										}
-										props.editor.view.dispatch(
-											props.editor.state.tr.setMeta(blockSelectionPluginKey, next),
-										);
+										props.editor.view.focus();
 									}}
 									onPointerDown={(event) => {
 										event.stopPropagation();

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -2,7 +2,7 @@
 
 import { Editor, Node } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { splitGridColumnsRaw } from '@nao/shared/story-segments';
 
 import {
@@ -150,7 +150,7 @@ function dispatchEditorMouseDown(target: Element, init?: MouseEventInit): void {
 	}
 }
 
-function dispatchEditorKeyDown(editor: Editor, key: 'Backspace' | 'Delete'): KeyboardEvent {
+function dispatchEditorKeyDown(editor: Editor, key: string): KeyboardEvent {
 	editor.view.focus();
 	const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
 	editor.view.dom.dispatchEvent(event);
@@ -550,6 +550,23 @@ describe('story block selection', () => {
 			expect(editor.state.doc.childCount).toBe(1);
 			expect(editor.state.doc.textContent).toBe('BB');
 			expect(blockSelectionPluginKey.getState(editor.state)).toEqual(emptySelection());
+		});
+
+		it('cancels block deletion after keyboard caret movement', () => {
+			const [first, , third] = topLevelBlockPositions(editor.state.doc);
+			selectBlocks(editor, [first, third], first);
+
+			const endOfTextblock = vi.spyOn(editor.view, 'endOfTextblock').mockReturnValue(false);
+			const arrowEvent = dispatchEditorKeyDown(editor, 'ArrowDown');
+			endOfTextblock.mockRestore();
+
+			expect(arrowEvent.defaultPrevented).toBe(false);
+			expect(blockSelectionPluginKey.getState(editor.state)).toEqual(emptySelection());
+
+			dispatchEditorKeyDown(editor, 'Backspace');
+
+			expect(editor.state.doc.childCount).toBe(3);
+			expect(editor.state.doc.textContent).toBe('AABBCC');
 		});
 
 		it('deletes mixed blocks and columns from several grids in one keypress', () => {

--- a/apps/frontend/tests/story-block-selection.test.ts
+++ b/apps/frontend/tests/story-block-selection.test.ts
@@ -84,6 +84,10 @@ const FIRST_THREE_COLUMN_GRID = `<grid widths="1,1,1">
 <chart query_id="q2" chart_type="bar" x_axis_key="month" />
 <chart query_id="q3" chart_type="area" x_axis_key="month" />
 </grid>`;
+const FIRST_TWO_COLUMN_GRID = `<grid widths="1,1">
+<chart query_id="q1" chart_type="line" x_axis_key="month" />
+<chart query_id="q2" chart_type="bar" x_axis_key="month" />
+</grid>`;
 const SECOND_THREE_COLUMN_GRID = `<grid widths="1,1,1">
 <table query_id="q4" />
 <chart query_id="q5" chart_type="bar" x_axis_key="month" />
@@ -144,6 +148,13 @@ function dispatchEditorMouseDown(target: Element, init?: MouseEventInit): void {
 			value: elementFromPoint,
 		});
 	}
+}
+
+function dispatchEditorKeyDown(editor: Editor, key: 'Backspace' | 'Delete'): KeyboardEvent {
+	editor.view.focus();
+	const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+	editor.view.dom.dispatchEvent(event);
+	return event;
 }
 
 function dispatchEditorMouseDownAtPosition(
@@ -477,6 +488,126 @@ describe('story block selection', () => {
 			);
 
 			expect(selectColumnFromHandle(editor.state, 4, 1)).toBeNull();
+		});
+	});
+
+	describe('deleting the selection', () => {
+		it('removes one grid column and collapses a two-column grid to a plain block', () => {
+			const gridEditor = createDocumentEditor([
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_THREE_COLUMN_GRID } },
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_TWO_COLUMN_GRID } },
+			]);
+			const [threeColumnGridPos] = topLevelBlockPositions(gridEditor.state.doc);
+			selectMixed(gridEditor, [], [{ gridPos: threeColumnGridPos, index: 1 }]);
+
+			const firstEvent = dispatchEditorKeyDown(gridEditor, 'Backspace');
+
+			expect(firstEvent.defaultPrevented).toBe(true);
+			expect(gridEditor.state.doc.child(0).type.name).toBe('gridBlock');
+			const remainingColumns = splitGridColumnsRaw(
+				gridEditor.state.doc.child(0).attrs.rawContent as string,
+			).columns;
+			expect(remainingColumns).toHaveLength(2);
+			expect(remainingColumns[0]).toContain('query_id="q1"');
+			expect(remainingColumns[1]).toContain('query_id="q3"');
+			expect(blockSelectionPluginKey.getState(gridEditor.state)).toEqual(emptySelection());
+
+			const [, twoColumnGridPos] = topLevelBlockPositions(gridEditor.state.doc);
+			selectMixed(gridEditor, [], [{ gridPos: twoColumnGridPos, index: 0 }]);
+			const secondEvent = dispatchEditorKeyDown(gridEditor, 'Backspace');
+
+			expect(secondEvent.defaultPrevented).toBe(true);
+			expect(gridEditor.state.doc.child(1).type.name).toBe('chartBlock');
+			expect(gridEditor.state.doc.child(1).attrs.rawTag).toContain('query_id="q2"');
+			expect(blockSelectionPluginKey.getState(gridEditor.state)).toEqual(emptySelection());
+			gridEditor.destroy();
+		});
+
+		it('removes the grid when its last column is selected', () => {
+			const gridEditor = createDocumentEditor([
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_GRID } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'After' }] },
+			]);
+			const [gridPos] = topLevelBlockPositions(gridEditor.state.doc);
+			selectMixed(gridEditor, [], [{ gridPos, index: 0 }]);
+
+			const event = dispatchEditorKeyDown(gridEditor, 'Backspace');
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(gridEditor.state.doc.childCount).toBe(1);
+			expect(gridEditor.state.doc.child(0).textContent).toBe('After');
+			expect(blockSelectionPluginKey.getState(gridEditor.state)).toEqual(emptySelection());
+			gridEditor.destroy();
+		});
+
+		it('deletes several selected top-level blocks', () => {
+			const [first, , third] = topLevelBlockPositions(editor.state.doc);
+			selectBlocks(editor, [first, third], first);
+
+			const event = dispatchEditorKeyDown(editor, 'Backspace');
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(editor.state.doc.childCount).toBe(1);
+			expect(editor.state.doc.textContent).toBe('BB');
+			expect(blockSelectionPluginKey.getState(editor.state)).toEqual(emptySelection());
+		});
+
+		it('deletes mixed blocks and columns from several grids in one keypress', () => {
+			const mixedEditor = createDocumentEditor([
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Remove A' }] },
+				{ type: 'gridBlock', attrs: { rawContent: FIRST_THREE_COLUMN_GRID } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Remove B' }] },
+				{ type: 'gridBlock', attrs: { rawContent: SECOND_THREE_COLUMN_GRID } },
+				{ type: 'paragraph', content: [{ type: 'text', text: 'Keep' }] },
+			]);
+			const [firstBlockPos, firstGridPos, secondBlockPos, secondGridPos] = topLevelBlockPositions(
+				mixedEditor.state.doc,
+			);
+			selectMixed(
+				mixedEditor,
+				[firstBlockPos, secondBlockPos],
+				[
+					{ gridPos: firstGridPos, index: 1 },
+					{ gridPos: secondGridPos, index: 0 },
+					{ gridPos: secondGridPos, index: 2 },
+				],
+			);
+
+			const event = dispatchEditorKeyDown(mixedEditor, 'Delete');
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(mixedEditor.state.doc.childCount).toBe(3);
+			expect(mixedEditor.state.doc.child(0).type.name).toBe('gridBlock');
+			const firstGridColumns = splitGridColumnsRaw(
+				mixedEditor.state.doc.child(0).attrs.rawContent as string,
+			).columns;
+			expect(firstGridColumns).toHaveLength(2);
+			expect(firstGridColumns[0]).toContain('query_id="q1"');
+			expect(firstGridColumns[1]).toContain('query_id="q3"');
+			expect(mixedEditor.state.doc.child(1).type.name).toBe('chartBlock');
+			expect(mixedEditor.state.doc.child(1).attrs.rawTag).toContain('query_id="q5"');
+			expect(mixedEditor.state.doc.child(2).textContent).toBe('Keep');
+			expect(blockSelectionPluginKey.getState(mixedEditor.state)).toEqual(emptySelection());
+			mixedEditor.destroy();
+		});
+
+		it('handles deletion from outside the editor when focus is lost', () => {
+			const [first] = topLevelBlockPositions(editor.state.doc);
+			selectBlocks(editor, [first], first);
+			const outside = document.createElement('div');
+			document.body.appendChild(outside);
+			const event = new KeyboardEvent('keydown', {
+				key: 'Backspace',
+				bubbles: true,
+				cancelable: true,
+			});
+
+			outside.dispatchEvent(event);
+
+			expect(event.defaultPrevented).toBe(true);
+			expect(editor.state.doc.textContent).toBe('BBCC');
+			expect(blockSelectionPluginKey.getState(editor.state)).toEqual(emptySelection());
+			outside.remove();
 		});
 	});
 


### PR DESCRIPTION
## Summary

- `Backspace` in the story editor now removes exactly the blocks and grid columns you have selected/highlighted.
- Deleting one chart from a row no longer wipes the whole row. 

### Follow up

`story-block-selection.ts` is becoming messy. Note how `view.focus()` appears 7 times. We should refactor all the block drag and selection code. I'll wait for PR #1348 to be merged or closed to avoid big conflicts

Closes #1393

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

