### PR TITLE
[fix : story] data unavailable due to wrong `query_id`

### DIFF
--- a/apps/backend/src/services/story-template-validation.ts
+++ b/apps/backend/src/services/story-template-validation.ts
@@ -1,14 +1,53 @@
 import { findUnreferencedStoryFilters, validateSqlFilterTemplate } from '@nao/shared/sql-template';
-import { getStoryFiltersFromCode } from '@nao/shared/story-segments';
+import { extractQueryIds, getStoryFiltersFromCode } from '@nao/shared/story-segments';
+import { QueryIdSchema } from '@nao/shared/tools';
 
 import { env } from '../env';
+import * as executeSqlQueries from '../queries/execute-sql.queries';
 import * as storyQueries from '../queries/story.queries';
 
 export async function getStoryTemplateWarnings(chatId: string, code: string): Promise<string[]> {
-	if (!env.BETA_STORY_FILTERS_ENABLED) {
+	const warnings: string[] = [];
+	warnings.push(...(await getQueryReferenceWarnings(chatId, code)));
+	if (env.BETA_STORY_FILTERS_ENABLED) {
+		warnings.push(...(await getFilterWarnings(chatId, code)));
+	}
+	return warnings;
+}
+
+async function getQueryReferenceWarnings(chatId: string, code: string): Promise<string[]> {
+	const referencedIds = extractQueryIds(code);
+	if (referencedIds.size === 0) {
 		return [];
 	}
 
+	const warnings: string[] = [];
+	const wellFormedIds = new Set<string>();
+	for (const queryId of referencedIds) {
+		if (QueryIdSchema.safeParse(queryId).success) {
+			wellFormedIds.add(queryId);
+		} else {
+			warnings.push(
+				`Story references query_id "${queryId}", which is not a valid query id. Use the exact id returned in an execute_sql tool output (the "id" field, which looks like "query_..."); a chart/table/map block with an invalid query_id renders empty.`,
+			);
+		}
+	}
+
+	if (wellFormedIds.size > 0) {
+		const existing = await executeSqlQueries.getLatestSqlQueriesByIds(chatId, wellFormedIds);
+		for (const queryId of wellFormedIds) {
+			if (!existing[queryId]) {
+				warnings.push(
+					`Story references query_id "${queryId}", which was not produced by any execute_sql call in this chat. Run execute_sql first and use the exact id returned in its output (the "id" field); a chart/table/map block with an unknown query_id renders empty.`,
+				);
+			}
+		}
+	}
+
+	return warnings;
+}
+
+async function getFilterWarnings(chatId: string, code: string): Promise<string[]> {
 	const filters = getStoryFiltersFromCode(code);
 	const knownFilterIds = filters.map((filter) => filter.id);
 	const sqlQueries = await storyQueries.getSqlQueriesFromCode(chatId, code);

--- a/apps/backend/src/services/story-template-validation.ts
+++ b/apps/backend/src/services/story-template-validation.ts
@@ -4,53 +4,56 @@ import { QueryIdSchema } from '@nao/shared/tools';
 
 import { env } from '../env';
 import * as executeSqlQueries from '../queries/execute-sql.queries';
-import * as storyQueries from '../queries/story.queries';
+
+type SqlQueryMap = Record<string, { sqlQuery: string; databaseId?: string }>;
 
 export async function getStoryTemplateWarnings(chatId: string, code: string): Promise<string[]> {
 	const warnings: string[] = [];
-	warnings.push(...(await getQueryReferenceWarnings(chatId, code)));
+	const { wellFormedIds, malformedWarnings } = partitionReferencedQueryIds(code);
+	warnings.push(...malformedWarnings);
+
+	const sqlQueries =
+		wellFormedIds.size > 0 ? await executeSqlQueries.getLatestSqlQueriesByIds(chatId, wellFormedIds) : {};
+
+	warnings.push(...getMissingQueryWarnings(wellFormedIds, sqlQueries));
+
 	if (env.BETA_STORY_FILTERS_ENABLED) {
-		warnings.push(...(await getFilterWarnings(chatId, code)));
+		warnings.push(...getFilterWarnings(code, sqlQueries));
 	}
+
 	return warnings;
 }
 
-async function getQueryReferenceWarnings(chatId: string, code: string): Promise<string[]> {
-	const referencedIds = extractQueryIds(code);
-	if (referencedIds.size === 0) {
-		return [];
-	}
-
-	const warnings: string[] = [];
+function partitionReferencedQueryIds(code: string): { wellFormedIds: Set<string>; malformedWarnings: string[] } {
 	const wellFormedIds = new Set<string>();
-	for (const queryId of referencedIds) {
+	const malformedWarnings: string[] = [];
+	for (const queryId of extractQueryIds(code)) {
 		if (QueryIdSchema.safeParse(queryId).success) {
 			wellFormedIds.add(queryId);
 		} else {
-			warnings.push(
+			malformedWarnings.push(
 				`Story references query_id "${queryId}", which is not a valid query id. Use the exact id returned in an execute_sql tool output (the "id" field, which looks like "query_..."); a chart/table/map block with an invalid query_id renders empty.`,
 			);
 		}
 	}
+	return { wellFormedIds, malformedWarnings };
+}
 
-	if (wellFormedIds.size > 0) {
-		const existing = await executeSqlQueries.getLatestSqlQueriesByIds(chatId, wellFormedIds);
-		for (const queryId of wellFormedIds) {
-			if (!existing[queryId]) {
-				warnings.push(
-					`Story references query_id "${queryId}", which was not produced by any execute_sql call in this chat. Run execute_sql first and use the exact id returned in its output (the "id" field); a chart/table/map block with an unknown query_id renders empty.`,
-				);
-			}
+function getMissingQueryWarnings(wellFormedIds: Set<string>, sqlQueries: SqlQueryMap): string[] {
+	const warnings: string[] = [];
+	for (const queryId of wellFormedIds) {
+		if (!sqlQueries[queryId]) {
+			warnings.push(
+				`Story references query_id "${queryId}", which was not produced by any execute_sql call in this chat. Run execute_sql first and use the exact id returned in its output (the "id" field); a chart/table/map block with an unknown query_id renders empty.`,
+			);
 		}
 	}
-
 	return warnings;
 }
 
-async function getFilterWarnings(chatId: string, code: string): Promise<string[]> {
+function getFilterWarnings(code: string, sqlQueries: SqlQueryMap): string[] {
 	const filters = getStoryFiltersFromCode(code);
 	const knownFilterIds = filters.map((filter) => filter.id);
-	const sqlQueries = await storyQueries.getSqlQueriesFromCode(chatId, code);
 	const warnings: string[] = [];
 
 	for (const duplicateId of findDuplicateFilterIds(knownFilterIds)) {

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -683,10 +683,14 @@ function extractSeriesFromRawAttrs(attrString: string): ParsedChartBlock['series
 
 export function extractQueryIds(code: string): Set<string> {
 	const ids = new Set<string>();
-	const regex = /<(?:chart|table|map)\s+[^>]*?\bquery_id\s*=\s*"([^"]+)"/g;
-	let match: RegExpExecArray | null;
-	while ((match = regex.exec(code)) !== null) {
-		ids.add(match[1]);
+	for (const tagRegex of [chartTagRegex('g'), tableTagRegex('g'), mapTagRegex('g')]) {
+		let match: RegExpExecArray | null;
+		while ((match = tagRegex.exec(code)) !== null) {
+			const { query_id } = parseChartAttributes(match[1]);
+			if (query_id) {
+				ids.add(query_id);
+			}
+		}
 	}
 	return ids;
 }

--- a/apps/shared/src/tools/index.ts
+++ b/apps/shared/src/tools/index.ts
@@ -10,6 +10,7 @@ export * as list from './list';
 export * as loadSkill from './load-skill';
 export * as mcpCall from './mcp-call';
 export * as mcpConnect from './mcp-connect';
+export { QueryIdSchema } from './query-id';
 export * as readFile from './read';
 export * as readQueryResult from './read-query-result';
 export * as searchFiles from './search';


### PR DESCRIPTION
## Issue

Some LLM models take the liberty of assigning common English names to `query_ids` when querying data, and then passing them to stories to create blocks of charts, tables, or maps.

## Solution

To prevent this issue from recurring, I added a validator that checks the format of the query ID and verifies it corresponds to an `execute_sql` result produced in the same chat. Mismatches are surfaced as non-blocking template_warnings so the agent fixes the reference before finishing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

