### PR TITLE
feat(charts) add horizontal bar built-in chart type

### DIFF
--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -58,11 +58,11 @@ export default createTool<displayChart.Input, displayChart.Output>({
 			};
 		}
 
-		if (chartType === 'progress_bar' && series.length !== 1) {
+		if (chartType === 'horizontal_bar' && series.length !== 1) {
 			return {
 				_version: '1',
 				success: false,
-				error: 'Progress bar charts require exactly one series.',
+				error: 'Horizontal bar charts require exactly one series.',
 			};
 		}
 

--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -58,21 +58,13 @@ export default createTool<displayChart.Input, displayChart.Output>({
 			};
 		}
 
-		if (chartType === 'horizontal_bar' && series.length !== 1) {
-			return {
-				_version: '1',
-				success: false,
-				error: 'Horizontal bar charts require exactly one series.',
-			};
-		}
-
 		// Validate series is not empty
 		if (series.length === 0) {
 			return { _version: '1', success: false, error: 'At least one series is required.' };
 		}
 
 		// Stacked charts require at least two series
-		if (displayChart.isStackedChartType(chartType) && series.length < 2) {
+		if (displayChart.isStackedChartType(chartType) && chartType !== 'horizontal_bar' && series.length < 2) {
 			return {
 				_version: '1',
 				success: false,

--- a/apps/backend/src/agents/tools/display-chart.ts
+++ b/apps/backend/src/agents/tools/display-chart.ts
@@ -58,6 +58,14 @@ export default createTool<displayChart.Input, displayChart.Output>({
 			};
 		}
 
+		if (chartType === 'progress_bar' && series.length !== 1) {
+			return {
+				_version: '1',
+				success: false,
+				error: 'Progress bar charts require exactly one series.',
+			};
+		}
+
 		// Validate series is not empty
 		if (series.length === 0) {
 			return { _version: '1', success: false, error: 'At least one series is required.' };

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -152,8 +152,8 @@ export function SystemPrompt({
 					absolute totals.
 				</ListItem>
 				<ListItem>
-					Use "progress_bar" to compare one metric across a handful of categories as a share of the largest;
-					use one series and sort and limit the rows in SQL.
+					Use "horizontal_bar" for sideways bars with full-width tracks when comparing one metric across a
+					handful of categories; use one series and sort and limit the rows in SQL.
 				</ListItem>
 				<ListItem>
 					Use "pie" or "donut" to show how a single measure splits across categories (part-to-whole); both

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -152,8 +152,9 @@ export function SystemPrompt({
 					absolute totals.
 				</ListItem>
 				<ListItem>
-					Use "horizontal_bar" for sideways bars with full-width tracks when comparing one metric across a
-					handful of categories; use one series and sort and limit the rows in SQL.
+					Use "horizontal_bar" for sideways tracked bars comparing one or more metrics across a handful of
+					categories; multiple series stack within each row. Use "horizontal_bar_100" when each row's
+					composition should sum to 100%, and sort and limit the rows in SQL.
 				</ListItem>
 				<ListItem>
 					Use "pie" or "donut" to show how a single measure splits across categories (part-to-whole); both

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -152,6 +152,10 @@ export function SystemPrompt({
 					absolute totals.
 				</ListItem>
 				<ListItem>
+					Use "progress_bar" to compare one metric across a handful of categories as a share of the largest;
+					use one series and sort and limit the rows in SQL.
+				</ListItem>
+				<ListItem>
 					Use "pie" or "donut" to show how a single measure splits across categories (part-to-whole); both
 					take exactly one series, and slices beyond the top 10 are grouped into an "Other" slice
 					automatically.

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -404,6 +404,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 	}
 
 	const isPie = chart.chartType === 'pie' || chart.chartType === 'donut';
+	const isProgress = chart.chartType === 'progress_bar';
 	const valueKey = chart.series[0]?.data_key ?? '';
 	const chartRows = isPie ? bucketPieData(rows, chart.xAxisKey, valueKey) : rows;
 
@@ -436,7 +437,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 					data-chart={chartData}
 					dangerouslySetInnerHTML={{ __html: svg }}
 				/>
-				{!isPie && <ChartLegend series={chart.series} />}
+				{!isPie && !isProgress && <ChartLegend series={chart.series} />}
 			</div>
 		);
 	} catch {

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -404,7 +404,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 	}
 
 	const isPie = chart.chartType === 'pie' || chart.chartType === 'donut';
-	const isProgress = chart.chartType === 'progress_bar';
+	const isHorizontalBar = chart.chartType === 'horizontal_bar';
 	const valueKey = chart.series[0]?.data_key ?? '';
 	const chartRows = isPie ? bucketPieData(rows, chart.xAxisKey, valueKey) : rows;
 
@@ -437,7 +437,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 					data-chart={chartData}
 					dangerouslySetInnerHTML={{ __html: svg }}
 				/>
-				{!isPie && !isProgress && <ChartLegend series={chart.series} />}
+				{!isPie && !isHorizontalBar && <ChartLegend series={chart.series} />}
 			</div>
 		);
 	} catch {

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -404,7 +404,8 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 	}
 
 	const isPie = chart.chartType === 'pie' || chart.chartType === 'donut';
-	const isHorizontalBar = chart.chartType === 'horizontal_bar';
+	const isHorizontalBar = chart.chartType === 'horizontal_bar' || chart.chartType === 'horizontal_bar_100';
+	const showLegend = !isPie && (!isHorizontalBar || chart.series.length >= 2);
 	const valueKey = chart.series[0]?.data_key ?? '';
 	const chartRows = isPie ? bucketPieData(rows, chart.xAxisKey, valueKey) : rows;
 
@@ -437,7 +438,7 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 					data-chart={chartData}
 					dangerouslySetInnerHTML={{ __html: svg }}
 				/>
-				{!isPie && !isHorizontalBar && <ChartLegend series={chart.series} />}
+				{showLegend && <ChartLegend series={chart.series} />}
 			</div>
 		);
 	} catch {
@@ -1610,7 +1611,7 @@ const TOOLTIP_SCRIPT_TEMPLATE = `
 			var isPie=!!pieColorMap;
 			var html='<div class="nao-tooltip-label">'+labelize(label!=null?label:'')+'</div>';
 			html+='<div class="nao-tooltip-rows">';
-			var isPercent=cfg.chartType==='stacked_bar_100'||cfg.chartType==='stacked_area_100';
+			var isPercent=cfg.chartType==='stacked_bar_100'||cfg.chartType==='stacked_area_100'||cfg.chartType==='horizontal_bar_100';
 			var isDualAxis=(cfg.series||[]).some(function(s){return s.y_axis==='right'});
 			var seriesTotal=0;
 			cfg.series.forEach(function(s){var sv=row[s.data_key];if(typeof sv==='number'&&!s.is_total)seriesTotal+=sv;});

--- a/apps/backend/tests/display-chart-tool.test.ts
+++ b/apps/backend/tests/display-chart-tool.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/db/db', () => ({ db: {} }));
+vi.mock('../src/queries/chat.queries', () => ({
+	getQueryResultByQueryId: vi.fn(async () => null),
+}));
+
+import displayChartTool from '../src/agents/tools/display-chart';
+import type { ToolContext } from '../src/types/tools';
+
+describe('display_chart execute', () => {
+	it('rejects progress bars with more than one series', async () => {
+		const context = {
+			generatedArtifacts: { charts: [], maps: [], stories: [] },
+		} as unknown as ToolContext;
+		const output = await displayChartTool.execute!(
+			{
+				query_id: 'query-1',
+				chart_type: 'progress_bar',
+				x_axis_key: 'category',
+				x_axis_type: 'category',
+				series: [{ data_key: 'revenue' }, { data_key: 'cost' }],
+				title: 'Revenue and cost',
+			},
+			{
+				experimental_context: context,
+			} as Parameters<NonNullable<typeof displayChartTool.execute>>[1],
+		);
+
+		expect(output).toMatchObject({
+			success: false,
+			error: 'Progress bar charts require exactly one series.',
+		});
+		expect(context.generatedArtifacts.charts).toHaveLength(0);
+	});
+});

--- a/apps/backend/tests/display-chart-tool.test.ts
+++ b/apps/backend/tests/display-chart-tool.test.ts
@@ -9,7 +9,7 @@ import displayChartTool from '../src/agents/tools/display-chart';
 import type { ToolContext } from '../src/types/tools';
 
 describe('display_chart execute', () => {
-	it('rejects horizontal bars with more than one series', async () => {
+	it('accepts horizontal bars with multiple series', async () => {
 		const context = {
 			generatedArtifacts: { charts: [], maps: [], stories: [] },
 		} as unknown as ToolContext;
@@ -27,9 +27,31 @@ describe('display_chart execute', () => {
 			} as Parameters<NonNullable<typeof displayChartTool.execute>>[1],
 		);
 
+		expect(output).toMatchObject({ success: true });
+		expect(context.generatedArtifacts.charts).toHaveLength(1);
+	});
+
+	it('requires multiple series for normalized horizontal bars', async () => {
+		const context = {
+			generatedArtifacts: { charts: [], maps: [], stories: [] },
+		} as unknown as ToolContext;
+		const output = await displayChartTool.execute!(
+			{
+				query_id: 'query-1',
+				chart_type: 'horizontal_bar_100',
+				x_axis_key: 'category',
+				x_axis_type: 'category',
+				series: [{ data_key: 'revenue' }],
+				title: 'Revenue share',
+			},
+			{
+				experimental_context: context,
+			} as Parameters<NonNullable<typeof displayChartTool.execute>>[1],
+		);
+
 		expect(output).toMatchObject({
 			success: false,
-			error: 'Horizontal bar charts require exactly one series.',
+			error: expect.stringContaining('requires at least two series'),
 		});
 		expect(context.generatedArtifacts.charts).toHaveLength(0);
 	});

--- a/apps/backend/tests/display-chart-tool.test.ts
+++ b/apps/backend/tests/display-chart-tool.test.ts
@@ -9,14 +9,14 @@ import displayChartTool from '../src/agents/tools/display-chart';
 import type { ToolContext } from '../src/types/tools';
 
 describe('display_chart execute', () => {
-	it('rejects progress bars with more than one series', async () => {
+	it('rejects horizontal bars with more than one series', async () => {
 		const context = {
 			generatedArtifacts: { charts: [], maps: [], stories: [] },
 		} as unknown as ToolContext;
 		const output = await displayChartTool.execute!(
 			{
 				query_id: 'query-1',
-				chart_type: 'progress_bar',
+				chart_type: 'horizontal_bar',
 				x_axis_key: 'category',
 				x_axis_type: 'category',
 				series: [{ data_key: 'revenue' }, { data_key: 'cost' }],
@@ -29,7 +29,7 @@ describe('display_chart execute', () => {
 
 		expect(output).toMatchObject({
 			success: false,
-			error: 'Progress bar charts require exactly one series.',
+			error: 'Horizontal bar charts require exactly one series.',
 		});
 		expect(context.generatedArtifacts.charts).toHaveLength(0);
 	});

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -137,9 +137,12 @@ export function ChartConfigEditDialog({
 	const [paletteHexes, setPaletteHexes] = useState<string[]>(DEFAULT_COLORS);
 	const supportsYAxisRange = !Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES.has(draft.chart_type);
 	const supportsAxisLabels = displayChart.chartTypeSupportsAxisLabels(draft.chart_type);
-	const canNormalize =
+	const isPercentNormalized = displayChart.isPercentStackedChartType(draft.chart_type);
+	const isHorizontalBar = baseChartType(draft.chart_type) === 'horizontal_bar';
+	const showNormalizeToggle =
 		displayChart.isStackedChartType(draft.chart_type) &&
-		(baseChartType(draft.chart_type) !== 'horizontal_bar' || draft.series.length >= 2);
+		(!isHorizontalBar || isPercentNormalized || draft.series.length >= 2);
+	const canEnableNormalize = !isHorizontalBar || draft.series.length >= 2;
 	const unsupportedNumberFormat = useMemo(
 		() =>
 			draft.series
@@ -347,7 +350,7 @@ export function ChartConfigEditDialog({
 						</Select>
 					</div>
 
-					{canNormalize && (
+					{showNormalizeToggle && (
 						<div className='flex items-center justify-between gap-3'>
 							<div className='grid gap-0.5'>
 								<label htmlFor='chart-normalize' className='text-sm font-semibold text-foreground'>
@@ -359,7 +362,8 @@ export function ChartConfigEditDialog({
 							</div>
 							<Switch
 								id='chart-normalize'
-								checked={displayChart.isPercentStackedChartType(draft.chart_type)}
+								checked={isPercentNormalized}
+								disabled={!isPercentNormalized && !canEnableNormalize}
 								onCheckedChange={(checked) =>
 									setDraft((prev) => ({
 										...prev,

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -56,6 +56,7 @@ const Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES = new Set<displayChart.ChartType>([
 	'kpi_card',
 	'radar',
 	'horizontal_bar',
+	'horizontal_bar_100',
 ]);
 
 type UnitPlacement = 'prefix' | 'suffix';
@@ -70,6 +71,9 @@ function baseChartType(type: displayChart.ChartType): displayChart.ChartType {
 	if (type === 'stacked_area_100') {
 		return 'stacked_area';
 	}
+	if (type === 'horizontal_bar_100') {
+		return 'horizontal_bar';
+	}
 	return type;
 }
 
@@ -80,6 +84,9 @@ function percentChartType(type: displayChart.ChartType): displayChart.ChartType 
 	}
 	if (type === 'stacked_area' || type === 'stacked_area_100') {
 		return 'stacked_area_100';
+	}
+	if (type === 'horizontal_bar' || type === 'horizontal_bar_100') {
+		return 'horizontal_bar_100';
 	}
 	return type;
 }
@@ -130,6 +137,9 @@ export function ChartConfigEditDialog({
 	const [paletteHexes, setPaletteHexes] = useState<string[]>(DEFAULT_COLORS);
 	const supportsYAxisRange = !Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES.has(draft.chart_type);
 	const supportsAxisLabels = displayChart.chartTypeSupportsAxisLabels(draft.chart_type);
+	const canNormalize =
+		displayChart.isStackedChartType(draft.chart_type) &&
+		(baseChartType(draft.chart_type) !== 'horizontal_bar' || draft.series.length >= 2);
 	const unsupportedNumberFormat = useMemo(
 		() =>
 			draft.series
@@ -337,7 +347,7 @@ export function ChartConfigEditDialog({
 						</Select>
 					</div>
 
-					{displayChart.isStackedChartType(draft.chart_type) && (
+					{canNormalize && (
 						<div className='flex items-center justify-between gap-3'>
 							<div className='grid gap-0.5'>
 								<label htmlFor='chart-normalize' className='text-sm font-semibold text-foreground'>

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils';
 const CHART_TYPE_OPTIONS: { value: displayChart.ChartType; label: string }[] = [
 	{ value: 'bar', label: 'Bar' },
 	{ value: 'stacked_bar', label: 'Stacked bar' },
-	{ value: 'progress_bar', label: 'Progress bar' },
+	{ value: 'horizontal_bar', label: 'Horizontal bar' },
 	{ value: 'line', label: 'Line' },
 	{ value: 'area', label: 'Area' },
 	{ value: 'stacked_area', label: 'Stacked area' },
@@ -55,7 +55,7 @@ const Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES = new Set<displayChart.ChartType>([
 	'pie',
 	'kpi_card',
 	'radar',
-	'progress_bar',
+	'horizontal_bar',
 ]);
 
 type UnitPlacement = 'prefix' | 'suffix';

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -19,6 +19,7 @@ import { cn } from '@/lib/utils';
 const CHART_TYPE_OPTIONS: { value: displayChart.ChartType; label: string }[] = [
 	{ value: 'bar', label: 'Bar' },
 	{ value: 'stacked_bar', label: 'Stacked bar' },
+	{ value: 'progress_bar', label: 'Progress bar' },
 	{ value: 'line', label: 'Line' },
 	{ value: 'area', label: 'Area' },
 	{ value: 'stacked_area', label: 'Stacked area' },
@@ -50,7 +51,12 @@ const SERIES_TYPE_OPTIONS: { value: displayChart.SeriesType; label: string; icon
 	{ value: 'area', label: 'Area', icon: ChartArea },
 ];
 
-const Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES = new Set<displayChart.ChartType>(['pie', 'kpi_card', 'radar']);
+const Y_AXIS_RANGE_UNSUPPORTED_CHART_TYPES = new Set<displayChart.ChartType>([
+	'pie',
+	'kpi_card',
+	'radar',
+	'progress_bar',
+]);
 
 type UnitPlacement = 'prefix' | 'suffix';
 
@@ -654,7 +660,7 @@ export function ChartConfigEditDialog({
 							</label>
 							<Switch
 								id='show-data-labels'
-								checked={Boolean(draft.show_data_labels)}
+								checked={displayChart.resolveShowDataLabels(draft.chart_type, draft.show_data_labels)}
 								onCheckedChange={(v) => setDraft((prev) => ({ ...prev, show_data_labels: v }))}
 							/>
 						</div>

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -23,6 +23,7 @@ import {
 } from 'recharts';
 
 import {
+	DATA_LABEL_ANCHOR_GAP,
 	DATA_LABEL_MARGIN_TOP,
 	DATA_LABEL_X_AXIS_FOOTROOM,
 	getDataLabelSetup,
@@ -47,7 +48,8 @@ import * as displayChart from './tools/display-chart';
 
 export const DEFAULT_COLORS = ['#104e64', '#f54900', '#009689', '#ffb900', '#fe9a00'];
 
-const AXIS_TICK = { fontSize: 12 };
+const CHART_LABEL_FONT_SIZE = 12;
+const AXIS_TICK = { fontSize: CHART_LABEL_FONT_SIZE };
 const CATEGORY_XAXIS_HEIGHT = 56;
 const X_AXIS_LABEL_HEIGHT = 22;
 
@@ -65,6 +67,8 @@ const STACK_SEPARATOR_WIDTH = 1;
  * passes an explicit `backgroundColor` and CSS vars do not resolve.
  */
 const DEFAULT_BACKGROUND = 'var(--background, #ffffff)';
+/** Resolves from the browser theme, with a concrete fallback for backend exports. */
+const MUTED_FOREGROUND = 'var(--muted-foreground, #6b7280)';
 
 /**
  * Reserved width for the Y axis band. Smaller than the Recharts default (60)
@@ -76,6 +80,14 @@ const VALUE_AXIS_DEFAULT_WIDTH = 40;
 const VALUE_AXIS_MAX_WIDTH = 120;
 const VALUE_AXIS_CHARACTER_WIDTH = 7;
 const VALUE_AXIS_PADDING = 12;
+const PROGRESS_CATEGORY_AXIS_MIN_WIDTH = 60;
+const PROGRESS_CATEGORY_AXIS_MAX_WIDTH = 180;
+const PROGRESS_CATEGORY_MAX_LABEL_CHARS = 24;
+const PROGRESS_BAR_SIZE = 10;
+const PROGRESS_BAR_RADIUS = 999;
+const PROGRESS_TRACK_COLOR = 'var(--muted, #e5e7eb)';
+const PROGRESS_ORIGINAL_VALUE_KEY = '__naoProgressValue';
+const PROGRESS_VALUE_LABEL_RIGHT_PADDING = 4;
 /** Reserves horizontal room for a rotated axis title so it does not overlap tick values. */
 const AXIS_LABEL_WIDTH = 20;
 
@@ -342,6 +354,9 @@ export function buildChart(props: BuildChartProps) {
 	if (resolved.chartType === 'radar') {
 		return buildRadarChart(resolved);
 	}
+	if (resolved.chartType === 'progress_bar') {
+		return buildProgressChart(resolved);
+	}
 	return buildBarChart(resolved);
 }
 
@@ -562,14 +577,7 @@ function renderCategoryXAxis({
 	xAxisLabel?: string;
 }) {
 	const tickFormatter = compact
-		? (value: string) => {
-				const label = labelFormatter(value);
-				if (maxLabelChars == null) {
-					return label;
-				}
-				const cap = Math.max(3, maxLabelChars);
-				return label.length > cap ? `${label.slice(0, cap - 1)}…` : label;
-			}
+		? (value: string) => formatCategoryTick(value, labelFormatter, maxLabelChars)
 		: labelFormatter;
 
 	return (
@@ -587,6 +595,167 @@ function renderCategoryXAxis({
 			height={CATEGORY_XAXIS_HEIGHT + labelFootroom + (xAxisLabel ? X_AXIS_LABEL_HEIGHT : 0)}
 			label={xAxisLabelProps(xAxisLabel)}
 			{...(compact ? { angle: -35, textAnchor: 'end' as const } : {})}
+		/>
+	);
+}
+
+function formatCategoryTick(value: string, labelFormatter: (value: string) => string, maxLabelChars?: number): string {
+	const label = labelFormatter(value);
+	if (maxLabelChars == null) {
+		return label;
+	}
+	const cap = Math.max(3, maxLabelChars);
+	return label.length > cap ? `${label.slice(0, cap - 1)}…` : label;
+}
+
+function buildProgressChart(props: ResolvedProps) {
+	const { data, xAxisKey, series, colorFor, labelFormatter, children, xAxisMaxLabelChars } = props;
+	const progressSeries = series[0];
+	const dataKey = progressSeries.data_key;
+	const values = data.map((row) => toFiniteNumber(row[dataKey]) ?? 0);
+	const maximum = values.reduce((current, value) => Math.max(current, Math.abs(value)), 0) || 1;
+	const valueFormat = getChartLevelValueFormat(series);
+	const showValueLabels = displayChart.resolveShowDataLabels(props.chartType, props.showDataLabels);
+	const labelCharacterLimit = xAxisMaxLabelChars ?? PROGRESS_CATEGORY_MAX_LABEL_CHARS;
+	const tickFormatter = (value: string) => formatCategoryTick(value, labelFormatter, labelCharacterLimit);
+	const categoryAxisWidth = computeProgressCategoryAxisWidth(data, xAxisKey, tickFormatter);
+	const valueLabelWidth = showValueLabels ? computeProgressValueLabelWidth(values, valueFormat) : 0;
+	const progressValueLabelsLayer = showValueLabels
+		? createProgressValueLabelsLayer(valueFormat, valueLabelWidth)
+		: undefined;
+	const margin = {
+		...props.margin,
+		right: (props.margin?.right ?? 0) + valueLabelWidth,
+	};
+	const progressData = data.map((row) => {
+		const value = toFiniteNumber(row[dataKey]) ?? 0;
+		return {
+			...row,
+			[PROGRESS_ORIGINAL_VALUE_KEY]: value,
+			[dataKey]: Math.abs(value),
+		};
+	});
+
+	return (
+		<BarChart data={progressData} layout='vertical' accessibilityLayer margin={margin}>
+			<XAxis type='number' hide domain={[0, maximum]} />
+			<YAxis
+				type='category'
+				dataKey={xAxisKey}
+				tick={AXIS_TICK}
+				tickLine={false}
+				axisLine={false}
+				width={categoryAxisWidth}
+				tickFormatter={tickFormatter}
+			/>
+			{children}
+			<Bar
+				dataKey={dataKey}
+				fill={colorFor(dataKey, 0)}
+				radius={[PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS]}
+				background={renderProgressBarBackground}
+				barSize={PROGRESS_BAR_SIZE}
+				isAnimationActive={Boolean(props.animate)}
+				animationDuration={CHART_ANIMATION_DURATION_MS}
+			/>
+			{progressValueLabelsLayer && <Customized component={progressValueLabelsLayer} />}
+		</BarChart>
+	);
+}
+
+function computeProgressCategoryAxisWidth(
+	data: Record<string, unknown>[],
+	xAxisKey: string,
+	tickFormatter: (value: string) => string,
+): number {
+	const longestLabelLength = data.reduce(
+		(current, row) => Math.max(current, tickFormatter(String(row[xAxisKey] ?? '')).length),
+		0,
+	);
+	return Math.min(
+		PROGRESS_CATEGORY_AXIS_MAX_WIDTH,
+		Math.max(
+			PROGRESS_CATEGORY_AXIS_MIN_WIDTH,
+			longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH + VALUE_AXIS_PADDING,
+		),
+	);
+}
+
+function computeProgressValueLabelWidth(values: number[], valueFormat?: displayChart.ValueFormat): number {
+	const longestLabelLength = values.reduce(
+		(current, value) => Math.max(current, formatChartValue(value, valueFormat).length),
+		0,
+	);
+	return Math.max(
+		VALUE_AXIS_DEFAULT_WIDTH,
+		longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH + DATA_LABEL_ANCHOR_GAP + PROGRESS_VALUE_LABEL_RIGHT_PADDING,
+	);
+}
+
+interface ProgressGraphicalPoint {
+	y?: number;
+	height?: number;
+	payload?: Record<string, unknown>;
+}
+
+interface ProgressLabelsLayerProps {
+	formattedGraphicalItems?: Array<{
+		item?: { type?: { displayName?: string } };
+		props?: { data?: ProgressGraphicalPoint[] };
+	}>;
+	offset?: {
+		left?: number;
+		width?: number;
+	};
+}
+
+function createProgressValueLabelsLayer(valueFormat: displayChart.ValueFormat | undefined, valueLabelWidth: number) {
+	function ProgressValueLabelsLayer({ formattedGraphicalItems, offset }: ProgressLabelsLayerProps) {
+		const bar = formattedGraphicalItems?.find((item) => item.item?.type?.displayName === 'Bar');
+		const trackEnd = (toFiniteNumber(offset?.left) ?? 0) + (toFiniteNumber(offset?.width) ?? 0);
+		const labelX = trackEnd + valueLabelWidth - PROGRESS_VALUE_LABEL_RIGHT_PADDING;
+		const points = bar?.props?.data ?? [];
+		if (points.length === 0) {
+			return null;
+		}
+		return (
+			<g className='recharts-progress-value-labels'>
+				{points.map((point) => {
+					const y = toFiniteNumber(point.y);
+					const height = toFiniteNumber(point.height);
+					if (y == null || height == null) {
+						return null;
+					}
+					const value = toFiniteNumber(point.payload?.[PROGRESS_ORIGINAL_VALUE_KEY]) ?? 0;
+					return (
+						<text
+							key={`${y}-${value}`}
+							x={labelX}
+							y={y + height / 2}
+							fill={MUTED_FOREGROUND}
+							fontSize={CHART_LABEL_FONT_SIZE}
+							textAnchor='end'
+							dominantBaseline='central'
+							className='recharts-progress-value-label'
+						>
+							{formatChartValue(value, valueFormat)}
+						</text>
+					);
+				})}
+			</g>
+		);
+	}
+	ProgressValueLabelsLayer.displayName = 'ProgressValueLabelsLayer';
+	return ProgressValueLabelsLayer;
+}
+
+function renderProgressBarBackground(backgroundProps: unknown) {
+	const rectProps = backgroundProps as RectangleProps;
+	return (
+		<Rectangle
+			{...rectProps}
+			fill={PROGRESS_TRACK_COLOR}
+			radius={[PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS]}
 		/>
 	);
 }
@@ -1008,7 +1177,11 @@ function renderComboSeries(
 	);
 }
 
-const AXIS_LABEL_STYLE = { textAnchor: 'middle' as const, fontSize: 12, fill: 'var(--muted-foreground, #6b7280)' };
+const AXIS_LABEL_STYLE = {
+	textAnchor: 'middle' as const,
+	fontSize: CHART_LABEL_FONT_SIZE,
+	fill: MUTED_FOREGROUND,
+};
 
 function axisLabel(label: string | undefined, side: displayChart.YAxisSide) {
 	if (!label) {

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -27,11 +27,13 @@ import {
 	DATA_LABEL_MARGIN_TOP,
 	DATA_LABEL_X_AXIS_FOOTROOM,
 	getDataLabelSetup,
+	getRenderedSeries,
 	PIE_LABELLED_OUTER_RADIUS,
 	renderDataLabelsLayer,
 	renderPieDataLabelsLayer,
 	shouldReserveDataLabelHeadroom,
 	shouldReserveStackTotalFootroom,
+	sumStackValue,
 } from './chart-data-labels';
 import { collectAxisValues, collectStackedAxisValues, resolveBarYAxisDomain, resolveYAxisDomain } from './chart-domain';
 import {
@@ -84,6 +86,8 @@ const HORIZONTAL_BAR_CATEGORY_AXIS_MIN_WIDTH = 60;
 const HORIZONTAL_BAR_CATEGORY_AXIS_MAX_WIDTH = 180;
 const HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS = 24;
 const HORIZONTAL_BAR_SIZE = 10;
+const HORIZONTAL_BAR_MAX_SIZE = 28;
+const HORIZONTAL_BAR_CATEGORY_GAP = '20%';
 const HORIZONTAL_BAR_RADIUS = 999;
 const HORIZONTAL_BAR_TRACK_COLOR = 'var(--muted, #e5e7eb)';
 const HORIZONTAL_BAR_ORIGINAL_VALUE_KEY = '__naoHorizontalBarValue';
@@ -354,7 +358,7 @@ export function buildChart(props: BuildChartProps) {
 	if (resolved.chartType === 'radar') {
 		return buildRadarChart(resolved);
 	}
-	if (resolved.chartType === 'horizontal_bar') {
+	if (resolved.chartType === 'horizontal_bar' || resolved.chartType === 'horizontal_bar_100') {
 		return buildHorizontalBarChart(resolved);
 	}
 	return buildBarChart(resolved);
@@ -609,36 +613,65 @@ function formatCategoryTick(value: string, labelFormatter: (value: string) => st
 }
 
 function buildHorizontalBarChart(props: ResolvedProps) {
-	const { data, xAxisKey, series, colorFor, labelFormatter, children, xAxisMaxLabelChars } = props;
-	const horizontalBarSeries = series[0];
-	const dataKey = horizontalBarSeries.data_key;
-	const values = data.map((row) => toFiniteNumber(row[dataKey]) ?? 0);
-	const maximum = values.reduce((current, value) => Math.max(current, Math.abs(value)), 0) || 1;
+	const { data, chartType, xAxisKey, series, colorFor, labelFormatter, children, xAxisMaxLabelChars } = props;
+	const isPercent = displayChart.isPercentStackedChartType(chartType);
+	const renderedSeries = getRenderedSeries(series, series.length > 1);
+	const hasMultipleSeries = renderedSeries.length > 1;
+	const seriesKeys = renderedSeries.map((item) => item.data_key);
+	const rowTotals = data.map((row) => sumStackValue(row, renderedSeries) ?? 0);
+	const maximum = rowTotals.reduce((current, value) => Math.max(current, Math.abs(value)), 0) || 1;
 	const valueFormat = getChartLevelValueFormat(series);
+	const valueFormatter = (value: number) =>
+		isPercent ? formatPercentAxisTick(value) : formatChartValue(value, valueFormat);
+	const labelValues = isPercent ? data.map(() => 1) : rowTotals;
 	const showValueLabels = displayChart.resolveShowDataLabels(props.chartType, props.showDataLabels);
 	const labelCharacterLimit = xAxisMaxLabelChars ?? HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS;
 	const tickFormatter = (value: string) => formatCategoryTick(value, labelFormatter, labelCharacterLimit);
 	const categoryAxisWidth = computeHorizontalBarCategoryAxisWidth(data, xAxisKey, tickFormatter);
-	const valueLabelWidth = showValueLabels ? computeHorizontalBarValueLabelWidth(values, valueFormat) : 0;
+	const valueLabelWidth = showValueLabels ? computeHorizontalBarValueLabelWidth(labelValues, valueFormatter) : 0;
 	const horizontalBarValueLabelsLayer = showValueLabels
-		? createHorizontalBarValueLabelsLayer(valueFormat, valueLabelWidth)
+		? createHorizontalBarValueLabelsLayer(valueFormatter, valueLabelWidth)
 		: undefined;
+	const separatorColor = props.backgroundColor ?? DEFAULT_BACKGROUND;
 	const margin = {
 		...props.margin,
 		right: (props.margin?.right ?? 0) + valueLabelWidth,
 	};
-	const horizontalBarData = data.map((row) => {
-		const value = toFiniteNumber(row[dataKey]) ?? 0;
-		return {
+	const horizontalBarData = data.map((row, rowIndex) => {
+		const normalizedRow: Record<string, unknown> = {
 			...row,
-			[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]: value,
-			[dataKey]: Math.abs(value),
+			[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]: labelValues[rowIndex],
 		};
+		for (const key of seriesKeys) {
+			normalizedRow[key] = Math.abs(toFiniteNumber(row[key]) ?? 0);
+		}
+		return normalizedRow;
 	});
 
 	return (
-		<BarChart data={horizontalBarData} layout='vertical' accessibilityLayer margin={margin}>
-			<XAxis type='number' hide domain={[0, maximum]} />
+		<BarChart
+			data={horizontalBarData}
+			layout='vertical'
+			accessibilityLayer
+			margin={margin}
+			{...(isPercent ? { stackOffset: 'expand' as const } : {})}
+			{...(hasMultipleSeries ? { barCategoryGap: HORIZONTAL_BAR_CATEGORY_GAP } : {})}
+		>
+			{hasMultipleSeries ? (
+				<XAxis
+					type='number'
+					domain={isPercent ? [0, 1] : [0, maximum]}
+					tick={AXIS_TICK}
+					tickLine={false}
+					axisLine={false}
+					minTickGap={12}
+					tickFormatter={
+						isPercent ? formatPercentAxisTick : (value: number) => formatValueYAxisTick(value, valueFormat)
+					}
+				/>
+			) : (
+				<XAxis type='number' hide domain={[0, maximum]} />
+			)}
 			<YAxis
 				type='category'
 				dataKey={xAxisKey}
@@ -649,15 +682,36 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 				tickFormatter={tickFormatter}
 			/>
 			{children}
-			<Bar
-				dataKey={dataKey}
-				fill={colorFor(dataKey, 0)}
-				radius={[HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS]}
-				background={renderHorizontalBarBackground}
-				barSize={HORIZONTAL_BAR_SIZE}
-				isAnimationActive={Boolean(props.animate)}
-				animationDuration={CHART_ANIMATION_DURATION_MS}
-			/>
+			{hasMultipleSeries ? (
+				renderedSeries.map((item, index) => (
+					<Bar
+						key={item.data_key}
+						dataKey={item.data_key}
+						fill={colorFor(item.data_key, index)}
+						stackId='stack'
+						background={index === 0 ? renderHorizontalBarBackground : undefined}
+						shape={renderHorizontalStackedBarShape(seriesKeys, item.data_key, separatorColor)}
+						maxBarSize={HORIZONTAL_BAR_MAX_SIZE}
+						isAnimationActive={Boolean(props.animate)}
+						animationDuration={CHART_ANIMATION_DURATION_MS}
+					/>
+				))
+			) : (
+				<Bar
+					dataKey={renderedSeries[0]?.data_key}
+					fill={colorFor(renderedSeries[0]?.data_key ?? '', 0)}
+					radius={[
+						HORIZONTAL_BAR_RADIUS,
+						HORIZONTAL_BAR_RADIUS,
+						HORIZONTAL_BAR_RADIUS,
+						HORIZONTAL_BAR_RADIUS,
+					]}
+					background={renderHorizontalBarBackground}
+					barSize={HORIZONTAL_BAR_SIZE}
+					isAnimationActive={Boolean(props.animate)}
+					animationDuration={CHART_ANIMATION_DURATION_MS}
+				/>
+			)}
 			{horizontalBarValueLabelsLayer && <Customized component={horizontalBarValueLabelsLayer} />}
 		</BarChart>
 	);
@@ -681,11 +735,8 @@ function computeHorizontalBarCategoryAxisWidth(
 	);
 }
 
-function computeHorizontalBarValueLabelWidth(values: number[], valueFormat?: displayChart.ValueFormat): number {
-	const longestLabelLength = values.reduce(
-		(current, value) => Math.max(current, formatChartValue(value, valueFormat).length),
-		0,
-	);
+function computeHorizontalBarValueLabelWidth(values: number[], valueFormatter: (value: number) => string): number {
+	const longestLabelLength = values.reduce((current, value) => Math.max(current, valueFormatter(value).length), 0);
 	return Math.max(
 		VALUE_AXIS_DEFAULT_WIDTH,
 		longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH +
@@ -711,10 +762,7 @@ interface HorizontalBarLabelsLayerProps {
 	};
 }
 
-function createHorizontalBarValueLabelsLayer(
-	valueFormat: displayChart.ValueFormat | undefined,
-	valueLabelWidth: number,
-) {
+function createHorizontalBarValueLabelsLayer(valueFormatter: (value: number) => string, valueLabelWidth: number) {
 	function HorizontalBarValueLabelsLayer({ formattedGraphicalItems, offset }: HorizontalBarLabelsLayerProps) {
 		const bar = formattedGraphicalItems?.find((item) => item.item?.type?.displayName === 'Bar');
 		const trackEnd = (toFiniteNumber(offset?.left) ?? 0) + (toFiniteNumber(offset?.width) ?? 0);
@@ -743,7 +791,7 @@ function createHorizontalBarValueLabelsLayer(
 							dominantBaseline='central'
 							className='recharts-horizontal-bar-value-label'
 						>
-							{formatChartValue(value, valueFormat)}
+							{valueFormatter(value)}
 						</text>
 					);
 				})}
@@ -869,7 +917,33 @@ export function isTopmostStackSegment(row: Record<string, unknown>, seriesKeys: 
 	return topKey === currentKey;
 }
 
+function isFirstNonZeroStackSegment(row: Record<string, unknown>, seriesKeys: string[], currentKey: string): boolean {
+	return seriesKeys.find((key) => typeof row[key] === 'number' && row[key] !== 0) === currentKey;
+}
+
 type RectangleProps = React.ComponentProps<typeof Rectangle>;
+
+function renderHorizontalStackedBarShape(seriesKeys: string[], currentKey: string, separatorColor: string) {
+	return function HorizontalStackedBarSegment(shapeProps: unknown) {
+		const rectProps = shapeProps as RectangleProps & { payload?: Record<string, unknown> };
+		const row = rectProps.payload ?? {};
+		const roundLeft = isFirstNonZeroStackSegment(row, seriesKeys, currentKey);
+		const roundRight = isTopmostStackSegment(row, seriesKeys, currentKey);
+		return (
+			<Rectangle
+				{...rectProps}
+				radius={[
+					roundLeft ? HORIZONTAL_BAR_RADIUS : 0,
+					roundRight ? HORIZONTAL_BAR_RADIUS : 0,
+					roundRight ? HORIZONTAL_BAR_RADIUS : 0,
+					roundLeft ? HORIZONTAL_BAR_RADIUS : 0,
+				]}
+				stroke={separatorColor}
+				strokeWidth={STACK_SEPARATOR_WIDTH}
+			/>
+		);
+	};
+}
 
 /**
  * Custom `<Bar>` shape that rounds the top corners of only the topmost non-zero segment of

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -23,11 +23,14 @@ import {
 } from 'recharts';
 
 import {
+	boxesOverlap,
 	DATA_LABEL_ANCHOR_GAP,
 	DATA_LABEL_MARGIN_TOP,
 	DATA_LABEL_X_AXIS_FOOTROOM,
 	getDataLabelSetup,
 	getRenderedSeries,
+	type LabelBox,
+	labelBox,
 	PIE_LABELLED_OUTER_RADIUS,
 	renderDataLabelsLayer,
 	renderPieDataLabelsLayer,
@@ -613,7 +616,8 @@ function formatCategoryTick(value: string, labelFormatter: (value: string) => st
 }
 
 function buildHorizontalBarChart(props: ResolvedProps) {
-	const { data, chartType, xAxisKey, series, colorFor, labelFormatter, children, xAxisMaxLabelChars } = props;
+	const { data, chartType, xAxisKey, series, colorFor, labelFormatter, children, xAxisInterval, xAxisMaxLabelChars } =
+		props;
 	const isPercent = displayChart.isPercentStackedChartType(chartType);
 	const renderedSeries = getRenderedSeries(series, series.length > 1);
 	const hasMultipleSeries = renderedSeries.length > 1;
@@ -678,6 +682,8 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 				tick={AXIS_TICK}
 				tickLine={false}
 				axisLine={false}
+				minTickGap={12}
+				interval={xAxisInterval ?? 'preserveStartEnd'}
 				width={categoryAxisWidth}
 				tickFormatter={tickFormatter}
 			/>
@@ -762,44 +768,71 @@ interface HorizontalBarLabelsLayerProps {
 	};
 }
 
+interface HorizontalBarValueLabel {
+	key: string;
+	text: string;
+	x: number;
+	y: number;
+}
+
 function createHorizontalBarValueLabelsLayer(valueFormatter: (value: number) => string, valueLabelWidth: number) {
 	function HorizontalBarValueLabelsLayer({ formattedGraphicalItems, offset }: HorizontalBarLabelsLayerProps) {
 		const bar = formattedGraphicalItems?.find((item) => item.item?.type?.displayName === 'Bar');
 		const trackEnd = (toFiniteNumber(offset?.left) ?? 0) + (toFiniteNumber(offset?.width) ?? 0);
 		const labelX = trackEnd + valueLabelWidth - HORIZONTAL_BAR_VALUE_LABEL_RIGHT_PADDING;
 		const points = bar?.props?.data ?? [];
-		if (points.length === 0) {
+		const labels = selectHorizontalBarValueLabels(points, labelX, valueFormatter);
+		if (labels.length === 0) {
 			return null;
 		}
 		return (
 			<g className='recharts-horizontal-bar-value-labels'>
-				{points.map((point) => {
-					const y = toFiniteNumber(point.y);
-					const height = toFiniteNumber(point.height);
-					if (y == null || height == null) {
-						return null;
-					}
-					const value = toFiniteNumber(point.payload?.[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]) ?? 0;
-					return (
-						<text
-							key={`${y}-${value}`}
-							x={labelX}
-							y={y + height / 2}
-							fill={MUTED_FOREGROUND}
-							fontSize={CHART_LABEL_FONT_SIZE}
-							textAnchor='end'
-							dominantBaseline='central'
-							className='recharts-horizontal-bar-value-label'
-						>
-							{valueFormatter(value)}
-						</text>
-					);
-				})}
+				{labels.map((label) => (
+					<text
+						key={label.key}
+						x={label.x}
+						y={label.y}
+						fill={MUTED_FOREGROUND}
+						fontSize={CHART_LABEL_FONT_SIZE}
+						textAnchor='end'
+						dominantBaseline='central'
+						className='recharts-horizontal-bar-value-label'
+					>
+						{label.text}
+					</text>
+				))}
 			</g>
 		);
 	}
 	HorizontalBarValueLabelsLayer.displayName = 'HorizontalBarValueLabelsLayer';
 	return HorizontalBarValueLabelsLayer;
+}
+
+function selectHorizontalBarValueLabels(
+	points: HorizontalBarGraphicalPoint[],
+	labelX: number,
+	valueFormatter: (value: number) => string,
+): HorizontalBarValueLabel[] {
+	const labels: HorizontalBarValueLabel[] = [];
+	let previousBox: LabelBox | null = null;
+	for (const point of points) {
+		const y = toFiniteNumber(point.y);
+		const height = toFiniteNumber(point.height);
+		if (y == null || height == null) {
+			continue;
+		}
+		const value = toFiniteNumber(point.payload?.[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]) ?? 0;
+		const text = valueFormatter(value);
+		const labelY = y + height / 2;
+		const halfWidth = (text.length * VALUE_AXIS_CHARACTER_WIDTH) / 2;
+		const box = labelBox(labelX, labelY, halfWidth, 'end', CHART_LABEL_FONT_SIZE);
+		if (previousBox && boxesOverlap(previousBox, box)) {
+			continue;
+		}
+		labels.push({ key: `${y}-${value}`, text, x: labelX, y: labelY });
+		previousBox = box;
+	}
+	return labels;
 }
 
 function renderHorizontalBarBackground(backgroundProps: unknown) {

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -95,6 +95,7 @@ const HORIZONTAL_BAR_RADIUS = 999;
 const HORIZONTAL_BAR_TRACK_COLOR = 'var(--muted, #e5e7eb)';
 const HORIZONTAL_BAR_ORIGINAL_VALUE_KEY = '__naoHorizontalBarValue';
 const HORIZONTAL_BAR_VALUE_LABEL_RIGHT_PADDING = 4;
+const HORIZONTAL_BAR_LABEL_VERTICAL_ROOM = Math.ceil(CHART_LABEL_FONT_SIZE / 2) + 2;
 /** Reserves horizontal room for a rotated axis title so it does not overlap tick values. */
 const AXIS_LABEL_WIDTH = 20;
 
@@ -616,21 +617,24 @@ function formatCategoryTick(value: string, labelFormatter: (value: string) => st
 }
 
 function buildHorizontalBarChart(props: ResolvedProps) {
-	const { data, chartType, xAxisKey, series, colorFor, labelFormatter, children, xAxisInterval, xAxisMaxLabelChars } =
-		props;
+	const { data, chartType, xAxisKey, series, colorFor, labelFormatter, children, xAxisInterval } = props;
 	const isPercent = displayChart.isPercentStackedChartType(chartType);
 	const renderedSeries = getRenderedSeries(series, series.length > 1);
 	const hasMultipleSeries = renderedSeries.length > 1;
 	const seriesKeys = renderedSeries.map((item) => item.data_key);
-	const rowTotals = data.map((row) => sumStackValue(row, renderedSeries) ?? 0);
-	const maximum = rowTotals.reduce((current, value) => Math.max(current, Math.abs(value)), 0) || 1;
+	const clampedRowTotals = data.map((row) =>
+		seriesKeys.reduce((total, key) => total + clampHorizontalBarValue(row[key]), 0),
+	);
+	const signedRowTotals = data.map((row) => sumStackValue(row, renderedSeries) ?? 0);
+	const maximum = clampedRowTotals.reduce((current, value) => Math.max(current, value), 0) || 1;
+	const visibleValueAxisDomainProps = isPercent ? { domain: [0, 1] as [number, number] } : {};
 	const valueFormat = getChartLevelValueFormat(series);
 	const valueFormatter = (value: number) =>
 		isPercent ? formatPercentAxisTick(value) : formatChartValue(value, valueFormat);
-	const labelValues = isPercent ? data.map(() => 1) : rowTotals;
+	const labelValues = isPercent ? clampedRowTotals.map((value) => (value > 0 ? 1 : 0)) : signedRowTotals;
 	const showValueLabels = displayChart.resolveShowDataLabels(props.chartType, props.showDataLabels);
-	const labelCharacterLimit = xAxisMaxLabelChars ?? HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS;
-	const tickFormatter = (value: string) => formatCategoryTick(value, labelFormatter, labelCharacterLimit);
+	const tickFormatter = (value: string) =>
+		formatCategoryTick(value, labelFormatter, HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS);
 	const categoryAxisWidth = computeHorizontalBarCategoryAxisWidth(data, xAxisKey, tickFormatter);
 	const valueLabelWidth = showValueLabels ? computeHorizontalBarValueLabelWidth(labelValues, valueFormatter) : 0;
 	const horizontalBarValueLabelsLayer = showValueLabels
@@ -639,7 +643,9 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 	const separatorColor = props.backgroundColor ?? DEFAULT_BACKGROUND;
 	const margin = {
 		...props.margin,
+		top: (props.margin?.top ?? 0) + HORIZONTAL_BAR_LABEL_VERTICAL_ROOM,
 		right: (props.margin?.right ?? 0) + valueLabelWidth,
+		bottom: (props.margin?.bottom ?? 0) + HORIZONTAL_BAR_LABEL_VERTICAL_ROOM,
 	};
 	const horizontalBarData = data.map((row, rowIndex) => {
 		const normalizedRow: Record<string, unknown> = {
@@ -647,7 +653,7 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 			[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]: labelValues[rowIndex],
 		};
 		for (const key of seriesKeys) {
-			normalizedRow[key] = Math.abs(toFiniteNumber(row[key]) ?? 0);
+			normalizedRow[key] = clampHorizontalBarValue(row[key]);
 		}
 		return normalizedRow;
 	});
@@ -664,7 +670,7 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 			{hasMultipleSeries ? (
 				<XAxis
 					type='number'
-					domain={isPercent ? [0, 1] : [0, maximum]}
+					{...visibleValueAxisDomainProps}
 					tick={AXIS_TICK}
 					tickLine={false}
 					axisLine={false}
@@ -721,6 +727,10 @@ function buildHorizontalBarChart(props: ResolvedProps) {
 			{horizontalBarValueLabelsLayer && <Customized component={horizontalBarValueLabelsLayer} />}
 		</BarChart>
 	);
+}
+
+function clampHorizontalBarValue(value: unknown): number {
+	return Math.max(0, toFiniteNumber(value) ?? 0);
 }
 
 function computeHorizontalBarCategoryAxisWidth(

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -80,14 +80,14 @@ const VALUE_AXIS_DEFAULT_WIDTH = 40;
 const VALUE_AXIS_MAX_WIDTH = 120;
 const VALUE_AXIS_CHARACTER_WIDTH = 7;
 const VALUE_AXIS_PADDING = 12;
-const PROGRESS_CATEGORY_AXIS_MIN_WIDTH = 60;
-const PROGRESS_CATEGORY_AXIS_MAX_WIDTH = 180;
-const PROGRESS_CATEGORY_MAX_LABEL_CHARS = 24;
-const PROGRESS_BAR_SIZE = 10;
-const PROGRESS_BAR_RADIUS = 999;
-const PROGRESS_TRACK_COLOR = 'var(--muted, #e5e7eb)';
-const PROGRESS_ORIGINAL_VALUE_KEY = '__naoProgressValue';
-const PROGRESS_VALUE_LABEL_RIGHT_PADDING = 4;
+const HORIZONTAL_BAR_CATEGORY_AXIS_MIN_WIDTH = 60;
+const HORIZONTAL_BAR_CATEGORY_AXIS_MAX_WIDTH = 180;
+const HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS = 24;
+const HORIZONTAL_BAR_SIZE = 10;
+const HORIZONTAL_BAR_RADIUS = 999;
+const HORIZONTAL_BAR_TRACK_COLOR = 'var(--muted, #e5e7eb)';
+const HORIZONTAL_BAR_ORIGINAL_VALUE_KEY = '__naoHorizontalBarValue';
+const HORIZONTAL_BAR_VALUE_LABEL_RIGHT_PADDING = 4;
 /** Reserves horizontal room for a rotated axis title so it does not overlap tick values. */
 const AXIS_LABEL_WIDTH = 20;
 
@@ -354,8 +354,8 @@ export function buildChart(props: BuildChartProps) {
 	if (resolved.chartType === 'radar') {
 		return buildRadarChart(resolved);
 	}
-	if (resolved.chartType === 'progress_bar') {
-		return buildProgressChart(resolved);
+	if (resolved.chartType === 'horizontal_bar') {
+		return buildHorizontalBarChart(resolved);
 	}
 	return buildBarChart(resolved);
 }
@@ -608,36 +608,36 @@ function formatCategoryTick(value: string, labelFormatter: (value: string) => st
 	return label.length > cap ? `${label.slice(0, cap - 1)}…` : label;
 }
 
-function buildProgressChart(props: ResolvedProps) {
+function buildHorizontalBarChart(props: ResolvedProps) {
 	const { data, xAxisKey, series, colorFor, labelFormatter, children, xAxisMaxLabelChars } = props;
-	const progressSeries = series[0];
-	const dataKey = progressSeries.data_key;
+	const horizontalBarSeries = series[0];
+	const dataKey = horizontalBarSeries.data_key;
 	const values = data.map((row) => toFiniteNumber(row[dataKey]) ?? 0);
 	const maximum = values.reduce((current, value) => Math.max(current, Math.abs(value)), 0) || 1;
 	const valueFormat = getChartLevelValueFormat(series);
 	const showValueLabels = displayChart.resolveShowDataLabels(props.chartType, props.showDataLabels);
-	const labelCharacterLimit = xAxisMaxLabelChars ?? PROGRESS_CATEGORY_MAX_LABEL_CHARS;
+	const labelCharacterLimit = xAxisMaxLabelChars ?? HORIZONTAL_BAR_CATEGORY_MAX_LABEL_CHARS;
 	const tickFormatter = (value: string) => formatCategoryTick(value, labelFormatter, labelCharacterLimit);
-	const categoryAxisWidth = computeProgressCategoryAxisWidth(data, xAxisKey, tickFormatter);
-	const valueLabelWidth = showValueLabels ? computeProgressValueLabelWidth(values, valueFormat) : 0;
-	const progressValueLabelsLayer = showValueLabels
-		? createProgressValueLabelsLayer(valueFormat, valueLabelWidth)
+	const categoryAxisWidth = computeHorizontalBarCategoryAxisWidth(data, xAxisKey, tickFormatter);
+	const valueLabelWidth = showValueLabels ? computeHorizontalBarValueLabelWidth(values, valueFormat) : 0;
+	const horizontalBarValueLabelsLayer = showValueLabels
+		? createHorizontalBarValueLabelsLayer(valueFormat, valueLabelWidth)
 		: undefined;
 	const margin = {
 		...props.margin,
 		right: (props.margin?.right ?? 0) + valueLabelWidth,
 	};
-	const progressData = data.map((row) => {
+	const horizontalBarData = data.map((row) => {
 		const value = toFiniteNumber(row[dataKey]) ?? 0;
 		return {
 			...row,
-			[PROGRESS_ORIGINAL_VALUE_KEY]: value,
+			[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]: value,
 			[dataKey]: Math.abs(value),
 		};
 	});
 
 	return (
-		<BarChart data={progressData} layout='vertical' accessibilityLayer margin={margin}>
+		<BarChart data={horizontalBarData} layout='vertical' accessibilityLayer margin={margin}>
 			<XAxis type='number' hide domain={[0, maximum]} />
 			<YAxis
 				type='category'
@@ -652,18 +652,18 @@ function buildProgressChart(props: ResolvedProps) {
 			<Bar
 				dataKey={dataKey}
 				fill={colorFor(dataKey, 0)}
-				radius={[PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS]}
-				background={renderProgressBarBackground}
-				barSize={PROGRESS_BAR_SIZE}
+				radius={[HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS]}
+				background={renderHorizontalBarBackground}
+				barSize={HORIZONTAL_BAR_SIZE}
 				isAnimationActive={Boolean(props.animate)}
 				animationDuration={CHART_ANIMATION_DURATION_MS}
 			/>
-			{progressValueLabelsLayer && <Customized component={progressValueLabelsLayer} />}
+			{horizontalBarValueLabelsLayer && <Customized component={horizontalBarValueLabelsLayer} />}
 		</BarChart>
 	);
 }
 
-function computeProgressCategoryAxisWidth(
+function computeHorizontalBarCategoryAxisWidth(
 	data: Record<string, unknown>[],
 	xAxisKey: string,
 	tickFormatter: (value: string) => string,
@@ -673,35 +673,37 @@ function computeProgressCategoryAxisWidth(
 		0,
 	);
 	return Math.min(
-		PROGRESS_CATEGORY_AXIS_MAX_WIDTH,
+		HORIZONTAL_BAR_CATEGORY_AXIS_MAX_WIDTH,
 		Math.max(
-			PROGRESS_CATEGORY_AXIS_MIN_WIDTH,
+			HORIZONTAL_BAR_CATEGORY_AXIS_MIN_WIDTH,
 			longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH + VALUE_AXIS_PADDING,
 		),
 	);
 }
 
-function computeProgressValueLabelWidth(values: number[], valueFormat?: displayChart.ValueFormat): number {
+function computeHorizontalBarValueLabelWidth(values: number[], valueFormat?: displayChart.ValueFormat): number {
 	const longestLabelLength = values.reduce(
 		(current, value) => Math.max(current, formatChartValue(value, valueFormat).length),
 		0,
 	);
 	return Math.max(
 		VALUE_AXIS_DEFAULT_WIDTH,
-		longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH + DATA_LABEL_ANCHOR_GAP + PROGRESS_VALUE_LABEL_RIGHT_PADDING,
+		longestLabelLength * VALUE_AXIS_CHARACTER_WIDTH +
+			DATA_LABEL_ANCHOR_GAP +
+			HORIZONTAL_BAR_VALUE_LABEL_RIGHT_PADDING,
 	);
 }
 
-interface ProgressGraphicalPoint {
+interface HorizontalBarGraphicalPoint {
 	y?: number;
 	height?: number;
 	payload?: Record<string, unknown>;
 }
 
-interface ProgressLabelsLayerProps {
+interface HorizontalBarLabelsLayerProps {
 	formattedGraphicalItems?: Array<{
 		item?: { type?: { displayName?: string } };
-		props?: { data?: ProgressGraphicalPoint[] };
+		props?: { data?: HorizontalBarGraphicalPoint[] };
 	}>;
 	offset?: {
 		left?: number;
@@ -709,24 +711,27 @@ interface ProgressLabelsLayerProps {
 	};
 }
 
-function createProgressValueLabelsLayer(valueFormat: displayChart.ValueFormat | undefined, valueLabelWidth: number) {
-	function ProgressValueLabelsLayer({ formattedGraphicalItems, offset }: ProgressLabelsLayerProps) {
+function createHorizontalBarValueLabelsLayer(
+	valueFormat: displayChart.ValueFormat | undefined,
+	valueLabelWidth: number,
+) {
+	function HorizontalBarValueLabelsLayer({ formattedGraphicalItems, offset }: HorizontalBarLabelsLayerProps) {
 		const bar = formattedGraphicalItems?.find((item) => item.item?.type?.displayName === 'Bar');
 		const trackEnd = (toFiniteNumber(offset?.left) ?? 0) + (toFiniteNumber(offset?.width) ?? 0);
-		const labelX = trackEnd + valueLabelWidth - PROGRESS_VALUE_LABEL_RIGHT_PADDING;
+		const labelX = trackEnd + valueLabelWidth - HORIZONTAL_BAR_VALUE_LABEL_RIGHT_PADDING;
 		const points = bar?.props?.data ?? [];
 		if (points.length === 0) {
 			return null;
 		}
 		return (
-			<g className='recharts-progress-value-labels'>
+			<g className='recharts-horizontal-bar-value-labels'>
 				{points.map((point) => {
 					const y = toFiniteNumber(point.y);
 					const height = toFiniteNumber(point.height);
 					if (y == null || height == null) {
 						return null;
 					}
-					const value = toFiniteNumber(point.payload?.[PROGRESS_ORIGINAL_VALUE_KEY]) ?? 0;
+					const value = toFiniteNumber(point.payload?.[HORIZONTAL_BAR_ORIGINAL_VALUE_KEY]) ?? 0;
 					return (
 						<text
 							key={`${y}-${value}`}
@@ -736,7 +741,7 @@ function createProgressValueLabelsLayer(valueFormat: displayChart.ValueFormat | 
 							fontSize={CHART_LABEL_FONT_SIZE}
 							textAnchor='end'
 							dominantBaseline='central'
-							className='recharts-progress-value-label'
+							className='recharts-horizontal-bar-value-label'
 						>
 							{formatChartValue(value, valueFormat)}
 						</text>
@@ -745,17 +750,17 @@ function createProgressValueLabelsLayer(valueFormat: displayChart.ValueFormat | 
 			</g>
 		);
 	}
-	ProgressValueLabelsLayer.displayName = 'ProgressValueLabelsLayer';
-	return ProgressValueLabelsLayer;
+	HorizontalBarValueLabelsLayer.displayName = 'HorizontalBarValueLabelsLayer';
+	return HorizontalBarValueLabelsLayer;
 }
 
-function renderProgressBarBackground(backgroundProps: unknown) {
+function renderHorizontalBarBackground(backgroundProps: unknown) {
 	const rectProps = backgroundProps as RectangleProps;
 	return (
 		<Rectangle
 			{...rectProps}
-			fill={PROGRESS_TRACK_COLOR}
-			radius={[PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS, PROGRESS_BAR_RADIUS]}
+			fill={HORIZONTAL_BAR_TRACK_COLOR}
+			radius={[HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS, HORIZONTAL_BAR_RADIUS]}
 		/>
 	);
 }

--- a/apps/shared/src/chart-data-labels.tsx
+++ b/apps/shared/src/chart-data-labels.tsx
@@ -107,7 +107,11 @@ export function formatDataLabel(value: unknown, valueFormat?: displayChart.Value
 }
 
 export function shouldReserveDataLabelHeadroom<Props extends DataLabelChartProps>(props: Props): boolean {
-	if (props.showDataLabels !== true || !isCartesianLabelChart(props.chartType)) {
+	if (
+		props.showDataLabels !== true ||
+		isHorizontalBarChart(props.chartType) ||
+		!isCartesianLabelChart(props.chartType)
+	) {
 		return false;
 	}
 	if (barChartUsesPaddedDomain(props)) {
@@ -124,7 +128,11 @@ export function shouldReserveDataLabelHeadroom<Props extends DataLabelChartProps
 }
 
 export function shouldReserveStackTotalFootroom<Props extends DataLabelChartProps>(props: Props): boolean {
-	if (props.showDataLabels !== true || !displayChart.isStackedChartType(props.chartType)) {
+	if (
+		props.showDataLabels !== true ||
+		isHorizontalBarChart(props.chartType) ||
+		!displayChart.isStackedChartType(props.chartType)
+	) {
 		return false;
 	}
 	if (displayChart.isPercentStackedChartType(props.chartType)) {
@@ -217,6 +225,10 @@ function isCartesianLabelChart(chartType: displayChart.ChartType): boolean {
 		displayChart.isStackedChartType(chartType) ||
 		chartType === 'mixed'
 	);
+}
+
+function isHorizontalBarChart(chartType: displayChart.ChartType): boolean {
+	return chartType === 'horizontal_bar' || chartType === 'horizontal_bar_100';
 }
 
 function barChartUsesPaddedDomain(props: DataLabelChartProps): boolean {
@@ -642,7 +654,10 @@ function boxesOverlap(a: LabelBox, b: LabelBox): boolean {
 	return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
 }
 
-function sumStackValue(row: Record<string, unknown> | undefined, series: displayChart.SeriesConfig[]): number | null {
+export function sumStackValue(
+	row: Record<string, unknown> | undefined,
+	series: displayChart.SeriesConfig[],
+): number | null {
 	if (!row) {
 		return null;
 	}

--- a/apps/shared/src/chart-data-labels.tsx
+++ b/apps/shared/src/chart-data-labels.tsx
@@ -78,7 +78,7 @@ interface LabelCandidate {
 	box: LabelBox;
 	text: string;
 	rank: number[];
-	textAnchor: 'start' | 'middle' | 'end';
+	textAnchor: LabelTextAnchor;
 }
 
 interface IndexedLabelCandidate {
@@ -87,7 +87,9 @@ interface IndexedLabelCandidate {
 	value: number;
 }
 
-interface LabelBox {
+export type LabelTextAnchor = 'start' | 'middle' | 'end';
+
+export interface LabelBox {
 	left: number;
 	right: number;
 	top: number;
@@ -634,23 +636,24 @@ function boxFitsBounds(box: LabelBox, bounds: LabelBox): boolean {
 	return box.left >= bounds.left && box.right <= bounds.right && box.top >= bounds.top && box.bottom <= bounds.bottom;
 }
 
-function labelBox(
+export function labelBox(
 	cx: number,
 	baselineY: number,
 	halfWidth: number,
-	textAnchor: LabelCandidate['textAnchor'] = 'middle',
+	textAnchor: LabelTextAnchor = 'middle',
+	fontSize = DATA_LABEL_FONT_SIZE,
 ): LabelBox {
 	const left = textAnchor === 'start' ? cx : textAnchor === 'end' ? cx - halfWidth * 2 : cx - halfWidth;
 	const right = textAnchor === 'start' ? cx + halfWidth * 2 : textAnchor === 'end' ? cx : cx + halfWidth;
 	return {
 		left: left - (textAnchor === 'start' ? 0 : DATA_LABEL_BOX_PADDING),
 		right: right + (textAnchor === 'end' ? 0 : DATA_LABEL_BOX_PADDING),
-		top: baselineY - DATA_LABEL_FONT_SIZE - DATA_LABEL_BOX_PADDING,
+		top: baselineY - fontSize - DATA_LABEL_BOX_PADDING,
 		bottom: baselineY + DATA_LABEL_BOX_PADDING,
 	};
 }
 
-function boxesOverlap(a: LabelBox, b: LabelBox): boolean {
+export function boxesOverlap(a: LabelBox, b: LabelBox): boolean {
 	return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
 }
 

--- a/apps/shared/src/chart-data-labels.tsx
+++ b/apps/shared/src/chart-data-labels.tsx
@@ -17,7 +17,7 @@ const DATA_LABEL_FONT_SIZE = 11;
 /** Approximate glyph width as a fraction of the font size; used to size collision boxes without a DOM. */
 const DATA_LABEL_CHAR_WIDTH_RATIO = 0.6;
 /** Vertical clearance between the anchor point/line (or bar edge) and the nearest edge of a label. */
-const DATA_LABEL_ANCHOR_GAP = 8;
+export const DATA_LABEL_ANCHOR_GAP = 8;
 /** Padding added around each label's collision box so neighbours keep a little breathing room. */
 const DATA_LABEL_BOX_PADDING = 2;
 /** Series kinds whose points we place labels for; stacked/pie use their own paths. */

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -4,6 +4,7 @@ export const BUILTIN_CHART_TYPES = [
 	'bar',
 	'stacked_bar',
 	'stacked_bar_100',
+	'progress_bar',
 	'line',
 	'area',
 	'stacked_area',
@@ -320,6 +321,7 @@ const STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar', 'stacked_bar_100'
 const PERCENT_STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar_100', 'stacked_area_100']);
 const X_AXIS_REQUIRED_CHART_TYPES = new Set<ChartType>([
 	'bar',
+	'progress_bar',
 	'line',
 	'area',
 	'stacked_area',
@@ -360,10 +362,14 @@ export function isPieChart(chartType: string): boolean {
 	return chartType === 'pie' || chartType === 'donut';
 }
 
-const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>(['pie', 'donut', 'kpi_card', 'radar']);
+const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>(['pie', 'donut', 'kpi_card', 'radar', 'progress_bar']);
 
 export function chartTypeSupportsAxisLabels(type: string): boolean {
 	return isBuiltinChartType(type) && !AXIS_LABEL_UNSUPPORTED_CHART_TYPES.has(type);
+}
+
+export function resolveShowDataLabels(type: string, showDataLabels?: boolean): boolean {
+	return showDataLabels ?? type === 'progress_bar';
 }
 
 export function chartTypeSupportsComboSeries(type: ChartType): boolean {

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -4,7 +4,7 @@ export const BUILTIN_CHART_TYPES = [
 	'bar',
 	'stacked_bar',
 	'stacked_bar_100',
-	'progress_bar',
+	'horizontal_bar',
 	'line',
 	'area',
 	'stacked_area',
@@ -321,7 +321,7 @@ const STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar', 'stacked_bar_100'
 const PERCENT_STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar_100', 'stacked_area_100']);
 const X_AXIS_REQUIRED_CHART_TYPES = new Set<ChartType>([
 	'bar',
-	'progress_bar',
+	'horizontal_bar',
 	'line',
 	'area',
 	'stacked_area',
@@ -362,14 +362,14 @@ export function isPieChart(chartType: string): boolean {
 	return chartType === 'pie' || chartType === 'donut';
 }
 
-const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>(['pie', 'donut', 'kpi_card', 'radar', 'progress_bar']);
+const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>(['pie', 'donut', 'kpi_card', 'radar', 'horizontal_bar']);
 
 export function chartTypeSupportsAxisLabels(type: string): boolean {
 	return isBuiltinChartType(type) && !AXIS_LABEL_UNSUPPORTED_CHART_TYPES.has(type);
 }
 
 export function resolveShowDataLabels(type: string, showDataLabels?: boolean): boolean {
-	return showDataLabels ?? type === 'progress_bar';
+	return showDataLabels ?? type === 'horizontal_bar';
 }
 
 export function chartTypeSupportsComboSeries(type: ChartType): boolean {

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -5,6 +5,7 @@ export const BUILTIN_CHART_TYPES = [
 	'stacked_bar',
 	'stacked_bar_100',
 	'horizontal_bar',
+	'horizontal_bar_100',
 	'line',
 	'area',
 	'stacked_area',
@@ -317,11 +318,19 @@ export type ConditionalFormatRule = z.infer<typeof ConditionalFormatRuleSchema>;
 export type ColumnConditionalFormats = z.infer<typeof ColumnConditionalFormatsSchema>;
 export type Output = z.infer<typeof OutputSchema>;
 
-const STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar', 'stacked_bar_100', 'stacked_area', 'stacked_area_100']);
-const PERCENT_STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar_100', 'stacked_area_100']);
+const STACKED_CHART_TYPES = new Set<ChartType>([
+	'stacked_bar',
+	'stacked_bar_100',
+	'horizontal_bar',
+	'horizontal_bar_100',
+	'stacked_area',
+	'stacked_area_100',
+]);
+const PERCENT_STACKED_CHART_TYPES = new Set<ChartType>(['stacked_bar_100', 'horizontal_bar_100', 'stacked_area_100']);
 const X_AXIS_REQUIRED_CHART_TYPES = new Set<ChartType>([
 	'bar',
 	'horizontal_bar',
+	'horizontal_bar_100',
 	'line',
 	'area',
 	'stacked_area',
@@ -362,7 +371,14 @@ export function isPieChart(chartType: string): boolean {
 	return chartType === 'pie' || chartType === 'donut';
 }
 
-const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>(['pie', 'donut', 'kpi_card', 'radar', 'horizontal_bar']);
+const AXIS_LABEL_UNSUPPORTED_CHART_TYPES = new Set<ChartType>([
+	'pie',
+	'donut',
+	'kpi_card',
+	'radar',
+	'horizontal_bar',
+	'horizontal_bar_100',
+]);
 
 export function chartTypeSupportsAxisLabels(type: string): boolean {
 	return isBuiltinChartType(type) && !AXIS_LABEL_UNSUPPORTED_CHART_TYPES.has(type);

--- a/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
+++ b/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
@@ -3,6 +3,7 @@ import { renderToString } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import { buildChart } from '../src/chart-builder';
+import { boxesOverlap, labelBox } from '../src/chart-data-labels';
 
 describe('buildChart horizontal bars', () => {
 	it('builds one horizontal bar series with category and hidden value axes', () => {
@@ -159,6 +160,32 @@ describe('buildChart horizontal bars', () => {
 		expect(labels[0].x).toBe(labels[1].x);
 	});
 
+	it('skips value labels and category ticks that do not fit', () => {
+		const rowCount = 96;
+		const chart = buildChart({
+			data: Array.from({ length: rowCount }, (_, index) => ({
+				category: `Month ${index + 1}`,
+				value: index + 1,
+			})),
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const yAxis = flattenChildren(chart.props.children).find((child) => getDisplayName(child) === 'YAxis');
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const labels = readHorizontalBarValueLabels(html);
+		const boxes = labels.map((label) => labelBox(label.x, label.y, (label.text.length * 7) / 2, 'end', 12));
+
+		expect(labels.length).toBeGreaterThan(0);
+		expect(labels.length).toBeLessThan(rowCount);
+		expect(labels[0].text).toBe('1');
+		expect(boxes.every((box, index) => boxes.slice(index + 1).every((other) => !boxesOverlap(box, other)))).toBe(
+			true,
+		);
+		expect(yAxis?.props.interval).toBe('preserveStartEnd');
+	});
+
 	it('shows value labels by default and removes their margin when hidden', () => {
 		const props = {
 			data: [{ category: 'First', value: 50 }],
@@ -180,8 +207,8 @@ describe('buildChart horizontal bars', () => {
 
 function readHorizontalBarValueLabels(
 	html: string,
-): Array<{ text: string; textAnchor: string | undefined; x: number }> {
-	const labels: Array<{ text: string; textAnchor: string | undefined; x: number }> = [];
+): Array<{ text: string; textAnchor: string | undefined; x: number; y: number }> {
+	const labels: Array<{ text: string; textAnchor: string | undefined; x: number; y: number }> = [];
 	const textPattern = /<text([^>]*)>([^<]*)<\/text>/g;
 	for (let match = textPattern.exec(html); match !== null; match = textPattern.exec(html)) {
 		const attributes = match[1];
@@ -189,8 +216,9 @@ function readHorizontalBarValueLabels(
 			continue;
 		}
 		const x = attributes.match(/\sx="([^"]+)"/)?.[1];
+		const y = attributes.match(/\sy="([^"]+)"/)?.[1];
 		const textAnchor = attributes.match(/\stext-anchor="([^"]+)"/)?.[1];
-		labels.push({ text: match[2], textAnchor, x: Number(x) });
+		labels.push({ text: match[2], textAnchor, x: Number(x), y: Number(y) });
 	}
 	return labels;
 }

--- a/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
+++ b/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
@@ -4,14 +4,14 @@ import { describe, expect, it } from 'vitest';
 
 import { buildChart } from '../src/chart-builder';
 
-describe('buildChart progress bars', () => {
-	it('builds one vertical bar series with category and hidden value axes', () => {
+describe('buildChart horizontal bars', () => {
+	it('builds one horizontal bar series with category and hidden value axes', () => {
 		const chart = buildChart({
 			data: [
 				{ category: 'First', value: 20 },
 				{ category: 'Second', value: 50 },
 			],
-			chartType: 'progress_bar',
+			chartType: 'horizontal_bar',
 			xAxisKey: 'category',
 			xAxisType: 'category',
 			series: [{ data_key: 'value' }],
@@ -31,14 +31,14 @@ describe('buildChart progress bars', () => {
 	it('applies the series value format to the always-visible labels', () => {
 		const chart = buildChart({
 			data: [{ category: 'First', value: 1200 }],
-			chartType: 'progress_bar',
+			chartType: 'horizontal_bar',
 			xAxisKey: 'category',
 			xAxisType: 'category',
 			series: [{ data_key: 'value', value_format: { d3_format: ',.0f', prefix: '$', suffix: ' USD' } }],
 		});
 		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
 
-		expect(readProgressValueLabels(html).map((label) => label.text)).toEqual(['$1,200 USD']);
+		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['$1,200 USD']);
 		expect(html).toContain('fill="var(--muted, #e5e7eb)"');
 	});
 
@@ -48,13 +48,13 @@ describe('buildChart progress bars', () => {
 				{ category: 'Short', value: 200 },
 				{ category: 'Long', value: 1200 },
 			],
-			chartType: 'progress_bar',
+			chartType: 'horizontal_bar',
 			xAxisKey: 'category',
 			xAxisType: 'category',
 			series: [{ data_key: 'value', value_format: { d3_format: ',.0f', prefix: '$', suffix: ' USD' } }],
 		});
 		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
-		const labels = readProgressValueLabels(html);
+		const labels = readHorizontalBarValueLabels(html);
 
 		expect(labels.map((label) => label.text)).toEqual(['$200 USD', '$1,200 USD']);
 		expect(labels[0].x).toBe(labels[1].x);
@@ -68,13 +68,13 @@ describe('buildChart progress bars', () => {
 				{ category: 'Missing', value: null },
 				{ category: 'Full', value: 100 },
 			],
-			chartType: 'progress_bar',
+			chartType: 'horizontal_bar',
 			xAxisKey: 'category',
 			xAxisType: 'category',
 			series: [{ data_key: 'value' }],
 		});
 		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
-		const labels = readProgressValueLabels(html);
+		const labels = readHorizontalBarValueLabels(html);
 
 		expect(labels.slice(0, 2).map((label) => label.text)).toEqual(['0', '0']);
 		expect(labels[0].x).toBe(labels[1].x);
@@ -83,7 +83,7 @@ describe('buildChart progress bars', () => {
 	it('shows value labels by default and removes their margin when hidden', () => {
 		const props = {
 			data: [{ category: 'First', value: 50 }],
-			chartType: 'progress_bar' as const,
+			chartType: 'horizontal_bar' as const,
 			xAxisKey: 'category',
 			xAxisType: 'category' as const,
 			series: [{ data_key: 'value' }],
@@ -93,18 +93,20 @@ describe('buildChart progress bars', () => {
 		const visibleHtml = renderToString(React.cloneElement(visibleChart, { width: 600, height: 300 }));
 		const hiddenHtml = renderToString(React.cloneElement(hiddenChart, { width: 600, height: 300 }));
 
-		expect(readProgressValueLabels(visibleHtml)).toHaveLength(1);
-		expect(readProgressValueLabels(hiddenHtml)).toHaveLength(0);
+		expect(readHorizontalBarValueLabels(visibleHtml)).toHaveLength(1);
+		expect(readHorizontalBarValueLabels(hiddenHtml)).toHaveLength(0);
 		expect(visibleChart.props.margin.right).toBeGreaterThan(hiddenChart.props.margin?.right ?? 0);
 	});
 });
 
-function readProgressValueLabels(html: string): Array<{ text: string; textAnchor: string | undefined; x: number }> {
+function readHorizontalBarValueLabels(
+	html: string,
+): Array<{ text: string; textAnchor: string | undefined; x: number }> {
 	const labels: Array<{ text: string; textAnchor: string | undefined; x: number }> = [];
 	const textPattern = /<text([^>]*)>([^<]*)<\/text>/g;
 	for (let match = textPattern.exec(html); match !== null; match = textPattern.exec(html)) {
 		const attributes = match[1];
-		if (!attributes.includes('recharts-progress-value-label')) {
+		if (!attributes.includes('recharts-horizontal-bar-value-label')) {
 			continue;
 		}
 		const x = attributes.match(/\sx="([^"]+)"/)?.[1];

--- a/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
+++ b/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
@@ -192,6 +192,8 @@ describe('buildChart horizontal bars', () => {
 		expect(axisTickTexts.length).toBeGreaterThan(0);
 		expect(axisTickTexts).not.toEqual(['0', '0', '1', '1', '1']);
 		expect(axisTickTexts).toEqual([...new Set(axisTickTexts)]);
+		expect(axisTickTexts.every((tickText) => !['First', 'Second'].includes(tickText))).toBe(true);
+		expect(axisTickTexts.every((tickText) => Number.isFinite(Number(tickText)))).toBe(true);
 	});
 
 	it('clamps mixed-sign series for the domain while preserving the signed total label', () => {
@@ -393,9 +395,40 @@ function readHorizontalBarValueLabels(
 }
 
 function readHorizontalBarValueAxisTicks(html: string): string[] {
-	const axisStart = html.indexOf('recharts-xAxis');
-	const nextAxisStart = html.indexOf('recharts-yAxis', axisStart);
-	const axisGroup = axisStart >= 0 ? html.slice(axisStart, nextAxisStart >= 0 ? nextAxisStart : undefined) : '';
+	const axisPattern = /<g\b([^>]*)>/g;
+	let axisStart: number | undefined;
+	for (let match = axisPattern.exec(html); match !== null; match = axisPattern.exec(html)) {
+		const className = match[1].match(/\sclass="([^"]+)"/)?.[1];
+		const classes = className?.split(/\s+/) ?? [];
+		if (classes.includes('recharts-cartesian-axis') && classes.includes('recharts-xAxis')) {
+			axisStart = match.index;
+			break;
+		}
+	}
+	if (axisStart === undefined) {
+		throw new Error(
+			'readHorizontalBarValueAxisTicks could not find a value-axis <g> with classes recharts-cartesian-axis and recharts-xAxis',
+		);
+	}
+
+	const groupPattern = /<g\b[^>]*>|<\/g>/g;
+	groupPattern.lastIndex = axisStart;
+	let depth = 0;
+	let axisEnd: number | undefined;
+	for (let match = groupPattern.exec(html); match !== null; match = groupPattern.exec(html)) {
+		depth += match[0] === '</g>' ? -1 : 1;
+		if (depth === 0) {
+			axisEnd = groupPattern.lastIndex;
+			break;
+		}
+	}
+	if (axisEnd === undefined) {
+		throw new Error(
+			'readHorizontalBarValueAxisTicks could not find the closing </g> for the recharts-xAxis value-axis group',
+		);
+	}
+
+	const axisGroup = html.slice(axisStart, axisEnd);
 	const tickTexts: string[] = [];
 	const textPattern = /<text([^>]*)>([\s\S]*?)<\/text>/g;
 	for (let match = textPattern.exec(axisGroup); match !== null; match = textPattern.exec(axisGroup)) {

--- a/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
+++ b/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
@@ -23,7 +23,17 @@ describe('buildChart horizontal bars', () => {
 
 		expect(chart.type.displayName).toBe('BarChart');
 		expect(chart.props.layout).toBe('vertical');
+		expect(chart.props.stackOffset).toBeUndefined();
+		expect(chart.props.barCategoryGap).toBeUndefined();
 		expect(bars).toHaveLength(1);
+		expect(bars[0].props).toMatchObject({
+			radius: [999, 999, 999, 999],
+			barSize: 10,
+		});
+		expect('stackId' in bars[0].props).toBe(false);
+		expect('shape' in bars[0].props).toBe(false);
+		expect('maxBarSize' in bars[0].props).toBe(false);
+		expect(bars[0].props.background).toBeTypeOf('function');
 		expect(xAxis?.props).toMatchObject({ type: 'number', hide: true, domain: [0, 50] });
 		expect(yAxis?.props).toMatchObject({ type: 'category', dataKey: 'category' });
 	});
@@ -59,6 +69,75 @@ describe('buildChart horizontal bars', () => {
 		expect(labels.map((label) => label.text)).toEqual(['$200 USD', '$1,200 USD']);
 		expect(labels[0].x).toBe(labels[1].x);
 		expect(labels.every((label) => label.textAnchor === 'end')).toBe(true);
+	});
+
+	it('stacks multiple series over one track and labels row totals', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'First', direct: 20, partner: 30, total: 50 },
+				{ category: 'Second', direct: 40, partner: 70, total: 110 },
+			],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }, { data_key: 'total', is_total: true }],
+		});
+		const children = flattenChildren(chart.props.children);
+		const bars = children.filter((child) => getDisplayName(child) === 'Bar');
+		const xAxis = children.find((child) => getDisplayName(child) === 'XAxis');
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+
+		expect(bars).toHaveLength(2);
+		expect(bars.map((bar) => bar.props.stackId)).toEqual(['stack', 'stack']);
+		expect(bars.every((bar) => !('barSize' in bar.props))).toBe(true);
+		expect(bars.map((bar) => bar.props.maxBarSize)).toEqual([28, 28]);
+		expect(chart.props.barCategoryGap).toBe('20%');
+		expect(bars.filter((bar) => Boolean(bar.props.background))).toHaveLength(1);
+		expect(xAxis?.props).toMatchObject({ type: 'number', domain: [0, 110] });
+		expect(xAxis?.props.hide).not.toBe(true);
+		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['50', '110']);
+
+		const leftSegment = bars[0].props.shape?.({ payload: { direct: 20, partner: 30 } });
+		const rightSegment = bars[1].props.shape?.({ payload: { direct: 20, partner: 30 } });
+		const onlyVisibleSegment = bars[1].props.shape?.({ payload: { direct: 0, partner: 30 } });
+		expect(leftSegment).toBeDefined();
+		expect(rightSegment).toBeDefined();
+		expect(onlyVisibleSegment).toBeDefined();
+		expect(leftSegment!.props).toMatchObject({
+			radius: [999, 0, 0, 999],
+			stroke: 'var(--background, #ffffff)',
+			strokeWidth: 1,
+		});
+		expect(rightSegment!.props).toMatchObject({
+			radius: [0, 999, 999, 0],
+			stroke: 'var(--background, #ffffff)',
+			strokeWidth: 1,
+		});
+		expect(onlyVisibleSegment!.props.radius).toEqual([999, 999, 999, 999]);
+	});
+
+	it('normalizes stacked horizontal bars to a percentage axis', () => {
+		const props = {
+			data: [{ category: 'First', direct: 20, partner: 30 }],
+			chartType: 'horizontal_bar_100' as const,
+			xAxisKey: 'category',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+		};
+		const chart = buildChart(props);
+		const labelledChart = buildChart({ ...props, showDataLabels: true });
+		const children = flattenChildren(chart.props.children);
+		const bars = children.filter((child) => getDisplayName(child) === 'Bar');
+		const xAxis = children.find((child) => getDisplayName(child) === 'XAxis');
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const labelledHtml = renderToString(React.cloneElement(labelledChart, { width: 600, height: 300 }));
+
+		expect(chart.props.stackOffset).toBe('expand');
+		expect(bars).toHaveLength(2);
+		expect(xAxis?.props.domain).toEqual([0, 1]);
+		expect(xAxis?.props.tickFormatter?.(0.5)).toBe('50%');
+		expect(readHorizontalBarValueLabels(html)).toHaveLength(0);
+		expect(readHorizontalBarValueLabels(labelledHtml).map((label) => label.text)).toEqual(['100%']);
 	});
 
 	it('renders zero and null values at the bar origin', () => {
@@ -116,7 +195,22 @@ function readHorizontalBarValueLabels(
 	return labels;
 }
 
-function flattenChildren(children: unknown): ReactElement[] {
+interface TestElementProps {
+	[key: string]: unknown;
+	background?: unknown;
+	barSize?: number;
+	domain?: unknown;
+	hide?: boolean;
+	maxBarSize?: number;
+	radius?: number[];
+	shape?: (props: unknown) => ReactElement<{ radius?: number[]; stroke?: string; strokeWidth?: number }>;
+	stackId?: string;
+	tickFormatter?: (value: number) => string;
+}
+
+type TestElement = ReactElement<TestElementProps>;
+
+function flattenChildren(children: unknown): TestElement[] {
 	if (Array.isArray(children)) {
 		return children.flatMap(flattenChildren);
 	}
@@ -126,10 +220,10 @@ function flattenChildren(children: unknown): ReactElement[] {
 	return [];
 }
 
-function isReactElement(value: unknown): value is ReactElement {
+function isReactElement(value: unknown): value is TestElement {
 	return typeof value === 'object' && value !== null && 'props' in value && 'type' in value;
 }
 
-function getDisplayName(element: ReactElement): string | undefined {
+function getDisplayName(element: TestElement): string | undefined {
 	return typeof element.type === 'string' ? element.type : (element.type as { displayName?: string }).displayName;
 }

--- a/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
+++ b/apps/shared/tests/chart-builder-horizontal-bar.test.tsx
@@ -39,6 +39,60 @@ describe('buildChart horizontal bars', () => {
 		expect(yAxis?.props).toMatchObject({ type: 'category', dataKey: 'category' });
 	});
 
+	it('adds vertical label room to caller-supplied margins', () => {
+		const props = {
+			data: [{ category: 'First', value: 50 }],
+			chartType: 'horizontal_bar' as const,
+			xAxisKey: 'category',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'value' }],
+		};
+		const chart = buildChart(props);
+		const chartWithMargin = buildChart({ ...props, margin: { top: 5, right: 5, bottom: 5 } });
+		const hiddenLabelsChart = buildChart({ ...props, showDataLabels: false });
+
+		expect(chart.props.margin.top).toBeGreaterThanOrEqual(8);
+		expect(chart.props.margin.bottom).toBeGreaterThanOrEqual(8);
+		expect(chartWithMargin.props.margin.top).toBe(chart.props.margin.top + 5);
+		expect(chartWithMargin.props.margin.right).toBe(chart.props.margin.right + 5);
+		expect(chartWithMargin.props.margin.bottom).toBe(chart.props.margin.bottom + 5);
+		expect(hiddenLabelsChart.props.margin.top).toBe(chart.props.margin.top);
+		expect(hiddenLabelsChart.props.margin.bottom).toBe(chart.props.margin.bottom);
+	});
+
+	it('keeps category labels beyond the rotated-axis limit and sizes the axis to fit', () => {
+		const chart = buildChart({
+			data: [{ category: 'Eleanor Roberts', value: 20 }],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+			labelFormatter: (value) => value,
+			xAxisMaxLabelChars: 14,
+		});
+		const yAxis = flattenChildren(chart.props.children).find((child) => getDisplayName(child) === 'YAxis');
+
+		expect(yAxis?.props.tickFormatter?.('Eleanor Roberts')).toBe('Eleanor Roberts');
+		expect(yAxis?.props.width).toBe(117);
+		expect(yAxis?.props.width).toBeLessThanOrEqual(180);
+	});
+
+	it('truncates category labels longer than 24 characters', () => {
+		const chart = buildChart({
+			data: [{ category: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', value: 20 }],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+			labelFormatter: (value) => value,
+		});
+		const yAxis = flattenChildren(chart.props.children).find((child) => getDisplayName(child) === 'YAxis');
+		const formattedLabel = yAxis?.props.tickFormatter?.('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+
+		expect(formattedLabel).toBe('ABCDEFGHIJKLMNOPQRSTUVW…');
+		expect(formattedLabel).toHaveLength(24);
+	});
+
 	it('applies the series value format to the always-visible labels', () => {
 		const chart = buildChart({
 			data: [{ category: 'First', value: 1200 }],
@@ -94,7 +148,8 @@ describe('buildChart horizontal bars', () => {
 		expect(bars.map((bar) => bar.props.maxBarSize)).toEqual([28, 28]);
 		expect(chart.props.barCategoryGap).toBe('20%');
 		expect(bars.filter((bar) => Boolean(bar.props.background))).toHaveLength(1);
-		expect(xAxis?.props).toMatchObject({ type: 'number', domain: [0, 110] });
+		expect(xAxis?.props).toMatchObject({ type: 'number' });
+		expect(xAxis?.props.domain).toBeUndefined();
 		expect(xAxis?.props.hide).not.toBe(true);
 		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['50', '110']);
 
@@ -115,6 +170,60 @@ describe('buildChart horizontal bars', () => {
 			strokeWidth: 1,
 		});
 		expect(onlyVisibleSegment!.props.radius).toEqual([999, 999, 999, 999]);
+	});
+
+	it('renders distinct value-axis ticks for all-zero multi-series data', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'First', direct: 0, partner: 0 },
+				{ category: 'Second', direct: 0, partner: 0 },
+			],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [
+				{ data_key: 'direct', value_format: { d3_format: ',.0f' } },
+				{ data_key: 'partner', value_format: { d3_format: ',.0f' } },
+			],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const axisTickTexts = readHorizontalBarValueAxisTicks(html);
+
+		expect(axisTickTexts.length).toBeGreaterThan(0);
+		expect(axisTickTexts).not.toEqual(['0', '0', '1', '1', '1']);
+		expect(axisTickTexts).toEqual([...new Set(axisTickTexts)]);
+	});
+
+	it('clamps mixed-sign series for the domain while preserving the signed total label', () => {
+		const chart = buildChart({
+			data: [{ category: 'First', direct: 100, partner: -100 }],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+		});
+		const xAxis = flattenChildren(chart.props.children).find((child) => getDisplayName(child) === 'XAxis');
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+
+		expect(xAxis?.props.domain).toBeUndefined();
+		expect(chart.props.data[0]).toMatchObject({ direct: 100, partner: 0 });
+		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['0']);
+	});
+
+	it('renders a negative single-series value at the origin with its signed label', () => {
+		const chart = buildChart({
+			data: [{ category: 'First', value: -30 }],
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const xAxis = flattenChildren(chart.props.children).find((child) => getDisplayName(child) === 'XAxis');
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+
+		expect(xAxis?.props.domain).toEqual([0, 1]);
+		expect(chart.props.data[0].value).toBe(0);
+		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['-30']);
 	});
 
 	it('normalizes stacked horizontal bars to a percentage axis', () => {
@@ -139,6 +248,23 @@ describe('buildChart horizontal bars', () => {
 		expect(xAxis?.props.tickFormatter?.(0.5)).toBe('50%');
 		expect(readHorizontalBarValueLabels(html)).toHaveLength(0);
 		expect(readHorizontalBarValueLabels(labelledHtml).map((label) => label.text)).toEqual(['100%']);
+	});
+
+	it('labels empty normalized rows as zero percent', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'Empty', direct: 0, partner: 0 },
+				{ category: 'Full', direct: 20, partner: 30 },
+			],
+			chartType: 'horizontal_bar_100',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'direct' }, { data_key: 'partner' }],
+			showDataLabels: true,
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+
+		expect(readHorizontalBarValueLabels(html).map((label) => label.text)).toEqual(['0%', '100%']);
 	});
 
 	it('renders zero and null values at the bar origin', () => {
@@ -186,6 +312,49 @@ describe('buildChart horizontal bars', () => {
 		expect(yAxis?.props.interval).toBe('preserveStartEnd');
 	});
 
+	it('keeps value labels inside a dense horizontal bar chart', () => {
+		const chartHeight = 300;
+		const fontSize = 12;
+		const chart = buildChart({
+			data: Array.from({ length: 60 }, (_, index) => ({
+				category: `Customer ${index + 1}`,
+				value: index + 1,
+			})),
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: chartHeight }));
+		const labels = readHorizontalBarValueLabels(html);
+		const labelTops = labels.map((label) => label.y - fontSize / 2);
+		const labelBottoms = labels.map((label) => label.y + fontSize / 2);
+
+		expect(labels.length).toBeGreaterThan(0);
+		expect(Math.min(...labelTops)).toBeGreaterThanOrEqual(0);
+		expect(Math.max(...labelBottoms)).toBeLessThanOrEqual(chartHeight);
+	});
+
+	it('keeps the first value label centered on its bar', () => {
+		const chart = buildChart({
+			data: Array.from({ length: 60 }, (_, index) => ({
+				category: `Customer ${index + 1}`,
+				value: index + 1,
+			})),
+			chartType: 'horizontal_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const labels = readHorizontalBarValueLabels(html);
+		const barCenters = readHorizontalBarCenters(html);
+
+		expect(labels.length).toBeGreaterThan(0);
+		expect(barCenters.length).toBeGreaterThan(0);
+		expect(labels[0].y).toBe(barCenters[0]);
+	});
+
 	it('shows value labels by default and removes their margin when hidden', () => {
 		const props = {
 			data: [{ category: 'First', value: 50 }],
@@ -223,6 +392,37 @@ function readHorizontalBarValueLabels(
 	return labels;
 }
 
+function readHorizontalBarValueAxisTicks(html: string): string[] {
+	const axisStart = html.indexOf('recharts-xAxis');
+	const nextAxisStart = html.indexOf('recharts-yAxis', axisStart);
+	const axisGroup = axisStart >= 0 ? html.slice(axisStart, nextAxisStart >= 0 ? nextAxisStart : undefined) : '';
+	const tickTexts: string[] = [];
+	const textPattern = /<text([^>]*)>([\s\S]*?)<\/text>/g;
+	for (let match = textPattern.exec(axisGroup); match !== null; match = textPattern.exec(axisGroup)) {
+		if (match[1].includes('recharts-cartesian-axis-tick-value')) {
+			tickTexts.push(match[2].replace(/<[^>]+>/g, ''));
+		}
+	}
+	return tickTexts;
+}
+
+function readHorizontalBarCenters(html: string): number[] {
+	const centers: number[] = [];
+	const barPattern = /<g([^>]*)><path([^>]*)>/g;
+	for (let match = barPattern.exec(html); match !== null; match = barPattern.exec(html)) {
+		const className = match[1].match(/\sclass="([^"]+)"/)?.[1];
+		if (!className?.split(' ').includes('recharts-bar-rectangle')) {
+			continue;
+		}
+		const y = match[2].match(/\sy="([^"]+)"/)?.[1];
+		const height = match[2].match(/\sheight="([^"]+)"/)?.[1];
+		if (y !== undefined && height !== undefined) {
+			centers.push(Number(y) + Number(height) / 2);
+		}
+	}
+	return centers;
+}
+
 interface TestElementProps {
 	[key: string]: unknown;
 	background?: unknown;
@@ -233,7 +433,8 @@ interface TestElementProps {
 	radius?: number[];
 	shape?: (props: unknown) => ReactElement<{ radius?: number[]; stroke?: string; strokeWidth?: number }>;
 	stackId?: string;
-	tickFormatter?: (value: number) => string;
+	tickFormatter?: (value: string | number) => string;
+	width?: number;
 }
 
 type TestElement = ReactElement<TestElementProps>;

--- a/apps/shared/tests/chart-builder-progress.test.tsx
+++ b/apps/shared/tests/chart-builder-progress.test.tsx
@@ -1,0 +1,133 @@
+import React, { type ReactElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { buildChart } from '../src/chart-builder';
+
+describe('buildChart progress bars', () => {
+	it('builds one vertical bar series with category and hidden value axes', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'First', value: 20 },
+				{ category: 'Second', value: 50 },
+			],
+			chartType: 'progress_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const children = flattenChildren(chart.props.children);
+		const bars = children.filter((child) => getDisplayName(child) === 'Bar');
+		const xAxis = children.find((child) => getDisplayName(child) === 'XAxis');
+		const yAxis = children.find((child) => getDisplayName(child) === 'YAxis');
+
+		expect(chart.type.displayName).toBe('BarChart');
+		expect(chart.props.layout).toBe('vertical');
+		expect(bars).toHaveLength(1);
+		expect(xAxis?.props).toMatchObject({ type: 'number', hide: true, domain: [0, 50] });
+		expect(yAxis?.props).toMatchObject({ type: 'category', dataKey: 'category' });
+	});
+
+	it('applies the series value format to the always-visible labels', () => {
+		const chart = buildChart({
+			data: [{ category: 'First', value: 1200 }],
+			chartType: 'progress_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value', value_format: { d3_format: ',.0f', prefix: '$', suffix: ' USD' } }],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+
+		expect(readProgressValueLabels(html).map((label) => label.text)).toEqual(['$1,200 USD']);
+		expect(html).toContain('fill="var(--muted, #e5e7eb)"');
+	});
+
+	it('renders formatted values in a fixed right-aligned column', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'Short', value: 200 },
+				{ category: 'Long', value: 1200 },
+			],
+			chartType: 'progress_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value', value_format: { d3_format: ',.0f', prefix: '$', suffix: ' USD' } }],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const labels = readProgressValueLabels(html);
+
+		expect(labels.map((label) => label.text)).toEqual(['$200 USD', '$1,200 USD']);
+		expect(labels[0].x).toBe(labels[1].x);
+		expect(labels.every((label) => label.textAnchor === 'end')).toBe(true);
+	});
+
+	it('renders zero and null values at the bar origin', () => {
+		const chart = buildChart({
+			data: [
+				{ category: 'Zero', value: 0 },
+				{ category: 'Missing', value: null },
+				{ category: 'Full', value: 100 },
+			],
+			chartType: 'progress_bar',
+			xAxisKey: 'category',
+			xAxisType: 'category',
+			series: [{ data_key: 'value' }],
+		});
+		const html = renderToString(React.cloneElement(chart, { width: 600, height: 300 }));
+		const labels = readProgressValueLabels(html);
+
+		expect(labels.slice(0, 2).map((label) => label.text)).toEqual(['0', '0']);
+		expect(labels[0].x).toBe(labels[1].x);
+	});
+
+	it('shows value labels by default and removes their margin when hidden', () => {
+		const props = {
+			data: [{ category: 'First', value: 50 }],
+			chartType: 'progress_bar' as const,
+			xAxisKey: 'category',
+			xAxisType: 'category' as const,
+			series: [{ data_key: 'value' }],
+		};
+		const visibleChart = buildChart(props);
+		const hiddenChart = buildChart({ ...props, showDataLabels: false });
+		const visibleHtml = renderToString(React.cloneElement(visibleChart, { width: 600, height: 300 }));
+		const hiddenHtml = renderToString(React.cloneElement(hiddenChart, { width: 600, height: 300 }));
+
+		expect(readProgressValueLabels(visibleHtml)).toHaveLength(1);
+		expect(readProgressValueLabels(hiddenHtml)).toHaveLength(0);
+		expect(visibleChart.props.margin.right).toBeGreaterThan(hiddenChart.props.margin?.right ?? 0);
+	});
+});
+
+function readProgressValueLabels(html: string): Array<{ text: string; textAnchor: string | undefined; x: number }> {
+	const labels: Array<{ text: string; textAnchor: string | undefined; x: number }> = [];
+	const textPattern = /<text([^>]*)>([^<]*)<\/text>/g;
+	for (let match = textPattern.exec(html); match !== null; match = textPattern.exec(html)) {
+		const attributes = match[1];
+		if (!attributes.includes('recharts-progress-value-label')) {
+			continue;
+		}
+		const x = attributes.match(/\sx="([^"]+)"/)?.[1];
+		const textAnchor = attributes.match(/\stext-anchor="([^"]+)"/)?.[1];
+		labels.push({ text: match[2], textAnchor, x: Number(x) });
+	}
+	return labels;
+}
+
+function flattenChildren(children: unknown): ReactElement[] {
+	if (Array.isArray(children)) {
+		return children.flatMap(flattenChildren);
+	}
+	if (isReactElement(children)) {
+		return [children];
+	}
+	return [];
+}
+
+function isReactElement(value: unknown): value is ReactElement {
+	return typeof value === 'object' && value !== null && 'props' in value && 'type' in value;
+}
+
+function getDisplayName(element: ReactElement): string | undefined {
+	return typeof element.type === 'string' ? element.type : (element.type as { displayName?: string }).displayName;
+}

--- a/apps/shared/tests/display-chart.test.ts
+++ b/apps/shared/tests/display-chart.test.ts
@@ -23,14 +23,14 @@ describe('display chart custom types', () => {
 
 	it('distinguishes built-in and custom chart types', () => {
 		expect(displayChart.isBuiltinChartType('line')).toBe(true);
-		expect(displayChart.isBuiltinChartType('progress_bar')).toBe(true);
+		expect(displayChart.isBuiltinChartType('horizontal_bar')).toBe(true);
 		expect(displayChart.isBuiltinChartType('bubble')).toBe(false);
 	});
 
-	it('defaults data labels on only for progress bars', () => {
-		expect(displayChart.resolveShowDataLabels('progress_bar', undefined)).toBe(true);
+	it('defaults data labels on only for horizontal bars', () => {
+		expect(displayChart.resolveShowDataLabels('horizontal_bar', undefined)).toBe(true);
 		expect(displayChart.resolveShowDataLabels('bar', undefined)).toBe(false);
-		expect(displayChart.resolveShowDataLabels('progress_bar', false)).toBe(false);
+		expect(displayChart.resolveShowDataLabels('horizontal_bar', false)).toBe(false);
 		expect(displayChart.resolveShowDataLabels('bar', true)).toBe(true);
 	});
 });

--- a/apps/shared/tests/display-chart.test.ts
+++ b/apps/shared/tests/display-chart.test.ts
@@ -24,13 +24,16 @@ describe('display chart custom types', () => {
 	it('distinguishes built-in and custom chart types', () => {
 		expect(displayChart.isBuiltinChartType('line')).toBe(true);
 		expect(displayChart.isBuiltinChartType('horizontal_bar')).toBe(true);
+		expect(displayChart.isBuiltinChartType('horizontal_bar_100')).toBe(true);
 		expect(displayChart.isBuiltinChartType('bubble')).toBe(false);
 	});
 
 	it('defaults data labels on only for horizontal bars', () => {
 		expect(displayChart.resolveShowDataLabels('horizontal_bar', undefined)).toBe(true);
+		expect(displayChart.resolveShowDataLabels('horizontal_bar_100', undefined)).toBe(false);
 		expect(displayChart.resolveShowDataLabels('bar', undefined)).toBe(false);
 		expect(displayChart.resolveShowDataLabels('horizontal_bar', false)).toBe(false);
+		expect(displayChart.resolveShowDataLabels('horizontal_bar_100', true)).toBe(true);
 		expect(displayChart.resolveShowDataLabels('bar', true)).toBe(true);
 	});
 });

--- a/apps/shared/tests/display-chart.test.ts
+++ b/apps/shared/tests/display-chart.test.ts
@@ -23,6 +23,14 @@ describe('display chart custom types', () => {
 
 	it('distinguishes built-in and custom chart types', () => {
 		expect(displayChart.isBuiltinChartType('line')).toBe(true);
+		expect(displayChart.isBuiltinChartType('progress_bar')).toBe(true);
 		expect(displayChart.isBuiltinChartType('bubble')).toBe(false);
+	});
+
+	it('defaults data labels on only for progress bars', () => {
+		expect(displayChart.resolveShowDataLabels('progress_bar', undefined)).toBe(true);
+		expect(displayChart.resolveShowDataLabels('bar', undefined)).toBe(false);
+		expect(displayChart.resolveShowDataLabels('progress_bar', false)).toBe(false);
+		expect(displayChart.resolveShowDataLabels('bar', true)).toBe(true);
 	});
 });

--- a/apps/shared/tests/percent-stacked.test.ts
+++ b/apps/shared/tests/percent-stacked.test.ts
@@ -14,6 +14,8 @@ describe('isStackedChartType', () => {
 	it('recognises absolute and normalized stacked types', () => {
 		expect(isStackedChartType('stacked_bar')).toBe(true);
 		expect(isStackedChartType('stacked_bar_100')).toBe(true);
+		expect(isStackedChartType('horizontal_bar')).toBe(true);
+		expect(isStackedChartType('horizontal_bar_100')).toBe(true);
 		expect(isStackedChartType('stacked_area')).toBe(true);
 		expect(isStackedChartType('stacked_area_100')).toBe(true);
 	});
@@ -28,7 +30,9 @@ describe('isStackedChartType', () => {
 describe('isPercentStackedChartType', () => {
 	it('matches only the 100% variants', () => {
 		expect(isPercentStackedChartType('stacked_bar_100')).toBe(true);
+		expect(isPercentStackedChartType('horizontal_bar_100')).toBe(true);
 		expect(isPercentStackedChartType('stacked_area_100')).toBe(true);
+		expect(isPercentStackedChartType('horizontal_bar')).toBe(false);
 		expect(isPercentStackedChartType('stacked_bar')).toBe(false);
 		expect(isPercentStackedChartType('stacked_area')).toBe(false);
 		expect(isPercentStackedChartType('bar')).toBe(false);
@@ -36,8 +40,9 @@ describe('isPercentStackedChartType', () => {
 });
 
 describe('chartTypeRequiresXAxisKey', () => {
-	it('requires an x-axis key for both 100% stacked variants', () => {
+	it('requires an x-axis key for all 100% stacked variants', () => {
 		expect(chartTypeRequiresXAxisKey('stacked_bar_100')).toBe(true);
+		expect(chartTypeRequiresXAxisKey('horizontal_bar_100')).toBe(true);
 		expect(chartTypeRequiresXAxisKey('stacked_area_100')).toBe(true);
 	});
 


### PR DESCRIPTION
## Summary

- Adds a **progress bar** chart to the built-in chart types. Each row gets a horizontal bar in a grey track, with the category on the left and the value in a column on the right.
- Bars are sized against the largest value in the data. Takes one column of values; the agent is told to sort and limit rows in SQL.
- Rebuilt on our own chart library instead of copying the example custom chart, so it works everywhere the other charts do: image export, stories, and the chart editor. The example file stays as the demo for project-defined charts.
- Values show by default and can be switched off in the chart editor.
- Small cleanup: the muted text colour, label size, and label gap were duplicated across the chart code and are now defined once.

Closes #1431

<img width="1520" height="882" alt="CleanShot 2026-08-21 at 18 33 43@2x" src="https://github.com/user-attachments/assets/a5eba5c8-5b2c-4b25-b349-1d085e9fb707" />
<img width="1508" height="986" alt="CleanShot 2026-08-21 at 18 33 57@2x" src="https://github.com/user-attachments/assets/4d4114df-d5f7-47f7-be5e-871b60869f3a" />
<img width="1530" height="934" alt="CleanShot 2026-08-21 at 18 32 28@2x" src="https://github.com/user-attachments/assets/b2401c0d-af91-465a-86c8-1c43199aa857" />
<img width="1592" height="926" alt="CleanShot 2026-08-21 at 18 34 18@2x" src="https://github.com/user-attachments/assets/e2c7fa40-c3ed-4f79-aec9-8e38ba7315e2" />
<img width="1504" height="980" alt="CleanShot 2026-08-21 at 18 34 38@2x" src="https://github.com/user-attachments/assets/8d2a41c0-d16e-4481-be5a-0541392d3949" />



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

