### PR TITLE
Fix(story): refresh admin live stories from nao data

### DIFF
--- a/apps/backend/src/queries/execute-sql.queries.ts
+++ b/apps/backend/src/queries/execute-sql.queries.ts
@@ -88,12 +88,18 @@ export async function getExecuteSqlOwnerByQueryId(
 export async function getExecuteSqlPartByQueryIdInChat(
 	chatId: string,
 	queryId: string,
-): Promise<{ toolCallId: string; toolInput: executeSql.Input; toolOutput: executeSql.Output } | null> {
+): Promise<{
+	toolCallId: string;
+	toolInput: executeSql.Input;
+	toolOutput: executeSql.Output;
+	adminMode: boolean;
+} | null> {
 	const [row] = await db
 		.select({
 			toolCallId: s.messagePart.toolCallId,
 			toolInput: s.messagePart.toolInput,
 			toolOutput: s.messagePart.toolOutput,
+			messageSource: s.chatMessage.source,
 		})
 		.from(s.messagePart)
 		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
@@ -117,6 +123,7 @@ export async function getExecuteSqlPartByQueryIdInChat(
 		toolCallId: row.toolCallId,
 		toolInput: executeSql.InputSchema.parse(row.toolInput),
 		toolOutput: executeSql.OutputSchema.parse(row.toolOutput),
+		adminMode: row.messageSource === 'admin',
 	};
 }
 
@@ -140,6 +147,7 @@ async function loadLatestExecuteSqlParts(chatId: string, queryIds: Set<string>) 
 		.select({
 			toolInput: s.messagePart.toolInput,
 			toolOutput: s.messagePart.toolOutput,
+			messageSource: s.chatMessage.source,
 		})
 		.from(s.messagePart)
 		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
@@ -162,13 +170,13 @@ async function loadLatestExecuteSqlParts(chatId: string, queryIds: Set<string>) 
 export async function getLatestSqlQueriesByIds(
 	chatId: string,
 	queryIds: Set<string>,
-): Promise<Record<string, { sqlQuery: string; databaseId?: string }>> {
+): Promise<Record<string, { sqlQuery: string; databaseId?: string; adminMode: boolean }>> {
 	if (queryIds.size === 0) {
 		return {};
 	}
 
 	const parts = await loadLatestExecuteSqlParts(chatId, queryIds);
-	const queries: Record<string, { sqlQuery: string; databaseId?: string }> = {};
+	const queries: Record<string, { sqlQuery: string; databaseId?: string; adminMode: boolean }> = {};
 	for (const part of parts) {
 		const output = part.toolOutput as { id?: string } | null;
 		const input = part.toolInput as { sql_query?: string; database_id?: string } | null;
@@ -176,6 +184,7 @@ export async function getLatestSqlQueriesByIds(
 			queries[output.id] = {
 				sqlQuery: input.sql_query,
 				...(input.database_id && { databaseId: input.database_id }),
+				adminMode: part.messageSource === 'admin',
 			};
 		}
 	}

--- a/apps/backend/src/queries/story.queries.ts
+++ b/apps/backend/src/queries/story.queries.ts
@@ -558,7 +558,7 @@ export async function upsertStoryDataCacheByStoryId(
 export async function getSqlQueriesFromCode(
 	chatId: string,
 	code: string,
-): Promise<Record<string, { sqlQuery: string; databaseId?: string }>> {
+): Promise<Record<string, { sqlQuery: string; databaseId?: string; adminMode: boolean }>> {
 	const queryIds = extractQueryIds(code);
 	if (queryIds.size === 0) {
 		return {};
@@ -570,7 +570,7 @@ export async function getSqlQueriesFromCode(
 export async function getSqlQueryById(
 	chatId: string,
 	queryId: string,
-): Promise<{ sqlQuery: string; databaseId?: string } | null> {
+): Promise<{ sqlQuery: string; databaseId?: string; adminMode: boolean } | null> {
 	const part = await executeSqlQueries.getExecuteSqlPartByQueryIdInChat(chatId, queryId);
 	if (!part) {
 		return null;
@@ -578,6 +578,7 @@ export async function getSqlQueryById(
 	return {
 		sqlQuery: part.toolInput.sql_query,
 		...(part.toolInput.database_id && { databaseId: part.toolInput.database_id }),
+		adminMode: part.adminMode,
 	};
 }
 

--- a/apps/backend/src/services/live-story.ts
+++ b/apps/backend/src/services/live-story.ts
@@ -5,6 +5,7 @@ import { CronExpressionParser } from 'cron-parser';
 import { z } from 'zod';
 
 import { llmTelemetry } from '../agents/telemetry';
+import { queryAppDb } from '../agents/tools/query-app-db';
 import { LiveStoryRefreshPrompt } from '../components/ai/live-story-refresh-prompt';
 import type { DBStoryDataCache } from '../db/abstractSchema';
 import { env } from '../env';
@@ -41,13 +42,18 @@ export async function executeLiveQuery(
 		throw new Error('Chat project not found');
 	}
 
+	const sqlQuery = stripSqlFilterBlocks(query.sqlQuery);
+	if (query.adminMode) {
+		return executeAppDatabaseSql(projectId, sqlQuery);
+	}
+
 	const project = await projectQueries.retrieveProjectById(projectId);
 	if (!project.path) {
 		throw new Error('Project path not configured');
 	}
 
 	const envVars = await projectQueries.getEnvVars(projectId);
-	return executeRawSql(stripSqlFilterBlocks(query.sqlQuery), project.path, query.databaseId, envVars);
+	return executeRawSql(sqlQuery, project.path, query.databaseId, envVars);
 }
 
 export interface RefreshResult {
@@ -70,22 +76,24 @@ export async function refreshStoryData(chatId: string, slug: string): Promise<Re
 		throw new Error('Chat project not found');
 	}
 
-	const project = await projectQueries.retrieveProjectById(chat.projectId);
-	if (!project.path) {
+	const hasWarehouseQueries = Object.values(sqlQueries).some((query) => !query.adminMode);
+	const project = hasWarehouseQueries ? await projectQueries.retrieveProjectById(chat.projectId) : null;
+	if (project && !project.path) {
 		throw new Error('Project path not configured');
 	}
 
 	const queryData: Record<string, { data: unknown[]; columns: string[] }> = {};
 
 	await Promise.all(
-		Object.entries(sqlQueries).map(async ([queryId, { sqlQuery, databaseId }]) => {
+		Object.entries(sqlQueries).map(async ([queryId, { sqlQuery, databaseId, adminMode }]) => {
+			const effectiveSql = stripSqlFilterBlocks(sqlQuery);
+			if (adminMode) {
+				queryData[queryId] = await executeAppDatabaseSql(chat.projectId, effectiveSql);
+				return;
+			}
+
 			const projectEnvVars = await projectQueries.getEnvVars(chat.projectId);
-			const result = await executeRawSql(
-				stripSqlFilterBlocks(sqlQuery),
-				project.path!,
-				databaseId,
-				projectEnvVars,
-			);
+			const result = await executeRawSql(effectiveSql, project!.path!, databaseId, projectEnvVars);
 			queryData[queryId] = result;
 		}),
 	);
@@ -174,6 +182,14 @@ export async function executeRawSql(
 
 	const data = await response.json();
 	return { data: data.data, columns: data.columns };
+}
+
+async function executeAppDatabaseSql(
+	projectId: string,
+	sqlQuery: string,
+): Promise<{ data: unknown[]; columns: string[] }> {
+	const { columns, rows } = await queryAppDb(projectId, sqlQuery);
+	return { data: rows, columns };
 }
 
 function isCacheExpired(cachedAt: Date, cacheSchedule: string | null): boolean {

--- a/apps/backend/tests/live-story.test.ts
+++ b/apps/backend/tests/live-story.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getChatInfo: vi.fn(),
+	getChatProjectId: vi.fn(),
+	getEnvVars: vi.fn(),
+	getLatestVersionByChatAndSlug: vi.fn(),
+	getSqlQueriesFromCode: vi.fn(),
+	getSqlQueryById: vi.fn(),
+	queryAppDb: vi.fn(),
+	retrieveProjectById: vi.fn(),
+	upsertStoryDataCache: vi.fn(),
+}));
+
+vi.mock('../src/agents/tools/query-app-db', () => ({
+	queryAppDb: mocks.queryAppDb,
+}));
+
+vi.mock('../src/queries/chat.queries', () => ({
+	getChatInfo: mocks.getChatInfo,
+	getChatProjectId: mocks.getChatProjectId,
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getEnvVars: mocks.getEnvVars,
+	retrieveProjectById: mocks.retrieveProjectById,
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectModelProvider: vi.fn(),
+}));
+
+vi.mock('../src/queries/story.queries', () => ({
+	getLatestVersionByChatAndSlug: mocks.getLatestVersionByChatAndSlug,
+	getSqlQueriesFromCode: mocks.getSqlQueriesFromCode,
+	getSqlQueryById: mocks.getSqlQueryById,
+	upsertStoryDataCache: mocks.upsertStoryDataCache,
+}));
+
+vi.mock('../src/queries/shared-story.queries', () => ({
+	getQueryDataFromCode: vi.fn(),
+}));
+
+vi.mock('../src/services/agent', () => ({
+	MAX_OUTPUT_TOKENS: 4096,
+}));
+
+vi.mock('../src/utils/llm', () => ({
+	getDefaultModelId: vi.fn(),
+	resolveDefaultModelSelection: vi.fn(),
+	resolveProviderModel: vi.fn(),
+}));
+
+vi.mock('../src/utils/schedule-task', () => ({
+	scheduleSaveLlmInferenceRecord: vi.fn(),
+}));
+
+vi.mock('../src/utils/story-query-data', () => ({
+	backfillMissingQueryData: vi.fn(),
+	findMissingQueryIds: vi.fn(),
+}));
+
+import { executeLiveQuery, refreshStoryData } from '../src/services/live-story';
+
+describe('live story SQL execution', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mocks.getChatInfo.mockResolvedValue({
+			projectId: 'project-1',
+			userId: 'user-1',
+			title: 'Chat',
+		});
+		mocks.getChatProjectId.mockResolvedValue('project-1');
+		mocks.getLatestVersionByChatAndSlug.mockResolvedValue({
+			code: '<table query="query_admin" />',
+			isLiveTextDynamic: false,
+		});
+		mocks.upsertStoryDataCache.mockResolvedValue({});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('refreshes admin-mode story queries from the app database', async () => {
+		mocks.getSqlQueriesFromCode.mockResolvedValue({
+			query_admin: {
+				sqlQuery: 'SELECT * FROM v_messages',
+				adminMode: true,
+			},
+		});
+		mocks.queryAppDb.mockResolvedValue({
+			_version: '1',
+			columns: ['chat_id'],
+			rows: [{ chat_id: 'chat-1' }],
+			rowCount: 1,
+		});
+
+		await expect(refreshStoryData('chat-1', 'usage')).resolves.toEqual({
+			queryData: {
+				query_admin: {
+					columns: ['chat_id'],
+					data: [{ chat_id: 'chat-1' }],
+				},
+			},
+		});
+
+		expect(mocks.queryAppDb).toHaveBeenCalledWith('project-1', 'SELECT * FROM v_messages');
+		expect(mocks.retrieveProjectById).not.toHaveBeenCalled();
+		expect(mocks.getEnvVars).not.toHaveBeenCalled();
+		expect(mocks.upsertStoryDataCache).toHaveBeenCalledWith('chat-1', 'usage', {
+			query_admin: {
+				columns: ['chat_id'],
+				data: [{ chat_id: 'chat-1' }],
+			},
+		});
+	});
+
+	it('keeps warehouse story queries on the existing SQL endpoint', async () => {
+		mocks.getSqlQueriesFromCode.mockResolvedValue({
+			query_warehouse: {
+				sqlQuery: 'SELECT * FROM orders',
+				databaseId: 'analytics',
+				adminMode: false,
+			},
+		});
+		mocks.retrieveProjectById.mockResolvedValue({ path: '/project' });
+		mocks.getEnvVars.mockResolvedValue({ TOKEN: 'secret' });
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({
+				columns: ['order_id'],
+				data: [{ order_id: 1 }],
+			}),
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(refreshStoryData('chat-1', 'orders')).resolves.toEqual({
+			queryData: {
+				query_warehouse: {
+					columns: ['order_id'],
+					data: [{ order_id: 1 }],
+				},
+			},
+		});
+
+		expect(mocks.queryAppDb).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+			sql: 'SELECT * FROM orders',
+			nao_project_folder: '/project',
+			database_id: 'analytics',
+			env_vars: { TOKEN: 'secret' },
+		});
+	});
+
+	it('uses the app database when a single live query came from admin mode', async () => {
+		mocks.getSqlQueryById.mockResolvedValue({
+			sqlQuery: 'SELECT chat_id FROM v_messages',
+			adminMode: true,
+		});
+		mocks.queryAppDb.mockResolvedValue({
+			_version: '1',
+			columns: ['chat_id'],
+			rows: [{ chat_id: 'chat-1' }],
+			rowCount: 1,
+		});
+
+		await expect(executeLiveQuery('chat-1', 'query_admin')).resolves.toEqual({
+			columns: ['chat_id'],
+			data: [{ chat_id: 'chat-1' }],
+		});
+
+		expect(mocks.queryAppDb).toHaveBeenCalledWith('project-1', 'SELECT chat_id FROM v_messages');
+		expect(mocks.retrieveProjectById).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- Refresh admin live stories from nao’s internal data.
- Keep warehouse story refreshes unchanged.

Closes #1474

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

