### PR TITLE
fix(cli): read Notion page titles by property type instead of name

### DIFF
--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -244,13 +244,13 @@ def extract_page_title(page: dict[str, Any], page_id: str) -> str:
     """Read a page's title from its properties, falling back to its ID."""
     properties = page.get("properties", {})
 
-    for prop_name in ["title", "Title", "Name", "name", "Page"]:
-        if prop_name in properties:
-            title_prop = properties[prop_name]
-            if title_prop.get("type") == "title":
-                title_array = title_prop.get("title", [])
-                if title_array:
-                    return "".join(t.get("plain_text", "") for t in title_array)
+    # Database rows name their title property freely (e.g. "Topic"), so match on the
+    # property type rather than a list of conventional names.
+    for title_prop in properties.values():
+        if title_prop.get("type") == "title":
+            title_array = title_prop.get("title", [])
+            if title_array:
+                return "".join(t.get("plain_text", "") for t in title_array)
 
     return page_id
 

--- a/cli/tests/nao_core/commands/sync/test_notion_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_provider.py
@@ -12,6 +12,7 @@ from nao_core.commands.sync.providers.notion.database import DatabaseExportError
 from nao_core.commands.sync.providers.notion.provider import (
     NotionSyncProvider,
     extract_notion_id,
+    extract_page_title,
     extract_view_id,
     markdown_filename,
     render_document,
@@ -111,6 +112,23 @@ def test_extract_notion_id_prefers_the_object_over_the_view():
     url = "https://notion.so/ws/marts-35e5f0e8a00080c69a81ef456a2b174b?v=" + "a" * 32
 
     assert extract_notion_id(url) == "35e5f0e8a00080c69a81ef456a2b174b"
+
+
+def test_extract_page_title_reads_a_custom_named_title_property():
+    page = {
+        "properties": {
+            "Owner": {"type": "people", "people": []},
+            "Topic": {"type": "title", "title": [{"plain_text": "Basic "}, {"plain_text": "Knowledge"}]},
+        }
+    }
+
+    assert extract_page_title(page, "35e5f0e8a00080c69a81ef456a2b174b") == "Basic Knowledge"
+
+
+def test_extract_page_title_falls_back_to_the_id_when_the_title_is_empty():
+    page = {"properties": {"Topic": {"type": "title", "title": []}}}
+
+    assert extract_page_title(page, "35e5f0e8a00080c69a81ef456a2b174b") == "35e5f0e8a00080c69a81ef456a2b174b"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1438

`extract_page_title` looked for titles using a list of conventional property
names (`title`, `Title`, `Name`, `name`, and `Page`).

Notion database entries can name their title property freely—for example,
`Topic`. The lookup therefore missed custom-named title properties and fell
back to the raw page ID for both the filename and frontmatter title.

The content still synced correctly, but the opaque filename made the document
difficult for agents to discover when listing files for relevant context.

Notion pages have a property of type `title`, so the lookup now identifies the
title by property type instead of name. Existing behavior is preserved for
regular pages, and empty titles still fall back to the page ID.

## Testing

- Added unit tests covering:
  - a custom-named title property (`Topic`);
  - an empty title falling back to the page ID.
- Notion and sync CLI test suites pass (111 tests).
- Tested against a real Notion workspace: a database entry now syncs as
  `ai-agents-karos-basic-knowledge-3ae5f0e8.md`, with its actual title in the
  frontmatter, instead of `3ae5f0e8…-3ae5f0e8.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

