### PR TITLE
fix(sandbox): disable runtime when KVM is unavailable

### DIFF
--- a/apps/backend/src/services/sandbox-runtime.ts
+++ b/apps/backend/src/services/sandbox-runtime.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 /**
  * The sandbox runtime is an optional native dependency, so whether a deployment can run code at
  * all is decided here, once, at startup. It lives apart from the tool that uses it because other
@@ -6,12 +8,31 @@
  */
 let boxlite: typeof import('@boxlite-ai/boxlite') | null = null;
 
-try {
-	boxlite = await import('@boxlite-ai/boxlite');
-} catch {
-	console.warn('⚠ sandbox runtime not installed — execute_sandboxed_code tool disabled (run `nao chat --sandbox`)');
+if (isSandboxHostSupported()) {
+	try {
+		boxlite = await import('@boxlite-ai/boxlite');
+	} catch {
+		console.warn(
+			'⚠ sandbox runtime not installed — execute_sandboxed_code tool disabled (run `nao chat --sandbox`)',
+		);
+	}
+} else {
+	console.warn('⚠ sandbox runtime unavailable on this host; execute_sandboxed_code tool disabled');
 }
 
 export const sandboxRuntime = boxlite;
 
 export const isSandboxAvailable = boxlite !== null;
+
+function isSandboxHostSupported(): boolean {
+	if (process.platform !== 'linux') {
+		return true;
+	}
+
+	try {
+		fs.accessSync('/dev/kvm', fs.constants.R_OK | fs.constants.W_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/apps/backend/tests/sandbox-runtime.test.ts
+++ b/apps/backend/tests/sandbox-runtime.test.ts
@@ -1,0 +1,119 @@
+import { constants } from 'fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentSettings } from '../src/types/agent-settings';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+
+type KvmAccess = 'missing' | 'denied' | 'usable';
+
+const sandboxEnabledSettings = {
+	experimental: { sandboxes: true },
+} as AgentSettings;
+
+async function loadSandboxModules(kvmAccess: KvmAccess, platform = 'linux') {
+	vi.resetModules();
+	Object.defineProperty(process, 'platform', { ...originalPlatform, value: platform });
+
+	const accessSync = vi.fn(() => {
+		if (kvmAccess !== 'usable') {
+			const error = new Error(kvmAccess === 'missing' ? 'ENOENT' : 'EACCES') as NodeJS.ErrnoException;
+			error.code = kvmAccess === 'missing' ? 'ENOENT' : 'EACCES';
+			throw error;
+		}
+	});
+
+	vi.doMock('fs', async (importOriginal) => {
+		const actual = await importOriginal<typeof import('fs')>();
+		return {
+			...actual,
+			accessSync,
+			default: { ...actual.default, accessSync },
+		};
+	});
+	vi.doMock('@boxlite-ai/boxlite', () => ({
+		CodeBox: class FakeCodeBox {},
+		ExecError: class FakeExecError extends Error {},
+		TimeoutError: class FakeTimeoutError extends Error {},
+	}));
+	vi.doMock('../src/db/db', () => ({ db: {} }));
+
+	const runtime = await import('../src/services/sandbox-runtime');
+	const sandboxTool = await import('../src/agents/tools/execute-sandboxed-code');
+	const { getTools } = await import('../src/agents/tools');
+	const { default: loadSkillTool } = await import('../src/agents/tools/load-skill');
+
+	return { accessSync, getTools, loadSkillTool, runtime, sandboxTool: sandboxTool.default };
+}
+
+async function loadPdfSkill(loadSkillTool: Awaited<ReturnType<typeof loadSandboxModules>>['loadSkillTool']) {
+	return (await loadSkillTool.execute!(
+		{ name: 'pdf-handling' },
+		{
+			experimental_context: { agentSettings: sandboxEnabledSettings },
+			toolCallId: 'sandbox-capability-test',
+			messages: [],
+		},
+	)) as { body: string };
+}
+
+afterEach(() => {
+	Object.defineProperty(process, 'platform', originalPlatform);
+	vi.restoreAllMocks();
+	vi.resetModules();
+	vi.doUnmock('fs');
+	vi.doUnmock('@boxlite-ai/boxlite');
+	vi.doUnmock('../src/db/db');
+});
+
+describe('sandbox runtime host capability', () => {
+	it.each(['missing', 'denied'] as const)(
+		'should not expose the sandbox when /dev/kvm is %s - regression for ENG-9189',
+		async (kvmAccess) => {
+			// Arrange
+			const modules = await loadSandboxModules(kvmAccess);
+
+			// Act
+			const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+			const pdfSkill = await loadPdfSkill(modules.loadSkillTool);
+
+			// Assert
+			expect(modules.accessSync).toHaveBeenCalledWith('/dev/kvm', constants.R_OK | constants.W_OK);
+			expect(modules.runtime.sandboxRuntime).toBeNull();
+			expect(modules.runtime.isSandboxAvailable).toBe(false);
+			expect(modules.sandboxTool).toBeNull();
+			expect(tools).not.toHaveProperty('execute_sandboxed_code');
+			expect(pdfSkill.body).not.toContain('pdfplumber');
+		},
+	);
+
+	it('should expose the sandbox when /dev/kvm is usable', async () => {
+		// Arrange
+		const modules = await loadSandboxModules('usable');
+
+		// Act
+		const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+		const pdfSkill = await loadPdfSkill(modules.loadSkillTool);
+
+		// Assert
+		expect(modules.accessSync).toHaveBeenCalledWith('/dev/kvm', constants.R_OK | constants.W_OK);
+		expect(modules.runtime.sandboxRuntime).not.toBeNull();
+		expect(modules.runtime.isSandboxAvailable).toBe(true);
+		expect(modules.sandboxTool).not.toBeNull();
+		expect(tools).toHaveProperty('execute_sandboxed_code');
+		expect(pdfSkill.body).toContain('pdfplumber');
+	});
+
+	it('should preserve the native runtime check on non-Linux hosts', async () => {
+		// Arrange
+		const modules = await loadSandboxModules('missing', 'darwin');
+
+		// Act
+		const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+
+		// Assert
+		expect(modules.accessSync).not.toHaveBeenCalled();
+		expect(modules.runtime.isSandboxAvailable).toBe(true);
+		expect(tools).toHaveProperty('execute_sandboxed_code');
+	});
+});

--- a/apps/frontend/src/components/settings/experimental.tsx
+++ b/apps/frontend/src/components/settings/experimental.tsx
@@ -150,7 +150,7 @@ export function SettingsExperimental({ isAdmin }: SettingsExperimentalProps) {
 						</a>
 						.
 						{!sandboxAvailable &&
-							' The runtime is not installed — on macOS or Linux, run `nao chat --sandbox` and restart nao.'}
+							' The sandbox runtime is unavailable on this host. Install it with `nao chat --sandbox` on a supported host.'}
 					</span>
 				}
 				control={


### PR DESCRIPTION
## Context

On Linux hosts without accessible `/dev/kvm`, Boxlite can abort the backend process when an agent invokes `execute_sandboxed_code`. This surfaced in Nao chats using Claude Opus 5 as a network error after the response began.

Linear: [ENG-9189](https://linear.app/lucis-life/issue/ENG-9189/nao-opus-5-sandbox-call-crashes-cloud-run-backend-without-kvm)

## Changes

- Check effective-user read/write access to `/dev/kvm` before importing Boxlite on Linux
- Disable sandbox tool exposure and sandbox-dependent skill guidance when the host is unsupported
- Preserve the existing native runtime path on non-Linux hosts
- Generalize the experimental-settings unavailable message
- Add regression coverage for missing, denied, and usable KVM access

## Verification

- Linux container without `/dev/kvm`: backend import succeeds, `isSandboxAvailable` is false, and `sandboxRuntime` is null
- Impacted tests: 39 passed
- Formatting, TypeScript, and ESLint passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

