### PR TITLE
Fix story preview bugs, and bugs of data Resolution for query ids

### DIFF
--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -168,6 +168,23 @@ export const sharedStoryRoutes = {
 		};
 	}),
 
+	getVersionQueryData: shareAccessProcedure
+		.input(z.object({ shareId: z.string(), versionNumber: z.number().int().positive() }))
+		.query(async ({ input, ctx }) => {
+			const shared = ctx.resource;
+			if (!shared.chatId) {
+				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Shared story has no chat.' });
+			}
+
+			const version = await storyQueries.getVersionByNumber(shared.chatId, shared.slug, input.versionNumber);
+			if (!version) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Story version not found.' });
+			}
+
+			const queryData = await sharedStoryQueries.getQueryDataFromCode(shared.chatId, version.code);
+			return { queryData };
+		}),
+
 	getLiveQueryData: chatProcedure
 		.input(z.object({ chatId: z.string(), queryId: z.string() }))
 		.query(async ({ input }) => {

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -200,6 +200,24 @@ export const storyRoutes = {
 			};
 		}),
 
+	getVersionQueryData: chatOwnerProcedure
+		.input(
+			z.object({
+				chatId: z.string(),
+				storySlug: z.string(),
+				versionNumber: z.number().int().positive(),
+			}),
+		)
+		.query(async ({ input }) => {
+			const version = await storyQueries.getVersionByNumber(input.chatId, input.storySlug, input.versionNumber);
+			if (!version) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Story version not found.' });
+			}
+
+			const queryData = await sharedStoryQueries.getQueryDataFromCode(input.chatId, version.code);
+			return { queryData };
+		}),
+
 	listStories: chatOwnerProcedure.input(z.object({ chatId: z.string() })).query(async ({ input }) => {
 		const stories = await storyQueries.listStoriesInChat(input.chatId);
 		return stories.map((s) => ({ storySlug: s.slug, title: s.title, latestVersion: s.latestVersion }));

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.test.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.test.ts
@@ -53,6 +53,38 @@ describe('getLatestRelevantStoryAgentState', () => {
 		});
 	});
 
+	it('detects a persisted interrupted story settled with an output error', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+				stopReason: 'interrupted',
+				state: 'output-error',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', false)).toEqual({
+			isStoryStreaming: false,
+			isStoryInterrupted: true,
+		});
+	});
+
+	it('keeps a completed story on an interrupted message uninterrupted', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+				stopReason: 'interrupted',
+				state: 'output-available',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', false)).toEqual({
+			isStoryStreaming: false,
+			isStoryInterrupted: false,
+		});
+	});
+
 	it('uses the newest matching story part', () => {
 		const messages = [
 			createStoryMessage({
@@ -77,10 +109,12 @@ function createStoryMessage({
 	messageId,
 	storySlug,
 	stopReason,
+	state = 'input-streaming',
 }: {
 	messageId: string;
 	storySlug: string;
 	stopReason?: 'interrupted';
+	state?: 'input-streaming' | 'output-error' | 'output-available';
 }) {
 	return {
 		id: messageId,
@@ -89,7 +123,7 @@ function createStoryMessage({
 		parts: [
 			{
 				type: 'tool-story',
-				state: 'input-streaming',
+				state,
 				input: { id: storySlug },
 			},
 		],

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.test.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getLatestRelevantStoryAgentState } from './use-story-viewer-agent-state';
+
+import type { UIMessage } from '@nao/backend/chat';
+
+vi.mock('@/contexts/agent.provider', () => ({
+	useAgentMessages: vi.fn(),
+	useOptionalAgentContext: vi.fn(),
+}));
+
+describe('getLatestRelevantStoryAgentState', () => {
+	it('treats a stopped streaming story without a stop reason as interrupted', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', false)).toEqual({
+			isStoryStreaming: true,
+			isStoryInterrupted: true,
+		});
+	});
+
+	it('keeps an actively streaming story uninterrupted', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', true)).toEqual({
+			isStoryStreaming: true,
+			isStoryInterrupted: false,
+		});
+	});
+
+	it('detects a persisted interrupted streaming story part', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+				stopReason: 'interrupted',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', true)).toEqual({
+			isStoryStreaming: false,
+			isStoryInterrupted: true,
+		});
+	});
+
+	it('uses the newest matching story part', () => {
+		const messages = [
+			createStoryMessage({
+				messageId: 'message-1',
+				storySlug: 'test-long',
+				stopReason: 'interrupted',
+			}),
+			createStoryMessage({
+				messageId: 'message-2',
+				storySlug: 'test-long',
+			}),
+		];
+
+		expect(getLatestRelevantStoryAgentState(messages, 'test-long', true)).toEqual({
+			isStoryStreaming: true,
+			isStoryInterrupted: false,
+		});
+	});
+});
+
+function createStoryMessage({
+	messageId,
+	storySlug,
+	stopReason,
+}: {
+	messageId: string;
+	storySlug: string;
+	stopReason?: 'interrupted';
+}) {
+	return {
+		id: messageId,
+		role: 'assistant',
+		stopReason,
+		parts: [
+			{
+				type: 'tool-story',
+				state: 'input-streaming',
+				input: { id: storySlug },
+			},
+		],
+	} as unknown as UIMessage;
+}

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.ts
@@ -15,29 +15,47 @@ export const useStoryViewerAgentState = (
 		() => (messages !== undefined ? (messages ?? []) : agentMessages),
 		[messages, agentMessages],
 	);
+	const isAgentRunningFromContext =
+		messages === undefined && (agent?.status === 'streaming' || agent?.status === 'submitted');
+	const isRunning = messages === undefined ? isAgentRunningFromContext : isChatAgentRunning;
 
 	const allStories = useMemo(() => findStories(effectiveMessages), [effectiveMessages]);
 	const draftStory = useMemo(() => findStoryDraft(effectiveMessages, storySlug), [effectiveMessages, storySlug]);
-
-	const isStoryStreaming = useMemo(
-		() => isLatestRelevantStoryPartStreaming(effectiveMessages, storySlug),
+	const latestStoryOutputVersion = useMemo(
+		() => findLatestStoryOutputVersion(effectiveMessages, storySlug),
 		[effectiveMessages, storySlug],
 	);
 
-	const isAgentRunningFromContext =
-		messages === undefined && (agent?.status === 'streaming' || agent?.status === 'submitted');
-	const isStoryStreamingRelevant =
-		isStoryStreaming && (messages === undefined ? isAgentRunningFromContext : isChatAgentRunning);
-	const isAgentRunning = isAgentRunningFromContext || isStoryStreamingRelevant;
+	const { isStoryStreaming, isStoryInterrupted } = useMemo(
+		() => getLatestRelevantStoryAgentState(effectiveMessages, storySlug, isRunning),
+		[effectiveMessages, storySlug, isRunning],
+	);
+
+	const isStoryUpdating = isStoryStreaming && isRunning;
+	const isAgentRunning = isAgentRunningFromContext || isStoryUpdating;
 
 	return {
 		allStories,
 		draftStory,
+		latestStoryOutputVersion,
 		isAgentRunning,
+		isStoryUpdating,
+		isStoryInterrupted,
 	};
 };
 
-function isLatestRelevantStoryPartStreaming(messages: UIMessage[], storySlug: string) {
+export function getLatestRelevantStoryAgentState(messages: UIMessage[], storySlug: string, isRunning: boolean) {
+	const partState = findLatestRelevantStoryPartState(messages, storySlug);
+	const isInputStreaming = partState?.isInputStreaming ?? false;
+	const isPersistedInterruption = partState?.isInterrupted ?? false;
+
+	return {
+		isStoryStreaming: isInputStreaming && !isPersistedInterruption,
+		isStoryInterrupted: isInputStreaming && (isPersistedInterruption || !isRunning),
+	};
+}
+
+function findLatestRelevantStoryPartState(messages: UIMessage[], storySlug: string) {
 	for (let m = messages.length - 1; m >= 0; m--) {
 		const parts = messages[m]?.parts ?? [];
 
@@ -52,13 +70,33 @@ function isLatestRelevantStoryPartStreaming(messages: UIMessage[], storySlug: st
 				continue;
 			}
 
-			return part.state === 'input-streaming' && messages[m]?.stopReason !== 'interrupted';
+			return {
+				isInputStreaming: part.state === 'input-streaming',
+				isInterrupted: messages[m]?.stopReason === 'interrupted',
+			};
 		}
 	}
 
-	return false;
+	return null;
 }
 
 function isStoryIdMatch(expectedId: string, candidateId: string) {
 	return expectedId === candidateId || expectedId.startsWith(candidateId) || candidateId.startsWith(expectedId);
+}
+
+function findLatestStoryOutputVersion(messages: UIMessage[], storySlug: string) {
+	for (let m = messages.length - 1; m >= 0; m--) {
+		const parts = messages[m]?.parts ?? [];
+
+		for (let p = parts.length - 1; p >= 0; p--) {
+			const part = parts[p];
+			if (part.type !== 'tool-story' || !part.output?.success || !isStoryIdMatch(storySlug, part.output.id)) {
+				continue;
+			}
+
+			return part.output.version;
+		}
+	}
+
+	return null;
 }

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-agent-state.ts
@@ -46,12 +46,12 @@ export const useStoryViewerAgentState = (
 
 export function getLatestRelevantStoryAgentState(messages: UIMessage[], storySlug: string, isRunning: boolean) {
 	const partState = findLatestRelevantStoryPartState(messages, storySlug);
-	const isInputStreaming = partState?.isInputStreaming ?? false;
-	const isPersistedInterruption = partState?.isInterrupted ?? false;
+	const isStreamingInput = partState?.isInputStreaming ?? false;
+	const isAbandonedByInterruption = Boolean(partState?.isInterrupted && !partState.hasCompletedOutput);
 
 	return {
-		isStoryStreaming: isInputStreaming && !isPersistedInterruption,
-		isStoryInterrupted: isInputStreaming && (isPersistedInterruption || !isRunning),
+		isStoryStreaming: isStreamingInput && !isAbandonedByInterruption,
+		isStoryInterrupted: isAbandonedByInterruption || (isStreamingInput && !isRunning),
 	};
 }
 
@@ -73,6 +73,7 @@ function findLatestRelevantStoryPartState(messages: UIMessage[], storySlug: stri
 			return {
 				isInputStreaming: part.state === 'input-streaming',
 				isInterrupted: messages[m]?.stopReason === 'interrupted',
+				hasCompletedOutput: part.state === 'output-available',
 			};
 		}
 	}

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-content.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-content.ts
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import type { StoryDraft } from '@/lib/story.utils';
 import type { QueryDataMap } from '@/components/story-embeds';
