### PR TITLE
feat(mcp): add chart_output=data mode for agent-rendered charts

### DIFF
--- a/apps/backend/src/mcp/chart-data-mode.ts
+++ b/apps/backend/src/mcp/chart-data-mode.ts
@@ -1,0 +1,58 @@
+import { displayChart } from '@nao/shared/tools';
+
+const MAX_INLINE_ROWS = 500;
+const MAX_INLINE_DATA_CHARS = 80_000;
+
+const DISPLAY_CHART_RETURNS =
+	'it returns the chart config and data rows with rendering instructions so you can render the chart ' +
+	'yourself as an interactive visualization (e.g. a recharts component in a code frame)';
+
+export const CHART_DATA_MODE_SERVER_INSTRUCTIONS =
+	' Chart workflow: when `ask_nao` returns `queries`, call `display_chart` with a `query_id` — ' +
+	`${DISPLAY_CHART_RETURNS} — do not just relay the embed link.`;
+
+export const CHART_DATA_MODE_ASK_NAO_ADDENDUM =
+	'\n\nCHARTS: when the result carries `queries` worth visualizing, follow up with `display_chart` on a ' +
+	`\`queries[].id\` — ${DISPLAY_CHART_RETURNS}.`;
+
+export const CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM =
+	'\n\nRENDERING: the result includes the chart config, the data rows and recharts mapping instructions — ' +
+	'if your platform can render code-based visualizations (React frames, artifacts, canvases…), render the ' +
+	'chart yourself as an interactive component from them instead of only sharing the embed link.';
+
+export const CHART_DATA_MODE_RESULT_NUDGE =
+	'To visualize these results, call `display_chart` with a `query_id` from `queries` — ' +
+	`${DISPLAY_CHART_RETURNS} — instead of answering with text only.`;
+
+const RENDER_INSTRUCTIONS = [
+	'RENDER THIS CHART for the user as an interactive visualization — do not answer with only links or a text list of the numbers. If your platform can render code-based visualizations (Dust interactive frames, Claude artifacts, canvases, React components…), build a single self-contained `recharts` component from the config and data below, inlining the data as a literal constant — never fetch it over the network. Only fall back to sharing the embed links from this result if no such rendering capability exists.',
+	'- Config mapping: `chart_type` → recharts component (`bar`→BarChart, `line`→LineChart, `area`→AreaChart, `pie`/`donut`→PieChart, `scatter`→ScatterChart, `radar`→RadarChart, `mixed`→ComposedChart with per-series `series_type`, `stacked_*`→shared `stackId`, `*_100`→stackOffset="expand", `kpi_card`→a stat card without a chart, `table`→a plain table).',
+	'- `x_axis_key` → XAxis dataKey; each `series[].data_key` → one mark (Bar/Line/Area/…) with its `color` and `label`; `value_format` hints number formatting; `y_axis: "right"` → secondary YAxis.',
+	'- Respect the series colors. Add a Tooltip, and a Legend when there are multiple series.',
+	'- Along with the rendered chart, always include the `Open in nao` link from this result so the user can explore the underlying analysis in nao.',
+].join('\n');
+
+export function buildAgentRenderedChartText(args: {
+	config: displayChart.ChartInput;
+	columns: string[];
+	rows: Record<string, unknown>[];
+}): string | null {
+	const { config, columns, rows } = args;
+	if (!displayChart.isNativeDisplayType(config.chart_type) || rows.length === 0 || rows.length > MAX_INLINE_ROWS) {
+		return null;
+	}
+
+	const dataJson = JSON.stringify(rows);
+	if (dataJson.length > MAX_INLINE_DATA_CHARS) {
+		return null;
+	}
+
+	const { query_id: _queryId, ...renderConfig } = config;
+	return [
+		RENDER_INSTRUCTIONS,
+		'',
+		`Chart config: ${JSON.stringify(renderConfig)}`,
+		'',
+		`Data (${rows.length} rows, columns: ${columns.join(', ')}): ${dataJson}`,
+	].join('\n');
+}

