### PR TITLE
feat(stories): allow inline title renaming

### DIFF
--- a/apps/backend/src/mcp/tools/context-layer.ts
+++ b/apps/backend/src/mcp/tools/context-layer.ts
@@ -247,6 +247,9 @@ function registerContextStoryTools(server: McpServer, ctx: McpContext): void {
 			const latestVersion = await fetchLatestStoryVersion(story);
 			const newTitle = title ?? story.title;
 			const newCode = content ?? latestVersion?.code ?? `# ${newTitle}\n`;
+			if (title !== undefined && title !== story.title) {
+				await storyQueries.renameStory(story.id, title);
+			}
 			const updated = await saveNewVersion(story, ctx, newTitle, newCode);
 			const embedUrl = storyEmbedUrl(story.id, ctx.projectId);
 			const validatedChatId = await resolveChartChatId(chat_id, ctx);

--- a/apps/backend/src/mcp/tools/context-layer.ts
+++ b/apps/backend/src/mcp/tools/context-layer.ts
@@ -214,7 +214,7 @@ function registerContextStoryTools(server: McpServer, ctx: McpContext): void {
 				.describe(
 					'Story UUID (from `list_stories.id`, `ask_nao.stories[].id`, or a prior `create_story`). Not the slug.',
 				),
-			title: z.string().optional().describe('New title. Omit to keep current.'),
+			title: z.string().trim().min(1).max(255).optional().describe('New title. Omit to keep current.'),
 			content: z
 				.string()
 				.optional()

--- a/apps/backend/src/queries/story.queries.ts
+++ b/apps/backend/src/queries/story.queries.ts
@@ -43,6 +43,10 @@ export async function getStoryById(storyId: string): Promise<DBStory | null> {
 	return row ?? null;
 }
 
+export async function renameStory(storyId: string, title: string): Promise<void> {
+	await db.update(s.story).set({ title }).where(eq(s.story.id, storyId)).execute();
+}
+
 export async function getStoryProjectId(storyId: string): Promise<string | null> {
 	const [row] = await db
 		.select({
@@ -210,10 +214,6 @@ export async function createStoryVersion(
 ): Promise<DBStoryVersion & { title: string }> {
 	const story = await getOrCreateStory({ chatId: data.chatId, slug: data.slug, title: data.title }, executor);
 
-	if (story.title !== data.title) {
-		await executor.update(s.story).set({ title: data.title }).where(eq(s.story.id, story.id)).execute();
-	}
-
 	const nextVersion = executor
 		.select({ v: sql<number>`coalesce(max(${s.storyVersion.version}), 0) + 1` })
 		.from(s.storyVersion)
@@ -231,7 +231,7 @@ export async function createStoryVersion(
 		.returning()
 		.execute();
 
-	return { ...created, title: data.title };
+	return { ...created, title: story.title };
 }
 
 export async function createStandaloneVersion(data: {
@@ -250,10 +250,6 @@ export async function createStandaloneVersion(data: {
 		title: data.title,
 	});
 
-	if (story.title !== data.title) {
-		await db.update(s.story).set({ title: data.title }).where(eq(s.story.id, story.id)).execute();
-	}
-
 	const nextVersion = db
 		.select({ v: sql<number>`coalesce(max(${s.storyVersion.version}), 0) + 1` })
 		.from(s.storyVersion)
@@ -271,7 +267,7 @@ export async function createStandaloneVersion(data: {
 		.returning()
 		.execute();
 
-	return { ...created, title: data.title };
+	return { ...created, title: story.title };
 }
 
 export async function createStandaloneStory(data: {

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -205,6 +205,12 @@ export const storyRoutes = {
 		return stories.map((s) => ({ storySlug: s.slug, title: s.title, latestVersion: s.latestVersion }));
 	}),
 
+	rename: storyOwnerProcedure
+		.input(z.object({ storyId: z.string(), title: z.string().min(1).max(255) }))
+		.mutation(async ({ input }) => {
+			await storyQueries.renameStory(input.storyId, input.title);
+		}),
+
 	createVersion: chatOwnerProcedure
 		.input(
 			z.object({

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -206,7 +206,7 @@ export const storyRoutes = {
 	}),
 
 	rename: storyOwnerProcedure
-		.input(z.object({ storyId: z.string(), title: z.string().min(1).max(255) }))
+		.input(z.object({ storyId: z.string(), title: z.string().trim().min(1).max(255) }))
 		.mutation(async ({ input }) => {
 			await storyQueries.renameStory(input.storyId, input.title);
 		}),

--- a/apps/backend/tests/story-title-persistence.test.ts
+++ b/apps/backend/tests/story-title-persistence.test.ts
@@ -1,0 +1,114 @@
+import '../src/env';
+
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { db as appDb } from '../src/db/db';
+import * as sqliteSchema from '../src/db/sqlite-schema';
+import { chat, project, story, user } from '../src/db/sqlite-schema';
+import {
+	createStandaloneVersion,
+	createStoryVersion,
+	getStandaloneStoryByUserAndSlug,
+	getStoryByChatAndSlug,
+	renameStory,
+} from '../src/queries/story.queries';
+
+vi.mock('../src/db/db', async () => {
+	const { drizzle } = await import('drizzle-orm/better-sqlite3');
+	const schema = await import('../src/db/sqlite-schema');
+	return { db: drizzle('./db.sqlite', { schema }) };
+});
+
+const db = drizzle('./db.sqlite', { schema: sqliteSchema });
+const userId = 'story-title-persistence-user';
+const projectId = 'story-title-persistence-project';
+const chatId = 'story-title-persistence-chat';
+
+async function cleanup() {
+	await db.delete(story).where(eq(story.projectId, projectId));
+	await db.delete(story).where(eq(story.chatId, chatId));
+	await db.delete(chat).where(eq(chat.id, chatId));
+	await db.delete(project).where(eq(project.id, projectId));
+	await db.delete(user).where(eq(user.id, userId));
+}
+
+describe('story title persistence', () => {
+	beforeEach(async () => {
+		await cleanup();
+		await db.insert(user).values({ id: userId, name: 'Story Owner', email: 'story-title-persistence@example.com' });
+		await db.insert(project).values({
+			id: projectId,
+			name: 'Story Title Persistence',
+			type: 'local',
+			path: '/tmp/story-title-persistence',
+		});
+		await db.insert(chat).values({ id: chatId, userId, projectId });
+	});
+
+	afterEach(cleanup);
+
+	afterAll(() => {
+		appDb.$client.close();
+		db.$client.close();
+	});
+
+	it('keeps a renamed chat story title when creating another version', async () => {
+		await createStoryVersion({
+			chatId,
+			slug: 'chat-story',
+			title: 'Original title',
+			code: '# Version 1',
+			action: 'create',
+			source: 'user',
+		});
+		const story = await getStoryByChatAndSlug(chatId, 'chat-story');
+		expect(story).not.toBeNull();
+
+		await renameStory(story!.id, 'Renamed title');
+		const version = await createStoryVersion({
+			chatId,
+			slug: 'chat-story',
+			title: 'Original title',
+			code: '# Version 2',
+			action: 'update',
+			source: 'user',
+		});
+
+		const stored = await getStoryByChatAndSlug(chatId, 'chat-story');
+		expect(version.title).toBe('Renamed title');
+		expect(stored?.title).toBe('Renamed title');
+		expect(stored?.slug).toBe('chat-story');
+	});
+
+	it('keeps a renamed standalone story title when creating another version', async () => {
+		await createStandaloneVersion({
+			userId,
+			projectId,
+			slug: 'standalone-story',
+			title: 'Original title',
+			code: '# Version 1',
+			action: 'create',
+			source: 'user',
+		});
+		const story = await getStandaloneStoryByUserAndSlug(userId, projectId, 'standalone-story');
+		expect(story).not.toBeNull();
+
+		await renameStory(story!.id, 'Renamed title');
+		const version = await createStandaloneVersion({
+			userId,
+			projectId,
+			slug: 'standalone-story',
+			title: 'Original title',
+			code: '# Version 2',
+			action: 'update',
+			source: 'user',
+		});
+
+		const stored = await getStandaloneStoryByUserAndSlug(userId, projectId, 'standalone-story');
+		expect(version.title).toBe('Renamed title');
+		expect(stored?.title).toBe('Renamed title');
+		expect(stored?.slug).toBe('standalone-story');
+	});
+});

--- a/apps/frontend/src/components/editable-story-title.tsx
+++ b/apps/frontend/src/components/editable-story-title.tsx
@@ -13,7 +13,6 @@ interface EditableStoryTitleProps {
 	heading: 'h1' | 'h3';
 	className?: string;
 	inputClassName?: string;
-	onClick?: () => void;
 }
 
 export function EditableStoryTitle({
@@ -23,12 +22,10 @@ export function EditableStoryTitle({
 	heading,
 	className,
 	inputClassName,
-	onClick,
 }: EditableStoryTitleProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const isEditingRef = useRef(false);
 	const submittingRef = useRef(false);
-	const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [isEditing, setIsEditing] = useState(false);
 	const [displayTitle, setDisplayTitle] = useState(currentTitle);
 	const [draft, setDraft] = useState(currentTitle);
@@ -47,42 +44,9 @@ export function EditableStoryTitle({
 		}
 	}, [currentTitle]);
 
-	useEffect(
-		() => () => {
-			if (clickTimerRef.current) {
-				clearTimeout(clickTimerRef.current);
-			}
-		},
-		[],
-	);
-
-	const handleClick = (event: MouseEvent<HTMLElement>) => {
-		if (!onClick) {
-			return;
-		}
-		if (!canEdit || !storyId) {
-			onClick();
-			return;
-		}
-
-		event.preventDefault();
-		event.stopPropagation();
-		if (clickTimerRef.current) {
-			clearTimeout(clickTimerRef.current);
-		}
-		clickTimerRef.current = setTimeout(() => {
-			clickTimerRef.current = null;
-			onClick();
-		}, 200);
-	};
-
 	const startEditing = (event: MouseEvent<HTMLElement>) => {
 		event.preventDefault();
 		event.stopPropagation();
-		if (clickTimerRef.current) {
-			clearTimeout(clickTimerRef.current);
-			clickTimerRef.current = null;
-		}
 		if (!canEdit || !storyId || renameStory.isPending) {
 			return;
 		}
@@ -163,7 +127,6 @@ export function EditableStoryTitle({
 	const Heading = heading;
 	return (
 		<Heading
-			onClick={handleClick}
 			onDoubleClick={startEditing}
 			className={cn(canEdit && storyId && !renameStory.isPending && 'cursor-text', className)}
 		>

--- a/apps/frontend/src/components/editable-story-title.tsx
+++ b/apps/frontend/src/components/editable-story-title.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import type { KeyboardEvent, MouseEvent } from 'react';
+
+import { invalidateStoryTitleCaches } from '@/lib/stories-cache';
+import { cn } from '@/lib/utils';
+import { trpc } from '@/main';
+
+interface EditableStoryTitleProps {
+	storyId?: string | null;
+	title: string;
+	canEdit: boolean;
+	heading: 'h1' | 'h3';
+	className?: string;
+	inputClassName?: string;
+	onClick?: () => void;
+}
+
+export function EditableStoryTitle({
+	storyId,
+	title: currentTitle,
+	canEdit,
+	heading,
+	className,
+	inputClassName,
+	onClick,
+}: EditableStoryTitleProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const isEditingRef = useRef(false);
+	const submittingRef = useRef(false);
+	const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [isEditing, setIsEditing] = useState(false);
+	const [displayTitle, setDisplayTitle] = useState(currentTitle);
+	const [draft, setDraft] = useState(currentTitle);
+
+	const renameStory = useMutation(
+		trpc.story.rename.mutationOptions({
+			onSuccess: (_data, _variables, _result, context) => {
+				invalidateStoryTitleCaches(context.client);
+			},
+		}),
+	);
+
+	useEffect(() => {
+		if (!isEditingRef.current) {
+			setDisplayTitle(currentTitle);
+		}
+	}, [currentTitle]);
+
+	useEffect(
+		() => () => {
+			if (clickTimerRef.current) {
+				clearTimeout(clickTimerRef.current);
+			}
+		},
+		[],
+	);
+
+	const handleClick = (event: MouseEvent<HTMLElement>) => {
+		if (!onClick) {
+			return;
+		}
+		if (!canEdit || !storyId) {
+			onClick();
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+		if (clickTimerRef.current) {
+			clearTimeout(clickTimerRef.current);
+		}
+		clickTimerRef.current = setTimeout(() => {
+			clickTimerRef.current = null;
+			onClick();
+		}, 200);
+	};
+
+	const startEditing = (event: MouseEvent<HTMLElement>) => {
+		event.preventDefault();
+		event.stopPropagation();
+		if (clickTimerRef.current) {
+			clearTimeout(clickTimerRef.current);
+			clickTimerRef.current = null;
+		}
+		if (!canEdit || !storyId || renameStory.isPending) {
+			return;
+		}
+
+		setDraft(displayTitle);
+		isEditingRef.current = true;
+		setIsEditing(true);
+		requestAnimationFrame(() => {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		});
+	};
+
+	const finishEditing = () => {
+		isEditingRef.current = false;
+		setIsEditing(false);
+	};
+
+	const cancel = () => {
+		setDraft(displayTitle);
+		finishEditing();
+	};
+
+	const submit = async () => {
+		if (!isEditingRef.current || submittingRef.current || !storyId) {
+			return;
+		}
+
+		const title = draft.trim();
+		if (!title || title === displayTitle) {
+			cancel();
+			return;
+		}
+
+		submittingRef.current = true;
+		try {
+			await renameStory.mutateAsync({ storyId, title });
+			setDisplayTitle(title);
+		} catch {
+			setDraft(displayTitle);
+		} finally {
+			submittingRef.current = false;
+			finishEditing();
+		}
+	};
+
+	const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			void submit();
+		} else if (event.key === 'Escape') {
+			event.preventDefault();
+			cancel();
+		}
+	};
+
+	if (isEditing) {
+		return (
+			<input
+				ref={inputRef}
+				value={draft}
+				maxLength={255}
+				aria-label='Story title'
+				onChange={(event) => setDraft(event.target.value)}
+				onBlur={() => void submit()}
+				onKeyDown={handleKeyDown}
+				onClick={(event) => event.stopPropagation()}
+				onDoubleClick={(event) => event.stopPropagation()}
+				disabled={renameStory.isPending}
+				className={cn(
+					'field-sizing-content w-auto min-w-20 max-w-full shrink rounded border border-border bg-transparent px-1 -mx-1 outline-none',
+					inputClassName,
+				)}
+			/>
+		);
+	}
+
+	const Heading = heading;
+	return (
+		<Heading
+			onClick={handleClick}
+			onDoubleClick={startEditing}
+			className={cn(canEdit && storyId && !renameStory.isPending && 'cursor-text', className)}
+		>
+			{displayTitle}
+		</Heading>
+	);
+}

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -18,7 +18,7 @@ import {
 	Upload,
 	X,
 } from 'lucide-react';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { StorySummary } from '@/lib/story.utils';
 import type { StoryViewMode } from './story-viewer.types';
@@ -26,6 +26,7 @@ import type { StoryRefreshFailure } from '@/components/story-page-header';
 import { useIsMobile } from '@/hooks/use-is-mobile';
 import { useToggleFavorite } from '@/hooks/use-toggle-favorite';
 import { StoryDownload } from '@/components/story-download';
+import { EditableStoryTitle } from '@/components/editable-story-title';
 import { Button } from '@/components/ui/button';
 import { trpc } from '@/main';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -118,30 +119,52 @@ export const StoryHeader = memo(function StoryHeader({
 	const isFavorited = !!storyId && (favorites?.storyIds.includes(storyId) ?? false);
 	const otherStories = useMemo(() => allStories.filter((s) => s.id !== storySlug), [allStories, storySlug]);
 	const hasMultiple = otherStories.length > 0;
+	const storyMenuTriggerRef = useRef<HTMLButtonElement>(null);
 	const isEditingCode = viewMode === 'code' && isCodeDirty && !isReadonlyMode;
 	const showSubHeader = viewMode === 'edit' || isEditingCode || !isViewingLatest;
 
 	const titleElement = hasMultiple ? (
-		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<button
-					type='button'
-					className='flex items-center gap-1 min-w-0 flex-1 cursor-pointer hover:text-foreground/80 transition-colors focus:outline-none'
-				>
-					<h3 className='text-sm font-medium truncate'>{title}</h3>
-					<ChevronDown className='size-3 shrink-0 text-muted-foreground' strokeWidth={2.25} />
-				</button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent align='start'>
-				{otherStories.map((story) => (
-					<DropdownMenuItem key={story.id} onClick={() => onSwitchStory(story.id)}>
-						<span className='truncate'>{story.title}</span>
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
-		</DropdownMenu>
+		<div className='flex min-w-0 flex-1 items-center gap-1'>
+			<EditableStoryTitle
+				storyId={storyId}
+				title={title}
+				canEdit={!isReadonlyMode}
+				heading='h3'
+				className='min-w-0 truncate text-sm font-medium'
+				inputClassName='text-sm font-medium'
+				onClick={() => storyMenuTriggerRef.current?.click()}
+			/>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<button
+						ref={storyMenuTriggerRef}
+						type='button'
+						aria-label='Switch story'
+						className='shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground focus:outline-none'
+					>
+						<ChevronDown className='size-3' strokeWidth={2.25} />
+					</button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align='start'>
+					{otherStories.map((story) => (
+						<DropdownMenuItem key={story.id} onClick={() => onSwitchStory(story.id)}>
+							<span className='truncate'>{story.title}</span>
+						</DropdownMenuItem>
+					))}
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
 	) : (
-		<h3 className='text-sm font-medium truncate flex-1'>{title}</h3>
+		<div className='min-w-0 flex-1'>
+			<EditableStoryTitle
+				storyId={storyId}
+				title={title}
+				canEdit={!isReadonlyMode}
+				heading='h3'
+				className='truncate text-sm font-medium'
+				inputClassName='text-sm font-medium'
+			/>
+		</div>
 	);
 
 	const versionNav = totalVersions > 1 && (

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -18,7 +18,7 @@ import {
 	Upload,
 	X,
 } from 'lucide-react';
-import { memo, useMemo, useRef } from 'react';
+import { memo, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { StorySummary } from '@/lib/story.utils';
 import type { StoryViewMode } from './story-viewer.types';
@@ -77,6 +77,19 @@ export interface StoryHeaderProps {
 	lastRefreshFailure?: StoryRefreshFailure | null;
 }
 
+function mergeStorySummaries(
+	messageStories: StorySummary[],
+	persistedStories: { storySlug: string; title: string }[],
+): StorySummary[] {
+	const storiesBySlug = new Map(messageStories.map((story) => [story.id, story]));
+
+	for (const story of persistedStories) {
+		storiesBySlug.set(story.storySlug, { id: story.storySlug, title: story.title });
+	}
+
+	return Array.from(storiesBySlug.values());
+}
+
 export const StoryHeader = memo(function StoryHeader({
 	title,
 	chatId,
@@ -117,9 +130,13 @@ export const StoryHeader = memo(function StoryHeader({
 	const { toggle: toggleFavorite, isPending: isFavoritePending } = useToggleFavorite('story');
 	const { data: favorites } = useQuery({ ...trpc.favorite.list.queryOptions(), enabled: !!storyId });
 	const isFavorited = !!storyId && (favorites?.storyIds.includes(storyId) ?? false);
-	const otherStories = useMemo(() => allStories.filter((s) => s.id !== storySlug), [allStories, storySlug]);
+	const { data: persistedStories = [] } = useQuery({
+		...trpc.story.listStories.queryOptions({ chatId }),
+		enabled: !isReadonlyMode,
+	});
+	const stories = useMemo(() => mergeStorySummaries(allStories, persistedStories), [allStories, persistedStories]);
+	const otherStories = useMemo(() => stories.filter((story) => story.id !== storySlug), [stories, storySlug]);
 	const hasMultiple = otherStories.length > 0;
-	const storyMenuTriggerRef = useRef<HTMLButtonElement>(null);
 	const isEditingCode = viewMode === 'code' && isCodeDirty && !isReadonlyMode;
 	const showSubHeader = viewMode === 'edit' || isEditingCode || !isViewingLatest;
 
@@ -132,18 +149,12 @@ export const StoryHeader = memo(function StoryHeader({
 				heading='h3'
 				className='min-w-0 truncate text-sm font-medium'
 				inputClassName='text-sm font-medium'
-				onClick={() => storyMenuTriggerRef.current?.click()}
 			/>
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
-					<button
-						ref={storyMenuTriggerRef}
-						type='button'
-						aria-label='Switch story'
-						className='shrink-0 cursor-pointer text-muted-foreground transition-colors hover:text-foreground focus:outline-none'
-					>
-						<ChevronDown className='size-3' strokeWidth={2.25} />
-					</button>
+					<Button type='button' variant='ghost-muted' size='icon-sm' aria-label='Switch story'>
+						<ChevronDown className='size-3.5' strokeWidth={2.25} />
+					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent align='start'>
 					{otherStories.map((story) => (

--- a/apps/frontend/src/components/story-page-header.tsx
+++ b/apps/frontend/src/components/story-page-header.tsx
@@ -20,6 +20,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 
 import type { StoryViewMode } from '@/components/side-panel/story-viewer.types';
+import { EditableStoryTitle } from '@/components/editable-story-title';
 import { useTimeAgo } from '@/hooks/use-time-ago';
 import { StoryDownload } from '@/components/story-download';
 import { Button } from '@/components/ui/button';
@@ -87,6 +88,7 @@ export interface StoryPageHeaderProps {
 	live?: LiveControls;
 	download?: DownloadConfig;
 	storyId?: string | null;
+	canRename?: boolean;
 	isShared?: boolean;
 	onShare?: () => void;
 	onOpenAnalytics?: () => void;
@@ -103,6 +105,7 @@ export function StoryPageHeader({
 	live,
 	download,
 	storyId,
+	canRename = false,
 	isShared = false,
 	onShare,
 	onOpenAnalytics,
@@ -112,7 +115,14 @@ export function StoryPageHeader({
 	return (
 		<div className='shrink-0'>
 			<header className='flex items-center gap-2 border-b bg-background px-4 py-2.5 md:px-6'>
-				<h1 className='min-w-0 truncate text-base font-medium'>{title}</h1>
+				<EditableStoryTitle
+					storyId={storyId}
+					title={title}
+					canEdit={canRename}
+					heading='h1'
+					className='min-w-0 max-w-full truncate text-base font-medium'
+					inputClassName='text-base font-medium'
+				/>
 				{authorName && <span className='shrink-0 text-sm text-muted-foreground'>by {authorName}</span>}
 
 				{versionControls && <VersionNav controls={versionControls} />}

--- a/apps/frontend/src/components/tool-calls/story.tsx
+++ b/apps/frontend/src/components/tool-calls/story.tsx
@@ -93,7 +93,7 @@ export const StoryToolCall = ({ toolPart }: ToolCallComponentProps<'story'>) => 
 		);
 	}
 
-	const title = output?.title ?? input.title ?? input.id;
+	const title = latestStory?.title ?? output?.title ?? input.title ?? input.id;
 	const actionLabel = input.action === 'create' ? 'Created' : input.action === 'update' ? 'Updated' : 'Replaced';
 	const statusLabel = isStreaming
 		? input.action === 'create'

--- a/apps/frontend/src/lib/stories-cache.ts
+++ b/apps/frontend/src/lib/stories-cache.ts
@@ -13,3 +13,12 @@ export function invalidateStoriesCaches(queryClient: QueryClient): void {
 	void queryClient.invalidateQueries({ queryKey: trpc.storyShare.list.queryKey() });
 	void queryClient.invalidateQueries({ queryKey: trpc.favorite.list.queryKey() });
 }
+
+export function invalidateStoryTitleCaches(queryClient: QueryClient): void {
+	invalidateStoriesCaches(queryClient);
+	void queryClient.invalidateQueries({ queryKey: trpc.story.listVersions.queryKey() });
+	void queryClient.invalidateQueries({ queryKey: trpc.story.listStories.queryKey() });
+	void queryClient.invalidateQueries({ queryKey: trpc.story.getLatest.queryKey() });
+	void queryClient.invalidateQueries({ queryKey: trpc.story.getStandalone.queryKey() });
+	void queryClient.invalidateQueries({ queryKey: trpc.storyShare.get.queryKey() });
+}

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -108,6 +108,7 @@ function StoryPreviewPage() {
 				}}
 				download={{ chatId, storySlug, isOwner: true }}
 				storyId={storyId}
+				canRename
 				isShared={isShared}
 				onShare={() => setIsShareDialogOpen(true)}
 				onOpenAnalytics={() => setIsAnalyticsOpen(true)}

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -263,6 +263,7 @@ function SharedStoryOwnerHeader({
 				}}
 				download={{ chatId, storySlug, isOwner: true }}
 				storyId={storyId}
+				canRename
 				isShared
 				onShare={() => setIsShareDialogOpen(true)}
 				onOpenAnalytics={() => setIsAnalyticsOpen(true)}

--- a/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
@@ -107,6 +107,7 @@ function StandaloneStoryPage() {
 				isOpeningChat={openStandaloneMutation.isPending}
 				download={{ storyId, isOwner: true }}
 				storyId={storyId}
+				canRename
 				live={
 					story.isLive
 						? {
@@ -208,6 +209,7 @@ function StandaloneEditableStory({
 				}}
 				download={{ storyId, isOwner: true }}
 				storyId={storyId}
+				canRename
 				isShared={isShared}
 				onShare={() => setIsShareDialogOpen(true)}
 				onOpenAnalytics={() => setIsAnalyticsOpen(true)}


### PR DESCRIPTION
## Summary
- Let story owners rename titles directly from the header.
- Keep renamed titles synced across story pages and chat cards without changing links.


https://github.com/user-attachments/assets/2d661288-70d6-4ad1-9e3c-c42848034a0e



Closes #1065

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

