### PR TITLE
Fix File Explorer failing to load when Git is unreachable

### DIFF
--- a/apps/backend/src/services/context-explorer-git.service.ts
+++ b/apps/backend/src/services/context-explorer-git.service.ts
@@ -173,13 +173,7 @@ export async function resolveContextExplorerGitSafely(
 		return await resolveContextExplorerGit(context);
 	} catch (error) {
 		const message = `Failed to resolve context explorer git for user ${context.userId} in project ${context.projectId}`;
-		const detail = error instanceof Error ? error.message : String(error);
-		try {
-			const { logger } = await import('../utils/logger');
-			logger.warn(message, { source: 'system', context: { error: detail } });
-		} catch {
-			console.warn(message, detail);
-		}
+		await logGitFailure(message, error);
 		return unavailable('git-unavailable', null);
 	}
 }
@@ -684,13 +678,7 @@ export async function cleanupContextWorktree(projectId: string, projectFolder: s
 		invalidateContextProjectPrefix(worktreeRoot);
 	} catch (error) {
 		const message = `Failed to clean up context worktree for user ${userId} in project ${projectId}`;
-		const detail = error instanceof Error ? error.message : String(error);
-		try {
-			const { logger } = await import('../utils/logger');
-			logger.warn(message, { source: 'system', context: { error: detail } });
-		} catch {
-			console.warn(message, detail);
-		}
+		await logGitFailure(message, error);
 	}
 }
 
@@ -708,6 +696,15 @@ export function assertSafeDestructiveWorktreeCommand(worktreeRoot: string, cwd: 
 			(subcommand === 'prune' && args.length === 2));
 	if (!allowed) {
 		throw new Error('Refusing destructive Git operation from outside the context worktree.');
+	}
+}
+
+async function logGitFailure(message: string, error: unknown): Promise<void> {
+	try {
+		const { logger, serializeError } = await import('../utils/logger');
+		logger.warn(message, { source: 'system', context: { error: serializeError(error) } });
+	} catch {
+		console.warn(message);
 	}
 }
 

--- a/apps/backend/src/services/context-explorer-git.service.ts
+++ b/apps/backend/src/services/context-explorer-git.service.ts
@@ -171,7 +171,15 @@ export async function resolveContextExplorerGitSafely(
 ): Promise<ContextExplorerGitResolution> {
 	try {
 		return await resolveContextExplorerGit(context);
-	} catch {
+	} catch (error) {
+		const message = `Failed to resolve context explorer git for user ${context.userId} in project ${context.projectId}`;
+		const detail = error instanceof Error ? error.message : String(error);
+		try {
+			const { logger } = await import('../utils/logger');
+			logger.warn(message, { source: 'system', context: { error: detail } });
+		} catch {
+			console.warn(message, detail);
+		}
 		return unavailable('git-unavailable', null);
 	}
 }

--- a/apps/backend/src/services/context-explorer-git.service.ts
+++ b/apps/backend/src/services/context-explorer-git.service.ts
@@ -166,6 +166,16 @@ export async function resolveContextExplorerGit(
 	}
 }
 