--- a/apps/backend/src/mcp/chart-data-mode.ts
+++ b/apps/backend/src/mcp/chart-data-mode.ts
@@ -16,18 +16,23 @@ export const CHART_DATA_MODE_ASK_NAO_ADDENDUM =
 	`\`queries[].id\` — ${DISPLAY_CHART_RETURNS}.`;
 
 export const CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM =
-	'\n\nRENDERING: the result includes the chart config, the data rows and recharts mapping instructions — ' +
-	'if your platform can render code-based visualizations (React frames, artifacts, canvases…), render the ' +
+	'\n\nRENDERING: when the result includes the chart config, the data rows and recharts mapping instructions ' +
+	'and your platform can render code-based visualizations (React frames, artifacts, canvases…), render the ' +
 	'chart yourself as an interactive component from them instead of only sharing the embed link.';
 
 export const CHART_DATA_MODE_RESULT_NUDGE =
-	'To visualize these results, call `display_chart` with a `query_id` from `queries` — ' +
-	`${DISPLAY_CHART_RETURNS} — instead of answering with text only.`;
+	'If a visualization would help answer the question, call `display_chart` with a `query_id` from `queries` — ' +
+	`${DISPLAY_CHART_RETURNS}.`;
+
+export const CHART_DATA_MODE_FALLBACK_NOTE =
+	'Chart data not inlined (custom chart type, empty result, or too many rows to inline) — ' +
+	'share the embed link from this result instead of rendering the chart yourself.';
 
 const RENDER_INSTRUCTIONS = [
 	'RENDER THIS CHART for the user as an interactive visualization — do not answer with only links or a text list of the numbers. If your platform can render code-based visualizations (Dust interactive frames, Claude artifacts, canvases, React components…), build a single self-contained `recharts` component from the config and data below, inlining the data as a literal constant — never fetch it over the network. Only fall back to sharing the embed links from this result if no such rendering capability exists.',
 	'- Config mapping: `chart_type` → recharts component (`bar`→BarChart, `line`→LineChart, `area`→AreaChart, `pie`/`donut`→PieChart, `scatter`→ScatterChart, `radar`→RadarChart, `mixed`→ComposedChart with per-series `series_type`, `stacked_*`→shared `stackId`, `*_100`→stackOffset="expand", `kpi_card`→a stat card without a chart, `table`→a plain table).',
-	'- `x_axis_key` → XAxis dataKey; each `series[].data_key` → one mark (Bar/Line/Area/…) with its `color` and `label`; `value_format` hints number formatting; `y_axis: "right"` → secondary YAxis.',
+	'- `x_axis_key` → XAxis dataKey (for `pie`/`donut` → `Pie` nameKey; for `radar` → PolarAngleAxis dataKey); each `series[].data_key` → one mark (Bar/Line/Area/…) with its `color` and `label`; `value_format` hints number formatting; `y_axis: "right"` → secondary YAxis.',
+	'- Omit series with `is_total: true` from `*_100` stacks — a pre-aggregated total would skew the percentages; render them normally in every other chart type.',
 	'- Respect the series colors. Add a Tooltip, and a Legend when there are multiple series.',
 	'- Along with the rendered chart, always include the `Open in nao` link from this result so the user can explore the underlying analysis in nao.',
 ].join('\n');

--- a/apps/backend/src/mcp/logging.ts
+++ b/apps/backend/src/mcp/logging.ts
@@ -5,11 +5,14 @@ import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sd
 
 import { insertMcpCallLog } from '../queries/mcp-endpoint.queries';
 import type { McpEndpointSettings } from '../types/mcp-endpoint';
+import { truncateMiddle } from '../utils/utils';
 
 export interface McpContext {
 	userId: string;
 	projectId: string;
 	settings: McpEndpointSettings;
+	/** When true, chart tools return config + data rows for the client agent to render itself instead of embed links/apps only. */
+	chartDataMode: boolean;
 }
 
 export type ToolContent = { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string };
