### PR TITLE
fix(prompt): forbid citing table doc profiling stats as data answers

### DIFF
--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -201,6 +201,13 @@ export function SystemPrompt({
 						an "exact" count based on the number of rows a limited query returned. To count rows, run a
 						separate query using COUNT(*) (or COUNT over a subquery) without a LIMIT/TOP clause.
 					</ListItem>,
+					<ListItem>
+						Table documentation files (columns.md, preview.md, ai_summary.md, how_to_use.md, ...) are for
+						understanding schema and semantics only. Their statistics (row counts, previews, aggregates) are
+						stale profiling snapshots — never present them as the answer to a data question. Any number you
+						present as an answer to a data question must come from a query executed in this conversation, or
+						be computed from such results.
+					</ListItem>,
 					...dialectSqlQueryRules,
 				]}
 			</List>

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -247,6 +247,17 @@ describe('SystemPrompt built-in skills', () => {
 	});
 });
 
+describe('SystemPrompt SQL query rules', () => {
+	it('forbids citing table documentation statistics as answers to data questions', () => {
+		const markdown = renderToMarkdown(SystemPrompt({}));
+
+		expect(markdown).toContain('never present them as the answer to a data question');
+		expect(markdown).toContain(
+			'must come from a query executed in this conversation, or be computed from such results',
+		);
+	});
+});
+
 describe('SystemPrompt display_map rules', () => {
 	it('includes the display_map rule by default', () => {
 		expect(renderToMarkdown(SystemPrompt({}))).toContain('display_map');


### PR DESCRIPTION
Fixes #1434

The agent could answer a quantitative question by quoting profiling statistics from table documentation files (`columns.md`, `preview.md`, `ai_summary.md`, `how_to_use.md`) instead of running a query — stale snapshots from the last profiling sync, sometimes inconsistent between files of the same table. It even emitted a `<citation-number>` tag with a fabricated query id, since no `execute_sql` result existed to cite.

## Changes

- Add a rule to the "SQL Query Rules" section of the default system prompt, next to the existing LIMIT rule: table docs are for schema and semantics only; any number presented as an answer to a data question must come from a query executed in the conversation, or be computed from such results.
- Add a unit test asserting the rule is present in the rendered prompt, following the existing substring-check style of `system-prompt.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

