### PR TITLE
fix(usage): use distinct colors for different message sources

### DIFF
--- a/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
@@ -50,11 +50,11 @@ const messageSeries = [
 	{ data_key: 'teamsMessageCount', color: 'var(--chart-3)', label: 'Teams' },
 	{ data_key: 'telegramMessageCount', color: 'var(--chart-4)', label: 'Telegram' },
 	{ data_key: 'whatsappMessageCount', color: 'var(--chart-5)', label: 'WhatsApp' },
-	{ data_key: 'adminMessageCount', color: 'var(--chart-7)', label: 'Admin mode' },
-	{ data_key: 'mcpMessageCount', color: 'var(--destructive)', label: 'MCP' },
+	{ data_key: 'adminMessageCount', color: 'var(--chart-6)', label: 'Admin mode' },
+	{ data_key: 'mcpMessageCount', color: 'var(--chart-7)', label: 'MCP' },
 	{
 		data_key: 'contextRecommendationsMessageCount',
-		color: 'var(--chart-6)',
+		color: 'var(--chart-8)',
 		label: 'Context recommendations',
 	},
 ] as const;

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -184,6 +184,9 @@ code.dollar:before {
 	--color-chart-3: var(--chart-3);
 	--color-chart-4: var(--chart-4);
 	--color-chart-5: var(--chart-5);
+	--color-chart-6: var(--chart-6);
+	--color-chart-7: var(--chart-7);
+	--color-chart-8: var(--chart-8);
 	--color-sidebar: var(--sidebar);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar-primary: var(--sidebar-primary);
@@ -237,7 +240,8 @@ code.dollar:before {
 	--chart-4: oklch(0.828 0.189 84.429);
 	--chart-5: oklch(0.769 0.188 70.08);
 	--chart-6: oklch(0.704 0.191 22.216);
-	--chart-7: oklch(0.646 0.222 41.116);
+	--chart-7: oklch(0.58 0.22 295);
+	--chart-8: oklch(0.52 0.18 265);
 
 	--sidebar: oklch(0.99 0 0);
 	--sidebar-foreground: oklch(0.129 0.042 264.695);
@@ -286,7 +290,8 @@ code.dollar:before {
 	--chart-4: oklch(0.88 0.18 84.429);
 	--chart-5: oklch(0.82 0.18 70.08);
 	--chart-6: oklch(0.76 0.19 22.216);
-	--chart-7: oklch(0.704 0.191 22.216);
+	--chart-7: oklch(0.72 0.22 295);
+	--chart-8: oklch(0.68 0.18 265);
 }
 
 @layer base {


### PR DESCRIPTION
Fixes #1444

### Summary of changes:

- Preserves original --chart-1 to --chart-6 theme tokens.
- Fixes duplicate hue on --chart-7 (Purple) and adds --chart-8 (Indigo) in styles.css.
- Maps each message source in _sidebar-layout.settings.usage.tsx to its dedicated chart variable (--chart-1 .. --chart-8) to avoid collisions between Admin mode, MCP, and Context recommendations.

### _Before :_ 

<img width="980" height="612" alt="image" src="https://github.com/user-attachments/assets/4ffd20ce-1ec4-4a8e-984e-7a2fc79b01e9" />

### _After :_

<img width="912" height="642" alt="updatedusagenao" src="https://github.com/user-attachments/assets/a6c9f67c-5bec-419e-b91f-c9f526048d45" />

Tested locally on the running frontend and verified across both light and dark themes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

