### PR TITLE
Add browser-based OAuth-style login flow for the CLI

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -36,6 +36,7 @@ import { authErrorRedirectRoutes } from './routes/auth-error-redirect';
 import { automationWebhookRoutes } from './routes/automation-webhook';
 import { brandingRoutes } from './routes/branding';
 import { chartRoutes } from './routes/chart';
+import { cliAuthRoutes } from './routes/cli-auth';
 import { deployRoutes } from './routes/deploy';
 import { embedStoryDownloadRoutes } from './routes/embed-story-download';
 import { githubRoutes } from './routes/github';
@@ -173,6 +174,10 @@ app.register(analyticsRoutes, {
 
 app.register(testRoutes, {
 	prefix: '/api/test',
+});
+
+app.register(cliAuthRoutes, {
+	prefix: '/api/cli-auth',
 });
 
 app.register(chartRoutes, {

--- a/apps/backend/src/routes/cli-auth.ts
+++ b/apps/backend/src/routes/cli-auth.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod/v4';
+
+import type { App } from '../app';
+import { authMiddleware } from '../middleware/auth';
+import { createCliAuthorizationCode, exchangeCliAuthorizationCode } from '../services/cli-auth.service';
+
+/**
+ * Browser-based login flow for the nao CLI. The CLI opens /cli-login in the
+ * browser, the logged-in user approves, and the frontend calls /authorize to
+ * mint a one-time code that it forwards to the CLI's localhost callback. The
+ * CLI then exchanges the code for a session token via /token.
+ */
+export const cliAuthRoutes = async (app: App) => {
+	app.post('/authorize', { preHandler: authMiddleware }, async (request) => {
+		const code = await createCliAuthorizationCode(request.user.id);
+		return { code };
+	});
+
+	app.post(
+		'/token',
+		{
+			schema: {
+				body: z.object({ code: z.string().min(1) }),
+			},
+		},
+		async (request, reply) => {
+			const token = await exchangeCliAuthorizationCode(request.body.code);
+			if (!token) {
+				return reply.status(400).send({ error: 'Invalid or expired authorization code' });
+			}
+			return { token };
+		},
+	);
+};

--- a/apps/backend/src/services/cli-auth.service.ts
+++ b/apps/backend/src/services/cli-auth.service.ts
@@ -1,0 +1,44 @@
+import { randomBytes } from 'node:crypto';
+
+import { getAuth } from '../auth';
+
+const CODE_IDENTIFIER_PREFIX = 'cli-auth';
+const CODE_TTL_MS = 5 * 60 * 1000;
+
+export async function createCliAuthorizationCode(userId: string): Promise<string> {
+	const auth = await getAuth();
+	const context = await auth.$context;
+
+	const session = await context.internalAdapter.createSession(userId, false, { userAgent: 'nao-cli' });
+	const code = randomBytes(32).toString('base64url');
+
+	await context.internalAdapter.createVerificationValue({
+		identifier: codeIdentifier(code),
+		value: session.token,
+		expiresAt: new Date(Date.now() + CODE_TTL_MS),
+	});
+
+	return code;
+}
+
+export async function exchangeCliAuthorizationCode(code: string): Promise<string | null> {
+	const auth = await getAuth();
+	const context = await auth.$context;
+
+	const verification = await context.internalAdapter.findVerificationValue(codeIdentifier(code));
+	if (!verification) {
+		return null;
+	}
+
+	await context.internalAdapter.deleteVerificationByIdentifier(verification.identifier);
+
+	if (verification.expiresAt < new Date()) {
+		return null;
+	}
+
+	return verification.value;
+}
+
+function codeIdentifier(code: string): string {
+	return `${CODE_IDENTIFIER_PREFIX}:${code}`;
+}

--- a/apps/backend/tests/cli-auth.test.ts
+++ b/apps/backend/tests/cli-auth.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	createSession: vi.fn(),
+	createVerificationValue: vi.fn(),
+	findVerificationValue: vi.fn(),
+	deleteVerificationByIdentifier: vi.fn(),
+}));
+
+vi.mock('../src/auth', () => ({
+	getAuth: vi.fn(async () => ({
+		$context: Promise.resolve({ internalAdapter: mocks }),
+	})),
+}));
+
+import { createCliAuthorizationCode, exchangeCliAuthorizationCode } from '../src/services/cli-auth.service';
+
+describe('cli-auth service', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('creates a session and a one-time code for the user', async () => {
+		mocks.createSession.mockResolvedValue({ token: 'session-token' });
+		mocks.createVerificationValue.mockResolvedValue({});
+
+		const code = await createCliAuthorizationCode('user-1');
+
+		expect(code).toBeTruthy();
+		expect(mocks.createSession).toHaveBeenCalledWith('user-1', false, { userAgent: 'nao-cli' });
+		expect(mocks.createVerificationValue).toHaveBeenCalledWith({
+			identifier: `cli-auth:${code}`,
+			value: 'session-token',
+			expiresAt: expect.any(Date),
+		});
+		const { expiresAt } = mocks.createVerificationValue.mock.calls[0][0];
+		expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+	});
+
+	it('exchanges a valid code for the session token and consumes it', async () => {
+		mocks.findVerificationValue.mockResolvedValue({
+			identifier: 'cli-auth:some-code',
+			value: 'session-token',
+			expiresAt: new Date(Date.now() + 60_000),
+		});
+
+		const token = await exchangeCliAuthorizationCode('some-code');
+
+		expect(token).toBe('session-token');
+		expect(mocks.findVerificationValue).toHaveBeenCalledWith('cli-auth:some-code');
+		expect(mocks.deleteVerificationByIdentifier).toHaveBeenCalledWith('cli-auth:some-code');
+	});
+
+	it('returns null for an unknown code', async () => {
+		mocks.findVerificationValue.mockResolvedValue(null);
+
+		expect(await exchangeCliAuthorizationCode('unknown')).toBeNull();
+		expect(mocks.deleteVerificationByIdentifier).not.toHaveBeenCalled();
+	});
+
+	it('returns null for an expired code and still consumes it', async () => {
+		mocks.findVerificationValue.mockResolvedValue({
+			identifier: 'cli-auth:expired-code',
+			value: 'session-token',
+			expiresAt: new Date(Date.now() - 1_000),
+		});
+
+		expect(await exchangeCliAuthorizationCode('expired-code')).toBeNull();
+		expect(mocks.deleteVerificationByIdentifier).toHaveBeenCalledWith('cli-auth:expired-code');
+	});
+});

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as EmbedRouteImport } from './routes/embed'
 import { Route as ConsentRouteImport } from './routes/consent'
