### PR TITLE
Fix chat with nao data wrong context (message_id column in v_messages view)

### DIFF
--- a/apps/backend/src/db/app-db-views.ts
+++ b/apps/backend/src/db/app-db-views.ts
@@ -107,7 +107,7 @@ function buildScopedViews(
 
 	const messages = {
 		chat_id: chatMessage.chatId,
-		message_id: chatMessage.id,
+		message_id: sql<string>`${chatMessage.id}`.as('message_id'),
 		user_id: chat.userId,
 		user_name: sql<string>`${user.name}`.as('user_name'),
 		title: chat.title,


### PR DESCRIPTION
## Summary

- Fixes admin mode queries failing when referencing `message_id` in `v_messages`
- The view's SQL selected `chatMessage.id` without an `.as('message_id')` alias, so the actual column was named `id` — but the system prompt (derived from JS object keys) told the LLM it was `message_id`
- Added the explicit alias so the SQL column name matches what the prompt advertises

## Test plan

- [x] Verified generated SQL now produces `"chat_message"."id" as "message_id"`
- [x] Verified all other views have no similar mismatch
- [ ] Test an admin mode chat query using `message_id` against `v_messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

