### PR TITLE
feat(test): report cache and verifier token usage

### DIFF
--- a/apps/backend/src/services/test-agent.service.ts
+++ b/apps/backend/src/services/test-agent.service.ts
@@ -3,9 +3,10 @@ import { generateText, ModelMessage, Output } from 'ai';
 import { z } from 'zod/v4';
 
 import { llmTelemetry } from '../agents/telemetry';
-import type { UIMessage } from '../types/chat';
+import type { TokenUsage, UIMessage } from '../types/chat';
 import type { ModelCosts } from '../types/llm';
 import type { QueryResult } from '../types/tools';
+import { addTokenUsage, convertToTokenUsage } from '../utils/ai';
 import { AgentRunResult, AgentService } from './agent';
 import { runSqlOverQueryResults } from './duckdb.service';
 
@@ -15,6 +16,8 @@ export interface VerificationResult {
 	/** The DuckDB query the agent wrote over its own query results */
 	sql: string | null;
 	error: string | null;
+	/** Usage across every verification attempt, including repairs */
+	usage?: TokenUsage;
 }
 
 export interface ToolCallResult {
@@ -87,6 +90,7 @@ export class TestAgentService extends AgentService {
 
 		let sql: string | null = null;
 		let error: string | null = null;
+		let usage: TokenUsage | undefined;
 
 		for (let attempt = 0; attempt < MAX_VERIFICATION_ATTEMPTS; attempt++) {
 			const result = await generateText({
@@ -95,15 +99,16 @@ export class TestAgentService extends AgentService {
 				messages,
 				experimental_telemetry: llmTelemetry('nao-test-verification', { projectId }),
 			});
+			usage = addTokenUsage(usage, convertToTokenUsage(result.usage));
 
 			sql = result.output.sql?.trim() || null;
 			if (!sql) {
-				return { data: null, sql: null, error: 'The agent could not answer from its query results.' };
+				return { data: null, sql: null, error: 'The agent could not answer from its query results.', usage };
 			}
 
 			try {
 				const { data } = await runSqlOverQueryResults(queryResults, sql);
-				return { data, sql, error: null };
+				return { data, sql, error: null, usage };
 			} catch (err) {
 				error = err instanceof Error ? err.message : String(err);
 				messages.push(
@@ -113,7 +118,7 @@ export class TestAgentService extends AgentService {
 			}
 		}
 
-		return { data: null, sql, error };
+		return { data: null, sql, error, usage };
 	}
 
 	private static _buildUserMessage(text: string): UIMessage {

--- a/apps/backend/src/utils/ai.ts
+++ b/apps/backend/src/utils/ai.ts
@@ -22,6 +22,29 @@ export const convertToTokenUsage = (usage: LanguageModelUsage): TokenUsage => ({
 	totalTokens: usage.totalTokens,
 });
 
+export const addTokenUsage = (...usages: (TokenUsage | undefined)[]): TokenUsage | undefined => {
+	const presentUsages = usages.filter((usage): usage is TokenUsage => usage !== undefined);
+	if (presentUsages.length === 0) {
+		return undefined;
+	}
+
+	const sum = (field: keyof TokenUsage): number | undefined => {
+		const values = presentUsages.map((usage) => usage[field]).filter((value) => value !== undefined);
+		return values.length === 0 ? undefined : values.reduce((total, value) => total + value, 0);
+	};
+
+	return {
+		inputTotalTokens: sum('inputTotalTokens'),
+		inputNoCacheTokens: sum('inputNoCacheTokens'),
+		inputCacheReadTokens: sum('inputCacheReadTokens'),
+		inputCacheWriteTokens: sum('inputCacheWriteTokens'),
+		outputTotalTokens: sum('outputTotalTokens'),
+		outputTextTokens: sum('outputTextTokens'),
+		outputReasoningTokens: sum('outputReasoningTokens'),
+		totalTokens: sum('totalTokens'),
+	};
+};
+
 export const convertToCost = (
 	usage: TokenUsage,
 	provider: LlmProvider,

--- a/apps/backend/tests/token-usage.test.ts
+++ b/apps/backend/tests/token-usage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TokenUsage } from '../src/types/chat';
+import { addTokenUsage } from '../src/utils/ai';
+
+describe('addTokenUsage', () => {
+	it('sums cache categories across verification attempts', () => {
+		const first: TokenUsage = {
+			inputTotalTokens: 100,
+			inputNoCacheTokens: 60,
+			inputCacheReadTokens: 30,
+			inputCacheWriteTokens: 10,
+			outputTotalTokens: 20,
+			outputTextTokens: 15,
+			outputReasoningTokens: 5,
+			totalTokens: 120,
+		};
+		const repair: TokenUsage = {
+			inputTotalTokens: 80,
+			inputNoCacheTokens: undefined,
+			inputCacheReadTokens: 80,
+			inputCacheWriteTokens: 0,
+			outputTotalTokens: 10,
+			outputTextTokens: 10,
+			outputReasoningTokens: undefined,
+			totalTokens: 90,
+		};
+
+		expect(addTokenUsage(first, repair)).toEqual({
+			inputTotalTokens: 180,
+			inputNoCacheTokens: 60,
+			inputCacheReadTokens: 110,
+			inputCacheWriteTokens: 10,
+			outputTotalTokens: 30,
+			outputTextTokens: 25,
+			outputReasoningTokens: 5,
+			totalTokens: 210,
+		});
+	});
+
+	it('preserves missing categories and accepts no attempts', () => {
+		expect(addTokenUsage()).toBeUndefined();
+		expect(
+			addTokenUsage({
+				inputTotalTokens: undefined,
+				inputNoCacheTokens: undefined,
+				inputCacheReadTokens: undefined,
+				inputCacheWriteTokens: undefined,
+				outputTotalTokens: 3,
+				outputTextTokens: undefined,
+				outputReasoningTokens: undefined,
+				totalTokens: 3,
+			}),
+		).toMatchObject({ inputNoCacheTokens: undefined, outputTotalTokens: 3 });
+	});
+});

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -47,6 +47,7 @@ class VerificationResult:
     expectedColumns: list[str]
     sql: str | None = None
     error: str | None = None
+    usage: TokenUsage | None = None
 
 
 @dataclass
@@ -149,6 +150,19 @@ class AgentClient:
             raise AgentClientError(f"Request failed: {response.status_code} {response.text}")
 
         data = response.json()
+        verification_data: dict[str, Any] | None = data.get("verification")
+        verification = None
+        if verification_data:
+            verification_usage = verification_data.get("usage")
+            verification = VerificationResult(
+                data=verification_data["data"],
+                expectedData=verification_data["expectedData"],
+                expectedColumns=verification_data["expectedColumns"],
+                sql=verification_data.get("sql"),
+                error=verification_data.get("error"),
+                usage=TokenUsage(**verification_usage) if verification_usage else None,
+            )
+
         return TestResult(
             text=data["text"],
             tool_calls=data["toolCalls"],
@@ -156,7 +170,7 @@ class AgentClient:
             cost=TokenCost(**data["cost"]),
             finish_reason=data["finishReason"],
             duration_ms=data.get("durationMs", 0),
-            verification=VerificationResult(**data["verification"]) if data.get("verification") else None,
+            verification=verification,
         )
 
 

--- a/cli/nao_core/commands/test/runner.py
+++ b/cli/nao_core/commands/test/runner.py
@@ -19,7 +19,7 @@ from nao_core.config.test import ComparisonConfig, TestConfig
 from nao_core.ui import UI
 
 from .case import TESTS_FOLDER, TestCase, discover_tests
-from .client import BACKEND_URL, AgentClientError, VerificationResult, get_client
+from .client import BACKEND_URL, AgentClientError, TokenUsage, VerificationResult, get_client
 from .compare import normalize_dataframe_numbers
 from .summary import ModelSummary, summarize, summarize_by_model
 
@@ -68,6 +68,8 @@ class TestRunResult:
     cost: float | None = None
     duration_ms: int | None = None
     tool_call_count: int | None = None
+    usage: TokenUsage | None = None
+    verification_usage: TokenUsage | None = None
     error: str | None = None
     details: TestRunDetails | None = None
 
@@ -235,6 +237,8 @@ def run_test(
                 cost=result.cost.totalCost,
                 duration_ms=result.duration_ms,
                 tool_call_count=tool_call_count,
+                usage=result.usage,
+                verification_usage=result.verification.usage,
                 details=TestRunDetails(
                     response_text=result.text,
                     actual_data=result.verification.data,
@@ -256,6 +260,7 @@ def run_test(
             cost=result.cost.totalCost,
             duration_ms=result.duration_ms,
             tool_call_count=tool_call_count,
+            usage=result.usage,
             details=TestRunDetails(
                 response_text=result.text,
                 tool_calls=result.tool_calls,

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -8,6 +8,7 @@ import pytest
 
 from nao_core.commands.test.case import TestCase as NaoTestCase
 from nao_core.commands.test.client import (
+    AgentClient,
     AgentClientError,
     TokenCost,
     TokenUsage,
@@ -164,6 +165,38 @@ def test_serialize_model_costs_uses_backend_field_names():
     }
 
 
+def test_agent_client_parses_verification_usage(monkeypatch):
+    test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
+    response = Mock(status_code=200)
+    response.json.return_value = {
+        "text": "done",
+        "toolCalls": [],
+        "usage": {"inputCacheReadTokens": 20, "totalTokens": 30},
+        "cost": {"totalCost": 0.1},
+        "finishReason": "stop",
+        "durationMs": 100,
+        "verification": {
+            "data": [{"total": 1}],
+            "expectedData": [{"total": 1}],
+            "expectedColumns": ["total"],
+            "sql": "SELECT total FROM query_abc",
+            "error": None,
+            "usage": {"inputNoCacheTokens": 4, "outputTotalTokens": 2, "totalTokens": 6},
+        },
+    }
+    session = Mock()
+    session.post.return_value = response
+    client = AgentClient()
+    monkeypatch.setattr(client, "_get_session", lambda: session)
+
+    result = client.run_test(test_case)
+
+    assert result.usage.inputCacheReadTokens == 20
+    assert result.verification is not None
+    assert result.verification.usage is not None
+    assert result.verification.usage.inputNoCacheTokens == 4
+
+
 def test_run_test_passes_configured_costs_to_client(monkeypatch):
     test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
     model = ModelConfig(provider="openai", model_id="custom-model")
@@ -197,7 +230,13 @@ def test_run_test_records_reference_sql_with_verification(monkeypatch):
     client.run_test.return_value = AgentTestResult(
         text="",
         tool_calls=[],
-        usage=TokenUsage(totalTokens=0),
+        usage=TokenUsage(
+            inputNoCacheTokens=10,
+            inputCacheReadTokens=20,
+            inputCacheWriteTokens=30,
+            outputTotalTokens=40,
+            totalTokens=100,
+        ),
         cost=TokenCost(totalCost=0),
         finish_reason="stop",
         duration_ms=1,
@@ -206,6 +245,13 @@ def test_run_test_records_reference_sql_with_verification(monkeypatch):
             expectedData=[{"total": 1}],
             expectedColumns=["total"],
             sql="SELECT total FROM query_abc",
+            usage=TokenUsage(
+                inputNoCacheTokens=5,
+                inputCacheReadTokens=6,
+                inputCacheWriteTokens=7,
+                outputTotalTokens=8,
+                totalTokens=26,
+            ),
         ),
     )
     monkeypatch.setattr(test_runner_module, "get_client", lambda **_: client)
@@ -216,6 +262,10 @@ def test_run_test_records_reference_sql_with_verification(monkeypatch):
     assert result.details is not None
     assert result.details.reference_sql == "select 1"
     assert result.details.verification_sql == "SELECT total FROM query_abc"
+    assert result.usage is not None
+    assert result.usage.inputCacheReadTokens == 20
+    assert result.verification_usage is not None
+    assert result.verification_usage.inputCacheReadTokens == 6
 
 
 def test_run_test_records_reference_sql_without_verification(monkeypatch):
@@ -419,6 +469,8 @@ def test_save_results_records_per_model_summaries(tmp_path):
             cost=0.2,
             duration_ms=1000,
             tool_call_count=2,
+            usage=TokenUsage(inputCacheReadTokens=90, totalTokens=100),
+            verification_usage=TokenUsage(inputNoCacheTokens=8, outputTotalTokens=2, totalTokens=10),
         ),
         NaoTestRunResult(
             name="orders",
@@ -439,3 +491,5 @@ def test_save_results_records_per_model_summaries(tmp_path):
     assert [model["model"] for model in data["by_model"]] == ["openai:gpt-4.1", "anthropic:claude-4-5"]
     assert data["by_model"][0]["pass_rate"] == 100.0
     assert data["by_model"][1]["avg_duration_ms"] == 3000
+    assert data["results"][0]["usage"]["inputCacheReadTokens"] == 90
+    assert data["results"][0]["verification_usage"]["inputNoCacheTokens"] == 8


### PR DESCRIPTION
Expose the token usage that the test path already computes instead of reducing every run to one total.

- aggregate verifier usage across repair attempts
- return verifier usage from the test API
- keep main-agent and verifier usage in CLI JSON reports
- preserve missing provider categories as null

Validation:
- full TypeScript lint and formatting pass
- full Python CLI lint passes
- backend token aggregation tests: 2 passed
- CLI runner/client tests: 26 passed
- preview deployment is blocked by actions/checkout's fork pull_request_target safety guard before checkout; it does not execute this code
- real-provider verification remains pending while this PR is draft

Fixes #1420

This PR was written using OpenAI GPT-5 (Codex).