### PR TITLE
fix(feature): make new-version indicator less alarming

### DIFF
--- a/apps/frontend/src/components/sidebar-version-notice.tsx
+++ b/apps/frontend/src/components/sidebar-version-notice.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { TriangleAlert } from 'lucide-react';
+import { CircleArrowUp } from 'lucide-react';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn, hideIf } from '@/lib/utils';
@@ -26,8 +26,8 @@ export function SidebarVersionNotice({ isCollapsed }: SidebarVersionNoticeProps)
 		return (
 			<Tooltip>
 				<TooltipTrigger asChild>
-					<div className='flex items-center justify-center p-2 mb-1 rounded-md text-amber-500'>
-						<TriangleAlert className='size-4' />
+					<div className='flex items-center justify-center p-2 mb-1 rounded-md text-green-500'>
+						<CircleArrowUp className='size-4' />
 					</div>
 				</TooltipTrigger>
 				<TooltipContent side='right'>{label}</TooltipContent>
@@ -40,9 +40,9 @@ export function SidebarVersionNotice({ isCollapsed }: SidebarVersionNoticeProps)
 			href={`https://github.com/getnao/nao/releases/tag/v${data.latestVersion}`}
 			target='_blank'
 			rel='noopener noreferrer'
-			className='flex items-center gap-2 px-3 py-2 mb-1 rounded-md text-xs text-amber-500 hover:bg-sidebar-accent transition-colors'
+			className='flex items-center gap-2 px-3 py-2 mb-1 rounded-md text-xs text-green-500 hover:bg-sidebar-accent transition-colors'
 		>
-			<TriangleAlert className='size-3.5 shrink-0' />
+			<CircleArrowUp className='size-3.5 shrink-0' />
 			<span className={cn('truncate transition-[opacity,visibility] duration-300', hideIf(isCollapsed))}>
 				{label}
 			</span>


### PR DESCRIPTION
Fixes #1407

Swapped the version update notice from TriangleAlert + text-amber-500 to CircleArrowUp + text-green-500 in both sidebar states (collapsed and expanded). No logic changes - just icon and color.

_Before / After:_ 

<img width="340" height="138" alt="bffix" src="https://github.com/user-attachments/assets/3a2dfd99-4be6-4c36-99bd-dd0f04b59886" /> 

<img width="332" height="152" alt="nfxx" src="https://github.com/user-attachments/assets/25238b14-138c-4a77-a333-cdd8de485e41" />

 
_Tested locally against the running app._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

