### PR TITLE
Add an adaptive prompt section describing the available context and what each template contains

### DIFF
--- a/apps/backend/src/components/ai/context-recommendations-prompt.tsx
+++ b/apps/backend/src/components/ai/context-recommendations-prompt.tsx
@@ -43,7 +43,7 @@ function ContextRecommendationsPrompt({
 					<ListItem>
 						Tool errors: v_messages where tool_state = &quot;output-error&quot; — cluster by the failing
 						table/column. Count how many tool calls failed per root cause. Cross-reference
-						databases/**/columns.md and description.md.
+						databases/**/columns.md.
 					</ListItem>
 					<ListItem>
 						Source-code context: if a warehouse gap traces back to SQL, dbt, docs, or application code in{' '}

--- a/apps/backend/src/components/ai/context-recommendations-prompt.tsx
+++ b/apps/backend/src/components/ai/context-recommendations-prompt.tsx
@@ -2,6 +2,7 @@ import { DBContextRecommendation } from '../../db/abstractSchema';
 import { Block, Bold, Code, List, ListItem, renderToMarkdown, Span, Title } from '../../lib/markdown';
 import type { FlaggedContextFile } from '../../services/context-recommendations.file-costs';
 import type { LinkedContextRepo } from '../../types/context-recommendation';
+import type { ContextPresence } from '../../utils/nao-config';
 
 type ExistingRecommendationSummary = Pick<
 	DBContextRecommendation,
@@ -17,6 +18,7 @@ type ContextRecommendationsPromptProps = {
 	linkedRepos?: LinkedContextRepo[];
 	contextRepoConnected?: boolean;
 	templates?: string[];
+	contextPresence?: ContextPresence;
 };
 
 export function renderContextRecommendationsPrompt(props: ContextRecommendationsPromptProps): string {
@@ -32,9 +34,12 @@ function ContextRecommendationsPrompt({
 	linkedRepos = [],
 	contextRepoConnected = false,
 	templates,
+	contextPresence,
 }: ContextRecommendationsPromptProps) {
-	const hasColumnsContext = templates === undefined || templates.includes('columns');
-	const hasProfilingContext = templates === undefined || templates.includes('profiling');
+	const hasColumnsContext =
+		contextPresence?.databases !== false && (templates === undefined || templates.includes('columns'));
+	const hasProfilingContext =
+		contextPresence?.databases !== false && (templates === undefined || templates.includes('profiling'));
 
 	return (
 		<Block>

--- a/apps/backend/src/components/ai/context-recommendations-prompt.tsx
+++ b/apps/backend/src/components/ai/context-recommendations-prompt.tsx
@@ -16,6 +16,7 @@ type ContextRecommendationsPromptProps = {
 	proposeFixes?: boolean;
 	linkedRepos?: LinkedContextRepo[];
 	contextRepoConnected?: boolean;
+	templates?: string[];
 };
 
 export function renderContextRecommendationsPrompt(props: ContextRecommendationsPromptProps): string {
@@ -30,7 +31,11 @@ function ContextRecommendationsPrompt({
 	proposeFixes = false,
 	linkedRepos = [],
 	contextRepoConnected = false,
+	templates,
 }: ContextRecommendationsPromptProps) {
+	const hasColumnsContext = templates === undefined || templates.includes('columns');
+	const hasProfilingContext = templates === undefined || templates.includes('profiling');
+
 	return (
 		<Block>
 			<Span>
@@ -42,8 +47,26 @@ function ContextRecommendationsPrompt({
 				<List ordered>
 					<ListItem>
 						Tool errors: v_messages where tool_state = &quot;output-error&quot; — cluster by the failing
-						table/column. Count how many tool calls failed per root cause. Cross-reference
-						databases/**/columns.md.
+						table/column. Count how many tool calls failed per root cause.
+						{hasColumnsContext && hasProfilingContext ? (
+							<>
+								{' '}
+								Cross-reference <Code>databases/**/columns.md</Code> for wrong-column failures and{' '}
+								<Code>databases/**/profiling.md</Code> (<Code>top_values</Code>) for wrong-value
+								failures.
+							</>
+						) : hasColumnsContext ? (
+							<>
+								{' '}
+								Cross-reference <Code>databases/**/columns.md</Code> for wrong-column failures.
+							</>
+						) : hasProfilingContext ? (
+							<>
+								{' '}
+								Cross-reference <Code>databases/**/profiling.md</Code> (<Code>top_values</Code>) for
+								wrong-value failures.
+							</>
+						) : null}
 					</ListItem>
 					<ListItem>
 						Source-code context: if a warehouse gap traces back to SQL, dbt, docs, or application code in{' '}

--- a/apps/backend/src/components/ai/context-recommendations-system-prompt.tsx
+++ b/apps/backend/src/components/ai/context-recommendations-system-prompt.tsx
@@ -3,12 +3,15 @@ import dbConfig, { Dialect } from '../../db/dbConfig';
 import { Block, Bold, Br, Code, CodeBlock, List, ListItem, renderToMarkdown, Span, Title } from '../../lib/markdown';
 import type { LinkedContextRepo } from '../../types/context-recommendation';
 import { ALLOWED_APP_DB_VIEWS } from '../../utils/app-db-allowlist';
+import type { ContextPresence } from '../../utils/nao-config';
 import { AppDbTimestamps } from './app-db-timestamps';
 import { NaoContextStructure } from './nao-context-structure';
 
 export function renderContextRecommendationsSystemPrompt(options?: {
 	proposeFixes?: boolean;
 	linkedRepos?: LinkedContextRepo[];
+	templates?: string[];
+	contextPresence?: ContextPresence;
 	contextRepoConnected?: boolean;
 	customInstructions?: string;
 }): string {
@@ -18,6 +21,8 @@ export function renderContextRecommendationsSystemPrompt(options?: {
 		<ContextRecommendationsSystemPrompt
 			proposeFixes={options?.proposeFixes ?? false}
 			linkedRepos={options?.linkedRepos ?? []}
+			templates={options?.templates}
+			contextPresence={options?.contextPresence}
 			contextRepoConnected={options?.contextRepoConnected ?? false}
 			customInstructions={customInstructions}
 		/>,
@@ -27,11 +32,15 @@ export function renderContextRecommendationsSystemPrompt(options?: {
 function ContextRecommendationsSystemPrompt({
 	proposeFixes,
 	linkedRepos,
+	templates,
+	contextPresence,
 	contextRepoConnected,
 	customInstructions,
 }: {
 	proposeFixes: boolean;
 	linkedRepos: LinkedContextRepo[];
+	templates?: string[];
+	contextPresence?: ContextPresence;
 	contextRepoConnected: boolean;
 	customInstructions?: string;
 }) {
@@ -50,7 +59,11 @@ function ContextRecommendationsSystemPrompt({
 				context that you may recommend improving, correcting, or extending.
 			</Span>
 
-			<NaoContextStructure />
+			<NaoContextStructure
+				templates={templates}
+				repoNames={linkedRepos.map((repo) => repo.name)}
+				contextPresence={contextPresence}
+			/>
 			<Span>
 				<Code>RULES.md</Code> and <Code>semantics/*.md</Code> hold the project-wide rules and metric definitions
 				the agent relies on — the most common place a fix belongs.

--- a/apps/backend/src/components/ai/nao-context-structure.tsx
+++ b/apps/backend/src/components/ai/nao-context-structure.tsx
@@ -1,28 +1,116 @@
-import { Block, Italic, List, ListItem, Title } from '../../lib/markdown';
+import { Block, Br, Code, List, ListItem, Title } from '../../lib/markdown';
+import type { ContextPresence } from '../../utils/nao-config';
 
 /** Explains how the nao project context is laid out on disk. Shared by every system prompt. */
-export function NaoContextStructure() {
+export function NaoContextStructure({
+	templates,
+	repoNames = [],
+	contextPresence,
+}: {
+	templates?: string[];
+	repoNames?: string[];
+	contextPresence?: ContextPresence;
+}) {
+	const visibleTemplates =
+		templates && templates.length > 0
+			? TEMPLATE_DESCRIPTIONS.filter(({ name }) => templates.includes(name))
+			: TEMPLATE_DESCRIPTIONS;
+	const repoPaths = repoNames.map((name) => `repos/${name}/`).join(', ');
+	const isPresent = (context: keyof ContextPresence) => contextPresence?.[context] !== false;
+
 	return (
 		<Block>
 			<Title level={2}>How nao Works</Title>
 			<List>
-				<ListItem>All the context available to you is stored as files in the project folder.</ListItem>
-				<ListItem>
-					In the <Italic>databases</Italic> folder you can find the databases context, each layer is a folder
-					from the databases, schema and then tables.
-				</ListItem>
-				<ListItem>
-					Folders are named like this: database=my_database, schema=my_schema, table=my_table.
-				</ListItem>
-				<ListItem>
-					Databases folders are named following this pattern: type={`<database_type>`}/database=
-					{`<database_name>`}/schema={`<schema_name>`}/table={`<table_name>`}.
-				</ListItem>
-				<ListItem>
-					Each table has files describing the table schema and the data in the table (like columns.md,
-					preview.md, etc.)
-				</ListItem>
+				{[
+					isPresent('rules') && (
+						<ListItem key='rules'>
+							<Code>RULES.md</Code> — project-wide rules; read it for project conventions.
+						</ListItem>
+					),
+					isPresent('semantics') && (
+						<ListItem key='semantics'>
+							<Code>semantics/</Code> — metric and business definitions; read them before calculating or
+							interpreting a named metric.
+						</ListItem>
+					),
+					isPresent('docs') && (
+						<ListItem key='docs'>
+							<Code>docs/</Code> — business documentation; read the relevant files before answering domain
+							questions.
+							{isPresent('notionDocs') && (
+								<>
+									{' '}
+									<Code>docs/notion/</Code> contains Notion content.
+								</>
+							)}
+						</ListItem>
+					),
+					repoNames.length > 0 && (
+						<ListItem key='repos'>
+							<Code>{repoPaths}</Code> — source repositories; read relevant dbt, SQL, application, or
+							documentation files to understand how data is produced.
+						</ListItem>
+					),
+					isPresent('databases') && (
+						<ListItem key='databases'>
+							<Code>databases/</Code> — warehouse context under{' '}
+							<Code>
+								type={'<database_type>'}/database={'<database_name>'}/schema={'<schema_name>'}/table=
+								{'<table_name>'}/
+							</Code>
+							. Inside each table folder:
+							<Br />
+							<List indent={1}>
+								{[
+									<ListItem key='annotations'>
+										<Code>annotations.md</Code> — human-written notes about this table; often empty,
+										but when it has content it is authoritative — prefer it over the generated files
+										if they disagree.
+									</ListItem>,
+									...visibleTemplates.map(({ name, description }) => (
+										<ListItem key={name}>
+											<Code>{name}.md</Code> — {description}
+										</ListItem>
+									)),
+								]}
+							</List>
+						</ListItem>
+					),
+				]}
 			</List>
 		</Block>
 	);
 }
+
+const TEMPLATE_DESCRIPTIONS = [
+	{
+		name: 'columns',
+		description:
+			'table description, row count, columns with types and descriptions, plus available partitioning, clustering, or index details; read before writing SQL and never guess column names.',
+	},
+	{
+		name: 'preview',
+		description:
+			'a handful of sample rows showing value formats; this is a tiny, non-representative sample, so never infer null rates, volumes, or value distributions from it.',
+	},
+	{
+		name: 'profiling',
+		description:
+			'per-column statistics as JSONL, including null and distinct counts, min/max, and top values; read before filtering on a column value or making a data-quality claim.',
+	},
+	{
+		name: 'query_history',
+		description:
+			'real table usage: query count, common joins, and top queries as SQL; read to find established join keys and query patterns.',
+	},
+	{
+		name: 'ai_summary',
+		description: (
+			<>
+				an LLM-written overview of the table, data-quality caveats, and suggested uses; use for orientation, but
+				verify specifics against <Code>columns.md</Code> and <Code>profiling.md</Code>.
+			</>
+		),
+	},
+] as const;

--- a/apps/backend/src/components/ai/nao-context-structure.tsx
+++ b/apps/backend/src/components/ai/nao-context-structure.tsx
@@ -15,6 +15,7 @@ export function NaoContextStructure({
 		templates && templates.length > 0
 			? TEMPLATE_DESCRIPTIONS.filter(({ name }) => templates.includes(name))
 			: TEMPLATE_DESCRIPTIONS;
+	const visibleTemplateNames = new Set(visibleTemplates.map(({ name }) => name));
 	const repoPaths = repoNames.map((name) => `repos/${name}/`).join(', ');
 	const isPresent = (context: keyof ContextPresence) => contextPresence?.[context] !== false;
 
@@ -70,7 +71,10 @@ export function NaoContextStructure({
 									</ListItem>,
 									...visibleTemplates.map(({ name, description }) => (
 										<ListItem key={name}>
-											<Code>{name}.md</Code> — {description}
+											<Code>{name}.md</Code> —{' '}
+											{typeof description === 'function'
+												? description(visibleTemplateNames)
+												: description}
 										</ListItem>
 									)),
 								]}
@@ -82,6 +86,32 @@ export function NaoContextStructure({
 		</Block>
 	);
 }
+
+function AiSummaryDescription({ visibleTemplateNames }: { visibleTemplateNames: ReadonlySet<string> }) {
+	const referencedTemplates = AI_SUMMARY_REFERENCE_TEMPLATES.filter((name) => visibleTemplateNames.has(name));
+
+	return (
+		<>
+			an LLM-written overview of the table, data-quality caveats, and suggested uses; use for orientation, but do
+			not treat it as ground truth
+			{referencedTemplates.length > 0 && (
+				<>
+					{' '}
+					— verify specifics against{' '}
+					{referencedTemplates.map((name, index) => (
+						<>
+							{index > 0 && ' and '}
+							<Code>{name}.md</Code>
+						</>
+					))}
+				</>
+			)}
+			.
+		</>
+	);
+}
+
+const AI_SUMMARY_REFERENCE_TEMPLATES = ['columns', 'profiling'] as const;
 
 const TEMPLATE_DESCRIPTIONS = [
 	{
@@ -106,11 +136,8 @@ const TEMPLATE_DESCRIPTIONS = [
 	},
 	{
 		name: 'ai_summary',
-		description: (
-			<>
-				an LLM-written overview of the table, data-quality caveats, and suggested uses; use for orientation, but
-				verify specifics against <Code>columns.md</Code> and <Code>profiling.md</Code>.
-			</>
+		description: (visibleTemplateNames: ReadonlySet<string>) => (
+			<AiSummaryDescription visibleTemplateNames={visibleTemplateNames} />
 		),
 	},
 ] as const;

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -9,6 +9,7 @@ import { tokenCounter } from '../../services/token-counter';
 import type { UserMemory } from '../../types/memory';
 import { MEMORY_CATEGORIES, MemoryCategory } from '../../types/memory';
 import { formatCurrentDate } from '../../utils/date';
+import type { ContextPresence } from '../../utils/nao-config';
 import { groupBy } from '../../utils/utils';
 import { getDialectSqlQueryRules, getDialectToolCallRules } from './dialect-rules';
 import { NaoContextStructure } from './nao-context-structure';
@@ -28,6 +29,9 @@ type SystemPromptProps = {
 	customCharts?: ChartPluginManifestEntry[];
 	/** Names of MCP servers the agent is allowed to call (tools discovered as on-disk specs). */
 	mcpServers?: string[];
+	templates?: string[];
+	repoNames?: string[];
+	contextPresence?: ContextPresence;
 	timezone?: string;
 	testMode?: boolean;
 	/** Names of the tools in the run's tool set — rules for surface-dependent tools (e.g. display_map) are only emitted when the tool is present. Omit to include every rule. */
@@ -51,6 +55,9 @@ export function SystemPrompt({
 	internalSkills = listInternalSkills(),
 	customCharts = [],
 	mcpServers = [],
+	templates,
+	repoNames = [],
+	contextPresence,
 	timezone,
 	testMode,
 	toolNames,
@@ -82,7 +89,7 @@ export function SystemPrompt({
 				<Br />
 				Skills can be mentioned using the / trigger.
 			</Span>
-			<NaoContextStructure />
+			<NaoContextStructure templates={templates} repoNames={repoNames} contextPresence={contextPresence} />
 			<Title level={2}>Persona</Title>
 			<List>
 				<ListItem>

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -64,6 +64,7 @@ import {
 	resolveProviderSettings,
 } from '../utils/llm';
 import { logger } from '../utils/logger';
+import { extractConfiguredRepos, extractConfiguredTemplates, extractContextPresence } from '../utils/nao-config';
 import { addPromptCache } from '../utils/prompt-cache';
 import { scheduleSaveLlmInferenceRecord } from '../utils/schedule-task';
 import { sanitizeTitle, TITLE_MAX_OUTPUT_TOKENS, titleFromPrompt, titleGenerationUserMessage } from '../utils/title';
@@ -599,6 +600,9 @@ class AgentManager {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
+		const templates = extractConfiguredTemplates(this._toolContext.projectFolder);
+		const repoNames = extractConfiguredRepos(this._toolContext.projectFolder).map((repo) => repo.name);
+		const contextPresence = extractContextPresence(this._toolContext.projectFolder);
 		const skills = skillService.getSkills(this.chat.projectId);
 		const customCharts = this._toolContext.supportsCustomCharts
 			? listChartPlugins(this._toolContext.projectFolder)
@@ -612,6 +616,9 @@ class AgentManager {
 				skills,
 				customCharts,
 				mcpServers,
+				templates,
+				repoNames,
+				contextPresence,
 				timezone,
 				testMode: this.chat.testMode,
 				toolNames: Object.keys(this._agentTools),

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -64,7 +64,7 @@ import {
 	resolveProviderSettings,
 } from '../utils/llm';
 import { logger } from '../utils/logger';
-import { extractConfiguredRepos, extractConfiguredTemplates, extractContextPresence } from '../utils/nao-config';
+import { readProjectContext } from '../utils/nao-config';
 import { addPromptCache } from '../utils/prompt-cache';
 import { scheduleSaveLlmInferenceRecord } from '../utils/schedule-task';
 import { sanitizeTitle, TITLE_MAX_OUTPUT_TOKENS, titleFromPrompt, titleGenerationUserMessage } from '../utils/title';
@@ -600,9 +600,8 @@ class AgentManager {
 		const memories = await memoryService.safeGetUserMemories(this.chat.userId, this.chat.projectId, this.chat.id);
 		const userRules = getUserRules(this._toolContext.projectFolder);
 		const connections = getConnections(this._toolContext.projectFolder);
-		const templates = extractConfiguredTemplates(this._toolContext.projectFolder);
-		const repoNames = extractConfiguredRepos(this._toolContext.projectFolder).map((repo) => repo.name);
-		const contextPresence = extractContextPresence(this._toolContext.projectFolder);
+		const { repos, templates, presence: contextPresence } = readProjectContext(this._toolContext.projectFolder);
+		const repoNames = repos.map((repo) => repo.name);
 		const skills = skillService.getSkills(this.chat.projectId);
 		const customCharts = this._toolContext.supportsCustomCharts
 			? listChartPlugins(this._toolContext.projectFolder)

--- a/apps/backend/src/services/context-recommendations.service.ts
+++ b/apps/backend/src/services/context-recommendations.service.ts
@@ -88,6 +88,7 @@ export async function runContextRecommendations(
 					proposeFixes,
 					linkedRepos,
 					templates,
+					contextPresence,
 					contextRepoConnected: !!contextRepo,
 				}),
 				source: 'contextRecommendations',

--- a/apps/backend/src/services/context-recommendations.service.ts
+++ b/apps/backend/src/services/context-recommendations.service.ts
@@ -15,7 +15,7 @@ import * as projectQueries from '../queries/project.queries';
 import { DEFAULT_MAX_AUTO_PRS_PER_RUN, RecommendationInsight } from '../types/context-recommendation';
 import { resolveDefaultModelSelection } from '../utils/llm';
 import { logger } from '../utils/logger';
-import { extractConfiguredRepos } from '../utils/nao-config';
+import { readProjectContext } from '../utils/nao-config';
 import { agentService } from './agent';
 import { autoCreateRecommendationPullRequests, resolveRecommendationRepo } from './context-pr.service';
 import { ensureFeedbackCoverage, normalizeFeedbackLinks } from './context-recommendations.feedback-coverage';
@@ -59,7 +59,10 @@ export async function runContextRecommendations(
 
 	try {
 		const project = await projectQueries.getProjectById(projectId);
-		const linkedRepos = project?.path ? extractConfiguredRepos(project.path) : [];
+		const projectContext = project?.path ? readProjectContext(project.path) : undefined;
+		const linkedRepos = projectContext?.repos ?? [];
+		const templates = projectContext?.templates;
+		const contextPresence = projectContext?.presence;
 		const contextRepo = await resolveRecommendationRepo(projectId);
 		const proposeFixes = !!project?.path && (!!contextRepo || linkedRepos.some((repo) => repo.repoFullName));
 		const fixCollector = proposeFixes
@@ -84,6 +87,7 @@ export async function runContextRecommendations(
 					fileReadCosts,
 					proposeFixes,
 					linkedRepos,
+					templates,
 					contextRepoConnected: !!contextRepo,
 				}),
 				source: 'contextRecommendations',
@@ -103,6 +107,8 @@ export async function runContextRecommendations(
 			systemPrompt: renderContextRecommendationsSystemPrompt({
 				proposeFixes,
 				linkedRepos,
+				templates,
+				contextPresence,
 				contextRepoConnected: !!contextRepo,
 				customInstructions: config?.customSystemPromptInstructions ?? undefined,
 			}),

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -111,9 +111,6 @@ function configuredTemplatesFrom(config: unknown): string[] {
 		}
 
 		const templates = getDatabaseTemplates(database);
-		if (templates === null) {
-			continue;
-		}
 		const migratedTemplates = [
 			...new Set(
 				templates
@@ -152,17 +149,17 @@ function hasDirectoryContent(directoryPath: string): boolean {
 	}
 }
 
-function getDatabaseTemplates(database: Record<string, unknown>): string[] | null {
+function getDatabaseTemplates(database: Record<string, unknown>): string[] {
 	if (!('templates' in database) && !('accessors' in database)) {
 		return [...DEFAULT_DATABASE_TEMPLATES];
 	}
 
 	const templates = 'templates' in database ? database.templates : database.accessors;
 	if (!Array.isArray(templates)) {
-		return null;
+		return [...DEFAULT_DATABASE_TEMPLATES];
 	}
 	const stringTemplates = templates.filter((template): template is string => typeof template === 'string');
-	return templates.length === 0 || stringTemplates.length > 0 ? stringTemplates : null;
+	return templates.length === 0 || stringTemplates.length > 0 ? stringTemplates : [...DEFAULT_DATABASE_TEMPLATES];
 }
 
 function loadConfig(configPath: string): unknown {

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -9,6 +9,16 @@ import type { LinkedContextRepo } from '../types/context-recommendation';
 import { logger } from './logger';
 
 const ENV_PATTERN = /\$?\{\{\s*env\(['"]([^'"]+)['"]\)\s*\}\}/g;
+const DATABASE_TEMPLATES = ['columns', 'preview', 'profiling', 'query_history', 'ai_summary'] as const;
+const DEFAULT_DATABASE_TEMPLATES = ['columns', 'query_history', 'preview'] as const;
+
+export type ContextPresence = {
+	rules: boolean;
+	semantics: boolean;
+	docs: boolean;
+	notionDocs: boolean;
+	databases: boolean;
+};
 
 export function extractRequiredEnvVars(projectFolder: string): string[] {
 	const configPath = path.join(projectFolder, 'nao_config.yaml');
@@ -60,6 +70,69 @@ export function extractConfiguredRepos(projectFolder: string): LinkedContextRepo
 			},
 		];
 	});
+}
+
+/** Returns the database templates enabled across all configured databases. */
+export function extractConfiguredTemplates(projectFolder: string): string[] {
+	const configPath = path.join(projectFolder, 'nao_config.yaml');
+	if (!fs.existsSync(configPath)) {
+		return [];
+	}
+
+	const config = loadConfig(configPath);
+	if (!isRecord(config) || !Array.isArray(config.databases)) {
+		return [];
+	}
+
+	const configuredTemplates = new Set<string>();
+	for (const database of config.databases) {
+		if (!isRecord(database)) {
+			continue;
+		}
+
+		const templates = getDatabaseTemplates(database);
+		for (const template of templates) {
+			const normalizedTemplate = template === 'how_to_use' ? 'query_history' : template;
+			if (normalizedTemplate !== 'description') {
+				configuredTemplates.add(normalizedTemplate);
+			}
+		}
+	}
+
+	return DATABASE_TEMPLATES.filter((template) => configuredTemplates.has(template));
+}
+
+/** Returns which filesystem-backed project context is available to read. */
+export function extractContextPresence(projectFolder: string): ContextPresence {
+	return {
+		rules: fs.existsSync(path.join(projectFolder, 'RULES.md')),
+		semantics: hasDirectoryContent(path.join(projectFolder, 'semantics')),
+		docs: hasDirectoryContent(path.join(projectFolder, 'docs')),
+		notionDocs: hasDirectoryContent(path.join(projectFolder, 'docs', 'notion')),
+		databases: hasDirectoryContent(path.join(projectFolder, 'databases')),
+	};
+}
+
+function hasDirectoryContent(directoryPath: string): boolean {
+	if (!fs.existsSync(directoryPath)) {
+		return false;
+	}
+	try {
+		return fs.readdirSync(directoryPath).length > 0;
+	} catch {
+		return false;
+	}
+}
+
+function getDatabaseTemplates(database: Record<string, unknown>): string[] {
+	if (!('templates' in database) && !('accessors' in database)) {
+		return [...DEFAULT_DATABASE_TEMPLATES];
+	}
+
+	const templates = 'templates' in database ? database.templates : database.accessors;
+	return Array.isArray(templates)
+		? templates.filter((template): template is string => typeof template === 'string')
+		: [];
 }
 
 function loadConfig(configPath: string): unknown {

--- a/apps/backend/src/utils/nao-config.ts
+++ b/apps/backend/src/utils/nao-config.ts
@@ -10,7 +10,7 @@ import { logger } from './logger';
 
 const ENV_PATTERN = /\$?\{\{\s*env\(['"]([^'"]+)['"]\)\s*\}\}/g;
 const DATABASE_TEMPLATES = ['columns', 'preview', 'profiling', 'query_history', 'ai_summary'] as const;
-const DEFAULT_DATABASE_TEMPLATES = ['columns', 'query_history', 'preview'] as const;
+const DEFAULT_DATABASE_TEMPLATES = ['columns', 'preview'] as const;
 
 export type ContextPresence = {
 	rules: boolean;
@@ -37,12 +37,39 @@ export function extractRequiredEnvVars(projectFolder: string): string[] {
 }
 
 export function extractConfiguredRepos(projectFolder: string): LinkedContextRepo[] {
-	const configPath = path.join(projectFolder, 'nao_config.yaml');
-	if (!fs.existsSync(configPath)) {
-		return [];
-	}
+	return configuredReposFrom(loadProjectConfig(projectFolder));
+}
 
-	const config = loadConfig(configPath);
+/** Returns configured database templates, falling back to the default when unavailable. */
+export function extractConfiguredTemplates(projectFolder: string): string[] {
+	return configuredTemplatesFrom(loadProjectConfig(projectFolder));
+}
+
+export function readProjectContext(projectFolder: string): {
+	repos: LinkedContextRepo[];
+	templates: string[];
+	presence: ContextPresence;
+} {
+	const config = loadProjectConfig(projectFolder);
+	return {
+		repos: configuredReposFrom(config),
+		templates: configuredTemplatesFrom(config),
+		presence: extractContextPresence(projectFolder),
+	};
+}
+
+/** Returns which filesystem-backed project context is available to read. */
+export function extractContextPresence(projectFolder: string): ContextPresence {
+	return {
+		rules: fs.existsSync(path.join(projectFolder, 'RULES.md')),
+		semantics: hasDirectoryContent(path.join(projectFolder, 'semantics')),
+		docs: hasDirectoryContent(path.join(projectFolder, 'docs')),
+		notionDocs: hasDirectoryContent(path.join(projectFolder, 'docs', 'notion')),
+		databases: hasDirectoryContent(path.join(projectFolder, 'databases')),
+	};
+}
+
+function configuredReposFrom(config: unknown): LinkedContextRepo[] {
 	if (!isRecord(config) || !Array.isArray(config.repos)) {
 		return [];
 	}
@@ -72,16 +99,9 @@ export function extractConfiguredRepos(projectFolder: string): LinkedContextRepo
 	});
 }
 
-/** Returns the database templates enabled across all configured databases. */
-export function extractConfiguredTemplates(projectFolder: string): string[] {
-	const configPath = path.join(projectFolder, 'nao_config.yaml');
-	if (!fs.existsSync(configPath)) {
-		return [];
-	}
-
-	const config = loadConfig(configPath);
+function configuredTemplatesFrom(config: unknown): string[] {
 	if (!isRecord(config) || !Array.isArray(config.databases)) {
-		return [];
+		return [...DEFAULT_DATABASE_TEMPLATES];
 	}
 
 	const configuredTemplates = new Set<string>();
@@ -91,26 +111,29 @@ export function extractConfiguredTemplates(projectFolder: string): string[] {
 		}
 
 		const templates = getDatabaseTemplates(database);
-		for (const template of templates) {
-			const normalizedTemplate = template === 'how_to_use' ? 'query_history' : template;
-			if (normalizedTemplate !== 'description') {
-				configuredTemplates.add(normalizedTemplate);
-			}
+		if (templates === null) {
+			continue;
+		}
+		const migratedTemplates = [
+			...new Set(
+				templates
+					.filter((template) => template !== 'description')
+					.map((template) => (template === 'how_to_use' ? 'query_history' : template)),
+			),
+		];
+		const resolvedTemplates = migratedTemplates.length > 0 ? migratedTemplates : DEFAULT_DATABASE_TEMPLATES;
+		for (const template of resolvedTemplates) {
+			configuredTemplates.add(template);
 		}
 	}
 
-	return DATABASE_TEMPLATES.filter((template) => configuredTemplates.has(template));
+	const resolvedTemplates = DATABASE_TEMPLATES.filter((template) => configuredTemplates.has(template));
+	return resolvedTemplates.length > 0 ? resolvedTemplates : [...DEFAULT_DATABASE_TEMPLATES];
 }
 
-/** Returns which filesystem-backed project context is available to read. */
-export function extractContextPresence(projectFolder: string): ContextPresence {
-	return {
-		rules: fs.existsSync(path.join(projectFolder, 'RULES.md')),
-		semantics: hasDirectoryContent(path.join(projectFolder, 'semantics')),
-		docs: hasDirectoryContent(path.join(projectFolder, 'docs')),
-		notionDocs: hasDirectoryContent(path.join(projectFolder, 'docs', 'notion')),
-		databases: hasDirectoryContent(path.join(projectFolder, 'databases')),
-	};
+function loadProjectConfig(projectFolder: string): unknown {
+	const configPath = path.join(projectFolder, 'nao_config.yaml');
+	return fs.existsSync(configPath) ? loadConfig(configPath) : null;
 }
 
 function hasDirectoryContent(directoryPath: string): boolean {
@@ -118,21 +141,28 @@ function hasDirectoryContent(directoryPath: string): boolean {
 		return false;
 	}
 	try {
-		return fs.readdirSync(directoryPath).length > 0;
+		return fs.readdirSync(directoryPath, { withFileTypes: true }).some((entry) => {
+			if (entry.isFile()) {
+				return true;
+			}
+			return entry.isDirectory() && hasDirectoryContent(path.join(directoryPath, entry.name));
+		});
 	} catch {
 		return false;
 	}
 }
 
-function getDatabaseTemplates(database: Record<string, unknown>): string[] {
+function getDatabaseTemplates(database: Record<string, unknown>): string[] | null {
 	if (!('templates' in database) && !('accessors' in database)) {
 		return [...DEFAULT_DATABASE_TEMPLATES];
 	}
 
 	const templates = 'templates' in database ? database.templates : database.accessors;
-	return Array.isArray(templates)
-		? templates.filter((template): template is string => typeof template === 'string')
-		: [];
+	if (!Array.isArray(templates)) {
+		return null;
+	}
+	const stringTemplates = templates.filter((template): template is string => typeof template === 'string');
+	return templates.length === 0 || stringTemplates.length > 0 ? stringTemplates : null;
 }
 
 function loadConfig(configPath: string): unknown {

--- a/apps/backend/tests/context-recommendations-prompt.test.ts
+++ b/apps/backend/tests/context-recommendations-prompt.test.ts
@@ -30,4 +30,38 @@ describe('context recommendations prompt', () => {
 		expect(markdown).not.toContain('`databases/**/profiling.md`');
 		expect(markdown).toContain('Count how many tool calls failed per root cause.');
 	});
+
+	it('omits database cross-references when database context is absent', () => {
+		const markdown = renderContextRecommendationsPrompt({
+			...BASE_PROPS,
+			templates: ['columns', 'profiling'],
+			contextPresence: {
+				rules: true,
+				semantics: true,
+				docs: true,
+				notionDocs: true,
+				databases: false,
+			},
+		});
+
+		expect(markdown).not.toContain('`databases/**/columns.md`');
+		expect(markdown).not.toContain('`databases/**/profiling.md`');
+	});
+
+	it('renders configured database cross-references when database context is present', () => {
+		const markdown = renderContextRecommendationsPrompt({
+			...BASE_PROPS,
+			templates: ['columns', 'profiling'],
+			contextPresence: {
+				rules: false,
+				semantics: false,
+				docs: false,
+				notionDocs: false,
+				databases: true,
+			},
+		});
+
+		expect(markdown).toContain('`databases/**/columns.md` for wrong-column failures');
+		expect(markdown).toContain('`databases/**/profiling.md` (`top_values`) for wrong-value failures');
+	});
 });

--- a/apps/backend/tests/context-recommendations-prompt.test.ts
+++ b/apps/backend/tests/context-recommendations-prompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderContextRecommendationsPrompt } from '../src/components/ai/context-recommendations-prompt';
+
+const BASE_PROPS = {
+	windowStart: new Date('2026-01-01T00:00:00.000Z'),
+	windowEnd: new Date('2026-02-01T00:00:00.000Z'),
+	existing: [],
+};
+
+describe('context recommendations prompt', () => {
+	it('names columns and profiling context when templates are unknown', () => {
+		const markdown = renderContextRecommendationsPrompt(BASE_PROPS);
+
+		expect(markdown).toContain('`databases/**/columns.md` for wrong-column failures');
+		expect(markdown).toContain('`databases/**/profiling.md` (`top_values`) for wrong-value failures');
+	});
+
+	it('names only columns context when only columns is configured', () => {
+		const markdown = renderContextRecommendationsPrompt({ ...BASE_PROPS, templates: ['columns'] });
+
+		expect(markdown).toContain('`databases/**/columns.md` for wrong-column failures');
+		expect(markdown).not.toContain('`databases/**/profiling.md`');
+	});
+
+	it('omits the cross-reference clause when neither diagnostic template is configured', () => {
+		const markdown = renderContextRecommendationsPrompt({ ...BASE_PROPS, templates: ['preview', 'query_history'] });
+
+		expect(markdown).not.toContain('`databases/**/columns.md`');
+		expect(markdown).not.toContain('`databases/**/profiling.md`');
+		expect(markdown).toContain('Count how many tool calls failed per root cause.');
+	});
+});

--- a/apps/backend/tests/context-recommendations-system-prompt.test.ts
+++ b/apps/backend/tests/context-recommendations-system-prompt.test.ts
@@ -3,6 +3,53 @@ import { describe, expect, it } from 'vitest';
 import { renderContextRecommendationsSystemPrompt } from '../src/components/ai/context-recommendations-system-prompt';
 
 describe('context recommendations system prompt', () => {
+	it('renders only configured project context and names repositories', () => {
+		const markdown = renderContextRecommendationsSystemPrompt({
+			templates: ['columns'],
+			contextPresence: {
+				rules: true,
+				semantics: false,
+				docs: false,
+				notionDocs: false,
+				databases: true,
+			},
+			linkedRepos: [
+				{
+					name: 'dbt',
+					contextPath: 'repos/dbt',
+					url: null,
+					branch: null,
+					localPath: null,
+					repoFullName: null,
+					provider: null,
+				},
+			],
+		});
+
+		expect(markdown).toContain('\n- `RULES.md` —');
+		expect(markdown).not.toContain('\n- `semantics/` —');
+		expect(markdown).not.toContain('\n- `docs/` —');
+		expect(markdown).toContain('\n- `repos/dbt/` —');
+		expect(markdown).toContain('\n- `databases/` —');
+		expect(markdown).toContain('\n\t- `annotations.md` —');
+		expect(markdown).toContain('\n\t- `columns.md` —');
+		expect(markdown).not.toContain('\n\t- `preview.md` —');
+		expect(markdown).not.toContain('\n\t- `profiling.md` —');
+		expect(markdown).not.toContain('\n\t- `query_history.md` —');
+		expect(markdown).not.toContain('\n\t- `ai_summary.md` —');
+	});
+
+	it('describes all folders and templates when project context is unknown', () => {
+		const markdown = renderContextRecommendationsSystemPrompt();
+
+		for (const contextPath of ['RULES.md', 'semantics/', 'docs/', 'databases/']) {
+			expect(markdown).toContain(`\n- \`${contextPath}\` —`);
+		}
+		for (const template of ['columns.md', 'preview.md', 'profiling.md', 'query_history.md', 'ai_summary.md']) {
+			expect(markdown).toContain(`\n\t- \`${template}\` —`);
+		}
+	});
+
 	it('includes custom instructions when configured', () => {
 		const markdown = renderContextRecommendationsSystemPrompt({
 			customInstructions: 'Prioritize recommendations about revenue definitions.',

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -235,15 +235,37 @@ describe('extractConfiguredTemplates', () => {
 		}
 	});
 
-	it('uses the default templates for malformed database templates', () => {
+	it('uses the default templates for a lone database with malformed templates', () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
 		try {
 			fs.writeFileSync(
 				path.join(dir, 'nao_config.yaml'),
-				['databases:', '  - type: duckdb', '    name: demo', '    templates: 5'].join('\n'),
+				['databases:', '  - type: duckdb', '    name: demo', '    templates: "columns"'].join('\n'),
 			);
 
 			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('includes defaults when one database has malformed templates', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    name: malformed',
+					'    templates: [123]',
+					'  - type: postgres',
+					'    name: configured',
+					'    templates: [profiling]',
+				].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview', 'profiling']);
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { extractConfiguredRepos } from '../src/utils/nao-config';
+import { extractConfiguredRepos, extractConfiguredTemplates, extractContextPresence } from '../src/utils/nao-config';
 
 vi.mock('../src/utils/logger', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -106,6 +106,160 @@ describe('extractConfiguredRepos', () => {
 					url: 'https://bitbucket.org/nao/dbt-models.git',
 				},
 			]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+});
+
+describe('extractConfiguredTemplates', () => {
+	it('uses the default templates when a database omits templates', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    name: demo',
+					'    profiling:',
+					'      refresh_policy: always',
+					'    ai_summary:',
+					'      refresh_policy: once',
+				].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview', 'query_history']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('returns the stable union across databases', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    name: first',
+					'    templates: [ai_summary, columns]',
+					'  - type: postgres',
+					'    name: second',
+					'    templates: [profiling, preview, columns]',
+				].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview', 'profiling', 'ai_summary']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('migrates how_to_use and drops description', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    name: demo',
+					'    templates: [description, how_to_use, unknown]',
+				].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['query_history']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('accepts accessors as a legacy templates alias', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				['databases:', '  - type: duckdb', '    name: demo', '    accessors: [columns, profiling]'].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'profiling']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('returns an empty list for missing or invalid config', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			expect(extractConfiguredTemplates(dir)).toEqual([]);
+
+			fs.writeFileSync(path.join(dir, 'nao_config.yaml'), 'databases: [');
+			expect(extractConfiguredTemplates(dir)).toEqual([]);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+});
+
+describe('extractContextPresence', () => {
+	it('reports missing context as absent', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			expect(extractContextPresence(dir)).toEqual({
+				rules: false,
+				semantics: false,
+				docs: false,
+				notionDocs: false,
+				databases: false,
+			});
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('reports empty context folders as absent', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			for (const folder of ['semantics', 'docs', 'databases']) {
+				fs.mkdirSync(path.join(dir, folder));
+			}
+
+			expect(extractContextPresence(dir)).toEqual({
+				rules: false,
+				semantics: false,
+				docs: false,
+				notionDocs: false,
+				databases: false,
+			});
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('reports non-empty context as present', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(path.join(dir, 'RULES.md'), '# Rules');
+			for (const [folder, file] of [
+				['semantics', 'metrics.md'],
+				['docs', 'overview.md'],
+				['docs/notion', 'workspace.md'],
+				['databases', 'context.md'],
+			]) {
+				const folderPath = path.join(dir, folder);
+				fs.mkdirSync(folderPath, { recursive: true });
+				fs.writeFileSync(path.join(folderPath, file), 'context');
+			}
+
+			expect(extractContextPresence(dir)).toEqual({
+				rules: true,
+				semantics: true,
+				docs: true,
+				notionDocs: true,
+				databases: true,
+			});
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}

--- a/apps/backend/tests/nao-config.test.ts
+++ b/apps/backend/tests/nao-config.test.ts
@@ -4,7 +4,12 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { extractConfiguredRepos, extractConfiguredTemplates, extractContextPresence } from '../src/utils/nao-config';
+import {
+	extractConfiguredRepos,
+	extractConfiguredTemplates,
+	extractContextPresence,
+	readProjectContext,
+} from '../src/utils/nao-config';
 
 vi.mock('../src/utils/logger', () => ({
 	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -129,7 +134,35 @@ describe('extractConfiguredTemplates', () => {
 				].join('\n'),
 			);
 
-			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview', 'query_history']);
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('uses the default templates when templates is empty', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				['databases:', '  - type: duckdb', '    name: demo', '    templates: []'].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('uses the default templates when migration removes every template', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				['databases:', '  - type: duckdb', '    name: demo', '    templates: [description]'].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}
@@ -190,13 +223,27 @@ describe('extractConfiguredTemplates', () => {
 		}
 	});
 
-	it('returns an empty list for missing or invalid config', () => {
+	it('uses the default templates for missing or invalid config', () => {
 		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
 		try {
-			expect(extractConfiguredTemplates(dir)).toEqual([]);
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
 
 			fs.writeFileSync(path.join(dir, 'nao_config.yaml'), 'databases: [');
-			expect(extractConfiguredTemplates(dir)).toEqual([]);
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('uses the default templates for malformed database templates', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				['databases:', '  - type: duckdb', '    name: demo', '    templates: 5'].join('\n'),
+			);
+
+			expect(extractConfiguredTemplates(dir)).toEqual(['columns', 'preview']);
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });
 		}
@@ -225,6 +272,7 @@ describe('extractContextPresence', () => {
 			for (const folder of ['semantics', 'docs', 'databases']) {
 				fs.mkdirSync(path.join(dir, folder));
 			}
+			fs.mkdirSync(path.join(dir, 'docs', 'notion'));
 
 			expect(extractContextPresence(dir)).toEqual({
 				rules: false,
@@ -244,9 +292,8 @@ describe('extractContextPresence', () => {
 			fs.writeFileSync(path.join(dir, 'RULES.md'), '# Rules');
 			for (const [folder, file] of [
 				['semantics', 'metrics.md'],
-				['docs', 'overview.md'],
 				['docs/notion', 'workspace.md'],
-				['databases', 'context.md'],
+				['databases/type=duckdb', 'context.md'],
 			]) {
 				const folderPath = path.join(dir, folder);
 				fs.mkdirSync(folderPath, { recursive: true });
@@ -259,6 +306,56 @@ describe('extractContextPresence', () => {
 				docs: true,
 				notionDocs: true,
 				databases: true,
+			});
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+});
+
+describe('readProjectContext', () => {
+	it('returns the same project context as the individual extractors', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			fs.writeFileSync(
+				path.join(dir, 'nao_config.yaml'),
+				[
+					'databases:',
+					'  - type: duckdb',
+					'    name: demo',
+					'    templates: [columns, profiling]',
+					'repos:',
+					'  - name: dbt',
+					'    url: https://github.com/nao/dbt-models.git',
+				].join('\n'),
+			);
+			fs.writeFileSync(path.join(dir, 'RULES.md'), '# Rules');
+			fs.mkdirSync(path.join(dir, 'docs'));
+			fs.writeFileSync(path.join(dir, 'docs', 'overview.md'), '# Overview');
+
+			expect(readProjectContext(dir)).toEqual({
+				repos: extractConfiguredRepos(dir),
+				templates: extractConfiguredTemplates(dir),
+				presence: extractContextPresence(dir),
+			});
+		} finally {
+			fs.rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	it('returns defaults and absent presence when config is missing', () => {
+		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-config-'));
+		try {
+			expect(readProjectContext(dir)).toEqual({
+				repos: [],
+				templates: ['columns', 'preview'],
+				presence: {
+					rules: false,
+					semantics: false,
+					docs: false,
+					notionDocs: false,
+					databases: false,
+				},
 			});
 		} finally {
 			fs.rmSync(dir, { force: true, recursive: true });

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -114,6 +114,98 @@ describe('SystemPrompt timezone rendering', () => {
 	});
 });
 
+describe('SystemPrompt context structure', () => {
+	it('describes all table templates when templates are omitted or empty', () => {
+		const withoutTemplates = renderToMarkdown(SystemPrompt({ internalSkills: [] }));
+		const withEmptyTemplates = renderToMarkdown(SystemPrompt({ templates: [], internalSkills: [] }));
+
+		for (const contextPath of ['RULES.md', 'semantics/', 'docs/', 'docs/notion/', 'databases/']) {
+			expect(withoutTemplates).toContain(`\`${contextPath}\``);
+		}
+		for (const template of ['columns.md', 'preview.md', 'profiling.md', 'query_history.md', 'ai_summary.md']) {
+			expect(withoutTemplates).toContain(`\n\t- \`${template}\``);
+			expect(withEmptyTemplates).toContain(`\n\t- \`${template}\``);
+		}
+		expect(withoutTemplates).toContain('\n\t- `annotations.md` —');
+		expect(withoutTemplates).toContain('Inside each table folder:');
+		expect(withoutTemplates).toContain('table description, row count, columns with types and descriptions');
+		expect(withoutTemplates).toContain('tiny, non-representative sample');
+		expect(withoutTemplates).toContain('per-column statistics as JSONL');
+		expect(withoutTemplates).toContain('common joins, and top queries as SQL');
+		expect(withoutTemplates).toContain('an LLM-written overview of the table');
+	});
+
+	it('describes only the configured table templates plus annotations', () => {
+		const markdown = renderToMarkdown(SystemPrompt({ templates: ['columns'], internalSkills: [] }));
+
+		expect(markdown).toContain('\n\t- `annotations.md` —');
+		expect(markdown).toContain('\n\t- `columns.md` —');
+		expect(markdown).not.toContain('`preview.md`');
+		expect(markdown).not.toContain('`profiling.md`');
+		expect(markdown).not.toContain('`query_history.md`');
+		expect(markdown).not.toContain('`ai_summary.md`');
+	});
+
+	it('shows only context reported as present', () => {
+		const absent = renderToMarkdown(
+			SystemPrompt({
+				contextPresence: {
+					rules: false,
+					semantics: false,
+					docs: false,
+					notionDocs: false,
+					databases: false,
+				},
+				internalSkills: [],
+			}),
+		);
+		const present = renderToMarkdown(
+			SystemPrompt({
+				contextPresence: {
+					rules: true,
+					semantics: true,
+					docs: true,
+					notionDocs: true,
+					databases: true,
+				},
+				internalSkills: [],
+			}),
+		);
+		const docsWithoutNotion = renderToMarkdown(
+			SystemPrompt({
+				contextPresence: {
+					rules: false,
+					semantics: false,
+					docs: true,
+					notionDocs: false,
+					databases: false,
+				},
+				internalSkills: [],
+			}),
+		);
+
+		for (const contextPath of ['RULES.md', 'semantics/', 'docs/', 'docs/notion/', 'databases/']) {
+			expect(absent).not.toContain(`\n- \`${contextPath}\``);
+			expect(present).toContain(`\`${contextPath}\``);
+		}
+		expect(docsWithoutNotion).toContain('`docs/` —');
+		expect(docsWithoutNotion).not.toContain('`docs/notion/`');
+	});
+
+	it('names configured repositories', () => {
+		const markdown = renderToMarkdown(SystemPrompt({ repoNames: ['dbt', 'api'], internalSkills: [] }));
+
+		expect(markdown).toContain('`repos/dbt/, repos/api/` —');
+	});
+
+	it('omits repositories when none are configured', () => {
+		const markdown = renderToMarkdown(SystemPrompt({ repoNames: [], internalSkills: [] }));
+
+		expect(markdown).not.toContain('`repos/<name>/`');
+		expect(markdown).not.toContain('— source repositories;');
+	});
+});
+
 describe('SystemPrompt saved files rules', () => {
 	it('tells the agent grep also searches inside saved files on a filesystem backend', () => {
 		const markdown = renderToMarkdown(SystemPrompt({ options: { canGrepSavedFiles: true } }));

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -5,6 +5,10 @@ import { SystemPrompt } from '../src/components/ai/system-prompt';
 import { renderToMarkdown } from '../src/lib/markdown';
 import { formatCurrentDate, resolveTimezone } from '../src/utils/date';
 
+function getTemplateLine(markdown: string, template: string): string {
+	return markdown.split('\n').find((line) => line.includes(`\`${template}.md\` —`)) ?? '';
+}
+
 describe('resolveTimezone', () => {
 	it('returns UTC when no timezone is provided', () => {
 		expect(resolveTimezone()).toBe('UTC');
@@ -144,6 +148,28 @@ describe('SystemPrompt context structure', () => {
 		expect(markdown).not.toContain('`profiling.md`');
 		expect(markdown).not.toContain('`query_history.md`');
 		expect(markdown).not.toContain('`ai_summary.md`');
+	});
+
+	it('references only visible source files from the ai_summary description', () => {
+		const bothVisible = getTemplateLine(
+			renderToMarkdown(SystemPrompt({ templates: ['ai_summary', 'columns', 'profiling'], internalSkills: [] })),
+			'ai_summary',
+		);
+		const columnsVisible = getTemplateLine(
+			renderToMarkdown(SystemPrompt({ templates: ['ai_summary', 'columns'], internalSkills: [] })),
+			'ai_summary',
+		);
+		const neitherVisible = getTemplateLine(
+			renderToMarkdown(SystemPrompt({ templates: ['ai_summary'], internalSkills: [] })),
+			'ai_summary',
+		);
+
+		expect(bothVisible).toContain('verify specifics against `columns.md` and `profiling.md`.');
+		expect(columnsVisible).toContain('verify specifics against `columns.md`.');
+		expect(columnsVisible).not.toContain('`profiling.md`');
+		expect(neitherVisible).not.toContain('`columns.md`');
+		expect(neitherVisible).not.toContain('`profiling.md`');
+		expect(neitherVisible).toContain('use for orientation, but do not treat it as ground truth.');
 	});
 
 	it('shows only context reported as present', () => {

--- a/cli/README.md
+++ b/cli/README.md
@@ -179,7 +179,7 @@ nao sync
 
 Syncs configured resources to local files:
 
-- **Databases** - generates markdown docs (`columns.md` with table schema, description, row count, and partition/clustering/index metadata, `query_history.md`, and `preview.md`) for each table into `databases/`
+- **Databases** - generates configured markdown docs for each table into `databases/` (`columns.md` and `preview.md` by default; optional `profiling.md`, `query_history.md`, and `ai_summary.md`)
 - **Git repositories** — clones or pulls repos into `repos/`
 - **Notion pages** — exports pages as markdown into `docs/notion/`. Databases are exported as markdown tables, whether configured directly or embedded inline in a page. A database embedded in a page is exported through one of its views — Notion exposes no way to tell which view a page renders, so the first one listed is used — applying that view's filters, sorts and visible columns rather than dumping the whole data source. A database configured by URL exports every row and column, unless the URL carries `?v=<view_id>`, in which case that view applies. When a database cannot be exported, its page fails to sync and the previously synced markdown is left untouched, rather than being rewritten without its table.
 

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -61,6 +61,12 @@ class DatabaseTemplate(str, Enum):
     QUERY_HISTORY = "query_history"
 
 
+DEFAULT_DATABASE_TEMPLATES = [
+    DatabaseTemplate.COLUMNS,
+    DatabaseTemplate.PREVIEW,
+]
+
+
 # Backward-compatible alias
 DatabaseAccessor = DatabaseTemplate
 
@@ -114,15 +120,11 @@ class DatabaseConfig(BaseModel, ABC):
         ),
     )
     templates: list[DatabaseTemplate] = Field(
-        default_factory=lambda: [
-            DatabaseTemplate.COLUMNS,
-            DatabaseTemplate.QUERY_HISTORY,
-            DatabaseTemplate.PREVIEW,
-        ],
+        default_factory=lambda: list(DEFAULT_DATABASE_TEMPLATES),
         description=(
             "Which default templates to render per table "
-            "(e.g., ['columns', 'query_history', 'profiling', 'ai_summary']). "
-            "Defaults to ['columns', 'query_history', 'preview']."
+            "(e.g., ['columns', 'preview', 'profiling', 'query_history', 'ai_summary']). "
+            "Defaults to ['columns', 'preview']; an empty list uses this default."
         ),
     )
     query_history_days: int | None = Field(
@@ -181,6 +183,8 @@ class DatabaseConfig(BaseModel, ABC):
                 if template != "description"
             ]
             data["templates"] = list(dict.fromkeys(migrated_templates))
+            if not data["templates"]:
+                data["templates"] = list(DEFAULT_DATABASE_TEMPLATES)
         return data
 
     profiling: ProfilingConfig = Field(

--- a/cli/tests/nao_core/commands/sync/integration/conftest.py
+++ b/cli/tests/nao_core/commands/sync/integration/conftest.py
@@ -33,11 +33,12 @@ def reset_template_engine():
 def synced(tmp_path_factory, db_config):
     """Run sync once for the whole module and return (state, output_path, config).
 
-    Profiling is explicitly enabled so that integration tests cover the full
-    template surface (profiling is opt-in during ``nao init``).
+    Optional templates are explicitly enabled so integration tests cover the
+    full template surface.
     """
-    if DatabaseTemplate.PROFILING not in db_config.templates:
-        db_config.templates.append(DatabaseTemplate.PROFILING)
+    for template in (DatabaseTemplate.PROFILING, DatabaseTemplate.QUERY_HISTORY):
+        if template not in db_config.templates:
+            db_config.templates.append(template)
 
     output = tmp_path_factory.mktemp(f"{db_config.type}_sync")
 

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -277,6 +277,23 @@ def test_templates_key_works_without_deprecation_warning():
     assert len(deprecation_warnings) == 0
 
 
+def test_empty_templates_use_default():
+    db = DuckDBConfig.model_validate({"type": "duckdb", "name": "test-db", "path": ":memory:", "templates": []})
+
+    assert db.templates == [DatabaseTemplate.COLUMNS, DatabaseTemplate.PREVIEW]
+
+
+def test_legacy_description_only_uses_default_after_migration():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        db = DuckDBConfig.model_validate(
+            {"type": "duckdb", "name": "test-db", "path": ":memory:", "templates": ["description"]}
+        )
+
+    assert db.templates == [DatabaseTemplate.COLUMNS, DatabaseTemplate.PREVIEW]
+    assert any("description" in str(warning.message) for warning in caught)
+
+
 def test_query_history_template_variant():
     """query_history can be added to the templates list."""
     from nao_core.config.databases.base import DatabaseTemplate
@@ -321,12 +338,9 @@ def test_legacy_description_removed_and_how_to_use_maps_to_query_history():
     assert any("how_to_use" in message and "query_history" in message for message in warning_messages)
 
 
-def test_default_templates_exclude_profiling():
-    """Default templates should not include profiling."""
-    from nao_core.config.databases.base import DatabaseTemplate
-
+def test_default_templates():
     db = DuckDBConfig(name="test-db", path=":memory:")
-    assert DatabaseTemplate.PROFILING not in db.templates
+    assert db.templates == [DatabaseTemplate.COLUMNS, DatabaseTemplate.PREVIEW]
 
 
 def test_ai_summary_refresh_config_defaults_to_always():

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -43,7 +43,7 @@ Send a single message asking for:
       • project: <name>
       • warehouse: BigQuery (project=<id>, dataset=<id>, auth=service-account)
       • scope: include=["analytics.fct_*", "analytics.dim_*"], exclude=[]
-      • templates: [columns, preview, description]
+      • templates: [columns, query_history, preview]
       • repos: company-dbt (git@github.com:org/company-dbt.git)
       • llm: anthropic (key via ${{ env('ANTHROPIC_API_KEY') }})
     ```
@@ -57,10 +57,10 @@ Send a single message asking for:
 Per database in the yaml, set:
 
 ```yaml
-templates: [columns, preview, description]
+templates: [columns, query_history, preview]
 ```
 
-That's the set this skill ships. Other values are valid per-warehouse (`how_to_use`, `profiling`, `ai_summary`, and `indexes` for ClickHouse) — see the docs link above — but stick to `[columns, preview, description]` unless the user specifically asks otherwise.
+Valid values are `columns`, `preview`, `profiling`, `query_history`, and `ai_summary`. This skill uses the default `[columns, query_history, preview]` unless the user specifically asks otherwise.
 
 **Don't use `accessors` — deprecated** (renamed to `templates`).
 
@@ -112,7 +112,7 @@ Regular human terminals aren't affected.
 - **Cap at ~100 tables.**
 - **One batch of questions.** Look up warehouse-specific fields from the docs, don't keep pinging the user.
 - **Run `nao init --no-tty`** with the yaml pre-written — never run `nao init` without the flag.
-- **Use `templates: [columns, preview, description]`.** Don't use `accessors`.
+- **Use `templates: [columns, query_history, preview]`.** Don't use `accessors`.
 - **Repos: SSH git URLs only.** No local paths in the `repos:` block.
 - **Print the `nao_config.yaml` summary** and get user confirmation before `nao sync`.
 - **Never have the user paste their LLM key into chat.**
@@ -133,7 +133,7 @@ databases:
       credentials_path: /path/to/service-account.json # or `sso: true`
       include: ['<dataset_pattern>.<table_pattern>'] # e.g. "analytics.fct_*" - use '*' as multiple patterns
       exclude: ['<pattern>']
-      templates: [columns, preview, description]
+      templates: [columns, query_history, preview]
 
 llm:
     providers:

--- a/skills/setup-context/SKILL.md
+++ b/skills/setup-context/SKILL.md
@@ -43,7 +43,7 @@ Send a single message asking for:
       • project: <name>
       • warehouse: BigQuery (project=<id>, dataset=<id>, auth=service-account)
       • scope: include=["analytics.fct_*", "analytics.dim_*"], exclude=[]
-      • templates: [columns, query_history, preview]
+      • templates: [columns, preview]
       • repos: company-dbt (git@github.com:org/company-dbt.git)
       • llm: anthropic (key via ${{ env('ANTHROPIC_API_KEY') }})
     ```
@@ -57,10 +57,10 @@ Send a single message asking for:
 Per database in the yaml, set:
 
 ```yaml
-templates: [columns, query_history, preview]
+templates: [columns, preview]
 ```
 
-Valid values are `columns`, `preview`, `profiling`, `query_history`, and `ai_summary`. This skill uses the default `[columns, query_history, preview]` unless the user specifically asks otherwise.
+Valid values are `columns`, `preview`, `profiling`, `query_history`, and `ai_summary`; the default is `[columns, preview]`. `profiling` and `query_history` are opt-in, and `query_history` requires BigQuery, Snowflake, Postgres, Redshift, Databricks, or a custom `query_history_sql`.
 
 **Don't use `accessors` — deprecated** (renamed to `templates`).
 
@@ -112,7 +112,7 @@ Regular human terminals aren't affected.
 - **Cap at ~100 tables.**
 - **One batch of questions.** Look up warehouse-specific fields from the docs, don't keep pinging the user.
 - **Run `nao init --no-tty`** with the yaml pre-written — never run `nao init` without the flag.
-- **Use `templates: [columns, query_history, preview]`.** Don't use `accessors`.
+- **Use `templates: [columns, preview]`.** Don't use `accessors`.
 - **Repos: SSH git URLs only.** No local paths in the `repos:` block.
 - **Print the `nao_config.yaml` summary** and get user confirmation before `nao sync`.
 - **Never have the user paste their LLM key into chat.**
@@ -133,7 +133,7 @@ databases:
       credentials_path: /path/to/service-account.json # or `sso: true`
       include: ['<dataset_pattern>.<table_pattern>'] # e.g. "analytics.fct_*" - use '*' as multiple patterns
       exclude: ['<pattern>']
-      templates: [columns, query_history, preview]
+      templates: [columns, preview]
 
 llm:
     providers:

--- a/skills/write-context-rules/SKILL.md
+++ b/skills/write-context-rules/SKILL.md
@@ -18,7 +18,7 @@ Anything else (per-table schema, full metric semantics, domain-specific rules) b
 
 | Location                                        | What's in it                                                                                                                                                                                               | Implication for `RULES.md`                                                                                                                                            |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `databases/type=*/database=*/schema=*/table=*/` | Per-table files synced from the warehouse: `columns.md`, `description.md`, `preview.md`, and (if enabled in `nao_config.yaml` `templates:`) `how_to_use.md`, `ai_summary.md`, `profiling.md`               | If rich per-table docs exist here, **don't restate columns** in `RULES.md` — point to the folder.                                                                     |
+| `databases/type=*/database=*/schema=*/table=*/` | Per-table files synced from the warehouse when enabled in `nao_config.yaml` `templates:`: `columns.md`, `preview.md`, `profiling.md`, `query_history.md`, `ai_summary.md`                                  | If rich per-table docs exist here, **don't restate columns** in `RULES.md` — point to the folder.                                                                     |
 | `repos/<name>/`                                 | Synced git repos (dbt, ETL, BI). A dbt repo has `models/**/schema.yml` (or `*.yml`) column docs, `*.md` model docs, and possibly a **semantic layer / MetricFlow** file (`semantic_models:` + `metrics:`). | Map the key files in the Context Map. If dbt schema docs cover columns, point there. If a semantic layer exists, **don't write a Key Metrics section** — route to it. |
 | `docs/`                                         | Free-text business docs (Notion exports, CRM definitions, analytics decisions).                                                                                                                            | Note they exist, what's in each, and when to read them. If a doc defines a metric/segment, point to it instead of redefining.                                         |
 | `semantics/`                                    | nao YAML semantic layer (from `add-semantic-layer`).                                                                                                                                                       | Same as a dbt semantic layer — route metrics to it, don't redefine.                                                                                                   |
@@ -45,7 +45,7 @@ Anything else (per-table schema, full metric semantics, domain-specific rules) b
 
 Before writing anything, survey the repo so the rest of the flow knows what to point to vs. what to write:
 
-- `nao_config.yaml` — which `templates:` are synced per database (do `how_to_use` / `ai_summary` / `profiling` exist?), which `repos:` are wired.
+- `nao_config.yaml` — which `templates:` are synced per database (do `columns` / `preview` / `profiling` / `query_history` / `ai_summary` exist?), which `repos:` are wired.
 - `databases/` — list tables and check how rich the per-table files are.
 - `repos/<name>/` — for each repo, find: column docs (`**/schema.yml`, `**/*.yml` with `models:`), model/domain docs (`*.md`), and a **semantic layer** (grep for `semantic_models:` / `metrics:` / MetricFlow). Note the paths.
 - `docs/` — list files and skim what each covers.
@@ -65,7 +65,7 @@ From `databases/` and `repos/<dbt>/`: Warehouse type/project/dataset, Data stack
 
 The orchestrator's index of where context lives. Built from Step 0. Cover:
 
-- **Per-table context** — what each table folder under `databases/` contains (e.g. `columns.md`, `how_to_use.md`, `ai_summary.md`, `profiling.md`) and one line on what each is for.
+- **Per-table context** — what each table folder under `databases/` contains (`columns.md`, `preview.md`, `profiling.md`, `query_history.md`, `ai_summary.md`) and one line on what each is for.
 - **Repos** — per repo, the key files and what they hold:
     ```
     - `repos/dbt/` — dbt project. Column docs: `models/silver.yml`. Domain decisions: `models/silver/*_ANALYTICS_DECISIONS.md`. Semantic layer (metrics): `models/silver_semantic_layer.yml`.
@@ -84,7 +84,7 @@ The orchestrator's index of where context lives. Built from Step 0. Cover:
 - `dim_users` — user dimension. See `databases/.../table=dim_users/`.
 ```
 
-**`### Tables detail`** — **conditional.** Only write per-table blocks (Purpose / Granularity / Key Columns ≤10 / Use For) **when no richer table documentation exists elsewhere** (no `how_to_use.md`/`ai_summary.md` per table, no dbt `schema.yml` column docs). If those exist, **do not restate columns** — the Most Used pointer + Context map already route there. Reserve `### Tables detail` for the few cross-table nuances/pitfalls not captured anywhere else (e.g. "weekly table has no `n_active_users` column").
+**`### Tables detail`** — **conditional.** Only write per-table blocks (Purpose / Granularity / Key Columns ≤10 / Use For) **when no richer table documentation exists elsewhere** (no `query_history.md`/`ai_summary.md` per table, no dbt `schema.yml` column docs). If those exist, **do not restate columns** — the Most Used pointer + Context map already route there. Reserve `### Tables detail` for the few cross-table nuances/pitfalls not captured anywhere else (e.g. "weekly table has no `n_active_users` column").
 
 ### Step 5 — `## Key Metrics Reference`
 

--- a/skills/write-context-rules/templates/RULES.md
+++ b/skills/write-context-rules/templates/RULES.md
@@ -27,7 +27,7 @@
 
 - `columns.md` — column names, types, descriptions
 - `profiling.md` — distinct counts, min/max, and **`top_values`** (the actual values present in each column). **Read before filtering on any column value.**
-- TODO: list any other synced templates (`description.md`, `how_to_use.md`, `ai_summary.md`, `preview.md`) and one line each.
+- TODO: list the synced templates (`columns.md`, `preview.md`, `profiling.md`, `query_history.md`, `ai_summary.md`) and one line each.
 
 **Repos:**
 
@@ -47,7 +47,7 @@
 
 ### Tables detail
 
-> ONLY include this section if no richer table docs exist elsewhere (no `how_to_use.md`/`ai_summary.md` per table, no dbt `schema.yml` column docs). If they exist, delete this section — the Most Used pointers + Context map already route there. Otherwise, reserve it for cross-table pitfalls not documented anywhere else.
+> ONLY include this section if no richer table docs exist elsewhere (no `query_history.md`/`ai_summary.md` per table, no dbt `schema.yml` column docs). If they exist, delete this section — the Most Used pointers + Context map already route there. Otherwise, reserve it for cross-table pitfalls not documented anywhere else.
 
 #### `table`
 


### PR DESCRIPTION
## Summary

- The agent now gets a short guide to the project context in its system prompt: what each folder is for, and what each per-table file contains and when to read it. Before, it was only told the files existed, so it often read the wrong one or none.
- The guide only mentions what the project actually has. The per-table file list comes from `nao_config.yaml`, and folders like `semantics/` or `docs/` appear only when they exist and have something in them so the agent never goes looking for something that isn't there.
- `annotations.md` is now called out as the place for human notes, and the agent is told to trust it over the generated files when they disagree.
- Removed leftover mentions of `description.md` and `how_to_use.md` in the recommendations prompt and the two context skills. Those files were deleted a while back and no longer exist.
- The checks run once per user message.

Closes #980

## Two decisions regarding the issue

- **Per project, not per table.** The issue asked for the file list to adapt to each table. The config already decides which files sync writes, and checking every table folder would mean scanning thousands of directories for the same answer. So the list adapts per project instead.
- **No regeneration on context push.** : The genuinely useful version where the prompt adapts to the user's DB ("read `annotations.md` first for what a column means", "check `crm.md` before sales questions") needs a model to read the files and understand them which is already what the `write-context-rules` skill already does, with a human reviewing the result. Doing it automatically on every sync would pay for that pass every time and ship it unreviewed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

