### PR TITLE
Tell the agent to use database id if multiple dbs are configured

### DIFF
--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -9,6 +9,7 @@ import { tokenCounter } from '../../services/token-counter';
 import type { UserMemory } from '../../types/memory';
 import { MEMORY_CATEGORIES, MemoryCategory } from '../../types/memory';
 import { formatCurrentDate } from '../../utils/date';
+import type { ConfiguredDatabase } from '../../utils/nao-config';
 import { groupBy } from '../../utils/utils';
 import { getDialectSqlQueryRules, getDialectToolCallRules } from './dialect-rules';
 import { NaoContextStructure } from './nao-context-structure';
@@ -22,6 +23,7 @@ type SystemPromptProps = {
 	memories?: UserMemory[];
 	userRules?: string;
 	connections?: Connection[];
+	configuredDatabases?: ConfiguredDatabase[];
 	skills?: Skill[];
 	/** Defaults to every skill nao ships; only tests pass this. */
 	internalSkills?: InternalSkill[];
@@ -47,6 +49,7 @@ export function SystemPrompt({
 	memories = [],
 	userRules,
 	connections = [],
+	configuredDatabases = [],
 	skills = [],
 	internalSkills = listInternalSkills(),
 	customCharts = [],
@@ -254,6 +257,8 @@ export function SystemPrompt({
 					</Block>
 				)}
 
+				{configuredDatabases.length >= 2 && <ConfiguredDatabasesBlock databases={configuredDatabases} />}
+
 				{skills.length > 0 && (
 					<Block>
 						<Title level={2}>Skills</Title>
@@ -282,6 +287,35 @@ export function SystemPrompt({
 			</Block>
 		</Block>
 	);
+}
+
+function ConfiguredDatabasesBlock({ databases }: { databases: ConfiguredDatabase[] }) {
+	return (
+		<Block>
+			<Title level={2}>Databases</Title>
+			<Span>
+				execute_sql's <Bold>database_id</Bold> must be one of:
+			</Span>
+			<List>
+				{databases.map((database) => (
+					<ListItem key={database.id}>
+						<Bold>{database.id}</Bold>
+						{formatConfiguredDatabaseDetails(database)}
+					</ListItem>
+				))}
+			</List>
+		</Block>
+	);
+}
+
+function formatConfiguredDatabaseDetails(database: ConfiguredDatabase): string {
+	const identifyingFields = ['path', 'database', 'project_id', 'dataset_id', 'catalog'] as const;
+	const details = [
+		database.type ? `type=${database.type}` : null,
+		...identifyingFields.map((field) => (database[field] ? `${field}=${database[field]}` : null)),
+	].filter((detail): detail is string => detail !== null);
+
+	return details.length > 0 ? ` — ${details.join(', ')}` : '';
 }
 
 /**

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -309,7 +309,7 @@ function ConfiguredDatabasesBlock({ databases }: { databases: ConfiguredDatabase
 }
 
 function formatConfiguredDatabaseDetails(database: ConfiguredDatabase): string {
-	const identifyingFields = ['path', 'database', 'project_id', 'dataset_id', 'catalog'] as const;
+	const identifyingFields = ['database', 'project_id', 'dataset_id', 'catalog'] as const;
 	const details = [
 		database.type ? `type=${database.type}` : null,
 		...identifyingFields.map((field) => (database[field] ? `${field}=${database[field]}` : null)),

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -64,6 +64,7 @@ import {
 	resolveProviderSettings,
 } from '../utils/llm';
 import { logger } from '../utils/logger';
+import { extractConfiguredDatabases } from '../utils/nao-config';
 import { addPromptCache } from '../utils/prompt-cache';
 import { scheduleSaveLlmInferenceRecord } from '../utils/schedule-task';
 import { sanitizeTitle, TITLE_MAX_OUTPUT_TOKENS, titleFromPrompt, titleGenerationUserMessage } from '../utils/title';
@@ -599,6 +600,7 @@ class AgentManager {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
+		const configuredDatabases = extractConfiguredDatabases(this._toolContext.projectFolder);
 		const skills = skillService.getSkills(this.chat.projectId);
 		const customCharts = this._toolContext.supportsCustomCharts
 			? listChartPlugins(this._toolContext.projectFolder)
@@ -609,6 +611,7 @@ class AgentManager {
 				memories,
 				userRules,
 				connections,
+				configuredDatabases,
 				skills,
 				customCharts,
 				mcpServers,

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -9,6 +9,14 @@ import type { LinkedContextRepo } from '../types/context-recommendation';
 import { logger } from './logger';
 
 const ENV_PATTERN = /\$?\{\{\s*env\(['"]([^'"]+)['"]\)\s*\}\}/g;
+const DATABASE_IDENTIFYING_FIELDS = ['path', 'database', 'project_id', 'dataset_id', 'catalog'] as const;
+
+type DatabaseIdentifyingField = (typeof DATABASE_IDENTIFYING_FIELDS)[number];
+
+export type ConfiguredDatabase = {
+	id: string;
+	type?: string;
+} & Partial<Record<DatabaseIdentifyingField, string>>;
 
 export function extractRequiredEnvVars(projectFolder: string): string[] {
 	const configPath = path.join(projectFolder, 'nao_config.yaml');
@@ -60,6 +68,50 @@ export function extractConfiguredRepos(projectFolder: string): LinkedContextRepo
 			},
 		];
 	});
+}
+
+export function extractConfiguredDatabases(projectFolder: string): ConfiguredDatabase[] {
+	const configPath = path.join(projectFolder, 'nao_config.yaml');
+	if (!fs.existsSync(configPath)) {
+		return [];
+	}
+
+	const config = loadConfig(configPath);
+	if (!isRecord(config) || !Array.isArray(config.databases)) {
+		return [];
+	}
+
+	return config.databases.flatMap((database) => {
+		if (!isRecord(database) || typeof database.name !== 'string' || database.name.trim() === '') {
+			return [];
+		}
+
+		const configuredDatabase: ConfiguredDatabase = { id: database.name.trim() };
+		const type = normalizeString(database.type);
+		if (type) {
+			configuredDatabase.type = type;
+		}
+
+		for (const field of DATABASE_IDENTIFYING_FIELDS) {
+			const value = normalizeIdentifyingValue(database[field]);
+			if (value) {
+				configuredDatabase[field] = value;
+			}
+		}
+
+		return [configuredDatabase];
+	});
+}
+
+function normalizeString(value: unknown): string | null {
+	return typeof value === 'string' && value.trim() !== '' ? value.trim() : null;
+}
+
+function normalizeIdentifyingValue(value: unknown): string | null {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return String(value);
+	}
+	return normalizeString(value);
 }
 
 function loadConfig(configPath: string): unknown {

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -116,11 +116,16 @@ function deriveDatabaseNameFromPath(databasePath: string): string {
 	if (trimmedPath === ':memory:') {
 		return 'memory';
 	}
-	if (/^(?:md|motherduck):/i.test(trimmedPath)) {
-		const remainder = trimmedPath.slice(trimmedPath.indexOf(':') + 1);
-		return remainder.split('?', 1)[0].trim() || 'motherduck';
+	const pathWithoutQuery = stripQueryString(trimmedPath);
+	if (/^(?:md|motherduck):/i.test(pathWithoutQuery)) {
+		const remainder = pathWithoutQuery.slice(pathWithoutQuery.indexOf(':') + 1);
+		return remainder.trim() || 'motherduck';
 	}
-	return path.parse(trimmedPath).name;
+	return path.parse(pathWithoutQuery).name;
+}
+
+function stripQueryString(databasePath: string): string {
+	return databasePath.split('?', 1)[0];
 }
 
 function normalizeString(value: unknown): string | null {

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -9,7 +9,7 @@ import type { LinkedContextRepo } from '../types/context-recommendation';
 import { logger } from './logger';
 
 const ENV_PATTERN = /\$?\{\{\s*env\(['"]([^'"]+)['"]\)\s*\}\}/g;
-const DATABASE_IDENTIFYING_FIELDS = ['path', 'database', 'project_id', 'dataset_id', 'catalog'] as const;
+const DATABASE_IDENTIFYING_FIELDS = ['database', 'project_id', 'dataset_id', 'catalog'] as const;
 
 type DatabaseIdentifyingField = (typeof DATABASE_IDENTIFYING_FIELDS)[number];
 
@@ -99,8 +99,28 @@ export function extractConfiguredDatabases(projectFolder: string): ConfiguredDat
 			}
 		}
 
+		const databasePath = normalizeString(database.path);
+		if (!configuredDatabase.database && databasePath) {
+			const databaseName = deriveDatabaseNameFromPath(databasePath);
+			if (databaseName) {
+				configuredDatabase.database = databaseName;
+			}
+		}
+
 		return [configuredDatabase];
 	});
+}
+
+function deriveDatabaseNameFromPath(databasePath: string): string {
+	const trimmedPath = databasePath.trim();
+	if (trimmedPath === ':memory:') {
+		return 'memory';
+	}
+	if (/^(?:md|motherduck):/i.test(trimmedPath)) {
+		const remainder = trimmedPath.slice(trimmedPath.indexOf(':') + 1);
+		return remainder.split('?', 1)[0].trim() || 'motherduck';
+	}
+	return path.parse(trimmedPath).name;
 }
 
 function normalizeString(value: unknown): string | null {

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -181,7 +181,7 @@ describe('extractConfiguredDatabases', () => {
 				{
 					id: 'duckdb-jaffle-shop',
 					type: 'duckdb',
-					path: './jaffle_shop.duckdb',
+					database: 'jaffle_shop',
 				},
 				{
 					id: 'bigquery-prod',
@@ -191,6 +191,44 @@ describe('extractConfiguredDatabases', () => {
 				},
 			]);
 			expect(databases[1]).not.toHaveProperty('credentials_path');
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('derives safe database names from DuckDB paths', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - name: in-memory',
+					'    type: duckdb',
+					'    path: ":memory:"',
+					'  - name: motherduck-analytics',
+					'    type: duckdb',
+					'    path: "md:analytics?motherduck_token=secret123"',
+					'  - name: motherduck-default',
+					'    type: duckdb',
+					'    path: "md:"',
+					'  - name: explicit-database',
+					'    type: duckdb',
+					'    path: ./ignored.duckdb',
+					'    database: configured_name',
+				].join('\n'),
+			);
+
+			const databases = extractConfiguredDatabases(dir);
+
+			expect(databases).toEqual([
+				{ id: 'in-memory', type: 'duckdb', database: 'memory' },
+				{ id: 'motherduck-analytics', type: 'duckdb', database: 'analytics' },
+				{ id: 'motherduck-default', type: 'duckdb', database: 'motherduck' },
+				{ id: 'explicit-database', type: 'duckdb', database: 'configured_name' },
+			]);
+			expect(JSON.stringify(databases)).not.toContain('secret123');
+			expect(JSON.stringify(databases)).not.toContain('motherduck_token');
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { extractConfiguredRepos } from '../src/utils/nao-config';
+import { extractConfiguredDatabases, extractConfiguredRepos } from '../src/utils/nao-config';
 
 vi.mock('../src/utils/logger', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -106,6 +106,91 @@ describe('extractConfiguredRepos', () => {
 					url: 'https://bitbucket.org/nao/dbt-models.git',
 				},
 			]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+});
+
+describe('extractConfiguredDatabases', () => {
+	it('returns an empty list when nao_config.yaml is missing', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			expect(extractConfiguredDatabases(dir)).toEqual([]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('returns an empty list when databases is absent', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(path.join(dir, 'nao_config.yaml'), 'project_name: demo\n');
+
+			expect(extractConfiguredDatabases(dir)).toEqual([]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('skips databases without a valid name', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    path: ./missing-name.duckdb',
+					'  - name: "  "',
+					'    type: postgres',
+					'  - name: 123',
+					'    type: bigquery',
+					'  - name: valid-database',
+					'    type: duckdb',
+				].join('\n'),
+			);
+
+			expect(extractConfiguredDatabases(dir)).toEqual([{ id: 'valid-database', type: 'duckdb' }]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('returns ids, types, and identifying fields without secret-bearing fields', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - name: duckdb-jaffle-shop',
+					'    type: duckdb',
+					'    path: ./jaffle_shop.duckdb',
+					'  - name: bigquery-prod',
+					'    type: bigquery',
+					'    project_id: nao-corp',
+					'    dataset_id: nao-corp.movies_silver',
+					'    credentials_path: ./credentials.json',
+				].join('\n'),
+			);
+
+			const databases = extractConfiguredDatabases(dir);
+
+			expect(databases).toEqual([
+				{
+					id: 'duckdb-jaffle-shop',
+					type: 'duckdb',
+					path: './jaffle_shop.duckdb',
+				},
+				{
+					id: 'bigquery-prod',
+					type: 'bigquery',
+					project_id: 'nao-corp',
+					dataset_id: 'nao-corp.movies_silver',
+				},
+			]);
+			expect(databases[1]).not.toHaveProperty('credentials_path');
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -212,6 +212,9 @@ describe('extractConfiguredDatabases', () => {
 					'  - name: motherduck-default',
 					'    type: duckdb',
 					'    path: "md:"',
+					'  - name: mysql-analytics',
+					'    type: mysql',
+					'    path: "mysql://host:3306/analytics?user=u&password=hunter2"',
 					'  - name: explicit-database',
 					'    type: duckdb',
 					'    path: ./ignored.duckdb',
@@ -225,10 +228,14 @@ describe('extractConfiguredDatabases', () => {
 				{ id: 'in-memory', type: 'duckdb', database: 'memory' },
 				{ id: 'motherduck-analytics', type: 'duckdb', database: 'analytics' },
 				{ id: 'motherduck-default', type: 'duckdb', database: 'motherduck' },
+				{ id: 'mysql-analytics', type: 'mysql', database: 'analytics' },
 				{ id: 'explicit-database', type: 'duckdb', database: 'configured_name' },
 			]);
-			expect(JSON.stringify(databases)).not.toContain('secret123');
-			expect(JSON.stringify(databases)).not.toContain('motherduck_token');
+			const serializedDatabases = JSON.stringify(databases);
+			expect(serializedDatabases).not.toContain('secret123');
+			expect(serializedDatabases).not.toContain('motherduck_token');
+			expect(serializedDatabases).not.toContain('hunter2');
+			expect(serializedDatabases).not.toContain('password');
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -164,6 +164,55 @@ describe('SystemPrompt saved files rules', () => {
 	});
 });
 
+describe('SystemPrompt configured database ids', () => {
+	it('renders every configured database when several are configured', () => {
+		const markdown = renderToMarkdown(
+			SystemPrompt({
+				configuredDatabases: [
+					{
+						id: 'duckdb-jaffle-shop',
+						type: 'duckdb',
+						path: './jaffle_shop.duckdb',
+					},
+					{
+						id: 'bigquery-prod',
+						type: 'bigquery',
+						project_id: 'nao-corp',
+						dataset_id: 'nao-corp.movies_silver',
+					},
+				],
+			}),
+		);
+
+		expect(markdown).toContain(
+			[
+				'## Databases',
+				'',
+				"execute_sql's **database_id** must be one of:",
+				'',
+				'- **duckdb-jaffle-shop** — type=duckdb, path=./jaffle_shop.duckdb',
+				'- **bigquery-prod** — type=bigquery, project_id=nao-corp, dataset_id=nao-corp.movies_silver',
+			].join('\n'),
+		);
+		expect(markdown).not.toContain('underlying database name, not a database_id');
+		expect(markdown).not.toContain('may have no context folder if it has not been synced');
+		expect(markdown).not.toContain('**clarification** tool instead of guessing');
+	});
+
+	it('renders no configured database block for zero or one database', () => {
+		const withoutDatabases = renderToMarkdown(SystemPrompt({ configuredDatabases: [] }));
+		const withOneDatabase = renderToMarkdown(
+			SystemPrompt({
+				configuredDatabases: [{ id: 'duckdb-jaffle-shop', type: 'duckdb', path: './jaffle_shop.duckdb' }],
+			}),
+		);
+
+		expect(withoutDatabases).not.toContain('## Databases');
+		expect(withOneDatabase).not.toContain('## Databases');
+		expect(withOneDatabase).not.toContain('duckdb-jaffle-shop');
+	});
+});
+
 describe('SystemPrompt local database rules', () => {
 	it('names the reserved database id and what it is for', () => {
 		const markdown = renderToMarkdown(SystemPrompt({}));

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -172,7 +172,7 @@ describe('SystemPrompt configured database ids', () => {
 					{
 						id: 'duckdb-jaffle-shop',
 						type: 'duckdb',
-						path: './jaffle_shop.duckdb',
+						database: 'jaffle_shop',
 					},
 					{
 						id: 'bigquery-prod',
@@ -190,20 +190,17 @@ describe('SystemPrompt configured database ids', () => {
 				'',
 				"execute_sql's **database_id** must be one of:",
 				'',
-				'- **duckdb-jaffle-shop** — type=duckdb, path=./jaffle_shop.duckdb',
+				'- **duckdb-jaffle-shop** — type=duckdb, database=jaffle_shop',
 				'- **bigquery-prod** — type=bigquery, project_id=nao-corp, dataset_id=nao-corp.movies_silver',
 			].join('\n'),
 		);
-		expect(markdown).not.toContain('underlying database name, not a database_id');
-		expect(markdown).not.toContain('may have no context folder if it has not been synced');
-		expect(markdown).not.toContain('**clarification** tool instead of guessing');
 	});
 
 	it('renders no configured database block for zero or one database', () => {
 		const withoutDatabases = renderToMarkdown(SystemPrompt({ configuredDatabases: [] }));
 		const withOneDatabase = renderToMarkdown(
 			SystemPrompt({
-				configuredDatabases: [{ id: 'duckdb-jaffle-shop', type: 'duckdb', path: './jaffle_shop.duckdb' }],
+				configuredDatabases: [{ id: 'duckdb-jaffle-shop', type: 'duckdb', database: 'jaffle_shop' }],
 			}),
 		);
 


### PR DESCRIPTION
## Summary
- When a project has several databases connected, the agent's first SQL query used to fail: nothing told it which database names it was allowed to use, so it either sent none or copied a folder name from the synced metadata. It retried and usually recovered, but the user saw a red error first.
- The agent is now handed the actual database names from `nao_config.yaml`, each with its type and a couple of identifying details, so it picks the right one on the first try.
- Databases that are configured but not yet synced are now visible to it too, previously they were entirely absent from what it could see, which is likely how most of these failures started.
- Nothing changes for single-database projects: the list is only added to the prompt when two or more are configured.


Closes #1004

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

