### PR TITLE
hotfix(stories): empty charts in HTML/PDF exports

### DIFF
--- a/apps/backend/src/components/generate-chart.tsx
+++ b/apps/backend/src/components/generate-chart.tsx
@@ -1,4 +1,4 @@
-import { bucketPieData, buildChart, defaultColorFor, labelize } from '@nao/shared';
+import { bucketPieData, buildChart, defaultColorFor, labelize, resolveDataKey } from '@nao/shared';
 import type { DateFormatSettings } from '@nao/shared/date';
 import { displayChart } from '@nao/shared/tools';
 import React from 'react';
@@ -53,11 +53,16 @@ export function renderChartToSvg(input: RenderChartInput): string {
 	const height = input.height ?? 500;
 	const margin = input.margin ?? { top: 10, right: 20, bottom: 5, left: 0 };
 	const includeLegend = input.includeLegend !== false;
-	const xAxisKey = config.x_axis_key ?? '';
+	// Query data may come from a re-execution whose column-name casing differs
+	// from the config (e.g. Snowflake uppercases unquoted identifiers, DuckDB
+	// preserves them as written), so resolve keys against the actual rows —
+	// mirroring what the frontend chart components do.
+	const xAxisKey = resolveDataKey(data, config.x_axis_key ?? undefined);
+	const series = config.series.map((s) => ({ ...s, data_key: resolveDataKey(data, s.data_key) }));
 
 	const colorFor = (key: string, index: number) => {
-		const series = config.series.find((s) => s.data_key === key);
-		return series?.color || defaultColorFor(key, index);
+		const matched = series.find((s) => s.data_key === key);
+		return matched?.color || defaultColorFor(key, index);
 	};
 
 	const labelFormatter = (value: string) => labelize(value, dateFormat);
@@ -65,13 +70,13 @@ export function renderChartToSvg(input: RenderChartInput): string {
 
 	const isPie = chartType === 'pie' || chartType === 'donut';
 
-	const chartData = isPie ? bucketPieData(data, xAxisKey, config.series[0]?.data_key ?? '') : data;
+	const chartData = isPie ? bucketPieData(data, xAxisKey, series[0]?.data_key ?? '') : data;
 
 	let legend: LegendEntry[] = [];
 	if (includeLegend) {
 		legend = isPie
 			? buildPieLegendEntries(chartData, xAxisKey, dateFormat)
-			: config.series.map((s, i) => ({
+			: series.map((s, i) => ({
 					label: s.label || labelize(s.data_key, dateFormat),
 					color: colorFor(s.data_key, i),
 				}));
@@ -88,7 +93,7 @@ export function renderChartToSvg(input: RenderChartInput): string {
 		xAxisKey,
 		xAxisType: config.x_axis_type === 'number' ? 'number' : 'category',
 		xAxisLabel: config.x_axis_label,
-		series: config.series,
+		series,
 		colorFor,
 		labelFormatter,
 		showGrid: true,

--- a/apps/backend/src/utils/story-html.tsx
+++ b/apps/backend/src/utils/story-html.tsx
@@ -30,6 +30,7 @@ import {
 	parseNumericValue,
 	pointTooltipKeys,
 	resolveBoundary,
+	resolveDataKey,
 	resolveMapConfig,
 	scaleBubbleRadius,
 	withOpacity,
@@ -392,12 +393,14 @@ function GridBlock({
 	);
 }
 
-function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: QueryDataMap | null }) {
+function ChartBlock({ chart: rawChart, queryData }: { chart: ParsedChartBlock; queryData: QueryDataMap | null }) {
 	const dateFormat = useContext(DateFormatContext);
-	const rows = queryData?.[chart.queryId]?.data as Record<string, unknown>[] | undefined;
+	const rows = queryData?.[rawChart.queryId]?.data as Record<string, unknown>[] | undefined;
 	if (!rows?.length) {
-		return <Placeholder label={chart.title || 'Chart'} message='Data unavailable' />;
+		return <Placeholder label={rawChart.title || 'Chart'} message='Data unavailable' />;
 	}
+
+	const chart = resolveChartKeys(rawChart, rows);
 
 	if (chart.chartType === 'kpi_card') {
 		return <KpiCards chart={chart} rows={rows} />;
@@ -442,6 +445,20 @@ function ChartBlock({ chart, queryData }: { chart: ParsedChartBlock; queryData: 
 	} catch {
 		return <Placeholder label={chart.title || 'Chart'} message='Could not render chart' />;
 	}
+}
+
+/**
+ * Query data may come from a re-execution whose column-name casing differs from
+ * the one the chart was authored against (e.g. Snowflake uppercases unquoted
+ * identifiers, DuckDB preserves them as written). Resolve the configured keys
+ * against the actual row keys, mirroring the frontend chart components.
+ */
+function resolveChartKeys(chart: ParsedChartBlock, rows: Record<string, unknown>[]): ParsedChartBlock {
+	return {
+		...chart,
+		xAxisKey: resolveDataKey(rows, chart.xAxisKey),
+		series: chart.series.map((s) => ({ ...s, data_key: resolveDataKey(rows, s.data_key) })),
+	};
 }
 
 function ChartLegend({ series }: { series: ParsedChartBlock['series'] }) {

--- a/apps/backend/tests/story-html-column-casing.test.ts
+++ b/apps/backend/tests/story-html-column-casing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { renderChartToSvg } from '../src/components/generate-chart';
+import { generateStoryHtml } from '../src/utils/story-html';
+
+/**
+ * A story authored against one execution (e.g. Snowflake, which uppercases
+ * unquoted identifiers) can be exported with query data from a re-execution
+ * whose column casing differs (e.g. DuckDB preserves aliases as written).
+ * Exports must resolve chart keys case-insensitively like the frontend does.
+ */
+const storyCode = `
+# Repro
+
+<chart query_id="query_repro" chart_type="kpi_card" series='[{"data_key":"NEW_ACCOUNTS","label":"Accounts"}]' />
+
+<chart query_id="query_repro" chart_type="bar" title="New Accounts per Month" x_axis_key="MONTH" x_axis_type="date" series='[{"data_key":"NEW_ACCOUNTS","label":"New accounts"}]' />
+`;
+
+const rows = [
+	{ month: '2025-09', new_accounts: 153 },
+	{ month: '2025-10', new_accounts: 201 },
+	{ month: '2025-11', new_accounts: 178 },
+];
+
+const queryData = { query_repro: { columns: Object.keys(rows[0]), data: rows } };
+
+const countBarShapes = (html: string) => (html.match(/recharts-rectangle[^>]*?d="/g) ?? []).length;
+
+describe('story export column-name casing', () => {
+	it('renders bar shapes when chart keys differ in case from the row keys', async () => {
+		const html = await generateStoryHtml({ title: 'Repro', code: storyCode }, queryData);
+		expect(countBarShapes(html)).toBe(rows.length);
+	});
+
+	it('renders KPI values when series keys differ in case from the row keys', async () => {
+		const html = await generateStoryHtml({ title: 'Repro', code: storyCode }, queryData);
+		expect(html).toContain('178');
+	});
+
+	it('resolves keys case-insensitively in renderChartToSvg', () => {
+		const svg = renderChartToSvg({
+			config: {
+				chart_type: 'bar',
+				x_axis_key: 'MONTH',
+				x_axis_type: 'category',
+				title: 'Casing',
+				series: [{ data_key: 'NEW_ACCOUNTS' }],
+			},
+			data: rows,
+		});
+		expect(countBarShapes(svg)).toBe(rows.length);
+	});
+});

--- a/apps/frontend/src/components/side-panel/story-chart-embed.tsx
+++ b/apps/frontend/src/components/side-panel/story-chart-embed.tsx
@@ -1,3 +1,4 @@
+import { resolveDataKey } from '@nao/shared';
 import { Code, Pencil } from 'lucide-react';
 import { memo, useContext, useMemo, useState } from 'react';
 import { StoryBlockDragContext } from './story-editor-drag-context';
@@ -40,7 +41,7 @@ export const StoryChartEmbed = memo(function StoryChartEmbed({
 	const data = useMemo(
 		() =>
 			sourceData?.data && chart.xAxisType === 'date'
-				? sortByDateKey(sourceData.data, chart.xAxisKey)
+				? sortByDateKey(sourceData.data, resolveDataKey(sourceData.data, chart.xAxisKey))
 				: (sourceData?.data ?? []),
 		[sourceData?.data, chart.xAxisType, chart.xAxisKey],
 	);


### PR DESCRIPTION
## Summary
- Story HTML/PDF exports treated chart `data_key` / `x_axis_key` as exact matches, so a re-execution with different identifier casing (Snowflake uppercase vs DuckDB mixed/lowercase) produced titles and KPI labels with blank plots.
- Exports now resolve keys with the same `resolveDataKey` case-insensitive fallback the in-app chart viewer already uses, including KPI cards, SVG generation, and date sorting on story embeds.
- Adds a regression test that feeds uppercase chart tags against lowercase rows and asserts bars and KPI values render.

## Test plan
- [ ] Re-export a story whose chart tags use uppercase keys and whose query data has lowercase/mixed-case columns; HTML and PDF should show KPI values and bar shapes.
- [ ] Export a story with matching casing (control) — charts still render as before.
- [ ] Open the same story in the app and confirm date-sorted charts still display.
- [ ] `npx vitest run tests/story-html-column-casing.test.ts` in `apps/backend`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

