### PR TITLE
[feat : Confluence] add confluence as a context provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,6 +206,17 @@ GITLAB_ALLOWED_USERS=
 
 NOTION_API_KEY=
 
+# Confluence (optional; referenced from nao_config.yaml via env())
+CONFLUENCE_BASE_URL=
+# Cloud: set the base URL, account email and an API token.
+CONFLUENCE_EMAIL=
+CONFLUENCE_API_TOKEN=
+# Data Center/Server: set the base URL and a personal access token.
+CONFLUENCE_PAT=
+# Data Center/Server: set the base URL and a username/password.
+CONFLUENCE_USERNAME=
+CONFLUENCE_PASSWORD=
+
 # ClickHouse (optional; use in nao_config.yaml with env() or for connection)
 CLICKHOUSE_HOST=localhost
 CLICKHOUSE_PORT=8123

--- a/apps/backend/src/services/context-explorer.service.ts
+++ b/apps/backend/src/services/context-explorer.service.ts
@@ -197,7 +197,11 @@ export function getFileEditability(
 			actionLabel: 'Open template',
 		});
 	}
-	if (projectPath.startsWith('repos/') || projectPath.startsWith('docs/notion/')) {
+	if (
+		projectPath.startsWith('repos/') ||
+		projectPath.startsWith('docs/notion/') ||
+		projectPath.startsWith('docs/confluence/')
+	) {
 		return readOnly('synced-source', {
 			message: 'This path is replaced by nao sync. Change its source in nao_config.yaml.',
 			actionKind: 'file',

--- a/apps/backend/tests/context-explorer-write.test.ts
+++ b/apps/backend/tests/context-explorer-write.test.ts
@@ -50,6 +50,7 @@ describe('context explorer worktree writes', () => {
 			'rendered.md.j2': 'template\n',
 			'repos/source.md': 'synced\n',
 			'docs/notion/page.md': 'notion\n',
+			'docs/confluence/page.md': 'confluence\n',
 			'.gitignore': 'ignored\n',
 		});
 		commitAll(seed);
@@ -65,6 +66,7 @@ describe('context explorer worktree writes', () => {
 			'rendered.md.j2': 'live template\n',
 			'repos/source.md': 'live synced\n',
 			'docs/notion/page.md': 'live notion\n',
+			'docs/confluence/page.md': 'live confluence\n',
 			'untracked.md': 'live only\n',
 			'.env': 'secret\n',
 			'nested/.env.local': 'nested secret\n',
@@ -226,6 +228,7 @@ describe('context explorer worktree writes', () => {
 		['/rendered.md', 'rendered-template', 'file', '/rendered.md.j2'],
 		['/repos/source.md', 'synced-source', 'file', '/nao_config.yaml'],
 		['/docs/notion/page.md', 'synced-source', 'file', '/nao_config.yaml'],
+		['/docs/confluence/page.md', 'synced-source', 'file', '/nao_config.yaml'],
 		['/untracked.md', 'not-tracked', null, null],
 	])('reports guidance for %s', async (filePath, reason, actionKind, actionPath) => {
 		const file = await readFileContent(filePath, access);

--- a/cli/nao_core/commands/sync/providers/__init__.py
+++ b/cli/nao_core/commands/sync/providers/__init__.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from .base import SyncProvider, SyncResult
+from .confluence.provider import ConfluenceSyncProvider
 from .databases.provider import DatabaseSyncProvider
 from .notion.provider import NotionSyncProvider
 from .repositories.provider import RepositorySyncProvider
@@ -10,6 +11,7 @@ from .repositories.provider import RepositorySyncProvider
 # Provider registry mapping CLI-friendly names to provider instances
 PROVIDER_REGISTRY: dict[str, SyncProvider] = {
     "notion": NotionSyncProvider(),
+    "confluence": ConfluenceSyncProvider(),
     "repositories": RepositorySyncProvider(),
     "databases": DatabaseSyncProvider(),
 }
@@ -22,6 +24,7 @@ PROVIDER_ALIASES: dict[str, str] = {
     "db": "databases",
     "dbs": "databases",
     "database": "databases",
+    "wiki": "confluence",
 }
 
 # Default providers in order of execution
@@ -83,6 +86,7 @@ __all__ = [
     "SyncProvider",
     "SyncResult",
     "ProviderSelection",
+    "ConfluenceSyncProvider",
     "DatabaseSyncProvider",
     "RepositorySyncProvider",
     "PROVIDER_REGISTRY",

--- a/cli/nao_core/commands/sync/providers/confluence/__init__.py
+++ b/cli/nao_core/commands/sync/providers/confluence/__init__.py
@@ -1,0 +1,3 @@
+from .provider import ConfluenceSyncProvider
+
+__all__ = ["ConfluenceSyncProvider"]

--- a/cli/nao_core/commands/sync/providers/confluence/client.py
+++ b/cli/nao_core/commands/sync/providers/confluence/client.py
@@ -164,6 +164,12 @@ class ConfluenceClient:
                 return
             start += len(results)
 
+        raise RuntimeError(
+            f"Confluence search returned more than {MAX_PAGES * PAGE_SIZE} results for CQL '{cql}'. "
+            "Refusing to continue with a truncated result set, which would delete already-synced "
+            "pages beyond the cap. Narrow the selector (e.g. scope a label to a space) and retry."
+        )
+
     def _to_page(self, payload: dict[str, Any]) -> ConfluencePage:
         space = payload.get("space") or {}
         version = payload.get("version") or {}

--- a/cli/nao_core/commands/sync/providers/confluence/client.py
+++ b/cli/nao_core/commands/sync/providers/confluence/client.py
@@ -1,0 +1,191 @@
+"""A thin Confluence REST client covering both Cloud and Data Center/Server.
+
+Both flavours expose the same v1 content API under `{base_url}/rest/api`; they differ only in
+how a request is authenticated. Keeping that difference in one place lets the sync provider treat
+a page the same way whichever deployment it came from.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from nao_core.config.confluence import ConfluenceConfig
+
+# Confluence page IDs are bare integers. URLs carry them either in the modern path form
+# (/pages/123456/Title) or the legacy query form (viewpage.action?pageId=123456).
+PAGE_ID_IN_PATH = re.compile(r"/pages/(\d+)")
+PAGE_ID_IN_QUERY = re.compile(r"[?&]pageId=(\d+)")
+BARE_PAGE_ID = re.compile(r"^\d+$")
+
+# The body rendering that resolves macros to HTML a reader would recognise, rather than the
+# raw storage XHTML whose macro placeholders convert to nothing useful. Ancestors come along so
+# the sync can mirror a page's place in the tree on disk.
+BODY_EXPANSION = "body.export_view,version,space,ancestors"
+
+# A search asks only for what tells an unchanged page apart from a changed one, so the body of a
+# page that already synced at this version is never fetched again.
+SEARCH_EXPANSION = "version,space"
+
+# Content is paged; a source with more items than this is read across several requests.
+PAGE_SIZE = 50
+
+# Bound every paging loop so a cursor that never advances cannot hang a worker thread.
+MAX_PAGES = 1000
+
+
+@dataclass
+class Ancestor:
+    """A parent of a page, as far up the tree as Confluence reports."""
+
+    id: str
+    title: str
+
+
+@dataclass
+class ConfluencePage:
+    """A fetched Confluence page reduced to what the sync writes to disk."""
+
+    id: str
+    title: str
+    space_key: str | None
+    version: int
+    html: str
+    url: str
+    content_type: str = "page"
+    ancestors: list[Ancestor] = field(default_factory=list)
+
+
+@dataclass
+class PageRef:
+    """A page to sync, with its version when a search already revealed it.
+
+    A search carries the version of every item it returns, so an unchanged page can be recognised
+    without fetching its body. A page named on its own carries no such hint, so its version is
+    unknown until it is fetched.
+    """
+
+    id: str
+    version: int | None = None
+
+
+def extract_page_id(reference: str) -> str:
+    """Extract a Confluence page ID from a raw ID or a URL that carries one.
+
+    URLs that identify a page only by space and title (the `/display/SPACE/Title` form) carry no
+    ID and cannot be resolved here; the page ID or an ID-bearing URL must be used instead.
+    """
+    reference = reference.strip()
+    if BARE_PAGE_ID.match(reference):
+        return reference
+
+    for pattern in (PAGE_ID_IN_PATH, PAGE_ID_IN_QUERY):
+        match = pattern.search(reference)
+        if match:
+            return match.group(1)
+
+    raise ValueError(
+        f"Could not extract a Confluence page ID from '{reference}'. "
+        "Use the numeric page ID or a URL that contains it (e.g. .../pages/123456/Title)."
+    )
+
+
+class ConfluenceClient:
+    """Reads pages and runs CQL searches against Confluence over its v1 REST API."""
+
+    def __init__(self, config: ConfluenceConfig, *, timeout: float = 30.0):
+        self._base = config.base_url.rstrip("/")
+        self._client = httpx.Client(
+            auth=self._auth(config),
+            headers=self._headers(config),
+            timeout=timeout,
+            follow_redirects=True,
+        )
+
+    def __enter__(self) -> "ConfluenceClient":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    @staticmethod
+    def _auth(config: ConfluenceConfig) -> httpx.Auth | None:
+        if config.deployment == "cloud":
+            return httpx.BasicAuth(config.email or "", config.api_token or "")
+        if config.personal_access_token:
+            return None
+        return httpx.BasicAuth(config.username or "", config.password or "")
+
+    @staticmethod
+    def _headers(config: ConfluenceConfig) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if config.deployment == "server" and config.personal_access_token:
+            headers["Authorization"] = f"Bearer {config.personal_access_token}"
+        return headers
+
+    def get_page(self, page_id: str) -> ConfluencePage:
+        """Fetch a single page with its rendered body, version and ancestors."""
+        response = self._client.get(
+            f"{self._base}/rest/api/content/{page_id}",
+            params={"expand": BODY_EXPANSION},
+        )
+        response.raise_for_status()
+        return self._to_page(response.json())
+
+    def search_refs(self, cql: str) -> Iterator[PageRef]:
+        """Yield a reference and version for every item a CQL search selects.
+
+        The body is left out so the search stays cheap: an unchanged page is recognised from its
+        version alone and its body is never fetched again. The v1 search is paged by start/limit
+        and reports a relative `_links.next` while more results remain.
+        """
+        start = 0
+        for _ in range(MAX_PAGES):
+            response = self._client.get(
+                f"{self._base}/rest/api/content/search",
+                params={"cql": cql, "start": start, "limit": PAGE_SIZE, "expand": SEARCH_EXPANSION},
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+            results = payload.get("results", [])
+            for result in results:
+                version = (result.get("version") or {}).get("number", 0) or 0
+                yield PageRef(id=str(result.get("id", "")), version=int(version))
+
+            if not payload.get("_links", {}).get("next") or not results:
+                return
+            start += len(results)
+
+    def _to_page(self, payload: dict[str, Any]) -> ConfluencePage:
+        space = payload.get("space") or {}
+        version = payload.get("version") or {}
+        body = (payload.get("body") or {}).get("export_view") or {}
+        ancestors = [
+            Ancestor(id=str(a.get("id", "")), title=a.get("title") or str(a.get("id", "")))
+            for a in payload.get("ancestors") or []
+        ]
+
+        return ConfluencePage(
+            id=str(payload.get("id", "")),
+            title=payload.get("title") or str(payload.get("id", "")),
+            space_key=space.get("key"),
+            version=int(version.get("number", 0) or 0),
+            html=body.get("value") or "",
+            url=self._page_url(payload),
+            content_type=payload.get("type") or "page",
+            ancestors=ancestors,
+        )
+
+    def _page_url(self, payload: dict[str, Any]) -> str:
+        webui = (payload.get("_links") or {}).get("webui")
+        if webui:
+            return f"{self._base}{webui}"
+        return f"{self._base}/pages/viewpage.action?pageId={payload.get('id', '')}"

--- a/cli/nao_core/commands/sync/providers/confluence/provider.py
+++ b/cli/nao_core/commands/sync/providers/confluence/provider.py
@@ -1,0 +1,378 @@
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import yaml
+from rich.console import Console
+from rich.markup import escape
+from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
+
+from nao_core.config.base import NaoConfig
+from nao_core.config.confluence import ConfluenceConfig
+
+from ..base import SyncProvider, SyncResult
+from .client import ConfluenceClient, ConfluencePage, extract_page_id
+
+console = Console()
+
+# Confluence titles run far longer than a path segment usefully can
+MAX_SLUG_LENGTH = 80
+
+# Pattern to match markdown images: ![alt](url). Confluence images point at attachment URLs that
+# need the same auth as the API, so the reference alone is of no use in the context layer.
+IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\([^)]+\)\n?")
+
+# Collapse the runs of blank lines that macro-wrapping divs leave behind once converted.
+BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
+
+# Pages and blog posts are the content types nao reads. Other kinds a space holds (whiteboards,
+# databases, attachments) carry no text the API exposes, so they are left out of every search.
+READABLE_TYPES = "type in (page, blogpost)"
+
+
+def strip_images(markdown: str) -> str:
+    """Replace markdown image references with a placeholder."""
+    return IMAGE_PATTERN.sub("[image]\n", markdown)
+
+
+def html_to_markdown(html: str) -> str:
+    """Convert Confluence's rendered HTML body to markdown."""
+    from nao_core.deps import require_dependency
+
+    require_dependency("markdownify", "confluence", "for Confluence integration")
+
+    from markdownify import markdownify
+
+    markdown = markdownify(html, heading_style="ATX")
+    markdown = strip_images(markdown)
+    return BLANK_LINES_PATTERN.sub("\n\n", markdown).strip()
+
+
+def slug(title: str) -> str:
+    """Reduce a title to a filesystem-safe, lowercase fragment."""
+    return re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "-").lower()[:MAX_SLUG_LENGTH]
+
+
+def segment(title: str, page_id: str) -> str:
+    """A path segment for a page, always carrying its ID so two pages never collide."""
+    stub = slug(title)
+    return f"{stub}-{page_id}" if stub else page_id
+
+
+def page_relative_path(page: ConfluencePage) -> Path:
+    """Where a page's markdown lives, mirroring its place in the Confluence tree.
+
+    A page sits under its space, then under a directory for each of its ancestors, so the folder
+    layout reads like the space's page tree. A page that itself has synced children keeps its body
+    in a file beside the directory that holds them (`runbooks-100.md` next to `runbooks-100/`).
+    Blog posts have no page tree, so they collect under a single `blog/` directory per space.
+    """
+    space = page.space_key or "unknown"
+    leaf = f"{segment(page.title, page.id)}.md"
+
+    if page.content_type == "blogpost":
+        return Path(f"space={space}") / "blog" / leaf
+
+    ancestors = [segment(ancestor.title, ancestor.id) for ancestor in page.ancestors]
+    return Path(f"space={space}", *ancestors, leaf)
+
+
+def render_document(page: ConfluencePage) -> str:
+    """Wrap a page's markdown body in YAML frontmatter.
+
+    The version is recorded so a later run can tell an unchanged page from an edited one and skip
+    re-fetching its body. Values are serialised rather than interpolated, so a title with a colon
+    stays a readable string instead of breaking every consumer of the frontmatter.
+    """
+    meta: dict[str, Any] = {
+        "title": page.title,
+        "id": page.id,
+        "space": page.space_key,
+        "version": page.version,
+        "url": page.url,
+    }
+    frontmatter = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True).strip()
+
+    return f"""---
+{frontmatter}
+---
+
+{html_to_markdown(page.html)}
+"""
+
+
+def read_existing_versions(output_path: Path) -> dict[str, tuple[Path, int]]:
+    """Map each already-synced page ID to its file and the version stored in its frontmatter.
+
+    The whole tree is walked, since a page's file can sit at any depth. A page whose frontmatter
+    cannot be read is left out: it is then treated as new and re-fetched, which is safe, where
+    trusting a half-read version could skip a real update.
+    """
+    versions: dict[str, tuple[Path, int]] = {}
+    if not output_path.exists():
+        return versions
+
+    for file_path in output_path.rglob("*.md"):
+        meta = read_frontmatter(file_path)
+        page_id = meta.get("id")
+        version = meta.get("version")
+        if page_id is not None and isinstance(version, int):
+            versions[str(page_id)] = (file_path, version)
+
+    return versions
+
+
+def read_frontmatter(file_path: Path) -> dict[str, Any]:
+    """Read the YAML frontmatter of a markdown file, returning an empty dict when absent."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return {}
+
+    if not content.startswith("---"):
+        return {}
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return {}
+
+    return meta if isinstance(meta, dict) else {}
+
+
+def build_label_cql(label: str) -> str:
+    """Build the CQL for a label, honouring the optional `SPACE:label` scoping."""
+    if ":" in label:
+        space, name = label.split(":", 1)
+        return f'label = "{name}" and space = "{space}" and {READABLE_TYPES}'
+    return f'label = "{label}" and {READABLE_TYPES}'
+
+
+def gather_page_refs(client: ConfluenceClient, config: ConfluenceConfig) -> dict[str, int | None]:
+    """Collect every page to sync, keyed by ID, keeping the version when a search revealed it.
+
+    A page named on its own — or the root of a tree — carries no version hint, so its value is
+    None and it is always fetched. A page reached through a search carries the version the search
+    reported, which lets an unchanged one be skipped. The first known version for an ID wins.
+    """
+    refs: dict[str, int | None] = {}
+
+    def note(page_id: str, version: int | None) -> None:
+        if page_id not in refs or (refs[page_id] is None and version is not None):
+            refs[page_id] = version
+
+    for reference in config.pages:
+        note(extract_page_id(reference), None)
+
+    for reference in config.page_trees:
+        root = extract_page_id(reference)
+        note(root, None)
+        for ref in client.search_refs(f"ancestor = {root} and type = page"):
+            note(ref.id, ref.version)
+
+    for label in config.labels:
+        for ref in client.search_refs(build_label_cql(label)):
+            note(ref.id, ref.version)
+
+    for space in config.spaces:
+        for ref in client.search_refs(f'space = "{space}" and {READABLE_TYPES}'):
+            note(ref.id, ref.version)
+
+    return refs
+
+
+def fetch_pages(client: ConfluenceClient, page_ids: list[str], threads: int) -> tuple[list[ConfluencePage], int]:
+    """Fetch each page's body, keeping a failure to the single page it belongs to."""
+    pages: dict[str, ConfluencePage] = {}
+    failed = 0
+
+    with Progress(
+        SpinnerColumn(style="dim"),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(bar_width=30, style="dim", complete_style="cyan", finished_style="green"),
+        TaskProgressColumn(),
+        console=console,
+        transient=False,
+    ) as progress:
+        task = progress.add_task("Syncing pages", total=len(page_ids))
+
+        def record(page_id: str) -> None:
+            nonlocal failed
+            try:
+                page = client.get_page(page_id)
+                pages[page_id] = page
+                progress.update(task, advance=1, description=f"Synced: {escape(page.title)}")
+            except Exception as error:  # noqa: BLE001 - one unreadable page must not stop the rest
+                failed += 1
+                console.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}")
+                progress.update(task, advance=1)
+
+        if threads <= 1 or len(page_ids) == 1:
+            for page_id in page_ids:
+                record(page_id)
+        else:
+            with ThreadPoolExecutor(max_workers=min(threads, len(page_ids))) as executor:
+                futures = {executor.submit(client.get_page, page_id): page_id for page_id in page_ids}
+                for future in as_completed(futures):
+                    page_id = futures[future]
+                    try:
+                        pages[page_id] = future.result()
+                        progress.update(task, advance=1, description=f"Synced: {escape(pages[page_id].title)}")
+                    except Exception as error:  # noqa: BLE001
+                        failed += 1
+                        console.print(
+                            f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}"
+                        )
+                        progress.update(task, advance=1)
+
+    return [pages[page_id] for page_id in page_ids if page_id in pages], failed
+
+
+def write_documents(pages: list[ConfluencePage], output_path: Path) -> tuple[set[Path], int]:
+    """Write fetched pages at their hierarchical path, keeping a write failure to its own page."""
+    written: set[Path] = set()
+    failed = 0
+
+    for page in pages:
+        relative = page_relative_path(page)
+        target = output_path / relative
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(render_document(page), encoding="utf-8")
+        except (OSError, UnicodeError) as error:
+            failed += 1
+            console.print(f"[bold red]✗[/bold red] Failed to write {escape(str(relative))}: {escape(str(error))}")
+            continue
+        written.add(target.resolve())
+
+    return written, failed
+
+
+def cleanup_stale_pages(kept: set[Path], output_path: Path, verbose: bool = False) -> int:
+    """Remove markdown files that were not part of this sync, then prune the folders left empty."""
+    if not output_path.exists():
+        return 0
+
+    removed_count = 0
+    for file_path in output_path.rglob("*.md"):
+        if file_path.resolve() not in kept:
+            file_path.unlink()
+            removed_count += 1
+            if verbose:
+                console.print(f"  [dim red]removing stale page:[/dim red] {file_path.relative_to(output_path)}")
+
+    prune_empty_dirs(output_path)
+    return removed_count
+
+
+def prune_empty_dirs(root: Path) -> None:
+    """Remove directories left empty once stale files are gone, deepest first."""
+    for directory in sorted((p for p in root.rglob("*") if p.is_dir()), key=lambda p: len(p.parts), reverse=True):
+        if not any(directory.iterdir()):
+            directory.rmdir()
+
+
+def cleanup_if_fully_synced(failed_pages: int, kept: set[Path], output_path: Path) -> int:
+    """Remove stale markdown only when every page synced.
+
+    A page that failed is absent from the kept set, so cleaning up after a partial run would
+    delete markdown that is still good, losing content to what is often a transient error.
+    """
+    if failed_pages:
+        console.print(
+            f"[yellow]⚠[/yellow]  Keeping existing files: {failed_pages} page(s) failed, so stale ones were "
+            "left in place and will remain until a run succeeds in full"
+        )
+        return 0
+
+    return cleanup_stale_pages(kept, output_path, verbose=True)
+
+
+class ConfluenceSyncProvider(SyncProvider):
+    """Provider for syncing Confluence pages, trees, labels and spaces."""
+
+    @property
+    def name(self) -> str:
+        return "Confluence"
+
+    @property
+    def emoji(self) -> str:
+        return "📘"
+
+    @property
+    def default_output_dir(self) -> str:
+        return "docs/confluence"
+
+    def get_items(self, config: NaoConfig) -> list[ConfluenceConfig]:
+        return [config.confluence] if config.confluence else []
+
+    def sync(
+        self,
+        items: list[ConfluenceConfig],
+        output_path: Path,
+        project_path: Path | None = None,
+        *,
+        threads: int = 1,
+    ) -> SyncResult:
+        """Sync Confluence content to the local filesystem as markdown files.
+
+        Pages named explicitly, whole subtrees, labels and spaces are resolved to a single set of
+        pages, then any page unchanged since its last sync is kept where it is and only changed or
+        new pages are fetched. Each page is written under a path that mirrors its place in the
+        Confluence tree. Stale files are removed once, and only when the run succeeded in full.
+        """
+        if not items:
+            return SyncResult(provider_name=self.name, items_synced=0, summary="No Confluence configuration configured")
+
+        config = items[0]
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
+        console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
+
+        with ConfluenceClient(config) as client:
+            refs = gather_page_refs(client, config)
+            existing = read_existing_versions(output_path)
+
+            reused, to_fetch = self._partition(refs, existing)
+            pages, fetch_failures = fetch_pages(client, to_fetch, threads)
+
+        written, write_failures = write_documents(pages, output_path)
+        failed_pages = fetch_failures + write_failures
+
+        kept = written | reused
+        removed_count = cleanup_if_fully_synced(failed_pages, kept, output_path)
+
+        pages_synced = len(kept)
+        summary = f"{pages_synced} pages synced as markdown"
+        if reused:
+            summary += f", {len(reused)} unchanged"
+        if removed_count:
+            summary += f", {removed_count} stale removed"
+
+        return SyncResult(
+            provider_name=self.name,
+            items_synced=pages_synced,
+            details={"synced": len(written), "unchanged": len(reused), "removed": removed_count},
+            summary=summary,
+        )
+
+    @staticmethod
+    def _partition(refs: dict[str, int | None], existing: dict[str, tuple[Path, int]]) -> tuple[set[Path], list[str]]:
+        """Split pages into those kept unchanged and those that must be fetched."""
+        reused: set[Path] = set()
+        to_fetch: list[str] = []
+
+        for page_id, version in refs.items():
+            known = existing.get(page_id)
+            if version is not None and known is not None and known[1] == version:
+                reused.add(known[0].resolve())
+            else:
+                to_fetch.append(page_id)
+
+        return reused, to_fetch

--- a/cli/nao_core/commands/sync/providers/confluence/provider.py
+++ b/cli/nao_core/commands/sync/providers/confluence/provider.py
@@ -1,6 +1,7 @@
 import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Lock
 from typing import Any
 
 import yaml
@@ -202,6 +203,7 @@ def fetch_pages(client: ConfluenceClient, page_ids: list[str], threads: int) -> 
     """Fetch each page's body, keeping a failure to the single page it belongs to."""
     pages: dict[str, ConfluencePage] = {}
     failed = 0
+    lock = Lock()
 
     with Progress(
         SpinnerColumn(style="dim"),
@@ -214,15 +216,20 @@ def fetch_pages(client: ConfluenceClient, page_ids: list[str], threads: int) -> 
         task = progress.add_task("Syncing pages", total=len(page_ids))
 
         def record(page_id: str) -> None:
+            """Fetch one page. Runs under threads, so shared state is mutated behind a lock."""
             nonlocal failed
             try:
                 page = client.get_page(page_id)
-                pages[page_id] = page
-                progress.update(task, advance=1, description=f"Synced: {escape(page.title)}")
             except Exception as error:  # noqa: BLE001 - one unreadable page must not stop the rest
-                failed += 1
+                with lock:
+                    failed += 1
                 console.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}")
                 progress.update(task, advance=1)
+                return
+
+            with lock:
+                pages[page_id] = page
+            progress.update(task, advance=1, description=f"Synced: {escape(page.title)}")
 
         if threads <= 1 or len(page_ids) == 1:
             for page_id in page_ids:

--- a/cli/nao_core/commands/sync/providers/confluence/provider.py
+++ b/cli/nao_core/commands/sync/providers/confluence/provider.py
@@ -1,5 +1,5 @@
 import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +25,10 @@ IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\([^)]+\)\n?")
 
 # Collapse the runs of blank lines that macro-wrapping divs leave behind once converted.
 BLANK_LINES_PATTERN = re.compile(r"\n{3,}")
+
+# YAML frontmatter: an opening `---` line, the metadata, then a closing `---` line. The delimiters
+# are anchored to the start of a line so a `---` inside a title or URL is never mistaken for one.
+FRONTMATTER_PATTERN = re.compile(r"\A---\n(.*?)\n---(?:\n|$)", re.DOTALL)
 
 # Pages and blog posts are the content types nao reads. Other kinds a space holds (whiteboards,
 # databases, attachments) carry no text the API exposes, so they are left out of every search.
@@ -130,27 +134,35 @@ def read_frontmatter(file_path: Path) -> dict[str, Any]:
     except (OSError, UnicodeError):
         return {}
 
-    if not content.startswith("---"):
-        return {}
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
+    match = FRONTMATTER_PATTERN.match(content)
+    if not match:
         return {}
 
     try:
-        meta = yaml.safe_load(parts[1])
+        meta = yaml.safe_load(match.group(1))
     except yaml.YAMLError:
         return {}
 
     return meta if isinstance(meta, dict) else {}
 
 
+def quote_cql(value: str) -> str:
+    """Quote a value as a CQL string literal, escaping the backslash and quote it reserves.
+
+    CQL wraps string literals in double quotes and escapes both `\\` and `"` with a backslash, so a
+    space key or label carrying either character keeps its literal meaning instead of terminating
+    the literal early and turning the rest of the query into syntax Confluence rejects.
+    """
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def build_label_cql(label: str) -> str:
     """Build the CQL for a label, honouring the optional `SPACE:label` scoping."""
     if ":" in label:
         space, name = label.split(":", 1)
-        return f'label = "{name}" and space = "{space}" and {READABLE_TYPES}'
-    return f'label = "{label}" and {READABLE_TYPES}'
+        return f"label = {quote_cql(name)} and space = {quote_cql(space)} and {READABLE_TYPES}"
+    return f"label = {quote_cql(label)} and {READABLE_TYPES}"
 
 
 def gather_page_refs(client: ConfluenceClient, config: ConfluenceConfig) -> dict[str, int | None]:
@@ -180,7 +192,7 @@ def gather_page_refs(client: ConfluenceClient, config: ConfluenceConfig) -> dict
             note(ref.id, ref.version)
 
     for space in config.spaces:
-        for ref in client.search_refs(f'space = "{space}" and {READABLE_TYPES}'):
+        for ref in client.search_refs(f"space = {quote_cql(space)} and {READABLE_TYPES}"):
             note(ref.id, ref.version)
 
     return refs
@@ -217,18 +229,7 @@ def fetch_pages(client: ConfluenceClient, page_ids: list[str], threads: int) -> 
                 record(page_id)
         else:
             with ThreadPoolExecutor(max_workers=min(threads, len(page_ids))) as executor:
-                futures = {executor.submit(client.get_page, page_id): page_id for page_id in page_ids}
-                for future in as_completed(futures):
-                    page_id = futures[future]
-                    try:
-                        pages[page_id] = future.result()
-                        progress.update(task, advance=1, description=f"Synced: {escape(pages[page_id].title)}")
-                    except Exception as error:  # noqa: BLE001
-                        failed += 1
-                        console.print(
-                            f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}"
-                        )
-                        progress.update(task, advance=1)
+                list(executor.map(record, page_ids))
 
     return [pages[page_id] for page_id in page_ids if page_id in pages], failed
 

--- a/cli/nao_core/config/__init__.py
+++ b/cli/nao_core/config/__init__.py
@@ -1,4 +1,5 @@
 from .base import NaoConfig, NaoConfigError, resolve_project_path
+from .confluence import ConfluenceConfig
 from .databases import (
     AnyDatabaseConfig,
     BigQueryConfig,
@@ -51,6 +52,7 @@ __all__ = [
     "ProviderAuthConfig",
     "ProviderConfig",
     "SlackConfig",
+    "ConfluenceConfig",
     "ComparisonConfig",
     "TestConfig",
     "InitError",

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from nao_core.ui import UI, ask_confirm, ask_select
 
+from .confluence import ConfluenceConfig
 from .databases import DATABASE_CONFIG_CLASSES, AnyDatabaseConfig, DatabaseTemplate, DatabaseType, parse_database_config
 from .error_handler import format_all_validation_errors
 from .llm import LLMConfig
@@ -41,6 +42,7 @@ class NaoConfig(BaseModel):
     databases: list[AnyDatabaseConfig] = Field(default_factory=list, description="The databases to use")
     repos: list[RepoConfig] = Field(default_factory=list, description="The repositories to use")
     notion: NotionConfig | None = Field(default=None, description="The Notion configurations")
+    confluence: ConfluenceConfig | None = Field(default=None, description="The Confluence configuration")
     llm: LLMConfig | None = Field(default=None, description="The LLM configuration")
     slack: SlackConfig | None = Field(default=None, description="The Slack configuration")
     mcp: McpConfig | None = Field(default=None, description="The MCP configuration")
@@ -95,6 +97,8 @@ class NaoConfig(BaseModel):
             UI.print("  Slack: configured")
         if existing.notion:
             UI.print("  Notion: configured")
+        if existing.confluence:
+            UI.print("  Confluence: configured")
         if existing.mcp:
             UI.print("  MCP: configured")
         if existing.skills:

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -71,12 +71,15 @@ class NaoConfig(BaseModel):
         databases = cls._prompt_databases()
         llm = cls._prompt_llm()
         cls._apply_default_templates(databases, llm)
+        confluence, notion = cls._prompt_docs()
 
         return cls(
             project_name=project_name,
             databases=databases,
             repos=cls._prompt_repos(),
             llm=llm,
+            confluence=confluence,
+            notion=notion,
         )
 
     @classmethod
@@ -113,10 +116,14 @@ class NaoConfig(BaseModel):
         if not llm:
             llm = cls._prompt_llm()
 
+        confluence, notion = cls._prompt_docs(existing)
+
         cls._apply_default_templates(new_databases, llm)
         databases.extend(new_databases)
 
-        return existing.model_copy(update={"databases": databases, "repos": repos, "llm": llm})
+        return existing.model_copy(
+            update={"databases": databases, "repos": repos, "llm": llm, "confluence": confluence, "notion": notion}
+        )
 
     @staticmethod
     def _prompt_databases(has_existing: bool = False) -> list[AnyDatabaseConfig]:
@@ -152,6 +159,48 @@ class NaoConfig(BaseModel):
         UI.success(f"Added repository: {repo_config.name}")
 
         return repos
+
+    @staticmethod
+    def _prompt_docs(existing: "NaoConfig | None" = None) -> tuple[ConfluenceConfig | None, NotionConfig | None]:
+        """Prompt for documentation providers synced into the project's `docs/` context.
+
+        Offers Confluence and Notion behind a single gate. Already-configured
+        providers are preserved and not offered again.
+        """
+        confluence = existing.confluence if existing else None
+        notion = existing.notion if existing else None
+
+        def remaining() -> list[str]:
+            options = []
+            if not confluence:
+                options.append("Confluence")
+            if not notion:
+                options.append("Notion")
+            return options
+
+        if not remaining():
+            return confluence, notion
+
+        prompt = (
+            "Add more documentation as context provider?"
+            if (confluence or notion)
+            else "Add documentation as context provider?"
+        )
+        if not ask_confirm(prompt, default=False):
+            return confluence, notion
+
+        while remaining():
+            choice = ask_select("Which documentation provider?", choices=[*remaining(), "Done"])
+            if choice == "Done":
+                break
+            if choice == "Confluence":
+                confluence = ConfluenceConfig.promptConfig()
+                UI.success("Added Confluence configuration")
+            elif choice == "Notion":
+                notion = NotionConfig.promptConfig()
+                UI.success("Added Notion configuration")
+
+        return confluence, notion
 
     @staticmethod
     def _prompt_llm() -> LLMConfig | None:

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -72,15 +72,12 @@ class NaoConfig(BaseModel):
         llm = cls._prompt_llm()
         cls._apply_default_templates(databases, llm)
         repos = cls._prompt_repos()
-        confluence, notion = cls._prompt_docs()
 
         return cls(
             project_name=project_name,
             databases=databases,
             repos=repos,
             llm=llm,
-            confluence=confluence,
-            notion=notion,
         )
 
     @classmethod
@@ -117,14 +114,10 @@ class NaoConfig(BaseModel):
         if not llm:
             llm = cls._prompt_llm()
 
-        confluence, notion = cls._prompt_docs(existing)
-
         cls._apply_default_templates(new_databases, llm)
         databases.extend(new_databases)
 
-        return existing.model_copy(
-            update={"databases": databases, "repos": repos, "llm": llm, "confluence": confluence, "notion": notion}
-        )
+        return existing.model_copy(update={"databases": databases, "repos": repos, "llm": llm})
 
     @staticmethod
     def _prompt_databases(has_existing: bool = False) -> list[AnyDatabaseConfig]:
@@ -160,48 +153,6 @@ class NaoConfig(BaseModel):
         UI.success(f"Added repository: {repo_config.name}")
 
         return repos
-
-    @staticmethod
-    def _prompt_docs(existing: "NaoConfig | None" = None) -> tuple[ConfluenceConfig | None, NotionConfig | None]:
-        """Prompt for documentation providers synced into the project's `docs/` context.
-
-        Offers Confluence and Notion behind a single gate. Already-configured
-        providers are preserved and not offered again.
-        """
-        confluence = existing.confluence if existing else None
-        notion = existing.notion if existing else None
-
-        def remaining() -> list[str]:
-            options = []
-            if not confluence:
-                options.append("Confluence")
-            if not notion:
-                options.append("Notion")
-            return options
-
-        if not remaining():
-            return confluence, notion
-
-        prompt = (
-            "Add more documentation as context provider?"
-            if (confluence or notion)
-            else "Add documentation as context provider?"
-        )
-        if not ask_confirm(prompt, default=False):
-            return confluence, notion
-
-        while remaining():
-            choice = ask_select("Which documentation provider?", choices=[*remaining(), "Done"])
-            if choice == "Done":
-                break
-            if choice == "Confluence":
-                confluence = ConfluenceConfig.promptConfig()
-                UI.success("Added Confluence configuration")
-            elif choice == "Notion":
-                notion = NotionConfig.promptConfig()
-                UI.success("Added Notion configuration")
-
-        return confluence, notion
 
     @staticmethod
     def _prompt_llm() -> LLMConfig | None:

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -71,12 +71,13 @@ class NaoConfig(BaseModel):
         databases = cls._prompt_databases()
         llm = cls._prompt_llm()
         cls._apply_default_templates(databases, llm)
+        repos = cls._prompt_repos()
         confluence, notion = cls._prompt_docs()
 
         return cls(
             project_name=project_name,
             databases=databases,
-            repos=cls._prompt_repos(),
+            repos=repos,
             llm=llm,
             confluence=confluence,
             notion=notion,

--- a/cli/nao_core/config/confluence/__init__.py
+++ b/cli/nao_core/config/confluence/__init__.py
@@ -75,17 +75,7 @@ class ConfluenceConfig(BaseModel):
                 username = ask_text("Username:", required_field=True)
                 password = ask_text("Password:", password=True, required_field=True)
 
-        UI.info("Enter Confluence page IDs or URLs to sync (comma-separated, optional):")
-        pages = _split(ask_text("Pages:"))
-
-        UI.info("Enter pages whose whole subtree to sync (comma-separated IDs or URLs, optional):")
-        page_trees = _split(ask_text("Page trees:"))
-
-        UI.info("Enter labels to sync, optionally scoped as SPACE:label (comma-separated, optional):")
-        labels = _split(ask_text("Labels:"))
-
-        UI.info("Enter Confluence space keys to sync in full (comma-separated, optional):")
-        spaces = _split(ask_text("Spaces:"))
+        pages, page_trees, labels, spaces = cls._promptContentSelectors()
 
         return ConfluenceConfig(
             base_url=base_url,  # type: ignore
@@ -100,6 +90,27 @@ class ConfluenceConfig(BaseModel):
             labels=labels,
             spaces=spaces,
         )
+
+    @staticmethod
+    def _promptContentSelectors() -> tuple[list[str], list[str], list[str], list[str]]:
+        """Prompt for what to sync, re-asking until at least one selector is provided."""
+        while True:
+            UI.info("Enter Confluence page IDs or URLs to sync (comma-separated, optional):")
+            pages = _split(ask_text("Pages:"))
+
+            UI.info("Enter pages whose whole subtree to sync (comma-separated IDs or URLs, optional):")
+            page_trees = _split(ask_text("Page trees:"))
+
+            UI.info("Enter labels to sync, optionally scoped as SPACE:label (comma-separated, optional):")
+            labels = _split(ask_text("Labels:"))
+
+            UI.info("Enter Confluence space keys to sync in full (comma-separated, optional):")
+            spaces = _split(ask_text("Spaces:"))
+
+            if pages or page_trees or labels or spaces:
+                return pages, page_trees, labels, spaces
+
+            UI.warn("Confluence needs at least one of pages, page trees, labels or spaces to sync.")
 
 
 def _split(value: str | None) -> list[str]:

--- a/cli/nao_core/config/confluence/__init__.py
+++ b/cli/nao_core/config/confluence/__init__.py
@@ -1,0 +1,107 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from nao_core.ui import UI, ask_select, ask_text
+
+Deployment = Literal["cloud", "server"]
+
+
+class ConfluenceConfig(BaseModel):
+    """Confluence configuration."""
+
+    base_url: str = Field(
+        description="The Confluence base URL, e.g. https://acme.atlassian.net/wiki (Cloud) "
+        "or https://confluence.acme.com (Data Center/Server)"
+    )
+    deployment: Deployment = Field(
+        default="cloud",
+        description="Which Confluence flavour to talk to: 'cloud' or 'server' (Data Center/Server)",
+    )
+    email: Optional[str] = Field(default=None, description="Account email for Confluence Cloud (Basic auth username)")
+    api_token: Optional[str] = Field(default=None, description="API token for Confluence Cloud (Basic auth password)")
+    personal_access_token: Optional[str] = Field(
+        default=None, description="Personal access token for Confluence Data Center/Server (Bearer auth)"
+    )
+    username: Optional[str] = Field(default=None, description="Username for Data Center/Server Basic auth")
+    password: Optional[str] = Field(default=None, description="Password for Data Center/Server Basic auth")
+    pages: list[str] = Field(
+        default_factory=list, description="The pages to sync, as numeric page IDs or URLs that carry one"
+    )
+    page_trees: list[str] = Field(
+        default_factory=list,
+        description="Pages whose whole subtree to sync (the page and all its descendants), as IDs or URLs",
+    )
+    labels: list[str] = Field(
+        default_factory=list,
+        description="Labels to sync; every page carrying one is pulled. Scope to a space with 'SPACE:label'",
+    )
+    spaces: list[str] = Field(default_factory=list, description="The space keys to sync in full, e.g. 'ENG' or 'DATA'")
+
+    @model_validator(mode="after")
+    def validate_config(self) -> "ConfluenceConfig":
+        if not (self.pages or self.page_trees or self.labels or self.spaces):
+            raise ValueError("Confluence needs at least one of 'pages', 'page_trees', 'labels' or 'spaces' to sync")
+
+        if self.deployment == "cloud":
+            if not self.email or not self.api_token:
+                raise ValueError("Confluence Cloud needs both 'email' and 'api_token'")
+        else:
+            has_pat = bool(self.personal_access_token)
+            has_basic = bool(self.username and self.password)
+            if not has_pat and not has_basic:
+                raise ValueError(
+                    "Confluence Data Center/Server needs either 'personal_access_token' "
+                    "or both 'username' and 'password'"
+                )
+
+        return self
+
+    @classmethod
+    def promptConfig(cls) -> "ConfluenceConfig":
+        """Interactively prompt the user for Confluence configuration."""
+        base_url = ask_text("Confluence base URL (e.g. https://acme.atlassian.net/wiki):", required_field=True)
+        deployment = ask_select("Confluence deployment:", choices=["cloud", "server"], default="cloud")
+
+        email = api_token = personal_access_token = username = password = None
+        if deployment == "cloud":
+            email = ask_text("Confluence account email:", required_field=True)
+            api_token = ask_text("Confluence API token:", password=True, required_field=True)
+        else:
+            personal_access_token = ask_text(
+                "Personal access token (leave empty to use username/password):", password=True
+            )
+            if not personal_access_token:
+                username = ask_text("Username:", required_field=True)
+                password = ask_text("Password:", password=True, required_field=True)
+
+        UI.info("Enter Confluence page IDs or URLs to sync (comma-separated, optional):")
+        pages = _split(ask_text("Pages:"))
+
+        UI.info("Enter pages whose whole subtree to sync (comma-separated IDs or URLs, optional):")
+        page_trees = _split(ask_text("Page trees:"))
+
+        UI.info("Enter labels to sync, optionally scoped as SPACE:label (comma-separated, optional):")
+        labels = _split(ask_text("Labels:"))
+
+        UI.info("Enter Confluence space keys to sync in full (comma-separated, optional):")
+        spaces = _split(ask_text("Spaces:"))
+
+        return ConfluenceConfig(
+            base_url=base_url,  # type: ignore
+            deployment=deployment,  # type: ignore
+            email=email,
+            api_token=api_token,
+            personal_access_token=personal_access_token,
+            username=username,
+            password=password,
+            pages=pages,
+            page_trees=page_trees,
+            labels=labels,
+            spaces=spaces,
+        )
+
+
+def _split(value: str | None) -> list[str]:
+    """Split a comma-separated prompt answer into a clean list."""
+    return [item.strip() for item in (value or "").split(",") if item.strip()]

--- a/cli/nao_core/config/confluence/__init__.py
+++ b/cli/nao_core/config/confluence/__init__.py
@@ -45,9 +45,14 @@ class ConfluenceConfig(BaseModel):
     def validate_config(self) -> "ConfluenceConfig":
         self._validate_base_url()
 
-        selectors = self.pages + self.page_trees + self.labels + self.spaces
-        if not selectors or any(not selector.strip() for selector in selectors):
+        selectors = [entry for field in SELECTOR_FIELDS for entry in getattr(self, field)]
+        if not selectors:
             raise ValueError("Confluence needs at least one of 'pages', 'page_trees', 'labels' or 'spaces' to sync")
+        if any(not entry.strip() for entry in selectors):
+            raise ValueError(
+                "Confluence selectors must not be empty; remove blank entries from "
+                "'pages', 'page_trees', 'labels' or 'spaces'"
+            )
 
         if self.deployment == "cloud":
             if not self.email or not self.api_token:

--- a/cli/nao_core/config/confluence/__init__.py
+++ b/cli/nao_core/config/confluence/__init__.py
@@ -1,10 +1,13 @@
 from typing import Literal, Optional
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, model_validator
 
 from nao_core.ui import UI, ask_select, ask_text
 
 Deployment = Literal["cloud", "server"]
+
+SELECTOR_FIELDS = ("pages", "page_trees", "labels", "spaces")
 
 
 class ConfluenceConfig(BaseModel):
@@ -40,7 +43,10 @@ class ConfluenceConfig(BaseModel):
 
     @model_validator(mode="after")
     def validate_config(self) -> "ConfluenceConfig":
-        if not (self.pages or self.page_trees or self.labels or self.spaces):
+        self._validate_base_url()
+
+        selectors = self.pages + self.page_trees + self.labels + self.spaces
+        if not selectors or any(not selector.strip() for selector in selectors):
             raise ValueError("Confluence needs at least one of 'pages', 'page_trees', 'labels' or 'spaces' to sync")
 
         if self.deployment == "cloud":
@@ -56,6 +62,14 @@ class ConfluenceConfig(BaseModel):
                 )
 
         return self
+
+    def _validate_base_url(self) -> None:
+        parsed = urlparse((self.base_url or "").strip())
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError(
+                "Confluence 'base_url' must be a non-empty absolute HTTP(S) URL, e.g. "
+                "https://acme.atlassian.net/wiki (Cloud) or https://confluence.acme.com (Data Center/Server)"
+            )
 
     @classmethod
     def promptConfig(cls) -> "ConfluenceConfig":

--- a/cli/nao_core/deps.py
+++ b/cli/nao_core/deps.py
@@ -41,6 +41,7 @@ _EXTRAS: dict[str, list[str]] = {
     "ollama": ["ollama"],
     # Integrations
     "notion": ["notion_client", "notion2md"],
+    "confluence": ["markdownify"],
     # Secret resolution backends
     "aws-secrets": ["boto3", "glom"],
     "k8s-secrets": ["kubernetes"],
@@ -125,6 +126,10 @@ def get_required_extras(config: NaoConfig) -> list[str]:
     if config.notion and "notion" not in seen:
         extras.append("notion")
         seen.add("notion")
+
+    if config.confluence and "confluence" not in seen:
+        extras.append("confluence")
+        seen.add("confluence")
 
     return extras
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -73,6 +73,9 @@ ollama = ["ollama>=0.4.0"]
 # depends on notion2md's marker for unconvertible databases. 3.1 is the floor because it
 # retries rate limits itself, which also covers the client notion2md builds internally.
 notion = ["notion-client>=3.1.0,<4", "notion2md>=2.9.0,<3"]
+# Confluence talks to the v1 REST API over httpx (a core dependency); markdownify turns the HTML
+# body Confluence renders into the markdown the context layer stores.
+confluence = ["markdownify>=0.13.0,<2"]
 
 # Secret resolution backends
 aws-secrets = ["boto3>=1.34.0", "glom>=23.0.0"]
@@ -83,7 +86,7 @@ all-databases = [
     "nao-core[postgres,bigquery,snowflake,duckdb,clickhouse,databricks,mysql,mssql,athena,trino,redshift,fabric,starrocks]",
 ]
 all-llms = ["nao-core[openai,anthropic,mistral,gemini,ollama]"]
-all = ["nao-core[all-databases,all-llms,notion,aws-secrets,k8s-secrets]"]
+all = ["nao-core[all-databases,all-llms,notion,confluence,aws-secrets,k8s-secrets]"]
 dev = ["pytest-cov", "pytest-timeout>=2.3.0"]
 
 [project.scripts]

--- a/cli/tests/nao_core/commands/sync/test_confluence_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_confluence_provider.py
@@ -1,0 +1,276 @@
+"""Unit tests for the Confluence sync provider."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from nao_core.commands.sync.providers.confluence.client import Ancestor, ConfluencePage, PageRef, extract_page_id
+from nao_core.commands.sync.providers.confluence.provider import (
+    ConfluenceSyncProvider,
+    build_label_cql,
+    html_to_markdown,
+    page_relative_path,
+    read_existing_versions,
+    render_document,
+    segment,
+)
+from nao_core.config.confluence import ConfluenceConfig
+
+
+def cloud_config(
+    *,
+    pages: list[str] | None = None,
+    page_trees: list[str] | None = None,
+    labels: list[str] | None = None,
+    spaces: list[str] | None = None,
+) -> ConfluenceConfig:
+    return ConfluenceConfig(
+        base_url="https://acme.atlassian.net/wiki",
+        deployment="cloud",
+        email="me@acme.com",
+        api_token="secret",
+        pages=pages or [],
+        page_trees=page_trees or [],
+        labels=labels or [],
+        spaces=spaces or [],
+    )
+
+
+def page(
+    page_id: str,
+    title: str = "Page",
+    version: int = 1,
+    html: str = "<p>body</p>",
+    content_type: str = "page",
+    ancestors: list[Ancestor] | None = None,
+) -> ConfluencePage:
+    return ConfluencePage(
+        id=page_id,
+        title=title,
+        space_key="ENG",
+        version=version,
+        html=html,
+        url=f"https://acme.atlassian.net/wiki/pages/{page_id}",
+        content_type=content_type,
+        ancestors=ancestors or [],
+    )
+
+
+class FakeClient:
+    """A stand-in for ConfluenceClient serving pages from memory and a fixed search result."""
+
+    def __init__(self, pages: dict[str, ConfluencePage], search: list[PageRef] | None = None):
+        self._pages = pages
+        self._search = search or []
+        self.fetched: list[str] = []
+
+    def __enter__(self) -> "FakeClient":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+    def get_page(self, page_id: str) -> ConfluencePage:
+        self.fetched.append(page_id)
+        if page_id not in self._pages:
+            raise RuntimeError(f"page {page_id} is unavailable")
+        return self._pages[page_id]
+
+    def search_refs(self, cql: str):
+        return iter(self._search)
+
+
+def patched(fake: FakeClient):
+    return patch(
+        "nao_core.commands.sync.providers.confluence.provider.ConfluenceClient",
+        return_value=fake,
+    )
+
+
+def test_extract_page_id_reads_ids_and_urls():
+    assert extract_page_id("123456") == "123456"
+    assert extract_page_id("https://acme.atlassian.net/wiki/spaces/ENG/pages/123456/Runbook") == "123456"
+    assert extract_page_id("https://confluence.acme.com/pages/viewpage.action?pageId=987654") == "987654"
+
+
+def test_extract_page_id_rejects_a_title_only_url():
+    with pytest.raises(ValueError):
+        extract_page_id("https://confluence.acme.com/display/ENG/Runbook")
+
+
+def test_segment_always_carries_the_page_id():
+    assert segment("Runbook Details", "123456") == "runbook-details-123456"
+    assert segment("!!!", "123456") == "123456"
+    assert segment("", "123456") == "123456"
+
+
+def test_page_relative_path_mirrors_the_tree():
+    ancestors = [Ancestor("10", "Engineering"), Ancestor("20", "Runbooks")]
+    path = page_relative_path(page("100", title="DB failover", ancestors=ancestors))
+
+    assert path == Path("space=ENG/engineering-10/runbooks-20/db-failover-100.md")
+
+
+def test_page_relative_path_places_a_root_page_directly_under_its_space():
+    assert page_relative_path(page("100", title="Overview")) == Path("space=ENG/overview-100.md")
+
+
+def test_page_relative_path_groups_blogposts_under_a_blog_folder():
+    path = page_relative_path(page("100", title="Release notes", content_type="blogpost"))
+
+    assert path == Path("space=ENG/blog/release-notes-100.md")
+
+
+def test_html_to_markdown_converts_and_strips_images():
+    markdown = html_to_markdown('<h1>Title</h1><p>Text</p><p><img src="https://x/att.png" alt="a"></p>')
+
+    assert "# Title" in markdown
+    assert "Text" in markdown
+    assert "att.png" not in markdown
+    assert "[image]" in markdown
+
+
+def test_render_document_records_versioned_frontmatter():
+    document = render_document(page("100", title="Runbook", version=7))
+
+    meta = yaml.safe_load(document.split("---")[1])
+    assert meta["id"] == "100"
+    assert meta["title"] == "Runbook"
+    assert meta["version"] == 7
+    assert meta["space"] == "ENG"
+    assert document.rstrip().endswith("body")
+
+
+@pytest.mark.parametrize("title", ["Schema: Orders", "# Draft", "true", "2026-01-01", '"quoted"'])
+def test_render_document_keeps_yaml_significant_titles_readable(title):
+    meta = yaml.safe_load(render_document(page("100", title=title)).split("---")[1])
+    assert meta["title"] == title
+
+
+def test_build_label_cql_scopes_to_a_space_when_asked():
+    assert build_label_cql("glossary") == 'label = "glossary" and type in (page, blogpost)'
+    assert build_label_cql("DATA:glossary") == 'label = "glossary" and space = "DATA" and type in (page, blogpost)'
+
+
+def test_read_existing_versions_walks_the_tree(tmp_path: Path):
+    nested = tmp_path / "space=ENG" / "runbooks-20"
+    nested.mkdir(parents=True)
+    (nested / "db-failover-100.md").write_text(render_document(page("100", version=4)), encoding="utf-8")
+    (tmp_path / "loose.md").write_text("no frontmatter here", encoding="utf-8")
+
+    versions = read_existing_versions(tmp_path)
+
+    assert versions["100"] == (nested / "db-failover-100.md", 4)
+    assert "loose" not in versions
+
+
+def test_sync_writes_explicit_pages_under_their_space(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    fake = FakeClient({"100": page("100", title="Runbook")})
+
+    with patched(fake):
+        result = provider.sync([cloud_config(pages=["100"])], tmp_path)
+
+    assert result.items_synced == 1
+    assert (tmp_path / "space=ENG" / "runbook-100.md").exists()
+    assert fake.fetched == ["100"]
+
+
+def test_sync_expands_a_page_tree(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    fake = FakeClient(
+        {"100": page("100", title="Root"), "200": page("200", title="Child")},
+        search=[PageRef("200", version=1)],
+    )
+
+    with patched(fake):
+        result = provider.sync([cloud_config(page_trees=["100"])], tmp_path)
+
+    assert sorted(fake.fetched) == ["100", "200"]
+    assert result.items_synced == 2
+
+
+def test_sync_pulls_pages_for_a_label(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    fake = FakeClient({"100": page("100")}, search=[PageRef("100", version=1)])
+
+    with patched(fake):
+        result = provider.sync([cloud_config(labels=["data-catalog"])], tmp_path)
+
+    assert fake.fetched == ["100"]
+    assert result.items_synced == 1
+
+
+def test_sync_skips_a_page_unchanged_since_last_run(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    existing = tmp_path / "space=ENG"
+    existing.mkdir(parents=True)
+    (existing / "page-100.md").write_text(render_document(page("100", version=5)), encoding="utf-8")
+    fake = FakeClient({"100": page("100", version=5)}, search=[PageRef("100", version=5)])
+
+    with patched(fake):
+        result = provider.sync([cloud_config(spaces=["ENG"])], tmp_path)
+
+    assert fake.fetched == []
+    assert result.details == {"synced": 0, "unchanged": 1, "removed": 0}
+
+
+def test_sync_refetches_a_page_that_changed(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    existing = tmp_path / "space=ENG"
+    existing.mkdir(parents=True)
+    (existing / "page-100.md").write_text(render_document(page("100", version=5)), encoding="utf-8")
+    fake = FakeClient({"100": page("100", version=6)}, search=[PageRef("100", version=6)])
+
+    with patched(fake):
+        result = provider.sync([cloud_config(spaces=["ENG"])], tmp_path)
+
+    assert fake.fetched == ["100"]
+    assert result.details == {"synced": 1, "unchanged": 0, "removed": 0}
+
+
+def test_sync_removes_stale_pages_and_prunes_empty_dirs(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    stale_dir = tmp_path / "space=OLD" / "gone-999"
+    stale_dir.mkdir(parents=True)
+    (stale_dir / "stale-888.md").write_text("outdated", encoding="utf-8")
+    fake = FakeClient({"100": page("100")})
+
+    with patched(fake):
+        result = provider.sync([cloud_config(pages=["100"])], tmp_path)
+
+    assert not (stale_dir / "stale-888.md").exists()
+    assert not (tmp_path / "space=OLD").exists()
+    assert result.details is not None and result.details["removed"] == 1
+
+
+def test_sync_keeps_existing_files_when_a_page_failed(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    stale = tmp_path / "space=OLD"
+    stale.mkdir(parents=True)
+    (stale / "stale-999.md").write_text("outdated", encoding="utf-8")
+    fake = FakeClient({"100": page("100")})
+
+    with patched(fake):
+        result = provider.sync([cloud_config(pages=["100", "404"])], tmp_path)
+
+    assert (stale / "stale-999.md").read_text() == "outdated"
+    assert result.details is not None and result.details["removed"] == 0
+
+
+def test_sync_places_a_blogpost_under_blog(tmp_path: Path):
+    provider = ConfluenceSyncProvider()
+    fake = FakeClient({"100": page("100", title="Release", content_type="blogpost")})
+
+    with patched(fake):
+        provider.sync([cloud_config(pages=["100"])], tmp_path)
+
+    assert (tmp_path / "space=ENG" / "blog" / "release-100.md").exists()
+
+
+def test_sync_reports_nothing_to_sync_without_config(tmp_path: Path):
+    result = ConfluenceSyncProvider().sync([], tmp_path)
+
+    assert result.items_synced == 0

--- a/cli/tests/nao_core/commands/sync/test_confluence_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_confluence_provider.py
@@ -12,7 +12,9 @@ from nao_core.commands.sync.providers.confluence.provider import (
     build_label_cql,
     html_to_markdown,
     page_relative_path,
+    quote_cql,
     read_existing_versions,
+    read_frontmatter,
     render_document,
     segment,
 )
@@ -152,6 +154,26 @@ def test_render_document_keeps_yaml_significant_titles_readable(title):
 def test_build_label_cql_scopes_to_a_space_when_asked():
     assert build_label_cql("glossary") == 'label = "glossary" and type in (page, blogpost)'
     assert build_label_cql("DATA:glossary") == 'label = "glossary" and space = "DATA" and type in (page, blogpost)'
+
+
+def test_build_label_cql_escapes_quotes_and_backslashes():
+    assert build_label_cql('gl"ossary') == 'label = "gl\\"ossary" and type in (page, blogpost)'
+    assert build_label_cql("SP\\ACE:tag") == 'label = "tag" and space = "SP\\\\ACE" and type in (page, blogpost)'
+
+
+def test_quote_cql_wraps_and_escapes():
+    assert quote_cql("ENG") == '"ENG"'
+    assert quote_cql('a"b\\c') == '"a\\"b\\\\c"'
+
+
+def test_read_frontmatter_keeps_a_title_that_contains_a_delimiter(tmp_path: Path):
+    file_path = tmp_path / "page.md"
+    file_path.write_text(render_document(page("100", title="Before --- After", version=9)), encoding="utf-8")
+
+    meta = read_frontmatter(file_path)
+
+    assert meta["title"] == "Before --- After"
+    assert meta["version"] == 9
 
 
 def test_read_existing_versions_walks_the_tree(tmp_path: Path):

--- a/cli/tests/nao_core/commands/sync/test_providers.py
+++ b/cli/tests/nao_core/commands/sync/test_providers.py
@@ -8,6 +8,7 @@ from nao_core.commands.sync.providers import (
     get_providers_by_names,
     parse_provider_arg,
 )
+from nao_core.commands.sync.providers.confluence.provider import ConfluenceSyncProvider
 from nao_core.commands.sync.providers.databases.provider import DatabaseSyncProvider
 from nao_core.commands.sync.providers.notion.provider import NotionSyncProvider
 from nao_core.commands.sync.providers.repositories.provider import RepositorySyncProvider
@@ -51,10 +52,11 @@ class TestGetAllProviders:
     def test_returns_list_of_providers(self):
         providers = get_all_providers()
 
-        assert len(providers) == 3
+        assert len(providers) == 4
         assert any(isinstance(p.provider, RepositorySyncProvider) for p in providers)
         assert any(isinstance(p.provider, DatabaseSyncProvider) for p in providers)
         assert any(isinstance(p.provider, NotionSyncProvider) for p in providers)
+        assert any(isinstance(p.provider, ConfluenceSyncProvider) for p in providers)
 
     def test_returns_copy_of_providers(self):
         providers1 = get_all_providers()

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -6,11 +6,9 @@ import pytest
 from pydantic import ValidationError
 
 from nao_core.config.base import LLM_OVERRIDE_NOTICE, NaoConfig, annotate_llm_override, annotate_optional_templates
-from nao_core.config.confluence import ConfluenceConfig
 from nao_core.config.databases.base import DatabaseTemplate, ProfilingRefreshPolicy
 from nao_core.config.databases.duckdb import DuckDBConfig
 from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
-from nao_core.config.notion import NotionConfig
 from nao_core.config.secrets import process_secrets
 
 
@@ -121,20 +119,7 @@ def test_apply_default_templates_with_llm():
     ]
 
 
-def _make_confluence() -> ConfluenceConfig:
-    return ConfluenceConfig(
-        base_url="https://acme.atlassian.net/wiki",
-        email="user@acme.co",
-        api_token="token",
-        spaces=["ENG"],
-    )
-
-
-def _make_notion() -> NotionConfig:
-    return NotionConfig(api_key="secret", pages=["https://notion.so/page"])
-
-
-def test_fresh_prompt_flow_collects_database_llm_repos_and_docs():
+def test_fresh_prompt_flow_only_collects_database_llm_and_repos():
     db = DuckDBConfig(name="test-db", path=":memory:")
     llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
     prompt_order = []
@@ -143,84 +128,20 @@ def test_fresh_prompt_flow_collects_database_llm_repos_and_docs():
         patch.object(NaoConfig, "_prompt_databases", side_effect=lambda: prompt_order.append("database") or [db]),
         patch.object(NaoConfig, "_prompt_llm", side_effect=lambda: prompt_order.append("llm") or llm),
         patch.object(NaoConfig, "_prompt_repos", side_effect=lambda: prompt_order.append("repos") or []),
-        patch.object(NaoConfig, "_prompt_docs", side_effect=lambda: prompt_order.append("docs") or (None, None)),
     ):
         config = NaoConfig.promptConfig("test-project")
 
-    assert prompt_order == ["database", "llm", "repos", "docs"]
+    assert prompt_order == ["database", "llm", "repos"]
     assert config.databases[0].templates == [
         DatabaseTemplate.COLUMNS,
         DatabaseTemplate.PREVIEW,
         DatabaseTemplate.AI_SUMMARY,
     ]
+    assert config.slack is None
     assert config.confluence is None
     assert config.notion is None
-    assert config.slack is None
     assert config.mcp is None
     assert config.skills is None
-
-
-@patch("nao_core.config.base.ask_confirm")
-def test_prompt_docs_returns_none_when_all_declined(mock_confirm):
-    mock_confirm.return_value = False
-
-    assert NaoConfig._prompt_docs() == (None, None)
-
-
-@patch("nao_core.config.base.UI")
-@patch("nao_core.config.base.ask_select")
-@patch("nao_core.config.base.ask_confirm")
-@patch("nao_core.config.notion.NotionConfig.promptConfig")
-@patch("nao_core.config.confluence.ConfluenceConfig.promptConfig")
-def test_prompt_docs_adds_both_providers_from_menu(mock_confluence, mock_notion, mock_confirm, mock_select, _mock_ui):
-    mock_confirm.return_value = True
-    mock_select.side_effect = ["Confluence", "Notion"]
-    confluence = _make_confluence()
-    notion = _make_notion()
-    mock_confluence.return_value = confluence
-    mock_notion.return_value = notion
-
-    assert NaoConfig._prompt_docs() == (confluence, notion)
-
-
-@patch("nao_core.config.base.UI")
-@patch("nao_core.config.base.ask_select")
-@patch("nao_core.config.base.ask_confirm")
-@patch("nao_core.config.confluence.ConfluenceConfig.promptConfig")
-def test_prompt_docs_stops_when_user_selects_done(mock_confluence, mock_confirm, mock_select, _mock_ui):
-    mock_confirm.return_value = True
-    mock_select.side_effect = ["Confluence", "Done"]
-    confluence = _make_confluence()
-    mock_confluence.return_value = confluence
-
-    assert NaoConfig._prompt_docs() == (confluence, None)
-
-
-@patch("nao_core.config.base.UI")
-def test_extend_prompts_docs_when_not_configured(_mock_ui):
-    existing = NaoConfig(project_name="test-project")
-    confluence = _make_confluence()
-
-    with (
-        patch.object(NaoConfig, "_prompt_databases", return_value=[]),
-        patch.object(NaoConfig, "_prompt_repos", return_value=[]),
-        patch.object(NaoConfig, "_prompt_llm", return_value=None),
-        patch.object(NaoConfig, "_prompt_docs", return_value=(confluence, None)),
-    ):
-        config = NaoConfig.promptConfig("ignored", existing=existing)
-
-    assert config.confluence is confluence
-
-
-@patch("nao_core.config.base.UI")
-@patch("nao_core.config.base.ask_confirm")
-def test_prompt_docs_skips_already_configured_providers(mock_confirm, _mock_ui):
-    confluence = _make_confluence()
-    notion = _make_notion()
-    existing = NaoConfig(project_name="test-project", confluence=confluence, notion=notion)
-
-    assert NaoConfig._prompt_docs(existing) == (confluence, notion)
-    mock_confirm.assert_not_called()
 
 
 def test_extend_handles_no_databases_and_no_llm():
@@ -230,7 +151,6 @@ def test_extend_handles_no_databases_and_no_llm():
         patch.object(NaoConfig, "_prompt_databases", return_value=[]),
         patch.object(NaoConfig, "_prompt_repos", return_value=[]),
         patch.object(NaoConfig, "_prompt_llm", return_value=None),
-        patch.object(NaoConfig, "_prompt_docs", return_value=(None, None)),
         patch("nao_core.config.base.UI"),
     ):
         config = NaoConfig.promptConfig("ignored", existing=existing)

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -6,9 +6,11 @@ import pytest
 from pydantic import ValidationError
 
 from nao_core.config.base import LLM_OVERRIDE_NOTICE, NaoConfig, annotate_llm_override, annotate_optional_templates
+from nao_core.config.confluence import ConfluenceConfig
 from nao_core.config.databases.base import DatabaseTemplate, ProfilingRefreshPolicy
 from nao_core.config.databases.duckdb import DuckDBConfig
 from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
+from nao_core.config.notion import NotionConfig
 from nao_core.config.secrets import process_secrets
 
 
@@ -119,7 +121,20 @@ def test_apply_default_templates_with_llm():
     ]
 
 
-def test_fresh_prompt_flow_only_collects_database_llm_and_repos():
+def _make_confluence() -> ConfluenceConfig:
+    return ConfluenceConfig(
+        base_url="https://acme.atlassian.net/wiki",
+        email="user@acme.co",
+        api_token="token",
+        spaces=["ENG"],
+    )
+
+
+def _make_notion() -> NotionConfig:
+    return NotionConfig(api_key="secret", pages=["https://notion.so/page"])
+
+
+def test_fresh_prompt_flow_collects_database_llm_repos_and_docs():
     db = DuckDBConfig(name="test-db", path=":memory:")
     llm = LLMConfig(providers=[ProviderConfig(provider=LLMProvider.OPENAI, api_key="sk-test")])
     prompt_order = []
@@ -128,19 +143,84 @@ def test_fresh_prompt_flow_only_collects_database_llm_and_repos():
         patch.object(NaoConfig, "_prompt_databases", side_effect=lambda: prompt_order.append("database") or [db]),
         patch.object(NaoConfig, "_prompt_llm", side_effect=lambda: prompt_order.append("llm") or llm),
         patch.object(NaoConfig, "_prompt_repos", side_effect=lambda: prompt_order.append("repos") or []),
+        patch.object(NaoConfig, "_prompt_docs", side_effect=lambda: prompt_order.append("docs") or (None, None)),
     ):
         config = NaoConfig.promptConfig("test-project")
 
-    assert prompt_order == ["database", "llm", "repos"]
+    assert prompt_order == ["database", "llm", "repos", "docs"]
     assert config.databases[0].templates == [
         DatabaseTemplate.COLUMNS,
         DatabaseTemplate.PREVIEW,
         DatabaseTemplate.AI_SUMMARY,
     ]
-    assert config.slack is None
+    assert config.confluence is None
     assert config.notion is None
+    assert config.slack is None
     assert config.mcp is None
     assert config.skills is None
+
+
+@patch("nao_core.config.base.ask_confirm")
+def test_prompt_docs_returns_none_when_all_declined(mock_confirm):
+    mock_confirm.return_value = False
+
+    assert NaoConfig._prompt_docs() == (None, None)
+
+
+@patch("nao_core.config.base.UI")
+@patch("nao_core.config.base.ask_select")
+@patch("nao_core.config.base.ask_confirm")
+@patch("nao_core.config.notion.NotionConfig.promptConfig")
+@patch("nao_core.config.confluence.ConfluenceConfig.promptConfig")
+def test_prompt_docs_adds_both_providers_from_menu(mock_confluence, mock_notion, mock_confirm, mock_select, _mock_ui):
+    mock_confirm.return_value = True
+    mock_select.side_effect = ["Confluence", "Notion"]
+    confluence = _make_confluence()
+    notion = _make_notion()
+    mock_confluence.return_value = confluence
+    mock_notion.return_value = notion
+
+    assert NaoConfig._prompt_docs() == (confluence, notion)
+
+
+@patch("nao_core.config.base.UI")
+@patch("nao_core.config.base.ask_select")
+@patch("nao_core.config.base.ask_confirm")
+@patch("nao_core.config.confluence.ConfluenceConfig.promptConfig")
+def test_prompt_docs_stops_when_user_selects_done(mock_confluence, mock_confirm, mock_select, _mock_ui):
+    mock_confirm.return_value = True
+    mock_select.side_effect = ["Confluence", "Done"]
+    confluence = _make_confluence()
+    mock_confluence.return_value = confluence
+
+    assert NaoConfig._prompt_docs() == (confluence, None)
+
+
+@patch("nao_core.config.base.UI")
+def test_extend_prompts_docs_when_not_configured(_mock_ui):
+    existing = NaoConfig(project_name="test-project")
+    confluence = _make_confluence()
+
+    with (
+        patch.object(NaoConfig, "_prompt_databases", return_value=[]),
+        patch.object(NaoConfig, "_prompt_repos", return_value=[]),
+        patch.object(NaoConfig, "_prompt_llm", return_value=None),
+        patch.object(NaoConfig, "_prompt_docs", return_value=(confluence, None)),
+    ):
+        config = NaoConfig.promptConfig("ignored", existing=existing)
+
+    assert config.confluence is confluence
+
+
+@patch("nao_core.config.base.UI")
+@patch("nao_core.config.base.ask_confirm")
+def test_prompt_docs_skips_already_configured_providers(mock_confirm, _mock_ui):
+    confluence = _make_confluence()
+    notion = _make_notion()
+    existing = NaoConfig(project_name="test-project", confluence=confluence, notion=notion)
+
+    assert NaoConfig._prompt_docs(existing) == (confluence, notion)
+    mock_confirm.assert_not_called()
 
 
 def test_extend_handles_no_databases_and_no_llm():
@@ -150,6 +230,7 @@ def test_extend_handles_no_databases_and_no_llm():
         patch.object(NaoConfig, "_prompt_databases", return_value=[]),
         patch.object(NaoConfig, "_prompt_repos", return_value=[]),
         patch.object(NaoConfig, "_prompt_llm", return_value=None),
+        patch.object(NaoConfig, "_prompt_docs", return_value=(None, None)),
         patch("nao_core.config.base.UI"),
     ):
         config = NaoConfig.promptConfig("ignored", existing=existing)

--- a/cli/tests/nao_core/config/test_confluence.py
+++ b/cli/tests/nao_core/config/test_confluence.py
@@ -1,0 +1,77 @@
+"""Validation tests for the Confluence configuration model."""
+
+import pytest
+from pydantic import ValidationError
+
+from nao_core.config.confluence import ConfluenceConfig
+
+
+def test_cloud_config_requires_email_and_token():
+    with pytest.raises(ValidationError):
+        ConfluenceConfig(base_url="https://acme.atlassian.net/wiki", deployment="cloud", pages=["100"])
+
+
+def test_cloud_config_is_valid_with_email_and_token():
+    config = ConfluenceConfig(
+        base_url="https://acme.atlassian.net/wiki",
+        deployment="cloud",
+        email="me@acme.com",
+        api_token="secret",
+        spaces=["ENG"],
+    )
+    assert config.deployment == "cloud"
+
+
+def test_server_config_accepts_a_personal_access_token():
+    config = ConfluenceConfig(
+        base_url="https://confluence.acme.com",
+        deployment="server",
+        personal_access_token="pat",
+        pages=["100"],
+    )
+    assert config.personal_access_token == "pat"
+
+
+def test_server_config_accepts_username_and_password():
+    config = ConfluenceConfig(
+        base_url="https://confluence.acme.com",
+        deployment="server",
+        username="user",
+        password="pass",
+        pages=["100"],
+    )
+    assert config.username == "user"
+
+
+def test_server_config_requires_some_credential():
+    with pytest.raises(ValidationError):
+        ConfluenceConfig(base_url="https://confluence.acme.com", deployment="server", pages=["100"])
+
+
+def test_config_requires_some_content_selector():
+    with pytest.raises(ValidationError):
+        ConfluenceConfig(
+            base_url="https://acme.atlassian.net/wiki",
+            deployment="cloud",
+            email="me@acme.com",
+            api_token="secret",
+        )
+
+
+def test_config_accepts_page_trees_or_labels_alone():
+    trees = ConfluenceConfig(
+        base_url="https://acme.atlassian.net/wiki",
+        deployment="cloud",
+        email="me@acme.com",
+        api_token="secret",
+        page_trees=["164100"],
+    )
+    labels = ConfluenceConfig(
+        base_url="https://acme.atlassian.net/wiki",
+        deployment="cloud",
+        email="me@acme.com",
+        api_token="secret",
+        labels=["DATA:glossary"],
+    )
+    assert trees.page_trees == ["164100"]
+    assert labels.labels == ["DATA:glossary"]

--- a/cli/tests/nao_core/config/test_confluence.py
+++ b/cli/tests/nao_core/config/test_confluence.py
@@ -1,5 +1,7 @@
 """Validation tests for the Confluence configuration model."""
 
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
@@ -75,3 +77,18 @@ def test_config_accepts_page_trees_or_labels_alone():
     )
     assert trees.page_trees == ["164100"]
     assert labels.labels == ["DATA:glossary"]
+
+
+@patch("nao_core.config.confluence.UI")
+@patch("nao_core.config.confluence.ask_text")
+def test_prompt_reasks_content_selectors_until_one_is_provided(mock_ask_text, _mock_ui):
+    """A first empty pass through the selectors should re-prompt instead of crashing."""
+    empty_round = ["", "", "", ""]
+    filled_round = ["", "", "", "ENG"]
+    mock_ask_text.side_effect = [*empty_round, *filled_round]
+
+    pages, page_trees, labels, spaces = ConfluenceConfig._promptContentSelectors()
+
+    assert (pages, page_trees, labels) == ([], [], [])
+    assert spaces == ["ENG"]
+    assert mock_ask_text.call_count == 8

--- a/cli/tests/nao_core/config/test_confluence.py
+++ b/cli/tests/nao_core/config/test_confluence.py
@@ -79,6 +79,30 @@ def test_config_accepts_page_trees_or_labels_alone():
     assert labels.labels == ["DATA:glossary"]
 
 
+@pytest.mark.parametrize("base_url", ["", "   ", "acme.atlassian.net/wiki", "ftp://acme.atlassian.net"])
+def test_config_rejects_a_non_absolute_http_base_url(base_url):
+    with pytest.raises(ValidationError):
+        ConfluenceConfig(
+            base_url=base_url,
+            deployment="cloud",
+            email="me@acme.com",
+            api_token="secret",
+            spaces=["ENG"],
+        )
+
+
+@pytest.mark.parametrize("selectors", [{"pages": ["100", ""]}, {"spaces": ["  "]}, {"labels": ["ENG:glossary", ""]}])
+def test_config_rejects_blank_selector_entries(selectors):
+    with pytest.raises(ValidationError):
+        ConfluenceConfig(
+            base_url="https://acme.atlassian.net/wiki",
+            deployment="cloud",
+            email="me@acme.com",
+            api_token="secret",
+            **selectors,
+        )
+
+
 @patch("nao_core.config.confluence.UI")
 @patch("nao_core.config.confluence.ask_text")
 def test_prompt_reasks_content_selectors_until_one_is_provided(mock_ask_text, _mock_ui):

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-10T11:52:08.5784Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -1200,7 +1200,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2243,6 +2243,19 @@ wheels = [
 ]
 
 [[package]]
+name = "markdownify"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/ab/d1297139c0e2ceb151ae564c8c4f57ac0155d8f1f8b4cbd5d6523c82ea36/markdownify-1.2.3.tar.gz", hash = "sha256:1a176f05522c8a2cb1dd3ab9d307dcdadbed5c26ae717855bfc42b3b6d38d937", size = 18852, upload-time = "2026-06-30T20:27:39.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/10/fa543d484e8b1199243fe20eedd02cc5af050edebce98a7293a5773df592/markdownify-1.2.3-py3-none-any.whl", hash = "sha256:a189a0bedfd14009030fde5f85bb6f77c56897cb839b5c25315dd7d4e3e290ba", size = 15732, upload-time = "2026-06-30T20:27:38.094Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2619,6 +2632,7 @@ all = [
     { name = "google-genai" },
     { name = "ibis-framework", extra = ["athena", "bigquery", "clickhouse", "databricks", "duckdb", "mssql", "mysql", "postgres", "snowflake", "trino"] },
     { name = "kubernetes" },
+    { name = "markdownify" },
     { name = "mistralai" },
     { name = "mysql-connector-python" },
     { name = "notion-client" },
@@ -2664,6 +2678,9 @@ bigquery = [
 clickhouse = [
     { name = "clickhouse-driver" },
     { name = "ibis-framework", extra = ["clickhouse"] },
+]
+confluence = [
+    { name = "markdownify" },
 ]
 databricks = [
     { name = "certifi" },
@@ -2762,9 +2779,10 @@ requires-dist = [
     { name = "ibis-framework", extras = ["trino"], marker = "extra == 'trino'", specifier = ">=9.0.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "kubernetes", marker = "extra == 'k8s-secrets'", specifier = ">=29.0.0" },
+    { name = "markdownify", marker = "extra == 'confluence'", specifier = ">=0.13.0,<2" },
     { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.11.1,<2.0.0" },
     { name = "mysql-connector-python", marker = "extra == 'starrocks'", specifier = "==9.5.0" },
-    { name = "nao-core", extras = ["all-databases", "all-llms", "notion", "aws-secrets", "k8s-secrets"], marker = "extra == 'all'" },
+    { name = "nao-core", extras = ["all-databases", "all-llms", "notion", "confluence", "aws-secrets", "k8s-secrets"], marker = "extra == 'all'" },
     { name = "nao-core", extras = ["openai", "anthropic", "mistral", "gemini", "ollama"], marker = "extra == 'all-llms'" },
     { name = "nao-core", extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "starrocks"], marker = "extra == 'all-databases'" },
     { name = "notion-client", marker = "extra == 'notion'", specifier = ">=3.1.0,<4" },
@@ -2790,7 +2808,7 @@ requires-dist = [
     { name = "sshtunnel", marker = "extra == 'redshift'", specifier = ">=0.4.0" },
     { name = "uvicorn", specifier = ">=0.40.0" },
 ]
-provides-extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "starrocks", "openai", "anthropic", "mistral", "gemini", "ollama", "notion", "aws-secrets", "k8s-secrets", "all-databases", "all-llms", "all", "dev"]
+provides-extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", "databricks", "mysql", "mssql", "athena", "trino", "redshift", "fabric", "starrocks", "openai", "anthropic", "mistral", "gemini", "ollama", "notion", "confluence", "aws-secrets", "k8s-secrets", "all-databases", "all-llms", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4360,8 +4378,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/scripts/generate-config-docs.py
+++ b/scripts/generate-config-docs.py
@@ -45,6 +45,7 @@ from nao_core.config.llm import (  # noqa: E402
     LLMConfig,
     LLMProvider,
 )
+from nao_core.config.confluence import ConfluenceConfig  # noqa: E402
 from nao_core.config.mcp import McpConfig  # noqa: E402
 from nao_core.config.notion import NotionConfig  # noqa: E402
 from nao_core.config.repos.base import RepoConfig  # noqa: E402
@@ -246,6 +247,14 @@ def _section_notion() -> str:
     return "\n".join(parts)
 
 
+def _section_confluence() -> str:
+    parts: list[str] = []
+    parts.append("## Confluence\n")
+    parts.append(_fields_table(ConfluenceConfig))
+    parts.append("")
+    return "\n".join(parts)
+
+
 def _section_slack() -> str:
     parts: list[str] = []
     parts.append("## Slack\n")
@@ -314,6 +323,21 @@ notion:
   pages:
     - https://notion.so/my-page-id
 
+confluence:
+  base_url: ${{ env('CONFLUENCE_BASE_URL') }}
+  deployment: cloud
+  email: ${{ env('CONFLUENCE_EMAIL') }}
+  api_token: ${{ env('CONFLUENCE_API_TOKEN') }}
+  pages:
+    - https://acme.atlassian.net/wiki/spaces/ENG/pages/123456/Runbook
+  page_trees:
+    - 123456
+  labels:
+    - data-catalog
+    - DATA:glossary
+  spaces:
+    - DATA
+
 slack:
   bot_token: ${{ env('SLACK_BOT_TOKEN') }}
   signing_secret: ${{ env('SLACK_SIGNING_SECRET') }}
@@ -350,6 +374,7 @@ def generate_markdown() -> str:
                 "databases": "[DatabaseConfig[]](#databases)",
                 "repos": "[RepoConfig[]](#repos)",
                 "notion": "[NotionConfig](#notion)",
+                "confluence": "[ConfluenceConfig](#confluence)",
                 "llm": "[LLMConfig](#llm)",
                 "slack": "[SlackConfig](#slack)",
                 "mcp": "[McpConfig](#mcp)",
@@ -363,6 +388,7 @@ def generate_markdown() -> str:
     parts.append(_section_llm())
     parts.append(_section_repos())
     parts.append(_section_notion())
+    parts.append(_section_confluence())
     parts.append(_section_slack())
     parts.append(_section_mcp())
     parts.append(_section_skills())


### PR DESCRIPTION
## Summary

- [x] add Confluence as context provider
<img width="418" height="179" alt="image" src="https://github.com/user-attachments/assets/d5b2794a-1cdb-4ff8-b0bf-9637ef1c24fe" />

- [x] add configuration prompt of Confluence and Notion to the nao CLI `init`
<img width="757" height="737" alt="(cli sarah in -noo-ak-3example on feat92_odd_confluence_as_context_provider uw run noo init-" src="https://github.com/user-attachments/assets/42eb9213-6d9b-4a35-91c7-f93b6d1af373" />

## Related issue

Fix #962 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