+import type { StoryDraft } from '@/lib/story.utils';
+import { useThrottledValue } from '@/hooks/use-throttled-value';
 import { trpc } from '@/main';
+
+const STORY_STREAM_THROTTLE_INTERVAL_MS = 120;
 
 interface UseStoryViewerContentParams {
 	storySlug: string;
@@ -11,6 +14,8 @@ interface UseStoryViewerContentParams {
 	draftStory: StoryDraft | null;
 	currentVersion: { code: string } | undefined;
 	storedTitle: string | undefined;
+	isViewingLatest: boolean;
+	isStoryInterrupted: boolean;
 	isReadonlyMode?: boolean;
 }
 
@@ -21,54 +26,76 @@ export const useStoryViewerContent = ({
 	draftStory,
 	currentVersion,
 	storedTitle,
+	isViewingLatest,
+	isStoryInterrupted,
 	isReadonlyMode,
 }: UseStoryViewerContentParams) => {
 	const [isBridgingDraft, setIsBridgingDraft] = useState(false);
-	const wasStoryStreamingRef = useRef(Boolean(draftStory?.isStreaming));
+	const isStoryStreaming = Boolean(draftStory?.isStreaming);
+	const wasStoryStreamingRef = useRef(isStoryStreaming);
+	const bridgeBaselineCodeRef = useRef<string | undefined>(undefined);
+	const committedCodeRef = useRef(currentVersion?.code);
 	const viewedStorySlugRef = useRef(storySlug);
+	const throttledDraftCode = useThrottledValue(draftStory?.code, STORY_STREAM_THROTTLE_INTERVAL_MS, isStoryStreaming);
 
 	if (viewedStorySlugRef.current !== storySlug) {
 		viewedStorySlugRef.current = storySlug;
-		wasStoryStreamingRef.current = Boolean(draftStory?.isStreaming);
+		wasStoryStreamingRef.current = isStoryStreaming;
+		bridgeBaselineCodeRef.current = undefined;
+		committedCodeRef.current = currentVersion?.code;
 		if (isBridgingDraft) {
 			setIsBridgingDraft(false);
 		}
 	}
 
 	useEffect(() => {
-		const isStoryStreaming = Boolean(draftStory?.isStreaming);
 		if (wasStoryStreamingRef.current && !isStoryStreaming) {
-			setIsBridgingDraft(true);
+			if (isViewingLatest && !isStoryInterrupted) {
+				bridgeBaselineCodeRef.current = committedCodeRef.current;
+				setIsBridgingDraft(true);
+			} else {
+				bridgeBaselineCodeRef.current = undefined;
+				setIsBridgingDraft(false);
+			}
 		}
 		wasStoryStreamingRef.current = isStoryStreaming;
-	}, [draftStory?.isStreaming]);
+		committedCodeRef.current = currentVersion?.code;
+	}, [isStoryStreaming, isStoryInterrupted, isViewingLatest, currentVersion?.code]);
 
 	useEffect(() => {
 		if (!isBridgingDraft) {
 			return;
 		}
 		const committedCaughtUp = Boolean(currentVersion && draftStory && currentVersion.code === draftStory.code);
-		if (!draftStory || committedCaughtUp) {
+		const committedChanged = Boolean(currentVersion && currentVersion.code !== bridgeBaselineCodeRef.current);
+		if (!draftStory || !isViewingLatest || isStoryInterrupted || committedCaughtUp || committedChanged) {
+			bridgeBaselineCodeRef.current = undefined;
 			setIsBridgingDraft(false);
 		}
-	}, [isBridgingDraft, draftStory, currentVersion]);
+	}, [isBridgingDraft, draftStory, currentVersion, isStoryInterrupted, isViewingLatest]);
 
