### PR TITLE
Org members inherit access to all projects

### DIFF
--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -452,20 +452,10 @@ const ensureDefaultProject = async (org: DBOrganization): Promise<void> => {
 	}
 
 	const projectName = projectPath.split('/').pop() || 'Default Project';
-	const project = await projectQueries.createProject({
+	await projectQueries.createProject({
 		name: projectName,
 		type: 'local',
 		path: projectPath,
 		orgId: org.id,
 	});
-
-	// Add all org members to the new project
-	const orgMembers = await db.select().from(s.orgMember).where(eq(s.orgMember.orgId, org.id)).execute();
-	for (const member of orgMembers) {
-		await projectQueries.addProjectMember({
-			projectId: project.id,
-			userId: member.userId,
-			role: member.role,
-		});
-	}
 };

--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -374,12 +374,13 @@ export const listOrgProjectsWithAccess = async (orgId: string, userId: string): 
 		.select({
 			id: s.project.id,
 			name: s.project.name,
-			role: sql<UserRole>`coalesce(${s.projectMember.role}, 'viewer')`,
+			role: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role}, 'viewer')`,
 			createdAt: s.project.createdAt,
 			updatedAt: s.project.updatedAt,
 		})
 		.from(s.project)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.projectId, s.project.id), eq(s.projectMember.userId, userId)))
+		.leftJoin(s.orgMember, and(eq(s.orgMember.orgId, s.project.orgId), eq(s.orgMember.userId, userId)))
 		.where(eq(s.project.orgId, orgId))
 		.orderBy(asc(s.project.name))
 		.execute();

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -149,7 +149,6 @@ export const listProjectMembersWithRoles = async (projectId: string): Promise<Us
 			name: s.user.name,
 			email: s.user.email,
 			role: s.projectMember.role,
-			messagingProviderCode: s.user.messagingProviderCode,
 		})
 		.from(s.user)
 		.innerJoin(s.projectMember, eq(s.projectMember.userId, s.user.id))
@@ -167,7 +166,6 @@ export const listUsersWithProjectAccess = async (projectId: string): Promise<Use
 			name: s.user.name,
 			email: s.user.email,
 			role: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role})`,
-			messagingProviderCode: s.user.messagingProviderCode,
 		})
 		.from(s.user)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.userId, s.user.id), eq(s.projectMember.projectId, projectId)))

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -105,7 +105,7 @@ export const listUserProjectsWithRoles = async (userId: string): Promise<UserPro
 	const results = await db
 		.select({
 			project: s.project,
-			userRole: sql<UserRole>`coalesce(${s.projectMember.role}, 'viewer')`,
+			userRole: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role}, 'viewer')`,
 		})
 		.from(s.project)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.projectId, s.project.id), eq(s.projectMember.userId, userId)))

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -208,8 +208,8 @@ export const getProjectByUserId = async (
 		return null;
 	}
 
-	const membership = await getProjectMember(project.id, userId);
-	return membership ? project : null;
+	const role = await getUserRoleInProject(project.id, userId);
+	return role ? project : null;
 };
 
 export const checkProjectHasMoreThanOneAdmin = async (projectId: string): Promise<boolean> => {

--- a/apps/backend/src/routes/deploy.ts
+++ b/apps/backend/src/routes/deploy.ts
@@ -8,7 +8,6 @@ import yaml from 'js-yaml';
 import type { App } from '../app';
 import { env } from '../env';
 import { ensureContextRecommendationsScheduleForNewProject } from '../handlers/context-recommendations.handler';
-import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
 import { validateApiKey } from '../services/api-key.service';
 
@@ -84,14 +83,6 @@ export const deployRoutes = async (app: App) => {
 				projectId = project.id;
 				status = 'created';
 
-				const orgMembers = await orgQueries.listOrgMembersWithUsers(org.id);
-				for (const member of orgMembers) {
-					await projectQueries.addProjectMember({
-						projectId,
-						userId: member.id,
-						role: member.role,
-					});
-				}
 				await ensureContextRecommendationsScheduleForNewProject(projectId);
 			}
 

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -703,6 +703,10 @@ export const projectRoutes = {
 		return projectQueries.listProjectMembersWithRoles(ctx.project.id);
 	}),
 
+	listUsersWithAccess: projectProtectedProcedure.query(async ({ ctx }) => {
+		return projectQueries.listUsersWithProjectAccess(ctx.project.id);
+	}),
+
 	getProjectMembersByChatId: protectedProcedure
 		.input(z.object({ chatId: z.string() }))
 		.query(async ({ ctx, input }) => {

--- a/apps/backend/src/types/project.ts
+++ b/apps/backend/src/types/project.ts
@@ -5,7 +5,6 @@ export interface UserWithRole {
 	name: string;
 	email: string;
 	role: UserRole;
-	messagingProviderCode: string | null;
 }
 
 export type ProjectChatsFacetKey = 'userName' | 'userRole' | 'toolState' | 'feedback' | 'source';

--- a/apps/backend/src/utils/project-import.utils.ts
+++ b/apps/backend/src/utils/project-import.utils.ts
@@ -7,7 +7,6 @@ import yaml from 'js-yaml';
 import type { DBProject } from '../db/abstractSchema';
 import { env } from '../env';
 import { ensureContextRecommendationsScheduleForNewProject } from '../handlers/context-recommendations.handler';
-import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
 
 export function createTempProjectDir(prefix: string): string {
@@ -90,14 +89,6 @@ export async function createNewProject({
 		orgId,
 	});
 
-	const orgMembers = await orgQueries.listOrgMembersWithUsers(orgId);
-	for (const member of orgMembers) {
-		await projectQueries.addProjectMember({
-			projectId: project.id,
-			userId: member.id,
-			role: member.role,
-		});
-	}
 	await ensureContextRecommendationsScheduleForNewProject(project.id);
 
 	return { projectId: project.id, projectName, status: 'created' as const };

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -7,7 +7,13 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { db as appDb } from '../src/db/db';
 import * as sqliteSchema from '../src/db/sqlite-schema';
 import { organization, orgMember, project, projectMember, user } from '../src/db/sqlite-schema';
-import { listProjectMembersWithRoles, listUsersWithProjectAccess } from '../src/queries/project.queries';
+import { env, isCloud } from '../src/env';
+import {
+	getProjectByUserId,
+	getUserRoleInProject,
+	listProjectMembersWithRoles,
+	listUsersWithProjectAccess,
+} from '../src/queries/project.queries';
 
 vi.mock('../src/db/db', async () => {
 	const { drizzle } = await import('drizzle-orm/better-sqlite3');
@@ -28,11 +34,15 @@ async function cleanup() {
 	await db.delete(user).where(eq(user.id, 'pau-org-only'));
 	await db.delete(user).where(eq(user.id, 'pau-both'));
 	await db.delete(user).where(eq(user.id, 'pau-ctx'));
+	await db.delete(user).where(eq(user.id, 'pau-none'));
 }
 
 describe('project accessible users', () => {
+	const originalDefaultProjectPath = env.NAO_DEFAULT_PROJECT_PATH;
+
 	beforeEach(async () => {
 		await cleanup();
+		env.NAO_DEFAULT_PROJECT_PATH = '/tmp/pau';
 		await db.insert(organization).values({ id: 'pau-org', name: 'PAU', slug: 'pau-org' });
 		await db.insert(project).values([
 			{ id: 'pau-proj', orgId: 'pau-org', name: 'PAU', type: 'local', path: '/tmp/pau' },
@@ -50,6 +60,9 @@ describe('project accessible users', () => {
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-ctx', 'PAU Ctx', 'pau-ctx@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-none', 'PAU None', 'pau-none@example.com');
 		await db.insert(projectMember).values([
 			{ projectId: 'pau-proj', userId: 'pau-direct', role: 'admin' },
 			{ projectId: 'pau-proj', userId: 'pau-both', role: 'viewer' },
@@ -62,7 +75,10 @@ describe('project accessible users', () => {
 		]);
 	});
 
-	afterEach(cleanup);
+	afterEach(async () => {
+		env.NAO_DEFAULT_PROJECT_PATH = originalDefaultProjectPath;
+		await cleanup();
+	});
 
 	afterAll(() => {
 		appDb.$client.close();
@@ -90,5 +106,31 @@ describe('project accessible users', () => {
 		const soloUsers = await listUsersWithProjectAccess('pau-solo');
 
 		expect(soloUsers.map(({ id }) => id).sort()).toEqual(['pau-direct']);
+	});
+
+	it('returns the self-hosted project for an org-only member', async () => {
+		expect(isCloud).toBe(false);
+
+		const result = await getProjectByUserId('pau-org-only');
+
+		expect(result?.id).toBe('pau-proj');
+	});
+
+	it('resolves an org-only member role from the organization', async () => {
+		const role = await getUserRoleInProject('pau-proj', 'pau-org-only');
+
+		expect(role).toBe('user');
+	});
+
+	it('prefers a project member role over the organization role', async () => {
+		const role = await getUserRoleInProject('pau-proj', 'pau-both');
+
+		expect(role).toBe('viewer');
+	});
+
+	it('returns null for a user without project or organization membership', async () => {
+		const result = await getProjectByUserId('pau-none');
+
+		expect(result).toBeNull();
 	});
 });

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -57,8 +57,8 @@ describe('project accessible users', () => {
 			{ id: 'pau-solo', orgId: null, name: 'PAU Solo', type: 'local', path: '/tmp/pau-solo' },
 		]);
 		db.$client
-			.prepare('insert into user (id, name, email) values (?, ?, ?)')
-			.run('pau-direct', 'PAU Direct', 'pau-direct@example.com');
+			.prepare('insert into user (id, name, email, messaging_provider_code) values (?, ?, ?, ?)')
+			.run('pau-direct', 'PAU Direct', 'pau-direct@example.com', 'pau-secret-code');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-org-only', 'PAU Org Only', 'pau-org-only@example.com');
@@ -119,6 +119,14 @@ describe('project accessible users', () => {
 		const teamUsers = await listProjectMembersWithRoles('pau-proj');
 
 		expect(teamUsers.map(({ id }) => id).sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct']);
+	});
+
+	it('omits messaging provider codes from user listings', async () => {
+		const accessibleUsers = await listUsersWithProjectAccess('pau-proj');
+		const teamUsers = await listProjectMembersWithRoles('pau-proj');
+
+		expect(accessibleUsers.every((accessibleUser) => !('messagingProviderCode' in accessibleUser))).toBe(true);
+		expect(teamUsers.every((teamUser) => !('messagingProviderCode' in teamUser))).toBe(true);
 	});
 
 	it('self-hosted project without org returns only direct members', async () => {

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -13,10 +13,12 @@ import { db as appDb } from '../src/db/db';
 import * as sqliteSchema from '../src/db/sqlite-schema';
 import { organization, orgMember, project, projectMember, user } from '../src/db/sqlite-schema';
 import { env, isCloud } from '../src/env';
+import { listOrgProjectsWithAccess } from '../src/queries/organization.queries';
 import {
 	getProjectByUserId,
 	getUserRoleInProject,
 	listProjectMembersWithRoles,
+	listUserProjectsWithRoles,
 	listUsersWithProjectAccess,
 } from '../src/queries/project.queries';
 
@@ -37,6 +39,7 @@ async function cleanup() {
 	await db.delete(organization).where(eq(organization.id, 'pau-org'));
 	await db.delete(user).where(eq(user.id, 'pau-direct'));
 	await db.delete(user).where(eq(user.id, 'pau-org-only'));
+	await db.delete(user).where(eq(user.id, 'pau-org-admin'));
 	await db.delete(user).where(eq(user.id, 'pau-both'));
 	await db.delete(user).where(eq(user.id, 'pau-ctx'));
 	await db.delete(user).where(eq(user.id, 'pau-none'));
@@ -61,6 +64,9 @@ describe('project accessible users', () => {
 			.run('pau-org-only', 'PAU Org Only', 'pau-org-only@example.com');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-org-admin', 'PAU Org Admin', 'pau-org-admin@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-both', 'PAU Both', 'pau-both@example.com');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
@@ -76,6 +82,7 @@ describe('project accessible users', () => {
 		]);
 		await db.insert(orgMember).values([
 			{ orgId: 'pau-org', userId: 'pau-org-only', role: 'user' },
+			{ orgId: 'pau-org', userId: 'pau-org-admin', role: 'admin' },
 			{ orgId: 'pau-org', userId: 'pau-both', role: 'admin' },
 		]);
 	});
@@ -94,9 +101,16 @@ describe('project accessible users', () => {
 		const users = await listUsersWithProjectAccess('pau-proj');
 		const rolesById = new Map(users.map(({ id, role }) => [id, role]));
 
-		expect([...rolesById.keys()].sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct', 'pau-org-only']);
+		expect([...rolesById.keys()].sort()).toEqual([
+			'pau-both',
+			'pau-ctx',
+			'pau-direct',
+			'pau-org-admin',
+			'pau-org-only',
+		]);
 		expect(rolesById.get('pau-direct')).toBe('admin');
 		expect(rolesById.get('pau-org-only')).toBe('user');
+		expect(rolesById.get('pau-org-admin')).toBe('admin');
 		expect(rolesById.get('pau-both')).toBe('viewer');
 		expect(rolesById.get('pau-ctx')).toBe('context_admin');
 	});
@@ -131,6 +145,36 @@ describe('project accessible users', () => {
 		const role = await getUserRoleInProject('pau-proj', 'pau-both');
 
 		expect(role).toBe('viewer');
+	});
+
+	it('returns inherited organization roles in user project listings', async () => {
+		const userProjects = await listUserProjectsWithRoles('pau-org-only');
+		const adminProjects = await listUserProjectsWithRoles('pau-org-admin');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.userRole).toBe('user');
+		expect(adminProjects).toHaveLength(1);
+		expect(adminProjects[0]?.userRole).toBe('admin');
+	});
+
+	it('returns inherited organization roles in organization project listings', async () => {
+		const userProjects = await listOrgProjectsWithAccess('pau-org', 'pau-org-only');
+		const adminProjects = await listOrgProjectsWithAccess('pau-org', 'pau-org-admin');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.role).toBe('user');
+		expect(adminProjects).toHaveLength(1);
+		expect(adminProjects[0]?.role).toBe('admin');
+	});
+
+	it('prefers explicit roles in both project listings', async () => {
+		const userProjects = await listUserProjectsWithRoles('pau-both');
+		const orgProjects = await listOrgProjectsWithAccess('pau-org', 'pau-both');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.userRole).toBe('viewer');
+		expect(orgProjects).toHaveLength(1);
+		expect(orgProjects[0]?.role).toBe('viewer');
 	});
 
 	it('returns null for a user without project or organization membership', async () => {

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -1,8 +1,13 @@
-import '../src/env';
-
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+	process.env.MODE = 'test';
+	process.env.NAO_MODE = 'self-hosted';
+});
+
+import '../src/env';
 
 import { db as appDb } from '../src/db/db';
 import * as sqliteSchema from '../src/db/sqlite-schema';

--- a/apps/frontend/src/hooks/use-share-dialog.ts
+++ b/apps/frontend/src/hooks/use-share-dialog.ts
@@ -2,19 +2,11 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { trpc } from '@/main';
 
-export function useMemberPicker(currentUserId: string | undefined, initialIds?: string[], chatId?: string) {
+export function useMemberPicker(currentUserId: string | undefined, initialIds: string[] | undefined, chatId: string) {
 	const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(() => new Set(initialIds));
 	const [search, setSearch] = useState('');
 
-	const membersByChatQuery = useQuery({
-		...trpc.project.getProjectMembersByChatId.queryOptions({ chatId: chatId! }),
-		enabled: !!chatId,
-	});
-	const membersDefaultQuery = useQuery({
-		...trpc.project.listAllUsersWithRoles.queryOptions(),
-		enabled: !chatId,
-	});
-	const membersQuery = chatId ? membersByChatQuery : membersDefaultQuery;
+	const membersQuery = useQuery(trpc.project.getProjectMembersByChatId.queryOptions({ chatId }));
 
 	const otherMembers = useMemo(() => {
 		return (membersQuery.data ?? []).filter((m) => m.id !== currentUserId);

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
@@ -138,7 +138,7 @@ function RouteComponent() {
 		enabled: perUserSpendEnabled,
 	});
 	const projectMembers = useQuery({
-		...trpc.project.listAllUsersWithRoles.queryOptions(),
+		...trpc.project.listUsersWithAccess.queryOptions(),
 		enabled: perUserSpendEnabled,
 	});
 


### PR DESCRIPTION
## Summary

- Members of an organization can now access all the org's project without an admin adding them to
  it one by one. This fixes new users getting stuck on "No project configured" bug.
- Being in the org is what grants access; people still don't show up in the project's team
  list unless they were added there explicitly.
- Their permission level comes from their org role, unless they've been given a specific
  role on the project, which wins.

Closes #1173


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