+export async function resolveContextExplorerGitSafely(
+	context: ContextExplorerGitContext,
+): Promise<ContextExplorerGitResolution> {
+	try {
+		return await resolveContextExplorerGit(context);
+	} catch {
+		return unavailable('git-unavailable', null);
+	}
+}
+
 export async function requireContextExplorerGit(
 	context: ContextExplorerGitContext,
 ): Promise<{ repo: ResolvedContextRepo; context: ContextExplorerGitContext & { token: string } }> {

--- a/apps/backend/src/services/context-explorer.service.ts
+++ b/apps/backend/src/services/context-explorer.service.ts
@@ -17,12 +17,7 @@ import { spawn } from 'child_process';
 import fs from 'fs/promises';
 
 import type { ContextRepoState, ResolvedContextRepo } from '../utils/context-repo';
-import {
-	getCommittedProjectPaths,
-	getWorktreeProjectRoot,
-	normalizeProjectPath,
-	toContextRepoState,
-} from '../utils/context-repo';
+import { getCommittedProjectPaths, getWorktreeProjectRoot, normalizeProjectPath } from '../utils/context-repo';
 import { getRipgrepPath } from '../utils/ripgrep';
 import { assertNoSymlinkInWritePath, canonicalizeWriteRoot, writeFileAtomically } from '../utils/safe-file-write';
 import {
@@ -48,13 +43,6 @@ export interface FileEditability {
 	guidance: FileEditabilityGuidance | null;
 }
 
-export interface FileTreeResponse {
-	entries: FileTreeEntry[];
-	repo: ContextRepoState | null;
-	gitUnavailableReason: FileEditabilityReason | null;
-	gitUnavailableMessage: string | null;
-}
-
 export interface ContextExplorerFileAccess {
 	projectFolder: string;
 	git: ContextExplorerGitResolution;
@@ -71,18 +59,7 @@ type RipgrepMatchEntry = {
 };
 
 export async function getFileTree(projectFolder: string): Promise<FileTreeEntry[]> {
-	return readDirectoryRecursive(projectFolder, projectFolder, new Set<string>());
-}
-
-export async function getFileTreeResponse(access: ContextExplorerFileAccess): Promise<FileTreeResponse> {
-	const repo = availableRepo(access.git);
-	const trackedPaths = repo ? getCommittedProjectPaths(repo) : new Set<string>();
-	return {
-		entries: await readDirectoryRecursive(access.projectFolder, access.projectFolder, trackedPaths),
-		repo: access.git.status === 'available' ? toContextRepoState(access.git.repo) : access.git.repo,
-		gitUnavailableReason: access.git.status === 'unavailable' ? access.git.reason : null,
-		gitUnavailableMessage: access.git.status === 'unavailable' ? access.git.message : null,
-	};
+	return readDirectoryRecursive(projectFolder, projectFolder);
 }
 
 export async function readFileContent(
@@ -379,11 +356,7 @@ function runContentSearch(
 	});
 }
 
-async function readDirectoryRecursive(
-	dirPath: string,
-	projectFolder: string,
-	trackedPaths: Set<string>,
-): Promise<FileTreeEntry[]> {
+async function readDirectoryRecursive(dirPath: string, projectFolder: string): Promise<FileTreeEntry[]> {
 	const dirEntries = await fs.readdir(dirPath, { withFileTypes: true });
 
 	const parentRelativePath = path.relative(projectFolder, dirPath);
@@ -396,7 +369,7 @@ async function readDirectoryRecursive(
 		const virtualPath = '/' + path.relative(projectFolder, fullPath);
 
 		if (entry.isDirectory()) {
-			const children = await readDirectoryRecursive(fullPath, projectFolder, trackedPaths);
+			const children = await readDirectoryRecursive(fullPath, projectFolder);
 			entries.push({
 				name: entry.name,
 				path: virtualPath,
@@ -404,12 +377,10 @@ async function readDirectoryRecursive(
 				children,
 			});
 		} else if (entry.isFile()) {
-			const projectPath = path.relative(projectFolder, fullPath).split(path.sep).join('/');
 			entries.push({
 				name: entry.name,
 				path: virtualPath,
 				type: 'file',
-				isTracked: trackedPaths.has(projectPath),
 			});
 		}
 	}

--- a/apps/backend/src/trpc/context-explorer.routes.ts
+++ b/apps/backend/src/trpc/context-explorer.routes.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import * as userQueries from '../queries/user.queries';
 import type { ContextExplorerFileAccess } from '../services/context-explorer.service';
 import {
-	getFileTreeResponse,
+	getFileTree,
 	MAX_CONTEXT_FILE_SIZE,
 	readFileContent,
 	searchFileContents,
@@ -24,6 +24,7 @@ import {
 	getContextFileDiff,
 	getContextRepositoryStatus,
 	resolveContextExplorerGit,
+	resolveContextExplorerGitSafely,
 	suggestContextBranchName,
 	switchContextBranch,
 } from '../services/context-explorer-git.service';
@@ -77,12 +78,12 @@ export const contextExplorerRoutes = {
 	}),
 
 	getFileTree: contextAdminProtectedProcedure.query(async ({ ctx }) => {
-		const access = await createFileAccess(ctx.project.id, ctx.project.path, ctx.user);
-		return getFileTreeResponse(access);
+		const entries = await getFileTree(requireProjectPath(ctx.project.path));
+		return { entries };
 	}),
 
 	readFile: contextAdminProtectedProcedure.input(z.object({ path: z.string() })).query(async ({ ctx, input }) => {
-		const access = await createFileAccess(ctx.project.id, ctx.project.path, ctx.user);
+		const access = await createSafeFileAccess(ctx.project.id, ctx.project.path, ctx.user);
 		return readFileContent(input.path, access);
 	}),
 
@@ -95,7 +96,7 @@ export const contextExplorerRoutes = {
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			const access = await createFileAccess(ctx.project.id, ctx.project.path, ctx.user);
+			const access = await createStrictFileAccess(ctx.project.id, ctx.project.path, ctx.user);
 			return writeFileContent(input.path, input.content, input.expectedHash, access);
 		}),
 
@@ -172,7 +173,19 @@ export const contextExplorerRoutes = {
 	}),
 };
 
-async function createFileAccess(
+async function createSafeFileAccess(
+	projectId: string,
+	projectPath: string | null,
+	user: { id: string; name: string; email: string },
+): Promise<ContextExplorerFileAccess> {
+	const context = await createGitContext(projectId, projectPath, user);
+	return {
+		projectFolder: context.projectFolder,
+		git: await resolveContextExplorerGitSafely(context),
+	};
+}
+
+async function createStrictFileAccess(
 	projectId: string,
 	projectPath: string | null,
 	user: { id: string; name: string; email: string },

--- a/apps/backend/tests/context-explorer-git.test.ts
+++ b/apps/backend/tests/context-explorer-git.test.ts
@@ -85,7 +85,7 @@ vi.mock('../src/utils/logger', () => ({
 }));
 
 import { __reloadEnvForTesting } from '../src/env';
-import { getFileTreeResponse, readFileContent, writeFileContent } from '../src/services/context-explorer.service';
+import { getFileTree, readFileContent, writeFileContent } from '../src/services/context-explorer.service';
 import {
 	assertSafeDestructiveWorktreeCommand,
 	assertSafeDestructiveWorktreeTarget,
@@ -105,6 +105,7 @@ import {
 	getDeploymentContextSource,
 	normalizeRemote,
 	resolveContextExplorerGit,
+	resolveContextExplorerGitSafely,
 	sanitizeContextSourceRepositoryUrl,
 	switchContextBranch,
 } from '../src/services/context-explorer-git.service';
@@ -609,12 +610,12 @@ describe('context explorer worktrees', () => {
 
 		const access = await fileAccess(fixture.context);
 		const status = await getContextRepositoryStatus(fixture.context);
-		const tree = await getFileTreeResponse(access);
+		const tree = await getFileTree(fixture.live);
 		const file = await readFileContent('/context.md', access);
 
 		expect(access.git).toMatchObject({ status: 'unavailable', reason: 'no-repo', repo: null });
 		expect(status).toMatchObject({ repo: null, gitUnavailableReason: 'no-repo', isGitRepository: false });
-		expect(tree.entries.map((entry) => entry.name)).toContain('context.md');
+		expect(tree.map((entry) => entry.name)).toContain('context.md');
 		expect(file).toMatchObject({
 			content: 'repository content\n',
 			isEditable: false,
@@ -973,6 +974,34 @@ describe('context explorer worktrees', () => {
 		expectLiveUnchanged(fixture.live, before);
 	});
 
+	it('reads source content as read-only when Git resolution throws', async () => {
+		const fixture = createFixture(temporaryRoots);
+		await ensureContextWorktree(fixture.context);
+		const originalPath = process.env.PATH;
+
+		try {
+			process.env.PATH = '';
+			const git = await resolveContextExplorerGitSafely(fixture.context);
+			const file = await readFileContent('/context.md', {
+				projectFolder: fixture.live,
+				git,
+			});
+
+			expect(git).toMatchObject({
+				status: 'unavailable',
+				reason: 'git-unavailable',
+				message: 'Repository status is temporarily unavailable.',
+			});
+			expect(file).toMatchObject({
+				content: 'live content\n',
+				isEditable: false,
+				reason: 'git-unavailable',
+			});
+		} finally {
+			process.env.PATH = originalPath;
+		}
+	});
+
 	it('reports line changes for tracked, untracked, and binary files without changing the live folder', async () => {
 		const fixture = createFixture(temporaryRoots, {
 			'nao_config.yaml': 'name: test\n',
@@ -1302,11 +1331,11 @@ describe('context explorer worktrees', () => {
 			const fixture = createFixture(temporaryRoots, files);
 			const before = snapshot(fixture.live);
 			const access = await fileAccess(fixture.context);
-			const tree = await getFileTreeResponse(access);
+			const tree = await getFileTree(fixture.live);
 			const file = await readFileContent('/context.md', access);
 
 			expect(access.git.status).toBe('unavailable');
-			expect(tree.entries.some((entry) => entry.name === 'context.md')).toBe(true);
+			expect(tree.some((entry) => entry.name === 'context.md')).toBe(true);
 			expect(file.isEditable).toBe(false);
 			expectLiveUnchanged(fixture.live, before);
 		}

--- a/apps/backend/tests/context-explorer-git.test.ts
+++ b/apps/backend/tests/context-explorer-git.test.ts
@@ -75,14 +75,17 @@ const loggerMocks = vi.hoisted(() => ({
 
 vi.mock('../src/queries/context-branch-ownership.queries', () => branchOwnershipMocks);
 vi.mock('../src/queries/context-recommendation.queries', () => contextConfigMocks);
-vi.mock('../src/utils/logger', () => ({
-	logger: {
-		warn: loggerMocks.warn,
-	},
-	serializeError: (error: unknown) => ({
-		message: error instanceof Error ? error.message : String(error),
-	}),
-}));
+vi.mock('../src/utils/logger', () => {
+	const redactCredentialedUrls = (value: string) => value.replace(/:\/\/[^/\s@]+@/g, '://***@');
+	return {
+		logger: {
+			warn: loggerMocks.warn,
+		},
+		serializeError: (error: unknown) => ({
+			message: redactCredentialedUrls(error instanceof Error ? error.message : String(error)),
+		}),
+	};
+});
 
 import { __reloadEnvForTesting } from '../src/env';
 import { getFileTree, readFileContent, writeFileContent } from '../src/services/context-explorer.service';
@@ -996,7 +999,7 @@ describe('context explorer worktrees', () => {
 				'Failed to resolve context explorer git for user user-1 in project project-id',
 				{
 					source: 'system',
-					context: { error: expect.any(String) },
+					context: { error: expect.objectContaining({ message: expect.any(String) }) },
 				},
 			);
 			expect(file).toMatchObject({
@@ -1007,6 +1010,34 @@ describe('context explorer worktrees', () => {
 		} finally {
 			process.env.PATH = originalPath;
 		}
+	});
+
+	it('redacts credentialed URLs from Git resolution errors', async () => {
+		const fixture = createFixture(temporaryRoots);
+		const provider = fixture.context.providerOverride;
+		if (!provider) {
+			throw new Error('Expected a local provider.');
+		}
+		vi.spyOn(provider, 'authenticatedRepoUrl').mockImplementation(() => {
+			throw new Error('Clone failed for https://oauth2:SECRET@example.com/repo.git');
+		});
+
+		await expect(resolveContextExplorerGitSafely(fixture.context)).resolves.toMatchObject({
+			status: 'unavailable',
+			reason: 'git-unavailable',
+		});
+		expect(loggerMocks.warn).toHaveBeenCalledWith(
+			'Failed to resolve context explorer git for user user-1 in project project-id',
+			{
+				source: 'system',
+				context: {
+					error: expect.objectContaining({
+						message: 'Clone failed for https://***@example.com/repo.git',
+					}),
+				},
+			},
+		);
+		expect(JSON.stringify(loggerMocks.warn.mock.calls.at(-1)?.[1])).not.toContain('SECRET');
 	});
 
 	it('reports line changes for tracked, untracked, and binary files without changing the live folder', async () => {

--- a/apps/backend/tests/context-explorer-git.test.ts
+++ b/apps/backend/tests/context-explorer-git.test.ts
@@ -992,6 +992,13 @@ describe('context explorer worktrees', () => {
 				reason: 'git-unavailable',
 				message: 'Repository status is temporarily unavailable.',
 			});
+			expect(loggerMocks.warn).toHaveBeenCalledWith(
+				'Failed to resolve context explorer git for user user-1 in project project-id',
+				{
+					source: 'system',
+					context: { error: expect.any(String) },
+				},
+			);
 			expect(file).toMatchObject({
 				content: 'live content\n',
 				isEditable: false,

--- a/apps/backend/tests/context-explorer-write.test.ts
+++ b/apps/backend/tests/context-explorer-write.test.ts
@@ -14,7 +14,7 @@ vi.hoisted(() => {
 
 import type { ContextExplorerFileAccess } from '../src/services/context-explorer.service';
 import {
-	getFileTreeResponse,
+	getFileTree,
 	MAX_CONTEXT_FILE_SIZE,
 	readFileContent,
 	searchFileContents,
@@ -119,11 +119,10 @@ describe('context explorer worktree writes', () => {
 				providerOverride: provider(bare),
 			}),
 		};
-		const tree = await getFileTreeResponse(readOnlyAccess);
+		const tree = await getFileTree(live);
 		const file = await readFileContent('/context.md', readOnlyAccess);
 
-		expect(tree).toMatchObject({ repo: null, gitUnavailableReason: 'no-repo' });
-		expect(tree.entries.map((entry) => entry.name)).toContain('context.md');
+		expect(tree.map((entry) => entry.name)).toContain('context.md');
 		expect(file).toMatchObject({
 			content: 'live content\n',
 			isEditable: false,
@@ -163,11 +162,11 @@ describe('context explorer worktree writes', () => {
 	});
 
 	it('excludes and rejects .git and environment files across tree, read, write, and search', async () => {
-		const tree = await getFileTreeResponse(access);
-		const nested = tree.entries.find((entry) => entry.name === 'nested');
+		const tree = await getFileTree(live);
+		const nested = tree.find((entry) => entry.name === 'nested');
 		const context = await readFileContent('/context.md', access);
 
-		expect(tree.entries.map((entry) => entry.name)).not.toEqual(expect.arrayContaining(['.git', '.env']));
+		expect(tree.map((entry) => entry.name)).not.toEqual(expect.arrayContaining(['.git', '.env']));
 		expect(nested?.children?.map((entry) => entry.name)).not.toContain('.env.local');
 		for (const protectedPath of ['/nested/repository/.git/config', '/.env', '/nested/.env.local']) {
 			await expect(readFileContent(protectedPath, access)).rejects.toMatchObject({ code: 'FORBIDDEN' });

--- a/apps/backend/tests/context-explorer.routes.test.ts
+++ b/apps/backend/tests/context-explorer.routes.test.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
 	connectContextRepository: vi.fn(),
+	getFileTree: vi.fn(),
 	getGithubToken: vi.fn(),
 	getGitlabToken: vi.fn(),
+	readFileContent: vi.fn(),
+	resolveContextExplorerGit: vi.fn(),
+	resolveContextExplorerGitSafely: vi.fn(),
+	resolveContextRepository: vi.fn(),
+	writeFileContent: vi.fn(),
 }));
 
 vi.mock('../src/auth', () => ({ getAuth: vi.fn() }));
@@ -24,11 +30,11 @@ vi.mock('../src/queries/user.queries', () => ({
 }));
 
 vi.mock('../src/services/context-explorer.service', () => ({
-	getFileTreeResponse: vi.fn(),
+	getFileTree: mocks.getFileTree,
 	MAX_CONTEXT_FILE_SIZE: 1024 * 1024,
-	readFileContent: vi.fn(),
+	readFileContent: mocks.readFileContent,
 	searchFileContents: vi.fn(),
-	writeFileContent: vi.fn(),
+	writeFileContent: mocks.writeFileContent,
 }));
 
 vi.mock('../src/services/context-explorer-git.service', () => ({
@@ -42,13 +48,20 @@ vi.mock('../src/services/context-explorer-git.service', () => ({
 	getChangedContextFiles: vi.fn(),
 	getContextFileDiff: vi.fn(),
 	getContextRepositoryStatus: vi.fn(),
-	resolveContextExplorerGit: vi.fn(),
+	resolveContextExplorerGit: mocks.resolveContextExplorerGit,
+	resolveContextExplorerGitSafely: mocks.resolveContextExplorerGitSafely,
 	suggestContextBranchName: vi.fn(),
 	switchContextBranch: vi.fn(),
 }));
 
 vi.mock('../src/services/context-explorer-pr.service', () => ({
 	pushContextExplorerBranch: vi.fn(),
+}));
+
+vi.mock('../src/utils/context-repo', () => ({
+	resolveContextRepository: mocks.resolveContextRepository,
+	resolveContextSourceGitToken: vi.fn(() => null),
+	sanitizeContextSourceRepositoryUrl: vi.fn((url: string) => url),
 }));
 
 import { contextExplorerRoutes } from '../src/trpc/context-explorer.routes';
@@ -61,6 +74,9 @@ describe('context explorer repository connection', () => {
 		vi.resetAllMocks();
 		mocks.getGithubToken.mockResolvedValue('github-token');
 		mocks.getGitlabToken.mockResolvedValue('gitlab-token');
+		mocks.resolveContextRepository.mockResolvedValue({
+			provider: 'github',
+		});
 		mocks.connectContextRepository.mockResolvedValue({
 			provider: 'gitlab',
 			repoFullName: 'nao/context',
@@ -113,6 +129,73 @@ describe('context explorer repository connection', () => {
 			message: 'Connect your GitLab account first.',
 		});
 		expect(mocks.connectContextRepository).not.toHaveBeenCalled();
+	});
+});
+
+describe('context explorer file access', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mocks.getGithubToken.mockResolvedValue('github-token');
+		mocks.resolveContextRepository.mockResolvedValue({ provider: 'github' });
+	});
+
+	it('returns the source file tree without resolving Git', async () => {
+		const entries = [
+			{ name: 'folder', path: '/folder', type: 'directory', children: [] },
+			{ name: 'nao_config.yaml', path: '/nao_config.yaml', type: 'file' },
+		];
+		mocks.getFileTree.mockResolvedValue(entries);
+		mocks.resolveContextExplorerGit.mockRejectedValue(new Error('clone failed'));
+		mocks.resolveContextExplorerGitSafely.mockRejectedValue(new Error('clone failed'));
+
+		await expect(createCaller().getFileTree()).resolves.toEqual({ entries });
+
+		expect(mocks.getFileTree).toHaveBeenCalledWith('/tmp/nao-project');
+		expect(mocks.resolveContextExplorerGit).not.toHaveBeenCalled();
+		expect(mocks.resolveContextExplorerGitSafely).not.toHaveBeenCalled();
+	});
+
+	it('uses safe Git resolution for reads and strict resolution for writes', async () => {
+		const unavailableGit = {
+			status: 'unavailable',
+			reason: 'git-unavailable',
+			message: 'Repository status is temporarily unavailable.',
+			repo: null,
+		};
+		const availableGit = {
+			status: 'available',
+			repo: {},
+			context: {},
+		};
+		mocks.resolveContextExplorerGitSafely.mockResolvedValue(unavailableGit);
+		mocks.resolveContextExplorerGit.mockResolvedValue(availableGit);
+		mocks.readFileContent.mockResolvedValue({
+			content: 'source\n',
+			hash: 'hash',
+			isEditable: false,
+			reason: 'git-unavailable',
+		});
+		mocks.writeFileContent.mockResolvedValue({ hash: 'updated-hash' });
+
+		await createCaller().readFile({ path: '/context.md' });
+		expect(mocks.resolveContextExplorerGitSafely).toHaveBeenCalledOnce();
+		expect(mocks.readFileContent).toHaveBeenCalledWith(
+			'/context.md',
+			expect.objectContaining({ git: unavailableGit }),
+		);
+
+		await createCaller().writeFile({
+			path: '/context.md',
+			content: 'updated\n',
+			expectedHash: '0'.repeat(64),
+		});
+		expect(mocks.resolveContextExplorerGit).toHaveBeenCalledOnce();
+		expect(mocks.writeFileContent).toHaveBeenCalledWith(
+			'/context.md',
+			'updated\n',
+			'0'.repeat(64),
+			expect.objectContaining({ git: availableGit }),
+		);
 	});
 });
 

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -147,7 +147,6 @@ export type FileTreeEntry = {
 	name: string;
 	path: string;
 	type: 'file' | 'directory';
-	isTracked?: boolean;
 	children?: FileTreeEntry[];
 };
 


### PR DESCRIPTION
## Summary

- The File Explorer file list now comes straight from the context folder. It no longer waits on the connected repo, so a repo problem can't stop your files from showing.
- Opening a file falls back to the folder's copy, read-only, when the repo can't be reached instead of erroring.
- Saving still fails with the real reason, so genuine problems stay visible.
- Removed the unused "tracked" flag from the file list.

## Why

Listing files and resolving the connected repo were one step, and that step can clone over the network. Any hiccup gave "Failed to load files" even though the files were readable the whole time. Now they're independent: files first, repo after, repo only decides what's editable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