-	const shouldUseDraftStory = Boolean(draftStory && (draftStory.isStreaming || isBridgingDraft || !currentVersion));
+	const shouldUseDraftStory = Boolean(
+		isViewingLatest &&
+		!isStoryInterrupted &&
+		draftStory &&
+		(draftStory.isStreaming || isBridgingDraft || !currentVersion),
+	);
+	const canUseDraftFallback = isViewingLatest && !currentVersion;
 
 	const storyTitle = useMemo(
 		() =>
 			shouldUseDraftStory
 				? (draftStory?.title ?? storedTitle ?? storySlug)
-				: (storedTitle ?? draftStory?.title ?? storySlug),
-		[shouldUseDraftStory, draftStory?.title, storedTitle, storySlug],
+				: (storedTitle ?? (canUseDraftFallback ? draftStory?.title : undefined) ?? storySlug),
+		[shouldUseDraftStory, draftStory?.title, storedTitle, storySlug, canUseDraftFallback],
 	);
 
 	const storyCode = useMemo(
 		() =>
 			shouldUseDraftStory
-				? (draftStory?.code ?? currentVersion?.code)
-				: (currentVersion?.code ?? draftStory?.code),
-		[shouldUseDraftStory, draftStory?.code, currentVersion?.code],
+				? (throttledDraftCode ?? currentVersion?.code)
+				: (currentVersion?.code ?? (canUseDraftFallback ? draftStory?.code : undefined)),
+		[shouldUseDraftStory, throttledDraftCode, currentVersion?.code, canUseDraftFallback, draftStory?.code],
 	);
 
 	const latestStoryQuery = useQuery({

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-content.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-content.ts
@@ -80,7 +80,7 @@ export const useStoryViewerContent = ({
 		draftStory &&
 		(draftStory.isStreaming || isBridgingDraft || !currentVersion),
 	);
-	const canUseDraftFallback = isViewingLatest && !currentVersion;
+	const canUseDraftFallback = isViewingLatest && !isStoryInterrupted && !currentVersion;
 
 	const storyTitle = useMemo(
 		() =>

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-stream-scroll.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-stream-scroll.ts
@@ -1,22 +1,42 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 import type { StoryViewMode } from '../story-viewer.types';
 
+const STREAM_SCROLL_BOTTOM_THRESHOLD = 64;
+
 interface UseStoryViewerStreamScrollParams {
 	scrollContainerRef: RefObject<HTMLDivElement | null>;
-	isStreaming: boolean;
+	isAppendingContent: boolean;
 	code?: string;
 	viewMode: StoryViewMode;
 }
 
 export const useStoryViewerStreamScroll = ({
 	scrollContainerRef,
-	isStreaming,
+	isAppendingContent,
 	code,
 	viewMode,
 }: UseStoryViewerStreamScrollParams) => {
+	const isNearBottomRef = useRef(true);
+	const hasContent = Boolean(code);
+
 	useEffect(() => {
-		if (!isStreaming) {
+		const container = scrollContainerRef.current;
+		if (!container) {
+			return;
+		}
+
+		const handleScroll = () => {
+			isNearBottomRef.current = isContainerNearBottom(container);
+		};
+
+		container.addEventListener('scroll', handleScroll);
+
+		return () => container.removeEventListener('scroll', handleScroll);
+	}, [scrollContainerRef, hasContent]);
+
+	useEffect(() => {
+		if (!isAppendingContent || !isNearBottomRef.current) {
 			return;
 		}
 
@@ -30,9 +50,19 @@ export const useStoryViewerStreamScroll = ({
 		}
 
 		const animationFrameId = requestAnimationFrame(() => {
-			container.scrollTop = container.scrollHeight;
+			if (isNearBottomRef.current) {
+				container.scrollTop = container.scrollHeight;
+			}
 		});
 
 		return () => cancelAnimationFrame(animationFrameId);
-	}, [scrollContainerRef, isStreaming, code, viewMode]);
+	}, [scrollContainerRef, isAppendingContent, code, viewMode]);
+};
+
+const isContainerNearBottom = (container: HTMLDivElement) => {
+	if (container.scrollHeight <= container.clientHeight) {
+		return true;
+	}
+
+	return container.scrollHeight - container.scrollTop - container.clientHeight <= STREAM_SCROLL_BOTTOM_THRESHOLD;
 };

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -148,14 +148,16 @@ export const useStoryViewerVersionActions = ({
 			return;
 		}
 
-		createVersionMutation.mutate({
-			chatId,
-			storySlug,
-			title: storyTitle,
-			code: currentVersionCode,
-			action: 'replace',
-		});
-		goToLatestVersion();
+		createVersionMutation.mutate(
+			{
+				chatId,
+				storySlug,
+				title: storyTitle,
+				code: currentVersionCode,
+				action: 'replace',
+			},
+			{ onSuccess: () => goToLatestVersion() },
+		);
 	}, [chatId, storySlug, storyTitle, currentVersionCode, isViewingLatest, createVersionMutation, goToLatestVersion]);
 
 	return {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -144,7 +144,7 @@ export const useStoryViewerVersionActions = ({
 
 	const handleRestore = useCallback(() => {
 		const hasVersionData = storyTitle !== undefined && currentVersionCode !== undefined;
-		if (!hasVersionData || isViewingLatest) {
+		if (!hasVersionData || isViewingLatest || createVersionMutation.isPending) {
 			return;
 		}
 

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -13,6 +13,7 @@ interface UseStoryViewerVersionActionsParams {
 	storyTitle?: string;
 	currentVersionCode?: string;
 	isViewingLatest: boolean;
+	goToLatestVersion: () => void;
 	tiptapEditorRef: MutableRefObject<TiptapEditor | null>;
 	codeViewRef: MutableRefObject<StoryCodeViewHandle | null>;
 	getEditModeCode?: () => string | null;
@@ -26,6 +27,7 @@ export const useStoryViewerVersionActions = ({
 	storyTitle,
 	currentVersionCode,
 	isViewingLatest,
+	goToLatestVersion,
 	tiptapEditorRef,
 	codeViewRef,
 	getEditModeCode,
@@ -153,7 +155,8 @@ export const useStoryViewerVersionActions = ({
 			code: currentVersionCode,
 			action: 'replace',
 		});
-	}, [chatId, storySlug, storyTitle, currentVersionCode, isViewingLatest, createVersionMutation]);
+		goToLatestVersion();
+	}, [chatId, storySlug, storyTitle, currentVersionCode, isViewingLatest, createVersionMutation, goToLatestVersion]);
 
 	return {
 		handleSave,

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-versions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-versions.ts
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useDebouncedCallback } from '@/hooks/use-debounced-callback';
 import { trpc } from '@/main';
+
+const STORY_REFRESH_DEBOUNCE_MS = 400;
 
 interface UseStoryViewerVersionsParams {
 	chatId: string;
 	storySlug: string;
 	isAgentRunning: boolean;
+	latestStoryOutputVersion?: number | null;
 	isReadonlyMode?: boolean;
 }
 
@@ -19,6 +23,7 @@ export const useStoryViewerVersions = ({
 	chatId,
 	storySlug,
 	isAgentRunning,
+	latestStoryOutputVersion = null,
 	isReadonlyMode,
 }: UseStoryViewerVersionsParams) => {
 	const queryClient = useQueryClient();
@@ -34,18 +39,37 @@ export const useStoryViewerVersions = ({
 		null,
 	);
 	const previousRunningRef = useRef(isAgentRunning);
+	const latestStoryOutputRef = useRef({ storySlug, version: latestStoryOutputVersion });
+	const refreshStoryData = useCallback(() => {
+		void refetch();
+		void queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
+		void queryClient.invalidateQueries({
+			queryKey: trpc.story.getLatest.queryKey({ chatId, storySlug }),
+		});
+	}, [chatId, queryClient, refetch, storySlug]);
+	const debouncedRefreshStoryData = useDebouncedCallback(refreshStoryData, STORY_REFRESH_DEBOUNCE_MS);
 
 	useEffect(() => {
 		if (previousRunningRef.current && !isAgentRunning) {
-			void refetch();
-			void queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
-			void queryClient.invalidateQueries({
-				queryKey: trpc.story.getLatest.queryKey({ chatId, storySlug }),
-			});
+			refreshStoryData();
 		}
 
 		previousRunningRef.current = isAgentRunning;
-	}, [isAgentRunning, queryClient, refetch, chatId, storySlug]);
+	}, [isAgentRunning, refreshStoryData]);
+
+	useEffect(() => {
+		if (latestStoryOutputRef.current.storySlug !== storySlug) {
+			latestStoryOutputRef.current = { storySlug, version: latestStoryOutputVersion };
+			return;
+		}
+
+		if (latestStoryOutputVersion === null || latestStoryOutputRef.current.version === latestStoryOutputVersion) {
+			return;
+		}
+
+		latestStoryOutputRef.current.version = latestStoryOutputVersion;
+		debouncedRefreshStoryData();
+	}, [debouncedRefreshStoryData, latestStoryOutputVersion, storySlug]);
 
 	useEffect(() => {
 		setHistoricalVersionSelection((selection) => {
@@ -67,6 +91,7 @@ export const useStoryViewerVersions = ({
 	const currentVersionIndex = selectedVersionIndex ?? versions.length - 1;
 	const currentVersion = versions[currentVersionIndex];
 	const currentVersionNumber = currentVersionIndex + 1;
+	const storedVersionNumber = currentVersion?.version ?? 0;
 	const isViewingLatest = selectedVersionIndex === null;
 
 	const goToPreviousVersion = useCallback(() => {
@@ -92,6 +117,10 @@ export const useStoryViewerVersions = ({
 		);
 	}, [chatId, selectedVersionIndex, storySlug, versions.length]);
 
+	const goToLatestVersion = useCallback(() => {
+		setHistoricalVersionSelection(null);
+	}, []);
+
 	return {
 		versions,
 		storyId,
@@ -99,9 +128,11 @@ export const useStoryViewerVersions = ({
 		archivedAt,
 		currentVersion,
 		currentVersionNumber,
+		storedVersionNumber,
 		isViewingLatest,
 		goToPreviousVersion,
 		goToNextVersion,
+		goToLatestVersion,
 	};
 };
 

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -63,6 +63,7 @@ export interface StoryHeaderProps {
 	onEnlarge: () => void;
 	isShared: boolean;
 	isAgentRunning: boolean;
+	isStoryUpdating: boolean;
 	isSaving?: boolean;
 	isReadonlyMode: boolean;
 	isLive: boolean;
@@ -100,6 +101,7 @@ export const StoryHeader = memo(function StoryHeader({
 	onEnlarge,
 	isShared,
 	isAgentRunning,
+	isStoryUpdating,
 	isSaving = false,
 	isReadonlyMode,
 	isLive,
@@ -142,6 +144,13 @@ export const StoryHeader = memo(function StoryHeader({
 		</DropdownMenu>
 	) : (
 		<h3 className='text-sm font-medium truncate flex-1'>{title}</h3>
+	);
+
+	const updatingIndicator = isStoryUpdating && (
+		<div className='flex shrink-0 items-center gap-1 text-xs text-muted-foreground' role='status'>
+			<Loader2 className='size-3 animate-spin' strokeWidth={2.25} />
+			<span>Updating…</span>
+		</div>
 	);
 
 	const versionNav = totalVersions > 1 && (
@@ -328,6 +337,7 @@ export const StoryHeader = memo(function StoryHeader({
 					</div>
 					<div className='flex items-center gap-2 border-b px-4 py-2'>
 						{titleElement}
+						{updatingIndicator}
 						{versionNav}
 					</div>
 				</>
@@ -343,6 +353,7 @@ export const StoryHeader = memo(function StoryHeader({
 						<X className='size-3.5' strokeWidth={2.25} />
 					</Button>
 					{titleElement}
+					{updatingIndicator}
 					{versionNav}
 					{viewModeToggle}
 					{liveControls}

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -407,7 +407,13 @@ export const StoryHeader = memo(function StoryHeader({
 							<span className='text-xs text-muted-foreground'>
 								Viewing v{currentVersion} of {totalVersions}
 							</span>
-							<Button variant='outline' size='sm' onClick={onRestore} className='gap-1.5'>
+							<Button
+								variant='outline'
+								size='sm'
+								onClick={onRestore}
+								disabled={isSaving}
+								className='gap-1.5'
+							>
 								<RotateCcw className='size-3' strokeWidth={2.25} />
 								<span>Restore</span>
 							</Button>

--- a/apps/frontend/src/components/side-panel/story-preview.tsx
+++ b/apps/frontend/src/components/side-panel/story-preview.tsx
@@ -1,6 +1,6 @@
 import { NO_CACHE_SCHEDULE } from '@nao/shared';
 import { splitCodeIntoSegments } from '@nao/shared/story-segments';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import type { ParsedChartBlock, ParsedMapBlock, ParsedTableBlock } from '@nao/shared/story-segments';
 
 import type { QueryDataMap } from '@/components/story-embeds';
@@ -11,11 +11,9 @@ import {
 } from '@/components/story-embeds';
 import { StoryFilterBar } from '@/components/story-filter-bar';
 import { SegmentList } from '@/components/story-rendering';
-import { StoryChartEmbed as StaticChartEmbed } from '@/components/side-panel/story-chart-embed';
-import { StoryMapEmbed as StaticMapEmbed } from '@/components/side-panel/story-map-embed';
-import { StoryTableEmbed as StaticTableEmbed } from '@/components/side-panel/story-table-embed';
 import { StoryQuerySqlProvider } from '@/contexts/story-query-sql';
 import { useStoryFilters } from '@/hooks/use-story-filters';
+import { stabilizeStorySegments } from '@/lib/story-segment-stability';
 import { trpc } from '@/main';
 
 interface StoryPreviewProps {
@@ -27,6 +25,9 @@ interface StoryPreviewProps {
 	storySlug: string;
 	versionKey?: string | number;
 	filtersEnabled?: boolean;
+	isStreaming?: boolean;
+	isDataPending?: boolean;
+	isViewingLatest?: boolean;
 }
 
 export const StoryPreview = memo(function StoryPreview({
@@ -38,8 +39,16 @@ export const StoryPreview = memo(function StoryPreview({
 	storySlug,
 	versionKey,
 	filtersEnabled = true,
+	isStreaming = false,
+	isDataPending = false,
+	isViewingLatest = true,
 }: StoryPreviewProps) {
-	const segments = useMemo(() => splitCodeIntoSegments(code), [code]);
+	const previousSegmentsRef = useRef<ReturnType<typeof splitCodeIntoSegments>>([]);
+	const segments = useMemo(() => {
+		const nextSegments = stabilizeStorySegments(splitCodeIntoSegments(code), previousSegmentsRef.current);
+		previousSegmentsRef.current = nextSegments;
+		return nextSegments;
+	}, [code]);
 	const isNoCacheMode = cacheSchedule === NO_CACHE_SCHEDULE;
 	const filterApi = useMemo(() => ({ kind: 'owned' as const, chatId, storySlug }), [chatId, storySlug]);
 	const storyFilters = useStoryFilters({
@@ -56,64 +65,79 @@ export const StoryPreview = memo(function StoryPreview({
 
 	const effectiveQueryData = storyFilters.queryData;
 
-	const useLiveUnfiltered = isNoCacheMode && !storyFilters.hasActiveFilters;
+	const useLiveUnfiltered = isViewingLatest && isNoCacheMode && !storyFilters.hasActiveFilters;
 	const querySqlSource = useMemo(
 		() => (storyFilters.filtersEnabled ? { api: filterApi, selections: storyFilters.debouncedSelections } : null),
 		[filterApi, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
 	);
 
 	const renderChart = useCallback(
-		(chart: ParsedChartBlock) => {
-			if (!effectiveQueryData && !useLiveUnfiltered) {
-				return <StaticChartEmbed chart={chart} />;
-			}
-			return (
-				<LiveChartEmbed
-					chart={chart}
-					queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
-					liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
-					hasActiveFilters={storyFilters.hasActiveFilters}
-					isRefreshing={storyFilters.isFiltering}
-				/>
-			);
-		},
-		[effectiveQueryData, useLiveUnfiltered, noCacheQuery, storyFilters.hasActiveFilters, storyFilters.isFiltering],
+		(chart: ParsedChartBlock) => (
+			<LiveChartEmbed
+				chart={chart}
+				queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
+				liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
+				hasActiveFilters={storyFilters.hasActiveFilters}
+				isRefreshing={storyFilters.isFiltering}
+				isStreaming={isStreaming}
+				isDataPending={isDataPending}
+			/>
+		),
+		[
+			effectiveQueryData,
+			useLiveUnfiltered,
+			noCacheQuery,
+			storyFilters.hasActiveFilters,
+			storyFilters.isFiltering,
+			isStreaming,
+			isDataPending,
+		],
 	);
 
 	const renderTable = useCallback(
-		(table: ParsedTableBlock) => {
-			if (!effectiveQueryData && !useLiveUnfiltered) {
-				return <StaticTableEmbed table={table} />;
-			}
-			return (
-				<LiveTableEmbed
-					table={table}
-					queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
-					liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
-					hasActiveFilters={storyFilters.hasActiveFilters}
-					isRefreshing={storyFilters.isFiltering}
-				/>
-			);
-		},
-		[effectiveQueryData, useLiveUnfiltered, noCacheQuery, storyFilters.hasActiveFilters, storyFilters.isFiltering],
+		(table: ParsedTableBlock) => (
+			<LiveTableEmbed
+				table={table}
+				queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
+				liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
+				hasActiveFilters={storyFilters.hasActiveFilters}
+				isRefreshing={storyFilters.isFiltering}
+				isStreaming={isStreaming}
+				isDataPending={isDataPending}
+			/>
+		),
+		[
+			effectiveQueryData,
+			useLiveUnfiltered,
+			noCacheQuery,
+			storyFilters.hasActiveFilters,
+			storyFilters.isFiltering,
+			isStreaming,
+			isDataPending,
+		],
 	);
 
 	const renderMap = useCallback(
-		(map: ParsedMapBlock) => {
-			if (!effectiveQueryData && !useLiveUnfiltered) {
-				return <StaticMapEmbed map={map} />;
-			}
-			return (
-				<LiveMapEmbed
-					map={map}
-					queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
-					liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
-					hasActiveFilters={storyFilters.hasActiveFilters}
-					isRefreshing={storyFilters.isFiltering}
-				/>
-			);
-		},
-		[effectiveQueryData, useLiveUnfiltered, noCacheQuery, storyFilters.hasActiveFilters, storyFilters.isFiltering],
+		(map: ParsedMapBlock) => (
+			<LiveMapEmbed
+				map={map}
+				queryData={useLiveUnfiltered ? undefined : effectiveQueryData}
+				liveQuery={useLiveUnfiltered ? noCacheQuery : undefined}
+				hasActiveFilters={storyFilters.hasActiveFilters}
+				isRefreshing={storyFilters.isFiltering}
+				isStreaming={isStreaming}
+				isDataPending={isDataPending}
+			/>
+		),
+		[
+			effectiveQueryData,
+			useLiveUnfiltered,
+			noCacheQuery,
+			storyFilters.hasActiveFilters,
+			storyFilters.isFiltering,
+			isStreaming,
+			isDataPending,
+		],
 	);
 
 	return (

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -26,6 +26,7 @@ import type { StoryCodeViewHandle } from './story-code-view';
 import { AssetAnalyticsDialog } from '@/components/asset-analytics-dialog';
 import { useSidePanel } from '@/contexts/side-panel';
 import { useDragAutoScroll } from '@/hooks/use-drag-auto-scroll';
+import { useStoryVersionQueryData } from '@/hooks/use-story-version-query-data';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 import { ReadonlyAgentMessagesProvider, useOptionalAgentContext } from '@/contexts/agent.provider';
 import { StoryChartEditProvider } from '@/contexts/story-chart-edit';
@@ -77,12 +78,10 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		useCallback(() => chatActivityStore.getActivity(chatId).running, [chatId]),
 	);
 
-	const { allStories, draftStory, isAgentRunning } = useStoryViewerAgentState(
-		storySlug,
-		chatMessages,
-		isChatAgentRunning,
-	);
+	const { allStories, draftStory, latestStoryOutputVersion, isAgentRunning, isStoryUpdating, isStoryInterrupted } =
+		useStoryViewerAgentState(storySlug, chatMessages, isChatAgentRunning);
 	const resolvedStorySlug = draftStory?.id ?? storySlug;
+	const isStoryStreaming = Boolean(draftStory?.isStreaming);
 	const prevSlugRef = useRef(resolvedStorySlug);
 	const {
 		versions,
@@ -91,10 +90,18 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		archivedAt,
 		currentVersion,
 		currentVersionNumber,
+		storedVersionNumber,
 		isViewingLatest,
 		goToPreviousVersion,
 		goToNextVersion,
-	} = useStoryViewerVersions({ chatId, storySlug: resolvedStorySlug, isAgentRunning, isReadonlyMode });
+		goToLatestVersion,
+	} = useStoryViewerVersions({
+		chatId,
+		storySlug: resolvedStorySlug,
+		isAgentRunning,
+		latestStoryOutputVersion,
+		isReadonlyMode,
+	});
 	const {
 		storyTitle,
 		storyCode,
@@ -109,7 +116,16 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		draftStory,
 		currentVersion,
 		storedTitle,
+		isViewingLatest,
+		isStoryInterrupted,
 		isReadonlyMode,
+	});
+	const { queryData: versionQueryData, isPending: isVersionQueryDataPending } = useStoryVersionQueryData({
+		chatId,
+		storySlug: resolvedStorySlug,
+		versionNumber: storedVersionNumber,
+		isViewingLatest,
+		latestQueryData: queryData ?? null,
 	});
 	const tabs = useMemo(() => parseStoryTabs(storyCode ?? ''), [storyCode]);
 	const isTabbedStory = Boolean(tabs?.length);
@@ -119,7 +135,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		chatId,
 		storySlug: resolvedStorySlug,
 		storyId,
-		versionNumber: currentVersionNumber > 0 ? currentVersionNumber : undefined,
+		versionNumber: storedVersionNumber > 0 ? storedVersionNumber : undefined,
 	});
 
 	const { handleSave, handleRestore, isSaving } = useStoryViewerVersionActions({
@@ -128,6 +144,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		storyTitle: storedTitle,
 		currentVersionCode: currentVersion?.code,
 		isViewingLatest,
+		goToLatestVersion,
 		tiptapEditorRef,
 		codeViewRef,
 		getEditModeCode,
@@ -188,7 +205,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 
 	useStoryViewerStreamScroll({
 		scrollContainerRef,
-		isStreaming: Boolean(draftStory?.isStreaming),
+		isAppendingContent: Boolean(draftStory?.isStreaming),
 		code: storyCode,
 		viewMode,
 	});
@@ -235,6 +252,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 				onEnlarge={handleEnlarge}
 				isShared={isShared}
 				isAgentRunning={isAgentRunning}
+				isStoryUpdating={isStoryUpdating}
 				isSaving={isSaving}
 				isReadonlyMode={isReadonlyMode}
 				isLive={isLive}
@@ -278,15 +296,18 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 								}
 								fullCode={storyCode}
 								cacheSchedule={cacheSchedule}
-								queryData={queryData ?? null}
+								queryData={versionQueryData}
 								chatId={chatId}
 								storySlug={resolvedStorySlug}
 								versionKey={isViewingLatest ? undefined : currentVersionNumber}
 								filtersEnabled={isViewingLatest && !isAgentRunning}
+								isStreaming={isStoryStreaming}
+								isDataPending={isVersionQueryDataPending}
+								isViewingLatest={isViewingLatest}
 							/>
 						)
 					) : viewMode === 'edit' ? (
-						<StoryEmbedDataProvider value={queryData ?? null}>
+						<StoryEmbedDataProvider value={versionQueryData}>
 							{isTabbedStory ? (
 								<StoryTabbedEditor
 									code={storyCode}

--- a/apps/frontend/src/components/story-embeds.tsx
+++ b/apps/frontend/src/components/story-embeds.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { displayChart } from '@nao/shared/tools';
 import type { ParsedChartBlock, ParsedMapBlock, ParsedTableBlock } from '@nao/shared/story-segments';
@@ -10,9 +10,12 @@ import { StoryTableEditControls } from '@/components/side-panel/story-table-embe
 import { StoryMapRender } from '@/components/story-map-embed';
 import { ChartDisplay } from '@/components/tool-calls/display-chart';
 import { DataTableCard } from '@/components/data-table-card';
+import { useSourceQuery } from '@/hooks/use-source-query';
+import { sortByDateKey } from '@/lib/charts.utils';
 import { cn } from '@/lib/utils';
 
 export type QueryDataMap = Record<string, { data: Record<string, unknown>[]; columns: string[] }>;
+type EmbedData = QueryDataMap[string];
 
 interface LiveQueryConfig {
 	queryOptions: (input: { chatId: string; queryId: string }) => object;
@@ -27,12 +30,12 @@ function EmbedPlaceholder({ children }: { children: React.ReactNode }) {
 	);
 }
 
-function EmbedLoading() {
+function EmbedLoading({ label = 'Loading live data...' }: { label?: string }) {
 	return (
 		<EmbedPlaceholder>
 			<span className='flex items-center justify-center'>
 				<Loader2 className='size-4 animate-spin mr-2' />
-				Loading live data...
+				{label}
 			</span>
 		</EmbedPlaceholder>
 	);
@@ -61,34 +64,62 @@ function useLiveQueryData(queryId: string, liveQuery?: LiveQueryConfig) {
 	});
 }
 
+function useResolvedEmbedData(
+	queryId: string,
+	{ queryData, liveQuery }: { queryData?: QueryDataMap | null; liveQuery?: LiveQueryConfig },
+) {
+	const liveQueryData = useLiveQueryData(queryId, liveQuery);
+	const savedData = liveQuery ? undefined : queryData?.[queryId];
+	const { sourceData } = useSourceQuery(!liveQuery && !savedData ? queryId : undefined);
+	const fallbackData = sourceData
+		? ({ data: sourceData.data, columns: sourceData.columns ?? [] } satisfies EmbedData)
+		: undefined;
+
+	return {
+		data: liveQuery ? (liveQueryData.data as EmbedData | undefined) : (savedData ?? fallbackData),
+		isLoading: Boolean(liveQuery && liveQueryData.isLoading),
+		isFetching: Boolean(liveQuery && liveQueryData.isFetching),
+	};
+}
+
 export const StoryChartEmbed = memo(function StoryChartEmbed({
 	chart,
 	queryData,
 	liveQuery,
 	hasActiveFilters = false,
 	isRefreshing = false,
+	isStreaming = false,
+	isDataPending = false,
 }: {
 	chart: ParsedChartBlock;
 	queryData?: QueryDataMap | null;
 	liveQuery?: LiveQueryConfig;
 	hasActiveFilters?: boolean;
 	isRefreshing?: boolean;
+	isStreaming?: boolean;
+	isDataPending?: boolean;
 }) {
-	const noCacheFetch = useLiveQueryData(chart.queryId, liveQuery);
-
-	const resolved = liveQuery
-		? (noCacheFetch.data as { data: Record<string, unknown>[]; columns: string[] } | undefined)
-		: queryData?.[chart.queryId];
-	const displayData = resolved?.data ?? [];
+	const resolvedData = useResolvedEmbedData(chart.queryId, { queryData, liveQuery });
+	const resolved = resolvedData.data;
+	const displayData = useMemo(
+		() =>
+			resolved?.data && chart.xAxisType === 'date'
+				? sortByDateKey(resolved.data, chart.xAxisKey)
+				: (resolved?.data ?? []),
+		[resolved?.data, chart.xAxisKey, chart.xAxisType],
+	);
 	const resolvedColumns = resolved?.columns ?? [];
-	const showRefreshing = isRefreshing || Boolean(liveQuery && noCacheFetch.isFetching);
+	const showRefreshing = isRefreshing || resolvedData.isFetching;
 
-	if (liveQuery && noCacheFetch.isLoading) {
+	if (resolvedData.isLoading) {
 		return <EmbedLoading />;
 	}
 
 	if (!resolved) {
-		return <EmbedPlaceholder>Chart data unavailable</EmbedPlaceholder>;
+		if (isStreaming || isDataPending) {
+			return <EmbedLoading label='Loading data...' />;
+		}
+		return <EmbedPlaceholder>Chart data unavailable (query: {chart.queryId})</EmbedPlaceholder>;
 	}
 
 	if (displayData.length === 0) {
@@ -104,7 +135,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 	}
 
 	return (
-		<StoryChartEmbedShell chart={chart} availableColumns={resolvedColumns} data={displayData}>
+		<StoryChartEmbedShell chart={chart} availableColumns={resolvedColumns} data={resolved.data}>
 			<EmbedRefreshing isRefreshing={showRefreshing}>
 				<ChartDisplay
 					data={displayData}
@@ -137,6 +168,8 @@ export const StoryMapEmbed = memo(function StoryMapEmbed({
 	liveQuery,
 	hasActiveFilters = false,
 	isRefreshing = false,
+	isStreaming = false,
+	isDataPending = false,
 	allowExpand,
 }: {
 	map: ParsedMapBlock;
@@ -144,22 +177,24 @@ export const StoryMapEmbed = memo(function StoryMapEmbed({
 	liveQuery?: LiveQueryConfig;
 	hasActiveFilters?: boolean;
 	isRefreshing?: boolean;
+	isStreaming?: boolean;
+	isDataPending?: boolean;
 	allowExpand?: boolean;
 }) {
-	const noCacheFetch = useLiveQueryData(map.queryId, liveQuery);
-
-	const resolved = liveQuery
-		? (noCacheFetch.data as { data: Record<string, unknown>[]; columns: string[] } | undefined)
-		: queryData?.[map.queryId];
+	const resolvedData = useResolvedEmbedData(map.queryId, { queryData, liveQuery });
+	const resolved = resolvedData.data;
 	const displayData = resolved?.data ?? [];
-	const showRefreshing = isRefreshing || Boolean(liveQuery && noCacheFetch.isFetching);
+	const showRefreshing = isRefreshing || resolvedData.isFetching;
 
-	if (liveQuery && noCacheFetch.isLoading) {
+	if (resolvedData.isLoading) {
 		return <EmbedLoading />;
 	}
 
 	if (!resolved) {
-		return <EmbedPlaceholder>Map data unavailable</EmbedPlaceholder>;
+		if (isStreaming || isDataPending) {
+			return <EmbedLoading label='Loading data...' />;
+		}
+		return <EmbedPlaceholder>Map data unavailable (query: {map.queryId})</EmbedPlaceholder>;
 	}
 
 	if (displayData.length === 0) {
@@ -185,26 +220,30 @@ export const StoryTableEmbed = memo(function StoryTableEmbed({
 	liveQuery,
 	hasActiveFilters = false,
 	isRefreshing = false,
+	isStreaming = false,
+	isDataPending = false,
 }: {
 	table: ParsedTableBlock;
 	queryData?: QueryDataMap | null;
 	liveQuery?: LiveQueryConfig;
 	hasActiveFilters?: boolean;
 	isRefreshing?: boolean;
+	isStreaming?: boolean;
+	isDataPending?: boolean;
 }) {
-	const noCacheFetch = useLiveQueryData(table.queryId, liveQuery);
+	const resolvedData = useResolvedEmbedData(table.queryId, { queryData, liveQuery });
+	const resolvedResult = resolvedData.data;
+	const showRefreshing = isRefreshing || resolvedData.isFetching;
 
-	const resolvedResult = liveQuery
-		? (noCacheFetch.data as { data: Record<string, unknown>[]; columns: string[] } | undefined)
-		: queryData?.[table.queryId];
-	const showRefreshing = isRefreshing || Boolean(liveQuery && noCacheFetch.isFetching);
-
-	if (liveQuery && noCacheFetch.isLoading) {
+	if (resolvedData.isLoading) {
 		return <EmbedLoading />;
 	}
 
 	if (!resolvedResult) {
-		return <EmbedPlaceholder>Table data unavailable</EmbedPlaceholder>;
+		if (isStreaming || isDataPending) {
+			return <EmbedLoading label='Loading data...' />;
+		}
+		return <EmbedPlaceholder>Table data unavailable (query: {table.queryId})</EmbedPlaceholder>;
 	}
 
 	if (!resolvedResult.data || resolvedResult.data.length === 0) {

--- a/apps/frontend/src/components/story-rendering.tsx
+++ b/apps/frontend/src/components/story-rendering.tsx
@@ -26,22 +26,15 @@ export const SegmentList = memo(function SegmentList({
 	renderTable,
 	renderMap,
 }: SegmentRendererProps) {
+	const blockOccurrences = new Map<string, number>();
+
 	return (
 		<>
 			{segments.map((segment, i) => {
-				const key = versionKey != null ? `${versionKey}-${i}` : i;
+				const key = getSegmentKey(segment, i, blockOccurrences, versionKey);
 				switch (segment.type) {
 					case 'markdown':
-						return (
-							<Streamdown
-								key={key}
-								mode='static'
-								plugins={markdownPlugins}
-								components={markdownComponents}
-							>
-								{segment.content}
-							</Streamdown>
-						);
+						return <MarkdownSegment key={key} content={segment.content} />;
 					case 'chart':
 						return <Fragment key={key}>{renderChart(segment.chart, i)}</Fragment>;
 					case 'table':
@@ -68,6 +61,14 @@ export const SegmentList = memo(function SegmentList({
 	);
 });
 
+const MarkdownSegment = memo(function MarkdownSegment({ content }: { content: string }) {
+	return (
+		<Streamdown mode='static' plugins={markdownPlugins} components={markdownComponents}>
+			{content}
+		</Streamdown>
+	);
+});
+
 const StoryGrid = memo(function StoryGrid({
 	cols,
 	widths,
@@ -83,6 +84,8 @@ const StoryGrid = memo(function StoryGrid({
 	renderTable: (table: ParsedTableBlock, key: number) => React.ReactNode;
 	renderMap: (map: ParsedMapBlock, key: number) => React.ReactNode;
 }) {
+	const blockOccurrences = new Map<string, number>();
+
 	return (
 		<div className='@container'>
 			<div
@@ -96,12 +99,10 @@ const StoryGrid = memo(function StoryGrid({
 					: {})}
 			>
 				{children.map((segment, i) => (
-					<StoryGridProvider key={i}>
+					<StoryGridProvider key={getSegmentKey(segment, i, blockOccurrences)}>
 						<div className='min-w-0'>
 							{segment.type === 'markdown' ? (
-								<Streamdown mode='static' plugins={markdownPlugins} components={markdownComponents}>
-									{segment.content}
-								</Streamdown>
+								<MarkdownSegment content={segment.content} />
 							) : segment.type === 'chart' ? (
 								renderChart(segment.chart, i)
 							) : segment.type === 'table' ? (
@@ -125,3 +126,33 @@ const StoryGrid = memo(function StoryGrid({
 		</div>
 	);
 });
+
+function getSegmentKey(
+	segment: Segment,
+	index: number,
+	blockOccurrences: Map<string, number>,
+	versionKey?: string | number,
+): string {
+	const blockIdentity = getBlockIdentity(segment, blockOccurrences);
+	const segmentIdentity = blockIdentity ?? `index:${index}`;
+	return versionKey != null ? `${versionKey}:${segmentIdentity}` : segmentIdentity;
+}
+
+function getBlockIdentity(segment: Segment, blockOccurrences: Map<string, number>): string | null {
+	const rawTag =
+		segment.type === 'chart'
+			? segment.chart.rawTag
+			: segment.type === 'table'
+				? segment.table.rawTag
+				: segment.type === 'map'
+					? segment.map.rawTag
+					: undefined;
+	if (!rawTag || (segment.type !== 'chart' && segment.type !== 'table' && segment.type !== 'map')) {
+		return null;
+	}
+
+	const sourceKey = `${segment.type}:${rawTag}`;
+	const occurrence = blockOccurrences.get(sourceKey) ?? 0;
+	blockOccurrences.set(sourceKey, occurrence + 1);
+	return `block:${sourceKey}:${occurrence}`;
+}

--- a/apps/frontend/src/hooks/use-debounced-callback.test.ts
+++ b/apps/frontend/src/hooks/use-debounced-callback.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDebouncedCallback } from './use-debounced-callback';
+
+describe('useDebouncedCallback', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('invokes once with the latest arguments after rapid calls', () => {
+		vi.useFakeTimers();
+		const callback = vi.fn();
+		const { result } = renderHook(() => useDebouncedCallback(callback, 120));
+
+		act(() => {
+			result.current('first');
+			vi.advanceTimersByTime(60);
+			result.current('second');
+			result.current('third');
+		});
+
+		expect(callback).not.toHaveBeenCalled();
+		act(() => vi.advanceTimersByTime(120));
+		expect(callback).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledWith('third');
+	});
+
+	it('clears a pending callback on unmount', () => {
+		vi.useFakeTimers();
+		const callback = vi.fn();
+		const { result, unmount } = renderHook(() => useDebouncedCallback(callback, 120));
+
+		act(() => result.current());
+		expect(vi.getTimerCount()).toBe(1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+
+		act(() => vi.advanceTimersByTime(120));
+		expect(callback).not.toHaveBeenCalled();
+	});
+});

--- a/apps/frontend/src/hooks/use-debounced-callback.ts
+++ b/apps/frontend/src/hooks/use-debounced-callback.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+export function useDebouncedCallback<Args extends unknown[]>(
+	callback: (...args: Args) => void,
+	delayMs: number,
+): (...args: Args) => void {
+	const callbackRef = useRef(callback);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	callbackRef.current = callback;
+
+	useEffect(
+		() => () => {
+			clearPendingCallback(timeoutRef);
+		},
+		[],
+	);
+
+	return useCallback(
+		(...args: Args) => {
+			clearPendingCallback(timeoutRef);
+			timeoutRef.current = setTimeout(() => {
+				timeoutRef.current = null;
+				callbackRef.current(...args);
+			}, delayMs);
+		},
+		[delayMs],
+	);
+}
+
+function clearPendingCallback(timeoutRef: React.RefObject<ReturnType<typeof setTimeout> | null>) {
+	if (timeoutRef.current !== null) {
+		clearTimeout(timeoutRef.current);
+		timeoutRef.current = null;
+	}
+}

--- a/apps/frontend/src/hooks/use-story-page-editor.ts
+++ b/apps/frontend/src/hooks/use-story-page-editor.ts
@@ -29,9 +29,11 @@ export function useStoryPageEditor({
 		storyId,
 		currentVersion,
 		currentVersionNumber,
+		storedVersionNumber,
 		isViewingLatest,
 		goToPreviousVersion,
 		goToNextVersion,
+		goToLatestVersion,
 	} = useStoryViewerVersions({ chatId, storySlug, isAgentRunning, isReadonlyMode });
 
 	const code = currentVersion?.code ?? latestCode;
@@ -49,6 +51,7 @@ export function useStoryPageEditor({
 		storyTitle,
 		currentVersionCode: code,
 		isViewingLatest,
+		goToLatestVersion,
 		tiptapEditorRef,
 		codeViewRef,
 		getEditModeCode,
@@ -79,6 +82,7 @@ export function useStoryPageEditor({
 		handleRestore,
 		versionNav: {
 			currentVersion: currentVersionNumber,
+			storedVersionNumber,
 			totalVersions: versions.length,
 			isViewingLatest,
 			goToPrevious: goToPreviousVersion,

--- a/apps/frontend/src/hooks/use-story-version-query-data.ts
+++ b/apps/frontend/src/hooks/use-story-version-query-data.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+
+import type { QueryDataMap } from '@/components/story-embeds';
+import { trpc } from '@/main';
+
+interface UseStoryVersionQueryDataParams {
+	chatId: string;
+	storySlug: string;
+	versionNumber: number;
+	isViewingLatest: boolean;
+	latestQueryData: QueryDataMap | null;
+	shareId?: string;
+}
+
+export function useStoryVersionQueryData({
+	chatId,
+	storySlug,
+	versionNumber,
+	isViewingLatest,
+	latestQueryData,
+	shareId,
+}: UseStoryVersionQueryDataParams): { queryData: QueryDataMap | null; isPending: boolean } {
+	const hasVersionNumber = Number.isInteger(versionNumber) && versionNumber > 0;
+	const shouldFetchHistoricalData = !isViewingLatest && hasVersionNumber;
+	const ownedVersionQuery = useQuery({
+		...trpc.story.getVersionQueryData.queryOptions({ chatId, storySlug, versionNumber }),
+		enabled: shouldFetchHistoricalData && !shareId,
+	});
+	const sharedVersionQuery = useQuery({
+		...trpc.storyShare.getVersionQueryData.queryOptions({ shareId: shareId ?? '', versionNumber }),
+		enabled: shouldFetchHistoricalData && Boolean(shareId),
+	});
+
+	if (isViewingLatest) {
+		return { queryData: latestQueryData, isPending: false };
+	}
+
+	const historicalVersionQuery = shareId ? sharedVersionQuery : ownedVersionQuery;
+	return {
+		queryData: (historicalVersionQuery.data?.queryData as QueryDataMap | null | undefined) ?? null,
+		isPending: !hasVersionNumber || historicalVersionQuery.isPending,
+	};
+}

--- a/apps/frontend/src/hooks/use-throttled-value.test.ts
+++ b/apps/frontend/src/hooks/use-throttled-value.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useThrottledValue } from './use-throttled-value';
+
+describe('useThrottledValue', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('emits the leading value and the latest trailing value', () => {
+		vi.useFakeTimers();
+		const { result, rerender } = renderHook(({ value, enabled }) => useThrottledValue(value, 120, enabled), {
+			initialProps: { value: 'first', enabled: true },
+		});
+
+		expect(result.current).toBe('first');
+		rerender({ value: 'second', enabled: true });
+		act(() => vi.advanceTimersByTime(60));
+		rerender({ value: 'third', enabled: true });
+		act(() => vi.advanceTimersByTime(59));
+		expect(result.current).toBe('first');
+		act(() => vi.advanceTimersByTime(1));
+		expect(result.current).toBe('third');
+	});
+
+	it('passes through immediately when throttling ends', () => {
+		vi.useFakeTimers();
+		const { result, rerender } = renderHook(({ value, enabled }) => useThrottledValue(value, 120, enabled), {
+			initialProps: { value: 'first', enabled: true },
+		});
+
+		rerender({ value: 'pending', enabled: true });
+		expect(result.current).toBe('first');
+		rerender({ value: 'final', enabled: false });
+		expect(result.current).toBe('final');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('cleans up a pending trailing update on unmount', () => {
+		vi.useFakeTimers();
+		const { rerender, unmount } = renderHook(({ value }) => useThrottledValue(value, 120), {
+			initialProps: { value: 'first' },
+		});
+
+		rerender({ value: 'pending' });
+		expect(vi.getTimerCount()).toBe(1);
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/apps/frontend/src/hooks/use-throttled-value.ts
+++ b/apps/frontend/src/hooks/use-throttled-value.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useThrottledValue<T>(value: T, interval: number, enabled = true): T {
+	const [throttledValue, setThrottledValue] = useState(value);
+	const pendingValueRef = useRef(value);
+	const lastUpdateAtRef = useRef(0);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const wasEnabledRef = useRef(false);
+
+	useEffect(() => {
+		pendingValueRef.current = value;
+
+		if (!enabled) {
+			clearScheduledUpdate(timeoutRef);
+			lastUpdateAtRef.current = 0;
+			wasEnabledRef.current = false;
+			setThrottledValue(value);
+			return;
+		}
+
+		const now = Date.now();
+		if (!wasEnabledRef.current) {
+			clearScheduledUpdate(timeoutRef);
+			wasEnabledRef.current = true;
+			lastUpdateAtRef.current = now;
+			setThrottledValue(value);
+			return;
+		}
+
+		const remaining = interval - (now - lastUpdateAtRef.current);
+		if (remaining <= 0) {
+			clearScheduledUpdate(timeoutRef);
+			lastUpdateAtRef.current = now;
+			setThrottledValue(value);
+			return;
+		}
+
+		clearScheduledUpdate(timeoutRef);
+		timeoutRef.current = setTimeout(() => {
+			timeoutRef.current = null;
+			lastUpdateAtRef.current = Date.now();
+			setThrottledValue(pendingValueRef.current);
+		}, remaining);
+	}, [enabled, interval, value]);
+
+	useEffect(
+		() => () => {
+			clearScheduledUpdate(timeoutRef);
+		},
+		[],
+	);
+
+	return enabled ? throttledValue : value;
+}
+
+function clearScheduledUpdate(timeoutRef: React.RefObject<ReturnType<typeof setTimeout> | null>) {
+	if (timeoutRef.current !== null) {
+		clearTimeout(timeoutRef.current);
+		timeoutRef.current = null;
+	}
+}

--- a/apps/frontend/src/lib/story-segment-stability.test.ts
+++ b/apps/frontend/src/lib/story-segment-stability.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { splitCodeIntoSegments } from '@nao/shared/story-segments';
+
+import { stabilizeStorySegments } from './story-segment-stability';
+
+describe('stabilizeStorySegments', () => {
+	it('reuses unchanged chart, table, and map blocks', () => {
+		const code = [
+			'<chart query_id="chart-query" chart_type="line" x_axis_key="month" />',
+			'<table query_id="table-query" />',
+			'<map query_id="map-query" latitude_key="latitude" longitude_key="longitude" />',
+		].join('\n');
+		const first = stabilizeStorySegments(splitCodeIntoSegments(code), []);
+		const second = stabilizeStorySegments(splitCodeIntoSegments(code), first);
+
+		if (
+			first[0]?.type !== 'chart' ||
+			first[1]?.type !== 'table' ||
+			first[2]?.type !== 'map' ||
+			second[0]?.type !== 'chart' ||
+			second[1]?.type !== 'table' ||
+			second[2]?.type !== 'map'
+		) {
+			throw new Error('Expected chart, table, and map segments');
+		}
+
+		expect(second[0].chart).toBe(first[0].chart);
+		expect(second[1].table).toBe(first[1].table);
+		expect(second[2].map).toBe(first[2].map);
+	});
+
+	it('keeps a changed block as a new object', () => {
+		const first = stabilizeStorySegments(
+			splitCodeIntoSegments('<chart query_id="query" chart_type="line" x_axis_key="month" />'),
+			[],
+		);
+		const second = stabilizeStorySegments(
+			splitCodeIntoSegments('<chart query_id="query" chart_type="bar" x_axis_key="month" />'),
+			first,
+		);
+
+		if (first[0]?.type !== 'chart' || second[0]?.type !== 'chart') {
+			throw new Error('Expected chart segments');
+		}
+
+		expect(second[0].chart).not.toBe(first[0].chart);
+	});
+
+	it('reuses unchanged blocks nested in grids', () => {
+		const code = `<grid cols="2">
+<chart query_id="chart-query" chart_type="bar" x_axis_key="category" />
+<table query_id="table-query" />
+</grid>`;
+		const first = stabilizeStorySegments(splitCodeIntoSegments(code), []);
+		const second = stabilizeStorySegments(splitCodeIntoSegments(code), first);
+
+		if (first[0]?.type !== 'grid' || second[0]?.type !== 'grid') {
+			throw new Error('Expected grid segments');
+		}
+		const firstChart = first[0].children[0];
+		const firstTable = first[0].children[1];
+		const secondChart = second[0].children[0];
+		const secondTable = second[0].children[1];
+		if (
+			firstChart?.type !== 'chart' ||
+			firstTable?.type !== 'table' ||
+			secondChart?.type !== 'chart' ||
+			secondTable?.type !== 'table'
+		) {
+			throw new Error('Expected nested chart and table segments');
+		}
+
+		expect(secondChart.chart).toBe(firstChart.chart);
+		expect(secondTable.table).toBe(firstTable.table);
+	});
+});

--- a/apps/frontend/src/lib/story-segment-stability.ts
+++ b/apps/frontend/src/lib/story-segment-stability.ts
@@ -1,0 +1,109 @@
+import type {
+	ParsedChartBlock,
+	ParsedFilterBlock,
+	ParsedMapBlock,
+	ParsedTableBlock,
+	Segment,
+} from '@nao/shared/story-segments';
+
+type StoryBlock = ParsedChartBlock | ParsedTableBlock | ParsedMapBlock | ParsedFilterBlock;
+type StoryBlockType = 'chart' | 'table' | 'map' | 'filter';
+
+export function stabilizeStorySegments(segments: Segment[], previousSegments: Segment[]): Segment[] {
+	const previousBlocks = collectStoryBlocks(previousSegments);
+	const occurrences = new Map<string, number>();
+	return segments.map((segment) => stabilizeSegment(segment, previousBlocks, occurrences));
+}
+
+function stabilizeSegment(
+	segment: Segment,
+	previousBlocks: Map<string, StoryBlock>,
+	occurrences: Map<string, number>,
+): Segment {
+	switch (segment.type) {
+		case 'chart':
+			return { ...segment, chart: reuseStoryBlock('chart', segment.chart, previousBlocks, occurrences) };
+		case 'table':
+			return { ...segment, table: reuseStoryBlock('table', segment.table, previousBlocks, occurrences) };
+		case 'map':
+			return { ...segment, map: reuseStoryBlock('map', segment.map, previousBlocks, occurrences) };
+		case 'filter':
+			return { ...segment, filter: reuseStoryBlock('filter', segment.filter, previousBlocks, occurrences) };
+		case 'grid':
+			return {
+				...segment,
+				children: segment.children.map((child) => stabilizeSegment(child, previousBlocks, occurrences)),
+			};
+		case 'markdown':
+			return segment;
+	}
+}
+
+function collectStoryBlocks(segments: Segment[]): Map<string, StoryBlock> {
+	const blocks = new Map<string, StoryBlock>();
+	const occurrences = new Map<string, number>();
+
+	const collect = (segment: Segment) => {
+		switch (segment.type) {
+			case 'chart':
+				storeStoryBlock('chart', segment.chart, blocks, occurrences);
+				break;
+			case 'table':
+				storeStoryBlock('table', segment.table, blocks, occurrences);
+				break;
+			case 'map':
+				storeStoryBlock('map', segment.map, blocks, occurrences);
+				break;
+			case 'filter':
+				storeStoryBlock('filter', segment.filter, blocks, occurrences);
+				break;
+			case 'grid':
+				segment.children.forEach(collect);
+				break;
+			case 'markdown':
+				break;
+		}
+	};
+
+	segments.forEach(collect);
+	return blocks;
+}
+
+function reuseStoryBlock<T extends StoryBlock>(
+	type: StoryBlockType,
+	block: T,
+	previousBlocks: Map<string, StoryBlock>,
+	occurrences: Map<string, number>,
+): T {
+	const key = getStoryBlockKey(type, block.rawTag, occurrences);
+	if (!key) {
+		return block;
+	}
+	return (previousBlocks.get(key) as T | undefined) ?? block;
+}
+
+function storeStoryBlock(
+	type: StoryBlockType,
+	block: StoryBlock,
+	blocks: Map<string, StoryBlock>,
+	occurrences: Map<string, number>,
+) {
+	const key = getStoryBlockKey(type, block.rawTag, occurrences);
+	if (key) {
+		blocks.set(key, block);
+	}
+}
+
+function getStoryBlockKey(
+	type: StoryBlockType,
+	rawTag: string | undefined,
+	occurrences: Map<string, number>,
+): string | null {
+	if (!rawTag) {
+		return null;
+	}
+	const sourceKey = `${type}:${rawTag}`;
+	const occurrence = occurrences.get(sourceKey) ?? 0;
+	occurrences.set(sourceKey, occurrence + 1);
+	return `${sourceKey}:${occurrence}`;
+}

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -26,6 +26,7 @@ import { StoryTableEditProvider } from '@/contexts/story-table-edit';
 import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useChatActivity } from '@/hooks/use-chat-activity';
 import { useStoryPageEditor } from '@/hooks/use-story-page-editor';
+import { useStoryVersionQueryData } from '@/hooks/use-story-version-query-data';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 
 export const Route = createFileRoute('/_sidebar-layout/stories/preview/$chatId/$storySlug')({
@@ -67,6 +68,13 @@ function StoryPreviewPage() {
 		storyTitle: story.title,
 		latestCode: story.code,
 		isAgentRunning: isChatRunning,
+	});
+	const { queryData, isPending: isQueryDataPending } = useStoryVersionQueryData({
+		chatId,
+		storySlug,
+		versionNumber: editor.versionNav.storedVersionNumber,
+		isViewingLatest: editor.versionNav.isViewingLatest,
+		latestQueryData: story.queryData as QueryDataMap | null,
 	});
 
 	const handleSelectionAsk = useCallback(
@@ -149,7 +157,7 @@ function StoryPreviewPage() {
 			<StoryPageBody
 				code={editor.code}
 				editor={editor}
-				queryData={story.queryData as QueryDataMap | null}
+				queryData={queryData}
 				preview={
 					<SelectionProvider key={storySlug}>
 						<HighlightBubble onAsk={handleSelectionAsk} disabled={isChatRunning} />
@@ -158,11 +166,13 @@ function StoryPreviewPage() {
 							{ chatId, storySlug, storyTitle: story.title, storyCode: editor.code },
 							<PreviewContent
 								code={editor.code}
-								queryData={story.queryData as QueryDataMap | null}
+								queryData={queryData}
 								chatId={chatId}
 								storySlug={storySlug}
 								cacheSchedule={story.cacheSchedule}
 								filtersEnabled={editor.versionNav.isViewingLatest && !editor.isCodeDirty}
+								isDataPending={isQueryDataPending}
+								isViewingLatest={editor.versionNav.isViewingLatest}
 							/>,
 						)}
 					</SelectionProvider>
@@ -240,6 +250,8 @@ function PreviewContent({
 	storySlug,
 	cacheSchedule,
 	filtersEnabled,
+	isDataPending,
+	isViewingLatest,
 }: {
 	code: string;
 	queryData: QueryDataMap | null;
@@ -247,16 +259,19 @@ function PreviewContent({
 	storySlug: string;
 	cacheSchedule?: string | null;
 	filtersEnabled: boolean;
+	isDataPending: boolean;
+	isViewingLatest: boolean;
 }) {
 	const isNoCacheMode = cacheSchedule === 'no-cache';
+	const useLiveUnfiltered = isViewingLatest && isNoCacheMode;
 	const filterApi = useMemo(
 		() => (filtersEnabled ? { kind: 'owned' as const, chatId, storySlug } : null),
 		[chatId, filtersEnabled, storySlug],
 	);
 
 	const noCacheQuery = useMemo(
-		() => (isNoCacheMode ? { queryOptions: trpc.story.getLiveQueryData.queryOptions, chatId } : undefined),
-		[isNoCacheMode, chatId],
+		() => (useLiveUnfiltered ? { queryOptions: trpc.story.getLiveQueryData.queryOptions, chatId } : undefined),
+		[useLiveUnfiltered, chatId],
 	);
 
 	const renderChart = useCallback(
@@ -274,13 +289,14 @@ function PreviewContent({
 		) => (
 			<StoryChartEmbed
 				chart={chart}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	const renderTable = useCallback(
@@ -294,13 +310,14 @@ function PreviewContent({
 		) => (
 			<StoryTableEmbed
 				table={table}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	const renderMap = useCallback(
@@ -314,14 +331,15 @@ function PreviewContent({
 		) => (
 			<StoryMapEmbed
 				map={map}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 				allowExpand
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	return (

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -22,6 +22,7 @@ import { SidePanelProvider } from '@/contexts/side-panel';
 import { SelectionProvider } from '@/contexts/text-selection';
 import { useSidePanel } from '@/hooks/use-side-panel';
 import { useStoryPageEditor } from '@/hooks/use-story-page-editor';
+import { useStoryVersionQueryData } from '@/hooks/use-story-version-query-data';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/main';
@@ -78,6 +79,14 @@ function SharedStoryPage() {
 		storyTitle: story?.title ?? '',
 		latestCode: story?.code ?? '',
 		isReadonlyMode: !isOwner,
+	});
+	const { queryData, isPending: isQueryDataPending } = useStoryVersionQueryData({
+		chatId: story?.chatId ?? '',
+		storySlug: story?.slug ?? '',
+		versionNumber: editor.versionNav.storedVersionNumber,
+		isViewingLatest: editor.versionNav.isViewingLatest,
+		latestQueryData: (story?.queryData as QueryDataMap | null | undefined) ?? null,
+		shareId,
 	});
 
 	if (isLoading) {
@@ -172,17 +181,19 @@ function SharedStoryPage() {
 							<StoryPageBody
 								code={editor.code}
 								editor={editor}
-								queryData={story.queryData as QueryDataMap | null}
+								queryData={queryData}
 								preview={
 									<SharedStoryContent
 										code={editor.code}
-										queryData={story.queryData as QueryDataMap | null}
+										queryData={queryData}
 										chatId={story.chatId!}
 										shareId={shareId}
 										cacheSchedule={story.cacheSchedule}
 										filtersEnabled={
 											!isOwner || (editor.versionNav.isViewingLatest && !editor.isCodeDirty)
 										}
+										isDataPending={isQueryDataPending}
+										isViewingLatest={editor.versionNav.isViewingLatest}
 									/>
 								}
 							/>
@@ -306,6 +317,8 @@ function SharedStoryContent({
 	shareId,
 	cacheSchedule,
 	filtersEnabled,
+	isDataPending,
+	isViewingLatest,
 }: {
 	code: string;
 	queryData: QueryDataMap | null;
@@ -313,16 +326,19 @@ function SharedStoryContent({
 	shareId: string;
 	cacheSchedule?: string | null;
 	filtersEnabled: boolean;
+	isDataPending: boolean;
+	isViewingLatest: boolean;
 }) {
 	const isNoCacheMode = cacheSchedule === 'no-cache';
+	const useLiveUnfiltered = isViewingLatest && isNoCacheMode;
 	const filterApi = useMemo(
 		() => (filtersEnabled ? { kind: 'shared' as const, shareId } : null),
 		[filtersEnabled, shareId],
 	);
 
 	const noCacheQuery = useMemo(
-		() => (isNoCacheMode ? { queryOptions: trpc.storyShare.getLiveQueryData.queryOptions, chatId } : undefined),
-		[isNoCacheMode, chatId],
+		() => (useLiveUnfiltered ? { queryOptions: trpc.storyShare.getLiveQueryData.queryOptions, chatId } : undefined),
+		[useLiveUnfiltered, chatId],
 	);
 
 	const renderChart = useCallback(
@@ -340,13 +356,14 @@ function SharedStoryContent({
 		) => (
 			<StoryChartEmbed
 				chart={chart}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	const renderTable = useCallback(
@@ -360,13 +377,14 @@ function SharedStoryContent({
 		) => (
 			<StoryTableEmbed
 				table={table}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	const renderMap = useCallback(
@@ -380,14 +398,15 @@ function SharedStoryContent({
 		) => (
 			<StoryMapEmbed
 				map={map}
-				queryData={isNoCacheMode && !hasActiveFilters ? undefined : data}
-				liveQuery={isNoCacheMode && !hasActiveFilters ? noCacheQuery : undefined}
+				queryData={useLiveUnfiltered && !hasActiveFilters ? undefined : data}
+				liveQuery={useLiveUnfiltered && !hasActiveFilters ? noCacheQuery : undefined}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 				allowExpand
 			/>
 		),
-		[isNoCacheMode, noCacheQuery],
+		[isDataPending, noCacheQuery, useLiveUnfiltered],
 	);
 
 	return (

--- a/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
@@ -20,6 +20,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { SelectionProvider } from '@/contexts/text-selection';
 import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useStoryPageEditor } from '@/hooks/use-story-page-editor';
+import { useStoryVersionQueryData } from '@/hooks/use-story-version-query-data';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
 import { trpc } from '@/main';
 
@@ -183,6 +184,13 @@ function StandaloneEditableStory({
 	const isShared = Boolean(shareQuery.data?.shareId);
 
 	const editor = useStoryPageEditor({ chatId, storySlug, storyTitle: title, latestCode: code });
+	const { queryData: versionQueryData, isPending: isQueryDataPending } = useStoryVersionQueryData({
+		chatId,
+		storySlug,
+		versionNumber: editor.versionNav.storedVersionNumber,
+		isViewingLatest: editor.versionNav.isViewingLatest,
+		latestQueryData: queryData,
+	});
 
 	const handleSelectionAsk = useCallback(
 		(data: SelectionData) => {
@@ -232,16 +240,17 @@ function StandaloneEditableStory({
 			<StoryPageBody
 				code={editor.code}
 				editor={editor}
-				queryData={queryData}
+				queryData={versionQueryData}
 				preview={
 					<SelectionProvider key={storySlug}>
 						<HighlightBubble onAsk={handleSelectionAsk} disabled={false} />
 						<StandaloneStoryContent
 							code={editor.code}
-							queryData={queryData}
+							queryData={versionQueryData}
 							chatId={chatId}
 							storySlug={storySlug}
 							filtersEnabled={editor.versionNav.isViewingLatest && !editor.isCodeDirty}
+							isDataPending={isQueryDataPending}
 						/>
 					</SelectionProvider>
 				}
@@ -281,12 +290,14 @@ function StandaloneStoryContent({
 	chatId,
 	storySlug,
 	filtersEnabled = true,
+	isDataPending = false,
 }: {
 	code: string;
 	queryData: QueryDataMap | null;
 	chatId?: string | null;
 	storySlug?: string;
 	filtersEnabled?: boolean;
+	isDataPending?: boolean;
 }) {
 	const filterApi = filtersEnabled && chatId && storySlug ? { kind: 'owned' as const, chatId, storySlug } : null;
 
@@ -308,9 +319,10 @@ function StandaloneStoryContent({
 				queryData={data}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[],
+		[isDataPending],
 	);
 
 	const renderTable = useCallback(
@@ -327,9 +339,10 @@ function StandaloneStoryContent({
 				queryData={data}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 			/>
 		),
-		[],
+		[isDataPending],
 	);
 
 	const renderMap = useCallback(
@@ -346,10 +359,11 @@ function StandaloneStoryContent({
 				queryData={data}
 				hasActiveFilters={hasActiveFilters}
 				isRefreshing={isRefreshing}
+				isDataPending={isDataPending}
 				allowExpand
 			/>
 		),
-		[],
+		[isDataPending],
 	);
 
 	return (


### PR DESCRIPTION
## Summary

- Charts and tables in the story preview now find their data while the agent is still writing, instead of showing "data unavailable" until it finishes.
- Older versions of a story now load their own data, so their charts render correctly even after the agent has made new queries.
- Cancelling the agent mid-write no longer leaves the unfinished text stuck in the panel, hiding every saved version behind it.
- The preview stops dragging you to the bottom while the agent writes. It follows along only if you're already at the bottom, and stays put once you scroll up.
- Long stories no longer lag and then dump everything at once — the preview does far less repeated work while streaming.
- Restoring an older version now takes you straight to the new version instead of leaving you to click forward through the arrows.

## Behavior note

Text-only edits don't show a live preview. The panel keeps the last saved version with an "Updating..." indicator until the edit lands. Streaming those edits meant redrawing the whole document per token, which caused huge lags and small text edits are a rare ask so I chose not to do this feature.

Closes #1426

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