+import { Route as CliLoginRouteImport } from './routes/cli-login'
 import { Route as SidebarLayoutRouteImport } from './routes/_sidebar-layout'
 import { Route as SidebarLayoutSettingsRouteImport } from './routes/_sidebar-layout.settings'
 import { Route as SidebarLayoutChatLayoutRouteImport } from './routes/_sidebar-layout._chat-layout'
@@ -85,6 +86,11 @@ const EmbedRoute = EmbedRouteImport.update({
 const ConsentRoute = ConsentRouteImport.update({
   id: '/consent',
   path: '/consent',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CliLoginRoute = CliLoginRouteImport.update({
+  id: '/cli-login',
+  path: '/cli-login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SidebarLayoutRoute = SidebarLayoutRouteImport.update({
@@ -327,6 +333,7 @@ const SidebarLayoutSettingsUsageReplayChatIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof SidebarLayoutChatLayoutIndexRoute
+  '/cli-login': typeof CliLoginRoute
   '/consent': typeof ConsentRoute
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
@@ -374,6 +381,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof SidebarLayoutChatLayoutIndexRoute
+  '/cli-login': typeof CliLoginRoute
   '/consent': typeof ConsentRoute
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
@@ -420,6 +428,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_sidebar-layout': typeof SidebarLayoutRouteWithChildren
+  '/cli-login': typeof CliLoginRoute
   '/consent': typeof ConsentRoute
   '/embed': typeof EmbedRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
@@ -471,6 +480,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/cli-login'
     | '/consent'
     | '/embed'
     | '/forgot-password'
@@ -518,6 +528,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/cli-login'
     | '/consent'
     | '/embed'
     | '/forgot-password'
@@ -563,6 +574,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/_sidebar-layout'
+    | '/cli-login'
     | '/consent'
     | '/embed'
     | '/forgot-password'
@@ -613,6 +625,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   SidebarLayoutRoute: typeof SidebarLayoutRouteWithChildren
+  CliLoginRoute: typeof CliLoginRoute
   ConsentRoute: typeof ConsentRoute
   EmbedRoute: typeof EmbedRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
@@ -663,6 +676,13 @@ declare module '@tanstack/react-router' {
       path: '/consent'
       fullPath: '/consent'
       preLoaderRoute: typeof ConsentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/cli-login': {
+      id: '/cli-login'
+      path: '/cli-login'
+      fullPath: '/cli-login'
+      preLoaderRoute: typeof CliLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_sidebar-layout': {
@@ -1122,6 +1142,7 @@ const EmbedRouteWithChildren = EmbedRoute._addFileChildren(EmbedRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   SidebarLayoutRoute: SidebarLayoutRouteWithChildren,
+  CliLoginRoute: CliLoginRoute,
   ConsentRoute: ConsentRoute,
   EmbedRoute: EmbedRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,

--- a/apps/frontend/src/routes/cli-login.tsx
+++ b/apps/frontend/src/routes/cli-login.tsx
@@ -1,0 +1,139 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useMutation } from '@tanstack/react-query';
+import { CheckCircle2, TerminalSquare, XCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { ErrorMessage } from '@/components/ui/error-message';
+import NaoLogo from '@/components/icons/nao-full-logo.svg';
+
+export const Route = createFileRoute('/cli-login')({
+	validateSearch: (search: Record<string, unknown>) => ({
+		port: typeof search.port === 'string' || typeof search.port === 'number' ? String(search.port) : undefined,
+		state: typeof search.state === 'string' ? search.state : undefined,
+	}),
+	component: CliLogin,
+});
+
+function parseCallbackPort(port: string | undefined): number | null {
+	if (!port || !/^\d+$/.test(port)) {
+		return null;
+	}
+	const parsed = Number(port);
+	if (parsed < 1 || parsed > 65535) {
+		return null;
+	}
+	return parsed;
+}
+
+function buildCallbackUrl(port: number, params: Record<string, string>): string {
+	return `http://127.0.0.1:${port}/callback?${new URLSearchParams(params)}`;
+}
+
+function CliLogin() {
+	const { port, state } = Route.useSearch();
+	const callbackPort = parseCallbackPort(port);
+
+	const decision = useMutation({
+		mutationFn: async (accept: boolean) => {
+			if (!callbackPort || !state) {
+				throw new Error('Invalid request.');
+			}
+			if (!accept) {
+				window.location.href = buildCallbackUrl(callbackPort, { error: 'access_denied', state });
+				return;
+			}
+			const response = await fetch('/api/cli-auth/authorize', {
+				method: 'POST',
+				credentials: 'include',
+			});
+			if (!response.ok) {
+				throw new Error('Could not authorize the CLI. Please try again.');
+			}
+			const { code } = (await response.json()) as { code: string };
+			window.location.href = buildCallbackUrl(callbackPort, { code, state });
+		},
+	});
+
+	if (!callbackPort || !state) {
+		return (
+			<CenteredCard>
+				<ErrorMessage message='Invalid CLI login request: missing or invalid port or state parameter.' />
+			</CenteredCard>
+		);
+	}
+
+	if (decision.isSuccess) {
+		const accepted = decision.variables;
+		return (
+			<CenteredCard>
+				<div className='flex flex-col items-center gap-4 text-center'>
+					{accepted ? (
+						<CheckCircle2 className='size-10 text-violet' />
+					) : (
+						<XCircle className='size-10 text-muted-foreground' />
+					)}
+					<div className='space-y-2'>
+						<h2 className='text-lg font-semibold'>{accepted ? 'CLI authorized' : 'Access denied'}</h2>
+						<p className='text-sm text-muted-foreground'>
+							{accepted
+								? 'You can close this window and return to your terminal.'
+								: 'You have denied the nao CLI access to your account. You can close this window.'}
+						</p>
+					</div>
+				</div>
+			</CenteredCard>
+		);
+	}
+
+	return (
+		<CenteredCard>
+			<Card className='bg-background'>
+				<CardHeader>
+					<CardTitle className='flex items-center gap-2'>
+						<TerminalSquare className='size-5' />
+						Authorize nao CLI
+					</CardTitle>
+					<CardDescription>
+						The nao CLI on this computer is requesting access to your nao account.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<p className='text-xs text-muted-foreground'>
+						Only continue if you started this login from your own terminal, for example by running{' '}
+						<code className='font-mono'>nao login</code> or <code className='font-mono'>nao test</code>.
+					</p>
+					{decision.isError && (
+						<div className='mt-3'>
+							<ErrorMessage message={decision.error.message} />
+						</div>
+					)}
+				</CardContent>
+				<CardFooter className='flex justify-end gap-2'>
+					<Button variant='outline' onClick={() => decision.mutate(false)} disabled={decision.isPending}>
+						Deny
+					</Button>
+					<Button
+						variant='primary-gradient'
+						onClick={() => decision.mutate(true)}
+						isLoading={decision.isPending}
+					>
+						Authorize
+					</Button>
+				</CardFooter>
+			</Card>
+		</CenteredCard>
+	);
+}
+
+function CenteredCard({ children }: { children: React.ReactNode }) {
+	return (
+		<div className='mx-auto w-full max-w-md p-8 my-auto'>
+			<div className='flex flex-col items-center gap-8 mb-10 pb-2'>
+				<NaoLogo className='w-20 h-auto text-foreground' />
+				<h1 className='font-borna text-2xl font-medium text-center'>Connect the CLI</h1>
+			</div>
+			{children}
+		</div>
+	);
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -206,6 +206,14 @@ databases:
       interval_days: 7
 ```
 
+### Log in
+
+```bash
+nao login
+```
+
+Connects the CLI to your nao account: it opens the app in your browser, asks you to approve the CLI, and stores the resulting session. Commands that talk to the backend (like `nao test`) trigger the same browser flow automatically when you are not logged in yet, and fall back to an email/password prompt when no browser is available. Use `nao logout` to revoke the stored session.
+
 ### Run tests
 
 ```bash
@@ -219,7 +227,7 @@ Options:
 - `--model` / `-m`: Models to test against (default: `openai:gpt-4.1`). Can be specified multiple times.
 - `--threads` / `-t`: Number of parallel threads (default: `1`)
 - `--select` / `-s`: Run only selected tests by name, yaml stem, or subfolder. Comma-separated.
-- `--username` / `-u`, `--password`: Credentials for the nao backend. Fall back to `NAO_USERNAME` / `NAO_PASSWORD`.
+- `--username` / `-u`, `--password`: Credentials for the nao backend, for non-interactive runs. Fall back to `NAO_USERNAME` / `NAO_PASSWORD`. When omitted, the CLI uses your stored login or opens the browser login flow.
 
 Examples:
 

--- a/cli/nao_core/auth.py
+++ b/cli/nao_core/auth.py
@@ -1,7 +1,13 @@
 """Authentication utilities for nao CLI."""
 
 import json
+import secrets
+import threading
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import requests
 
@@ -10,29 +16,186 @@ from nao_core.ui import UI, ask_text
 # Store credentials in user's home directory
 AUTH_FILE = Path.home() / ".nao" / "auth.json"
 
+BROWSER_LOGIN_TIMEOUT_SECONDS = 300
+
+CALLBACK_SUCCESS_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>nao CLI</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+               background: #0f0f0f; color: #e5e5e5; display: flex; align-items: center;
+               justify-content: center; height: 100vh; margin: 0; }
+        .card { text-align: center; }
+        h1 { font-size: 1.25rem; color: #fff; }
+        p { color: #888; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>{title}</h1>
+        <p>{message}</p>
+    </div>
+</body>
+</html>"""
+
+
+def _read_auth_file() -> dict:
+    if not AUTH_FILE.exists():
+        return {}
+
+    try:
+        return json.loads(AUTH_FILE.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _write_auth_file(data: dict) -> None:
+    AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    AUTH_FILE.write_text(json.dumps(data))
+
+
+def get_stored_token() -> str | None:
+    """Load the stored session token from disk."""
+    token = _read_auth_file().get("token")
+    return token if isinstance(token, str) and token else None
+
+
+def store_token(token: str) -> None:
+    """Store a session token to disk."""
+    _write_auth_file({"token": token})
+
 
 def get_stored_cookies() -> dict[str, str] | None:
     """Load stored session cookies from disk."""
-    if not AUTH_FILE.exists():
-        return None
-
-    try:
-        data = json.loads(AUTH_FILE.read_text())
-        return data.get("cookies")
-    except (json.JSONDecodeError, KeyError):
-        return None
+    return _read_auth_file().get("cookies")
 
 
 def store_cookies(cookies: dict[str, str]) -> None:
     """Store session cookies to disk."""
-    AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-    AUTH_FILE.write_text(json.dumps({"cookies": cookies}))
+    _write_auth_file({"cookies": cookies})
 
 
-def clear_stored_cookies() -> None:
-    """Remove stored session cookies."""
+def clear_stored_auth() -> None:
+    """Remove any stored session token or cookies."""
     if AUTH_FILE.exists():
         AUTH_FILE.unlink()
+
+
+class _CallbackResult:
+    """Outcome of the browser login callback."""
+
+    def __init__(self) -> None:
+        self.code: str | None = None
+        self.error: str | None = None
+        self.received = False
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """Receives the browser redirect that completes the login flow."""
+
+    expected_state: str = ""
+    result: _CallbackResult
+
+    def do_GET(self) -> None:  # noqa: N802 (http.server API)
+        parsed = urlparse(self.path)
+        if parsed.path != "/callback":
+            self.send_error(404)
+            return
+
+        params = parse_qs(parsed.query)
+        state = params.get("state", [""])[0]
+        if state != self.expected_state:
+            self._respond(400, "Login failed", "Invalid state parameter. Please retry from your terminal.")
+            return
+
+        error = params.get("error", [""])[0]
+        if error:
+            self.result.error = error
+            self.result.received = True
+            self._respond(200, "Access denied", "You can close this tab and return to your terminal.")
+            return
+
+        self.result.code = params.get("code", [""])[0] or None
+        self.result.received = True
+        title = "Login successful" if self.result.code else "Login failed"
+        self._respond(200, title, "You can close this tab and return to your terminal.")
+
+    def _respond(self, status: int, title: str, message: str) -> None:
+        body = CALLBACK_SUCCESS_PAGE.replace("{title}", title).replace("{message}", message).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:
+        pass
+
+
+def browser_login(backend_url: str, timeout: float = BROWSER_LOGIN_TIMEOUT_SECONDS) -> str | None:
+    """Log in by approving the CLI from the web app.
+
+    Opens the browser on the app's CLI authorization page, waits for the
+    redirect back to a localhost callback, and exchanges the one-time code
+    for a session token. Returns the token on success, None otherwise.
+    """
+    state = secrets.token_urlsafe(32)
+
+    handler = type("BoundCallbackHandler", (_CallbackHandler,), {"expected_state": state, "result": _CallbackResult()})
+    server = HTTPServer(("127.0.0.1", 0), handler)
+
+    try:
+        port = server.server_address[1]
+        query = urlencode({"port": port, "state": state})
+        login_url = f"{backend_url.rstrip('/')}/cli-login?{query}"
+
+        if not webbrowser.open(login_url):
+            UI.warn("Could not open a browser on this machine.")
+            return None
+
+        UI.print("[dim]Waiting for login in your browser...[/dim]")
+        UI.print(f"[dim]If it did not open, visit: {login_url}[/dim]")
+
+        result = handler.result
+        deadline = time.monotonic() + timeout
+        while not result.received:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                UI.error("Login timed out. Please try again.")
+                return None
+            server.timeout = remaining
+            server.handle_request()
+    finally:
+        server.server_close()
+
+    if result.error or not result.code:
+        UI.error("Login was denied in the browser.")
+        return None
+
+    return _exchange_code_for_token(backend_url, result.code)
+
+
+def _exchange_code_for_token(backend_url: str, code: str) -> str | None:
+    try:
+        response = requests.post(f"{backend_url}/api/cli-auth/token", json={"code": code})
+    except requests.RequestException as e:
+        UI.error(f"Connection error: {e}")
+        return None
+
+    if response.status_code != 200:
+        UI.error("Could not complete login: invalid or expired authorization code.")
+        return None
+
+    token = response.json().get("token")
+    if not token:
+        UI.error("Login succeeded but no session token was received.")
+        return None
+
+    store_token(token)
+    UI.success("Logged in successfully!")
+    return token
 
 
 def login(backend_url: str, email: str, password: str) -> dict[str, str] | None:
@@ -76,13 +239,11 @@ def login(backend_url: str, email: str, password: str) -> dict[str, str] | None:
         return None
 
 
-def prompt_login(backend_url: str) -> dict[str, str] | None:
+def prompt_password_login(backend_url: str) -> dict[str, str] | None:
     """Prompt user for credentials and authenticate.
 
     Returns session cookies on success, None on failure.
     """
-    UI.info("\n🔐 Authentication required\n")
-
     email = ask_text("Email:", required_field=True)
     password = ask_text("Password:", password=True, required_field=True)
 
@@ -92,16 +253,49 @@ def prompt_login(backend_url: str) -> dict[str, str] | None:
     return login(backend_url, email, password)
 
 
+def interactive_login(backend_url: str) -> bool:
+    """Log in via the browser, falling back to an email/password prompt.
+
+    Stores the resulting credentials on success and returns whether login
+    succeeded.
+    """
+    UI.info("\n🔐 Authentication required\n")
+
+    if browser_login(backend_url):
+        return True
+
+    UI.print("[dim]Falling back to email and password login.[/dim]")
+    return prompt_password_login(backend_url) is not None
+
+
+_interactive_login_lock = threading.Lock()
+
+
+def apply_stored_auth(session: requests.Session) -> bool:
+    """Attach stored credentials to the session. Returns whether any were found."""
+    token = get_stored_token()
+    if token:
+        session.headers["Authorization"] = f"Bearer {token}"
+        return True
+
+    cookies = get_stored_cookies()
+    if cookies:
+        session.cookies.update(cookies)
+        return True
+
+    return False
+
+
 def get_auth_session(
     backend_url: str,
     prompt_if_missing: bool = True,
     email: str | None = None,
     password: str | None = None,
 ) -> requests.Session:
-    """Get a requests session with authentication cookies.
+    """Get a requests session with authentication credentials.
 
     When email and password are provided, authenticates non-interactively.
-    Otherwise falls back to stored cookies or interactive prompt.
+    Otherwise falls back to stored credentials or a browser login.
     """
     session = requests.Session()
 
@@ -111,13 +305,12 @@ def get_auth_session(
             session.cookies.update(cookies)
         return session
 
-    cookies = get_stored_cookies()
+    if apply_stored_auth(session):
+        return session
 
-    if cookies:
-        session.cookies.update(cookies)
-    elif prompt_if_missing:
-        cookies = prompt_login(backend_url)
-        if cookies:
-            session.cookies.update(cookies)
+    if prompt_if_missing:
+        with _interactive_login_lock:
+            if not apply_stored_auth(session) and interactive_login(backend_url):
+                apply_stored_auth(session)
 
     return session

--- a/cli/nao_core/commands/__init__.py
+++ b/cli/nao_core/commands/__init__.py
@@ -3,6 +3,7 @@ from nao_core.commands.debug import debug
 from nao_core.commands.deploy import deploy
 from nao_core.commands.docs import docs
 from nao_core.commands.init import init
+from nao_core.commands.login import login, logout
 from nao_core.commands.migrate import migrate
 from nao_core.commands.reset_password import reset_password
 from nao_core.commands.skills import skills
@@ -16,6 +17,8 @@ __all__ = [
     "deploy",
     "docs",
     "init",
+    "login",
+    "logout",
     "migrate",
     "reset_password",
     "skills",

--- a/cli/nao_core/commands/login.py
+++ b/cli/nao_core/commands/login.py
@@ -1,0 +1,52 @@
+import os
+from typing import Annotated
+
+import requests
+from cyclopts import Parameter
+
+from nao_core import auth
+from nao_core.tracking import track_command
+from nao_core.ui import UI
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:5005")
+
+
+@track_command("login")
+def login(
+    backend_url: Annotated[
+        str | None,
+        Parameter(
+            name=["--backend-url"],
+            help="URL of the nao server to log in to. Falls back to BACKEND_URL env var.",
+        ),
+    ] = None,
+):
+    """Log in to nao from your browser."""
+    url = (backend_url or BACKEND_URL).rstrip("/")
+
+    if not auth.interactive_login(url):
+        raise SystemExit(1)
+
+
+@track_command("logout")
+def logout(
+    backend_url: Annotated[
+        str | None,
+        Parameter(
+            name=["--backend-url"],
+            help="URL of the nao server to log out from. Falls back to BACKEND_URL env var.",
+        ),
+    ] = None,
+):
+    """Log out of nao and revoke the stored session."""
+    url = (backend_url or BACKEND_URL).rstrip("/")
+
+    token = auth.get_stored_token()
+    if token:
+        try:
+            requests.post(f"{url}/api/auth/sign-out", headers={"Authorization": f"Bearer {token}"})
+        except requests.RequestException:
+            pass
+
+    auth.clear_stored_auth()
+    UI.success("Logged out.")

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -1,10 +1,11 @@
 import os
+import threading
 from dataclasses import dataclass
 from typing import Any
 
 import requests
 
-from nao_core.auth import clear_stored_cookies, get_auth_session, login, prompt_login
+from nao_core.auth import clear_stored_auth, get_auth_session, interactive_login, login
 from nao_core.config.llm import ModelCosts
 from nao_core.ui import UI
 
@@ -81,36 +82,38 @@ class AgentClient:
         self._email = email
         self._password = password
         self._session: requests.Session | None = None
+        self._auth_lock = threading.Lock()
+        self._auth_generation = 0
 
-    def _get_session(self) -> requests.Session:
-        """Get or create an authenticated session."""
-        if self._session is None:
-            self._session = get_auth_session(
-                self.backend_url,
-                email=self._email,
-                password=self._password,
-            )
-        return self._session
+    def _get_session(self) -> tuple[requests.Session, int]:
+        """Get or create an authenticated session, with its auth generation."""
+        with self._auth_lock:
+            if self._session is None:
+                self._session = get_auth_session(
+                    self.backend_url,
+                    email=self._email,
+                    password=self._password,
+                )
+            return self._session, self._auth_generation
 
-    def _reset_session(self) -> None:
-        """Reset the session (used after re-authentication)."""
-        self._session = None
+    def _handle_auth_retry(self, generation: int) -> bool:
+        """Handle 401 by re-authenticating. Only one thread re-authenticates at a time."""
+        with self._auth_lock:
+            if self._auth_generation != generation:
+                return True
 
-    def _handle_auth_retry(self) -> bool:
-        """Handle 401 by re-authenticating. Uses stored credentials when available."""
-        UI.warn("Session expired or unauthorized.")
-        clear_stored_cookies()
-        self._reset_session()
+            UI.warn("Session expired or unauthorized.")
+            clear_stored_auth()
+            self._session = None
 
-        if self._email and self._password:
-            cookies = login(self.backend_url, self._email, self._password)
-        else:
-            cookies = prompt_login(self.backend_url)
+            if self._email and self._password:
+                authenticated = login(self.backend_url, self._email, self._password) is not None
+            else:
+                authenticated = interactive_login(self.backend_url)
 
-        if cookies:
-            self._reset_session()
-            return True
-        return False
+            if authenticated:
+                self._auth_generation += 1
+            return authenticated
 
     def run_test(
         self,
@@ -121,7 +124,7 @@ class AgentClient:
         retry_auth: bool = True,
     ) -> TestResult:
         """Run a test prompt and return the result."""
-        session = self._get_session()
+        session, auth_generation = self._get_session()
         payload: dict[str, Any] = {
             "model": {
                 "provider": provider,
@@ -141,7 +144,7 @@ class AgentClient:
         )
 
         if response.status_code == 401:
-            if retry_auth and self._handle_auth_retry():
+            if retry_auth and self._handle_auth_retry(auth_generation):
                 return self.run_test(test_case, provider, model_id, costs=costs, retry_auth=False)
             raise AgentClientError("Unauthorized. Please check your credentials.")
 

--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -14,6 +14,8 @@ from nao_core.commands import (  # noqa: E402
     deploy,
     docs,
     init,
+    login,
+    logout,
     migrate,
     reset_password,
     skills,
@@ -31,6 +33,8 @@ app.command(debug)
 app.command(deploy)
 app.command(docs)
 app.command(init)
+app.command(login)
+app.command(logout)
 app.command(migrate)
 app.command(reset_password)
 app.command(skills)

--- a/cli/tests/nao_core/test_auth.py
+++ b/cli/tests/nao_core/test_auth.py
@@ -1,0 +1,126 @@
+import json
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+from urllib.request import urlopen
+
+import pytest
+import requests
+
+from nao_core import auth
+
+
+@pytest.fixture(autouse=True)
+def isolated_auth_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(auth, "AUTH_FILE", tmp_path / "auth.json")
+
+
+def test_token_storage_round_trip():
+    assert auth.get_stored_token() is None
+
+    auth.store_token("my-token")
+    assert auth.get_stored_token() == "my-token"
+
+    auth.clear_stored_auth()
+    assert auth.get_stored_token() is None
+
+
+def test_stored_cookies_still_readable():
+    auth.AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    auth.AUTH_FILE.write_text(json.dumps({"cookies": {"session": "abc"}}))
+
+    assert auth.get_stored_cookies() == {"session": "abc"}
+    assert auth.get_stored_token() is None
+
+
+def test_apply_stored_auth_prefers_bearer_token():
+    auth.store_token("my-token")
+    session = requests.Session()
+
+    assert auth.apply_stored_auth(session) is True
+    assert session.headers["Authorization"] == "Bearer my-token"
+
+
+def test_apply_stored_auth_falls_back_to_cookies():
+    auth.store_cookies({"session": "abc"})
+    session = requests.Session()
+
+    assert auth.apply_stored_auth(session) is True
+    assert session.cookies.get("session") == "abc"
+
+
+def test_apply_stored_auth_without_credentials():
+    assert auth.apply_stored_auth(requests.Session()) is False
+
+
+def _open_browser_and_callback(query_builder):
+    """Simulate the browser: hit the CLI callback with the given query params."""
+
+    def fake_open(url: str) -> bool:
+        params = parse_qs(urlparse(url).query)
+        port = params["port"][0]
+        state = params["state"][0]
+
+        def callback():
+            try:
+                urlopen(f"http://127.0.0.1:{port}/callback?{query_builder(state)}")
+            except OSError:
+                pass
+
+        threading.Thread(target=callback, daemon=True).start()
+        return True
+
+    return fake_open
+
+
+@patch("nao_core.auth.requests.post")
+@patch("nao_core.auth.webbrowser.open")
+def test_browser_login_success(mock_open, mock_post):
+    mock_open.side_effect = _open_browser_and_callback(lambda state: f"code=one-time-code&state={state}")
+    mock_post.return_value = MagicMock(status_code=200, json=lambda: {"token": "session-token"})
+
+    token = auth.browser_login("http://localhost:5005", timeout=10)
+
+    assert token == "session-token"
+    assert auth.get_stored_token() == "session-token"
+    mock_post.assert_called_once_with(
+        "http://localhost:5005/api/cli-auth/token",
+        json={"code": "one-time-code"},
+    )
+
+
+@patch("nao_core.auth.requests.post")
+@patch("nao_core.auth.webbrowser.open")
+def test_browser_login_denied(mock_open, mock_post):
+    mock_open.side_effect = _open_browser_and_callback(lambda state: f"error=access_denied&state={state}")
+
+    assert auth.browser_login("http://localhost:5005", timeout=10) is None
+    assert auth.get_stored_token() is None
+    mock_post.assert_not_called()
+
+
+@patch("nao_core.auth.requests.post")
+@patch("nao_core.auth.webbrowser.open")
+def test_browser_login_rejects_invalid_state(mock_open, mock_post):
+    mock_open.side_effect = _open_browser_and_callback(lambda state: "code=stolen-code&state=wrong-state")
+
+    assert auth.browser_login("http://localhost:5005", timeout=1) is None
+    mock_post.assert_not_called()
+
+
+@patch("nao_core.auth.webbrowser.open")
+def test_browser_login_returns_none_when_browser_unavailable(mock_open):
+    mock_open.return_value = False
+
+    assert auth.browser_login("http://localhost:5005", timeout=10) is None
+
+
+@patch("nao_core.auth.requests.post")
+@patch("nao_core.auth.webbrowser.open")
+def test_browser_login_exchange_failure(mock_open, mock_post):
+    mock_open.side_effect = _open_browser_and_callback(lambda state: f"code=expired-code&state={state}")
+    mock_post.return_value = MagicMock(status_code=400)
+
+    assert auth.browser_login("http://localhost:5005", timeout=10) is None
+    assert auth.get_stored_token() is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`nao test` previously prompted for email and password in the terminal. This PR replaces that with a browser-based login flow, similar to `gh auth login`:

1. The CLI starts a localhost callback server on a random port and opens `{backend}/cli-login?port=...&state=...` in the browser.
2. The web app (reusing the existing login page + redirect handling for unauthenticated users) shows an "Authorize nao CLI" page. On approval, the backend mints a dedicated CLI session and a one-time code (5 min TTL, stored in the better-auth `verification` table — no schema change).
3. The browser redirects to `http://127.0.0.1:{port}/callback?code=...&state=...`; the CLI validates the `state`, exchanges the code at `POST /api/cli-auth/token`, and stores the session token in `~/.nao/auth.json`.
4. The CLI authenticates subsequent requests with `Authorization: Bearer <session token>` (the already-enabled better-auth `bearer()` plugin accepts raw session tokens).

## Changes

### Backend
- `src/services/cli-auth.service.ts` — mints a dedicated CLI session (`userAgent: 'nao-cli'`) plus a one-time authorization code; exchanges/consumes codes.
- `src/routes/cli-auth.ts` — `POST /api/cli-auth/authorize` (session-authenticated, called by the frontend) and `POST /api/cli-auth/token` (code exchange, called by the CLI).

### Frontend
- `src/routes/cli-login.tsx` — authorization page with Authorize/Deny actions; denial redirects to the CLI callback with `error=access_denied` so the CLI stops waiting. Unauthenticated users are bounced through `/login` and back by the existing root session gate.

### CLI
- `nao_core/auth.py` — `browser_login()` (localhost callback server, `state` validation, code exchange, token storage), `interactive_login()` falling back to the email/password prompt when no browser is available, bearer-token sessions with backward compatibility for previously stored cookies.
- `nao_core/commands/login.py` — new `nao login` / `nao logout` commands (`logout` also revokes the session server-side via `POST /api/auth/sign-out`).
- `commands/test/client.py` — uses the new flow on missing auth and 401 retry; auth is now serialized behind a lock so `--threads N` cannot open multiple browser tabs.
- `--username`/`--password` flags and `NAO_USERNAME`/`NAO_PASSWORD` env vars still work for non-interactive runs.

## Testing

- End-to-end smoke test against a real backend (sqlite, first-user signup): real `browser_login()` with a scripted "browser" → authorize with session cookie → localhost callback → code exchange → bearer token accepted by `/api/test/run` (200) → bogus code rejected (400) → sign-out revokes the session.
- New unit tests: `apps/backend/tests/cli-auth.test.ts` (4 tests) and `cli/tests/nao_core/test_auth.py` (10 tests: storage round-trip, cookie backcompat, success/denied/invalid-state/timeout/exchange-failure flows).
- `npm run lint`, `npm run format:check`, `db:check-migrations`, and `cli make lint` all pass. Pre-existing, unrelated failures in the backend vitest suite (missing `.env`/git env) and one CLI debug test were verified to fail identically on `main`.

Per AGENTS.md, no browser screenshots/recordings were made for the frontend page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca58e574-e3a3-4a3a-9166-e83a1e7936a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca58e574-e3a3-4a3a-9166-e83a1e7936a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

