### PR TITLE
fix(cli): nao sync does not fetch table and column descriptions

### DIFF
--- a/cli/nao_core/config/databases/duckdb.py
+++ b/cli/nao_core/config/databases/duckdb.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field
 
@@ -15,6 +15,42 @@ from .context import DatabaseContext
 
 
 class DuckDBDatabaseContext(DatabaseContext):
+    """DuckDB context with table/column comment discovery via duckdb metadata functions."""
+
+    def description(self) -> str | None:
+        try:
+            query = (
+                "SELECT comment FROM duckdb_tables() "
+                f"WHERE schema_name = '{self._schema}' AND table_name = '{self._table_name}'"
+            )
+            row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
+            if row and row[0] is not None:
+                text = str(row[0]).strip()
+                if text:
+                    return text
+        except Exception:
+            pass
+        return None
+
+    def columns(self) -> list[dict[str, Any]]:
+        cols = super().columns()
+        try:
+            col_descs = self._fetch_column_descriptions()
+            for col in cols:
+                if desc := col_descs.get(col["name"]):
+                    col["description"] = desc
+        except Exception:
+            pass
+        return cols
+
+    def _fetch_column_descriptions(self) -> dict[str, str]:
+        query = (
+            "SELECT column_name, comment FROM duckdb_columns() "
+            f"WHERE schema_name = '{self._schema}' AND table_name = '{self._table_name}'"
+        )
+        rows = self._fetchall(self._conn.raw_sql(query))  # type: ignore[union-attr]
+        return {row[0]: str(row[1]) for row in rows if row[1] is not None}
+
     def _cast_complex_to_string(self, col_sql: str) -> str:
         return f"CAST({col_sql} AS VARCHAR)"
 


### PR DESCRIPTION
## Description

Related Issue: #1411

Previously, `DuckDBDatabaseContext` only overrode `_cast_complex_to_string` and inherited the base `DatabaseContext` implementations for `description()` and `columns()`, which returned `None` for all table and column descriptions. As a result, `nao sync` did not surface comments defined on DuckDB tables and columns.

This updates `DuckDBDatabaseContext` to query DuckDB's built-in metadata functions (`duckdb_tables()` and `duckdb_columns()`) scoped by schema and table name, extracting table comments and overlaying column comments onto base Ibis-derived metadata. Soft error handling ensures that sync never fails if metadata retrieval encounters an error.

## Changes Made

* **`DuckDBDatabaseContext.description()` (`cli/nao_core/config/databases/duckdb.py`)**

  * Queries `duckdb_tables()` for `comment`, scoped to the current `schema_name` and `table_name`.
  * Returns the stripped comment string if present, or `None`.
  * Gracefully catches metadata query exceptions and falls back to `None`.

* **`DuckDBDatabaseContext.columns()` (`cli/nao_core/config/databases/duckdb.py`)**

  * Calls `super().columns()` to preserve existing Ibis-derived column schemas, types, and nullability.
  * Queries `duckdb_columns()` via `_fetch_column_descriptions()` for column comments matching the schema and table.
  * Overlays non-null comments onto `col["description"]` while leaving uncommented columns as `None`.
  * Catches query errors gracefully without breaking column discovery.

## Validation

* `uv run pytest tests/nao_core/config/test_duckdb_context.py -v` — **7 passed**

  * `test_returns_table_comment`
  * `test_returns_none_when_no_comment`
  * `test_returns_none_on_metadata_query_failure`
  * `test_column_comments_are_overlaid`
  * `test_uncommented_column_remains_none`
  * `test_base_column_metadata_preserved`
  * `test_columns_fail_soft_on_metadata_error`

* `uv run pytest tests/nao_core/config/test_duckdb.py tests/nao_core/commands/sync/integration/test_duckdb.py -v` — **22 passed, 3 skipped**

  * All existing DuckDB configuration and sync integration tests pass.
* `uv run ruff check` / `uv run ruff format --check` on touched files — **all passed**.
* Self-contained behavioral verification against a DuckDB in-memory database:

<img width="489" height="212" alt="Screenshot From 2026-08-20 23-47-53" src="https://github.com/user-attachments/assets/d301247b-8b10-4780-ac6d-911bedec5711" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