@@ -81,6 +84,8 @@ export function withLogging<T>(toolName: string, ctx: McpContext, handler: Logge
 	};
 }
 
+const MAX_LOGGED_OUTPUT_CHARS = 10_000;
+
 function extractLoggableOutput(result: ToolResult | undefined): unknown {
 	if (!result) {
 		return undefined;
@@ -89,10 +94,20 @@ function extractLoggableOutput(result: ToolResult | undefined): unknown {
 		.filter((part): part is { type: 'text'; text: string } => part.type === 'text')
 		.map((part) => part.text)
 		.join('\n');
+	if (text.startsWith('{') || text.startsWith('[')) {
+		const parsed = tryParseJson(text);
+		if (parsed !== undefined) {
+			return parsed;
+		}
+	}
+	return truncateMiddle(text, MAX_LOGGED_OUTPUT_CHARS, ' … [truncated] … ');
+}
+
+function tryParseJson(text: string): unknown {
 	try {
 		return JSON.parse(text);
 	} catch {
-		return text;
+		return undefined;
 	}
 }
 

--- a/apps/backend/src/mcp/logging.ts
+++ b/apps/backend/src/mcp/logging.ts
@@ -94,7 +94,7 @@ function extractLoggableOutput(result: ToolResult | undefined): unknown {
 		.filter((part): part is { type: 'text'; text: string } => part.type === 'text')
 		.map((part) => part.text)
 		.join('\n');
-	if (text.startsWith('{') || text.startsWith('[')) {
+	if (text.length <= MAX_LOGGED_OUTPUT_CHARS && (text.startsWith('{') || text.startsWith('['))) {
 		const parsed = tryParseJson(text);
 		if (parsed !== undefined) {
 			return parsed;

--- a/apps/backend/src/mcp/routes.ts
+++ b/apps/backend/src/mcp/routes.ts
@@ -61,7 +61,12 @@ async function handleMcpRequest(request: FastifyRequest, reply: FastifyReply): P
 		return;
 	}
 
-	const server = await createMcpServer(request.mcpUserId, request.mcpProjectId, settings);
+	const server = await createMcpServer(
+		request.mcpUserId,
+		request.mcpProjectId,
+		settings,
+		isChartDataModeRequest(request),
+	);
 	const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 
 	reply.raw.on('close', () => {
@@ -72,6 +77,11 @@ async function handleMcpRequest(request: FastifyRequest, reply: FastifyReply): P
 	await server.connect(transport);
 	await transport.handleRequest(request.raw, reply.raw, request.body as Record<string, unknown>);
 	reply.hijack();
+}
+
+function isChartDataModeRequest(request: FastifyRequest): boolean {
+	const { chart_output } = request.query as { chart_output?: string };
+	return chart_output?.toLowerCase() === 'data';
 }
 
 function replyMethodNotAllowed(reply: FastifyReply) {

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { getCustomBoundaries, listUserProjects } from '../queries/project.queries';
 import type { McpEndpointSettings } from '../types/mcp-endpoint';
+import { CHART_DATA_MODE_SERVER_INSTRUCTIONS } from './chart-data-mode';
 import { registerNaoMcpApps } from './embed/ui-resources';
 import { registerAssetTools } from './tools/asset-tools';
 import { registerContextLayerTools } from './tools/context-layer';
@@ -24,9 +25,16 @@ export async function createMcpServer(
 	userId: string,
 	projectId: string,
 	settings: McpEndpointSettings,
+	chartDataMode = false,
 ): Promise<McpServer> {
-	const server = new McpServer({ name: 'nao', version: '0.1.0' }, { capabilities: { tools: {}, resources: {} } });
-	const ctx = { userId, projectId, settings };
+	const server = new McpServer(
+		{ name: 'nao', version: '0.1.0' },
+		{
+			capabilities: { tools: {}, resources: {} },
+			instructions: chartDataMode ? DATA_MODE_SERVER_INSTRUCTIONS : BASE_SERVER_INSTRUCTIONS,
+		},
+	);
+	const ctx = { userId, projectId, settings, chartDataMode };
 
 	if (settings.subAgentModeEnabled) {
 		registerSubAgentTools(server, ctx);
@@ -44,3 +52,9 @@ export async function createMcpServer(
 
 	return server;
 }
+
+const BASE_SERVER_INSTRUCTIONS =
+	'nao answers analytics questions backed by SQL queries on the connected data sources. ' +
+	'Default to `ask_nao` for analytics questions; prefer showing results as charts over text tables when the data suits it.';
+
+const DATA_MODE_SERVER_INSTRUCTIONS = BASE_SERVER_INSTRUCTIONS + CHART_DATA_MODE_SERVER_INSTRUCTIONS;

--- a/apps/backend/src/mcp/tools/asset-tools.ts
+++ b/apps/backend/src/mcp/tools/asset-tools.ts
@@ -6,7 +6,11 @@ import zodV3 from 'zod/v3';
 
 import displayChartTool from '../../agents/tools/display-chart';
 import * as storyQueries from '../../queries/story.queries';
-import { buildAgentRenderedChartText, CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM } from '../chart-data-mode';
+import {
+	buildAgentRenderedChartText,
+	CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM,
+	CHART_DATA_MODE_FALLBACK_NOTE,
+} from '../chart-data-mode';
 import {
 	buildChartToolResult,
 	buildMapToolResult,
@@ -151,15 +155,12 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 			const toolResult = buildChartToolResult(result.payload, { sandboxChartHtml: result.sandboxChartHtml });
 
 			if (ctx.chartDataMode) {
-				// Null for custom chart types and oversized results: the embed links then remain the intended fallback.
 				const chartText = buildAgentRenderedChartText({
 					config: artifact,
 					columns: result.queryData.columns,
 					rows: result.queryData.data,
 				});
-				if (chartText) {
-					toolResult.content.unshift({ type: 'text', text: chartText });
-				}
+				toolResult.content.unshift({ type: 'text', text: chartText ?? CHART_DATA_MODE_FALLBACK_NOTE });
 			}
 
 			return toolResult;

--- a/apps/backend/src/mcp/tools/asset-tools.ts
+++ b/apps/backend/src/mcp/tools/asset-tools.ts
@@ -6,6 +6,7 @@ import zodV3 from 'zod/v3';
 
 import displayChartTool from '../../agents/tools/display-chart';
 import * as storyQueries from '../../queries/story.queries';
+import { buildAgentRenderedChartText, CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM } from '../chart-data-mode';
 import {
 	buildChartToolResult,
 	buildMapToolResult,
@@ -35,6 +36,8 @@ const DISPLAY_CHART_DESCRIPTION =
 	'both the SQL and the chart in one shot. Also skip when you just called `create_story` or ' +
 	'`update_story` — the story embed already renders all its `<chart>` blocks; calling ' +
 	'`display_chart` again would duplicate them.';
+
+const DISPLAY_CHART_DATA_MODE_DESCRIPTION = DISPLAY_CHART_DESCRIPTION + CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM;
 
 const LIST_STORIES_DESCRIPTION = 'List nao stories.';
 
@@ -82,7 +85,7 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 		name: 'display_chart',
 		agentTool: displayChartTool,
 		title: 'Display Chart',
-		description: DISPLAY_CHART_DESCRIPTION,
+		description: ctx.chartDataMode ? DISPLAY_CHART_DATA_MODE_DESCRIPTION : DISPLAY_CHART_DESCRIPTION,
 		inputSchema: displayChart.ChartInputObjectSchema.extend({
 			chat_id: zodV3
 				.string()
@@ -119,22 +122,7 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 		mapInput: ({ chat_id: _chatId, ...input }) => input,
 		resolveChatId: (input) => input.chat_id ?? null,
 		formatResult: async ({ input, output, callLogId }) => {
-			const {
-				query_id,
-				chart_type,
-				x_axis_key,
-				x_axis_type,
-				x_axis_label,
-				series,
-				y_axis_min,
-				y_axis_max,
-				y_axis_label,
-				y_axis_right_min,
-				y_axis_right_max,
-				y_axis_right_label,
-				title,
-				chat_id,
-			} = input;
+			const { chat_id, ...artifact } = input;
 			if (!output.success) {
 				return {
 					content: [{ type: 'text' as const, text: output.error ?? 'Chart config is invalid.' }],
@@ -143,35 +131,38 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 			}
 
 			const validatedChatId = await resolveChartChatId(chat_id, ctx);
-			const result = await buildChartEmbedFromArtifact(
-				{
-					query_id,
-					chart_type,
-					x_axis_key,
-					x_axis_type,
-					x_axis_label,
-					series,
-					y_axis_min,
-					y_axis_max,
-					y_axis_label,
-					y_axis_right_min,
-					y_axis_right_max,
-					y_axis_right_label,
-					title,
-				},
-				ctx,
-				{ chatId: validatedChatId ?? null, callLogId },
-			);
+			const result = await buildChartEmbedFromArtifact(artifact, ctx, {
+				chatId: validatedChatId ?? null,
+				callLogId,
+			});
 
 			if (!result) {
-				return buildMissingQueryDataResult({ queryId: query_id, chatIdInput: chat_id, validatedChatId });
+				return buildMissingQueryDataResult({
+					queryId: artifact.query_id,
+					chatIdInput: chat_id,
+					validatedChatId,
+				});
 			}
 
 			if ('keyError' in result) {
 				return buildInvalidKeysResult(result.keyError);
 			}
 
-			return buildChartToolResult(result.payload, { sandboxChartHtml: result.sandboxChartHtml });
+			const toolResult = buildChartToolResult(result.payload, { sandboxChartHtml: result.sandboxChartHtml });
+
+			if (ctx.chartDataMode) {
+				// Null for custom chart types and oversized results: the embed links then remain the intended fallback.
+				const chartText = buildAgentRenderedChartText({
+					config: artifact,
+					columns: result.queryData.columns,
+					rows: result.queryData.data,
+				});
+				if (chartText) {
+					toolResult.content.unshift({ type: 'text', text: chartText });
+				}
+			}
+
+			return toolResult;
 		},
 	});
 }

--- a/apps/backend/src/mcp/tools/helpers.ts
+++ b/apps/backend/src/mcp/tools/helpers.ts
@@ -134,7 +134,11 @@ export async function buildChartEmbedFromArtifact(
 	artifact: displayChart.ChartInput,
 	ctx: McpContext,
 	opts: { chatId: string | null; callLogId: string },
-): Promise<{ payload: ChartToolPayload; sandboxChartHtml: string | null } | { keyError: ChartKeyError } | null> {
+): Promise<
+	| { payload: ChartToolPayload; sandboxChartHtml: string | null; queryData: ChartQueryData }
+	| { keyError: ChartKeyError }
+	| null
+> {
 	const {
 		query_id,
 		chart_type,
@@ -219,17 +223,19 @@ export async function buildChartEmbedFromArtifact(
 
 	const naoChatUrl = effectiveChatId ? chatUrl(effectiveChatId) : null;
 	let sandboxChartHtml: string | null = null;
-	try {
-		sandboxChartHtml = await buildChartSandboxHtml({
-			title,
-			chartBlock: block,
-			queryId: query_id,
-			columns: queryData.columns,
-			data: queryData.data,
-			naoChatUrl,
-		});
-	} catch (sandboxErr) {
-		logger.warn(`MCP sandbox HTML failed: ${String(sandboxErr)}`, { source: 'tool' });
+	if (!ctx.chartDataMode) {
+		try {
+			sandboxChartHtml = await buildChartSandboxHtml({
+				title,
+				chartBlock: block,
+				queryId: query_id,
+				columns: queryData.columns,
+				data: queryData.data,
+				naoChatUrl,
+			});
+		} catch (sandboxErr) {
+			logger.warn(`MCP sandbox HTML failed: ${String(sandboxErr)}`, { source: 'tool' });
+		}
 	}
 
 	const payload: ChartToolPayload = {
@@ -240,7 +246,7 @@ export async function buildChartEmbedFromArtifact(
 		title,
 		chatId: effectiveChatId,
 	};
-	return { payload, sandboxChartHtml };
+	return { payload, sandboxChartHtml, queryData };
 }
 
 type MapKeyError = { invalidKeys: string[]; availableColumns: string[] };

--- a/apps/backend/src/mcp/tools/sub-agent.ts
+++ b/apps/backend/src/mcp/tools/sub-agent.ts
@@ -9,6 +9,7 @@ import { agentService, defaultAgentToolsExcluding } from '../../services/agent';
 import { mcpService } from '../../services/mcp';
 import { skillService } from '../../services/skill';
 import type { UIMessage, UIMessagePart } from '../../types/chat';
+import { CHART_DATA_MODE_ASK_NAO_ADDENDUM, CHART_DATA_MODE_RESULT_NUDGE } from '../chart-data-mode';
 import type { McpContext, ToolResult } from '../logging';
 import { chatUrl } from '../urls';
 import { type AskNaoClarification, type AskNaoResult, askNaoRuns } from './ask-nao-runs';
@@ -42,6 +43,8 @@ const ASK_NAO_DESCRIPTION =
 	"CLARIFICATIONS: if the question is ambiguous, this returns `status: 'needs_clarification'` " +
 	'with a `clarification.question` (and optional `clarification.options`). Relay the question to the user, ' +
 	'then call `ask_nao` again with the SAME `chatId` and their answer as `question`.';
+
+const ASK_NAO_DATA_MODE_DESCRIPTION = ASK_NAO_DESCRIPTION + CHART_DATA_MODE_ASK_NAO_ADDENDUM;
 
 const GET_NAO_ANSWER_DESCRIPTION =
 	'Fetch the result of an `ask_nao` run that is still in progress. ' +
@@ -81,7 +84,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 	registerMcpTool(server, ctx, {
 		name: 'ask_nao',
 		title: 'Ask Nao',
-		description: ASK_NAO_DESCRIPTION,
+		description: ctx.chartDataMode ? ASK_NAO_DATA_MODE_DESCRIPTION : ASK_NAO_DESCRIPTION,
 		inputSchema: {
 			question: z
 				.string()
@@ -141,7 +144,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 				throw new Error(outcome.error);
 			}
 			if (outcome.kind === 'complete') {
-				return answerCompletePayload(outcome.result);
+				return answerCompletePayload(outcome.result, ctx);
 			}
 			return runningPayload(chat.id, naoChatUrl);
 		},
@@ -167,7 +170,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 		errorMessage: () => 'Failed to fetch the nao answer.',
 		handler: async ({ chatId }) => {
 			await assertChatAccess(ctx, chatId);
-			return resolveAnswerPayload(chatId);
+			return resolveAnswerPayload(chatId, ctx);
 		},
 	});
 }
@@ -222,13 +225,13 @@ async function waitForResultOrBudget(runPromise: Promise<AskNaoResult>, budgetMs
 	}
 }
 
-async function resolveAnswerPayload(chatId: string): Promise<ToolResult> {
+async function resolveAnswerPayload(chatId: string, ctx: McpContext): Promise<ToolResult> {
 	const state = askNaoRuns.get(chatId);
 	if (!state) {
-		return reconstructAnswerFromDb(chatId);
+		return reconstructAnswerFromDb(chatId, ctx);
 	}
 	if (state.status === 'complete') {
-		return answerCompletePayload(state.result);
+		return answerCompletePayload(state.result, ctx);
 	}
 	if (state.status === 'error') {
 		return answerErrorPayload(chatId, state.error);
@@ -241,16 +244,19 @@ async function resolveAnswerPayload(chatId: string): Promise<ToolResult> {
  * restart): rebuild the final answer from the persisted chat. Query/story metadata is
  * not reconstructed since it only lives on the in-memory run.
  */
-async function reconstructAnswerFromDb(chatId: string): Promise<ToolResult> {
+async function reconstructAnswerFromDb(chatId: string, ctx: McpContext): Promise<ToolResult> {
 	const answer = await extractAnswerFromChat(chatId);
-	return answerCompletePayload({
-		chatId,
-		chatUrl: chatUrl(chatId),
-		text: answer.text,
-		...(answer.clarification ? { clarification: answer.clarification } : {}),
-		queries: [],
-		story_ids: [],
-	});
+	return answerCompletePayload(
+		{
+			chatId,
+			chatUrl: chatUrl(chatId),
+			text: answer.text,
+			...(answer.clarification ? { clarification: answer.clarification } : {}),
+			queries: [],
+			story_ids: [],
+		},
+		ctx,
+	);
 }
 
 async function extractAnswerFromChat(chatId: string): Promise<AskNaoAnswer> {
@@ -282,19 +288,24 @@ function runningPayload(chatId: string, naoChatUrl: string): ToolResult {
 	};
 }
 
-function answerCompletePayload(result: AskNaoResult): ToolResult {
+function answerCompletePayload(result: AskNaoResult, ctx: McpContext): ToolResult {
 	if (result.clarification) {
 		return clarificationPayload(result, result.clarification);
 	}
 
+	const content: ToolResult['content'] = [
+		{
+			type: 'text' as const,
+			text: `${result.text}\n\n[chatId: ${result.chatId}]\n[chatUrl: ${result.chatUrl}]`,
+		},
+		{ type: 'text' as const, text: JSON.stringify({ queries: result.queries, story_ids: result.story_ids }) },
+	];
+	if (ctx.chartDataMode && result.queries.length > 0) {
+		content.push({ type: 'text' as const, text: CHART_DATA_MODE_RESULT_NUDGE });
+	}
+
 	return {
-		content: [
-			{
-				type: 'text' as const,
-				text: `${result.text}\n\n[chatId: ${result.chatId}]\n[chatUrl: ${result.chatUrl}]`,
-			},
-			{ type: 'text' as const, text: JSON.stringify({ queries: result.queries, story_ids: result.story_ids }) },
-		],
+		content,
 		structuredContent: { status: 'complete', ...result },
 	};
 }

--- a/apps/backend/src/mcp/tools/sub-agent.ts
+++ b/apps/backend/src/mcp/tools/sub-agent.ts
@@ -300,7 +300,7 @@ function answerCompletePayload(result: AskNaoResult, ctx: McpContext): ToolResul
 		},
 		{ type: 'text' as const, text: JSON.stringify({ queries: result.queries, story_ids: result.story_ids }) },
 	];
-	if (ctx.chartDataMode && result.queries.length > 0) {
+	if (ctx.chartDataMode && result.queries.length > 0 && result.story_ids.length === 0) {
 		content.push({ type: 'text' as const, text: CHART_DATA_MODE_RESULT_NUDGE });
 	}
 

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -348,7 +348,7 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		pageLabel: 'MCP Endpoint',
 		title: 'MCP Server Endpoint',
 		description: 'Allow external AI clients to connect to this workspace via MCP.',
-		keywords: ['model context protocol', 'claude desktop', 'cursor', 'external', 'api', 'bearer'],
+		keywords: ['model context protocol', 'claude desktop', 'cursor', 'dust', 'external', 'api', 'bearer'],
 	},
 	{
 		page: '/settings/mcp-endpoint',

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -264,6 +264,21 @@ function ConnectionCard() {
 			],
 		},
 		{
+			id: 'dust',
+			label: 'Dust',
+			methods: [
+				{
+					steps: [
+						'Open {Spaces > Tools} and click `Add Tool > Add MCP Server`.',
+						'Paste the URL below into the `MCP server URL` field — keep the `?chart_output=data` parameter: it returns chart config and data so Dust agents can render charts as interactive frames.',
+						'Authenticate in your browser when prompted.',
+					],
+					config: `${endpointUrl}?chart_output=data`,
+					configLabel: 'MCP Endpoint URL',
+				},
+			],
+		},
+		{
 			id: 'cli',
 			label: 'CLI',
 			methods: [

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -22,7 +22,7 @@ const ChartTypeNameSchema = z
 	.string()
 	.regex(/^[a-z][a-z0-9_-]*$/, 'Chart type must use lowercase letters, numbers, underscores, or hyphens.');
 const CustomChartTypeSchema = ChartTypeNameSchema.refine(
-	(type) => type !== 'table' && !(BUILTIN_CHART_TYPES as readonly string[]).includes(type),
+	(type) => !isNativeDisplayType(type),
 ).brand<'CustomChartType'>();
 const ChartTypeSchema = z.union([ChartTypeEnum, CustomChartTypeSchema]);
 
@@ -334,6 +334,11 @@ export type BuiltinChartInput = Omit<ChartInput, 'chart_type'> & { chart_type: C
 
 export function isBuiltinChartType(type: string): type is ChartType {
 	return (BUILTIN_CHART_TYPES as readonly string[]).includes(type);
+}
+
+/** Display types nao renders natively (as opposed to project-defined custom charts): builtins plus `table`. */
+export function isNativeDisplayType(type: string): boolean {
+	return type === 'table' || isBuiltinChartType(type);
 }
 
 export function isTableInput(input: Input): input is TableInput {


### PR DESCRIPTION
Closes #1401

## What

Adds an opt-in chart data mode to the MCP endpoint, enabled per connection via `?chart_output=data` on the endpoint URL. Clients that can't render MCP Apps embeds (e.g. Dust) currently only get an "Open in nao" link when `display_chart` returns; in data mode the tool result also carries the chart config, the resolved data rows, and recharts mapping instructions so the client's agent renders the chart itself as an interactive component. The "Open in nao" deep link is always kept.

## How

- `chart-data-mode.ts` (new): builds the agent-rendered chart payload — imperative render instructions + chart config JSON + row data JSON. Returns `null` for custom chart types, empty results, or oversized data (>500 rows / >80k chars), in which case the existing link/embed behavior is the fallback.
- The mode is read from the query param in `routes.ts` and threaded through `McpContext`; sandbox HTML is skipped in data mode.
- Since we can't configure the client agent's prompt, rendering guidance is layered into the server instructions, the `ask_nao`/`display_chart` tool descriptions, and a nudge appended to `ask_nao` results. The imperative phrasing was A/B tested on Dust: conditional wording falls back to links, imperative wording actually renders.
- MCP call logs now truncate stored tool output at 10k chars, since data-mode responses can carry full row data.
- Settings: new Dust tab in the MCP connection guide (with the `?chart_output=data` URL), plus a `dust` keyword in the settings search index.

## Behavior without the param

Unchanged — embeds/MCP Apps stay the default for clients like Claude.

## Testing

- `npm run lint` (tsc + eslint) clean across backend/frontend/shared
- Manually validated end-to-end on Dust: charts render as interactive frames; custom chart types and large results correctly fall back to links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1324" height="799" alt="Capture d’écran 2026-08-14 à 14 29 02" src="https://github.com/user-attachments/assets/77ad8279-b655-4f6b-88f9-7dba9521c9a6" />