### PR TITLE
feat(usage): add flexible time windows and include current month in usage analytics

### DIFF
--- a/apps/backend/src/queries/usage.queries.ts
+++ b/apps/backend/src/queries/usage.queries.ts
@@ -7,7 +7,7 @@ import { db } from '../db/db';
 import dbConfig, { Dialect } from '../db/dbConfig';
 import type { ModelCosts } from '../types/llm';
 import type { Granularity, TotalUsageRecord, UsageFilter, UsageRecord, UsageSource } from '../types/usage';
-import { fillMissingDates, getLookbackTimestamp } from '../utils/date';
+import { fillMissingDates, getLookbackTimestamp, resolvePeriodAndGranularity } from '../utils/date';
 import { getProjectDeclaredModels } from '../utils/llm';
 
 const COST_COLS = [
@@ -108,10 +108,13 @@ const INFERENCE_USAGE_SOURCE_EXPR = sql<UsageSource | null>`(
 )`;
 
 export const getMessagesUsage = async (projectId: string, filter: UsageFilter): Promise<UsageRecord[]> => {
-	const { granularity, provider } = filter;
+	const { granularity, period } = resolvePeriodAndGranularity({
+		period: filter.period,
+		granularity: filter.granularity,
+	});
 	const messageDateExpr = getDateExpr(s.chatMessage.createdAt, granularity);
 	const inferenceDateExpr = getDateExpr(s.llmInference.createdAt, granularity);
-	const lookbackTs = getLookbackTimestamp(granularity);
+	const lookbackTs = getLookbackTimestamp(granularity, period);
 	const messageLookbackFilter =
 		dbConfig.dialect === Dialect.Postgres
 			? sql`${s.chatMessage.createdAt} >= ${new Date(lookbackTs).toISOString()}`
@@ -123,9 +126,9 @@ export const getMessagesUsage = async (projectId: string, filter: UsageFilter): 
 
 	const messageWhereConditions = [eq(s.chat.projectId, projectId), messageLookbackFilter];
 	const inferenceWhereConditions = [eq(s.llmInference.projectId, projectId), inferenceLookbackFilter];
-	if (provider) {
-		messageWhereConditions.push(sql`${MESSAGE_USAGE_PROVIDER_EXPR} = ${provider}`);
-		inferenceWhereConditions.push(eq(s.llmInference.llmProvider, provider));
+	if (filter.provider) {
+		messageWhereConditions.push(sql`${MESSAGE_USAGE_PROVIDER_EXPR} = ${filter.provider}`);
+		inferenceWhereConditions.push(eq(s.llmInference.llmProvider, filter.provider));
 	}
 	addUserNameFilter(messageWhereConditions, filter.userNames);
 	addUserNameFilter(inferenceWhereConditions, filter.userNames);
@@ -253,12 +256,16 @@ export const getMessagesUsage = async (projectId: string, filter: UsageFilter): 
 		.from(combinedUsage)
 		.groupBy(({ date }) => date);
 
-	return fillMissingDates(rows.map(normalizeMessageUsageRow), granularity);
+	return fillMissingDates(rows.map(normalizeMessageUsageRow), granularity, period);
 };
 
 export const getTotalUsage = async (projectId: string, filter: UsageFilter): Promise<TotalUsageRecord> => {
-	const { granularity, provider } = filter;
-	const lookbackTs = getLookbackTimestamp(granularity);
+	const { granularity, period } = resolvePeriodAndGranularity({
+		period: filter.period,
+		granularity: filter.granularity,
+	});
+	const { provider } = filter;
+	const lookbackTs = getLookbackTimestamp(granularity, period);
 	const lookbackFilter =
 		dbConfig.dialect === Dialect.Postgres
 			? sql`${s.chatMessage.createdAt} >= ${new Date(lookbackTs).toISOString()}`

--- a/apps/backend/src/types/usage.ts
+++ b/apps/backend/src/types/usage.ts
@@ -6,8 +6,25 @@ import { llmProviderSchema } from './llm';
 export const granularitySchema = z.enum(['hour', 'day', 'month']);
 export type Granularity = z.infer<typeof granularitySchema>;
 
-export const usagePeriodSchema = z.enum(['24h', '7d', '15d', '30d', '60d', '90d', '6m']);
+export const USAGE_PERIODS = ['24h', '7d', '15d', '30d', '60d', '90d', '6m'] as const;
+export const usagePeriodSchema = z.enum(USAGE_PERIODS);
 export type UsagePeriod = z.infer<typeof usagePeriodSchema>;
+
+export const PERIOD_CONFIG: Record<UsagePeriod, { count: number; granularity: Granularity; label: string }> = {
+	'24h': { count: 24, granularity: 'hour', label: 'Last 24 hours' },
+	'7d': { count: 7, granularity: 'day', label: 'Last 7 days' },
+	'15d': { count: 15, granularity: 'day', label: 'Last 15 days' },
+	'30d': { count: 30, granularity: 'day', label: 'Last 30 days' },
+	'60d': { count: 60, granularity: 'day', label: 'Last 60 days' },
+	'90d': { count: 90, granularity: 'day', label: 'Last 90 days' },
+	'6m': { count: 6, granularity: 'month', label: 'Last 6 months' },
+};
+
+export const DEFAULT_PERIOD_BY_GRANULARITY: Record<Granularity, UsagePeriod> = {
+	hour: '24h',
+	day: '15d',
+	month: '6m',
+};
 
 export const USAGE_SOURCES = MESSAGE_SOURCES;
 export type UsageSource = (typeof USAGE_SOURCES)[number];

--- a/apps/backend/src/types/usage.ts
+++ b/apps/backend/src/types/usage.ts
@@ -6,11 +6,15 @@ import { llmProviderSchema } from './llm';
 export const granularitySchema = z.enum(['hour', 'day', 'month']);
 export type Granularity = z.infer<typeof granularitySchema>;
 
+export const usagePeriodSchema = z.enum(['24h', '7d', '15d', '30d', '60d', '90d', '6m']);
+export type UsagePeriod = z.infer<typeof usagePeriodSchema>;
+
 export const USAGE_SOURCES = MESSAGE_SOURCES;
 export type UsageSource = (typeof USAGE_SOURCES)[number];
 
 export const usageFilterSchema = z.object({
-	granularity: granularitySchema.default('day'),
+	granularity: granularitySchema.optional(),
+	period: usagePeriodSchema.optional(),
 	provider: llmProviderSchema.optional(),
 	userNames: z.array(z.string()).optional(),
 	sources: z.array(z.enum(USAGE_SOURCES)).optional(),

--- a/apps/backend/src/utils/date.ts
+++ b/apps/backend/src/utils/date.ts
@@ -1,4 +1,7 @@
 import type { Granularity, UsagePeriod, UsageRecord } from '../types/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG } from '../types/usage';
+
+export { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG };
 
 export function isValidIsoDateString(s: string): boolean {
 	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) {
@@ -9,73 +12,67 @@ export function isValidIsoDateString(s: string): boolean {
 	return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
 }
 
-export const PERIOD_CONFIG: Record<UsagePeriod, { count: number; granularity: Granularity }> = {
-	'24h': { count: 24, granularity: 'hour' },
-	'7d': { count: 7, granularity: 'day' },
-	'15d': { count: 15, granularity: 'day' },
-	'30d': { count: 30, granularity: 'day' },
-	'60d': { count: 60, granularity: 'day' },
-	'90d': { count: 90, granularity: 'day' },
-	'6m': { count: 6, granularity: 'month' },
-};
+export function getPeriodStartDate(period: UsagePeriod, now: Date = new Date()): Date {
+	const config = PERIOD_CONFIG[period] ?? PERIOD_CONFIG['15d'];
+	const date = new Date(now);
 
-export const DEFAULT_PERIOD_BY_GRANULARITY: Record<Granularity, UsagePeriod> = {
-	hour: '24h',
-	day: '15d',
-	month: '6m',
-};
+	if (config.granularity === 'month') {
+		return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - (config.count - 1), 1, 0, 0, 0, 0));
+	}
 
-export const lookbackPeriods = {
-	hour: 24,
-	day: 15,
-	month: 6,
-};
+	if (config.granularity === 'hour') {
+		date.setUTCHours(date.getUTCHours() - (config.count - 1), 0, 0, 0);
+		return date;
+	}
+
+	date.setUTCDate(date.getUTCDate() - (config.count - 1));
+	date.setUTCHours(0, 0, 0, 0);
+	return date;
+}
 
 export function resolvePeriodAndGranularity(options?: { period?: UsagePeriod; granularity?: Granularity }): {
 	period: UsagePeriod;
 	granularity: Granularity;
 	count: number;
+	startDate: Date;
 } {
-	if (options?.period && PERIOD_CONFIG[options.period]) {
-		const config = PERIOD_CONFIG[options.period];
-		return {
-			period: options.period,
-			granularity: options.granularity ?? config.granularity,
-			count: config.count,
-		};
+	const now = new Date();
+	const period =
+		options?.period && PERIOD_CONFIG[options.period]
+			? options.period
+			: options?.granularity && DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]
+				? DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]
+				: '15d';
+
+	const defaultGranularity = PERIOD_CONFIG[period].granularity;
+	const granularity = options?.granularity ?? defaultGranularity;
+	const startDate = getPeriodStartDate(period, now);
+
+	let count: number;
+	if (granularity === defaultGranularity) {
+		count = PERIOD_CONFIG[period].count;
+	} else if (granularity === 'month') {
+		count =
+			(now.getUTCFullYear() - startDate.getUTCFullYear()) * 12 +
+			(now.getUTCMonth() - startDate.getUTCMonth()) +
+			1;
+	} else if (granularity === 'day') {
+		count = Math.max(1, Math.round((now.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000)) + 1);
+	} else {
+		count = Math.max(1, Math.round((now.getTime() - startDate.getTime()) / (60 * 60 * 1000)) + 1);
 	}
-	if (options?.granularity && DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]) {
-		const period = DEFAULT_PERIOD_BY_GRANULARITY[options.granularity];
-		const config = PERIOD_CONFIG[period];
-		return {
-			period,
-			granularity: options.granularity,
-			count: config.count,
-		};
-	}
+
 	return {
-		period: '15d',
-		granularity: 'day',
-		count: 15,
+		period,
+		granularity,
+		count,
+		startDate,
 	};
 }
 
 export function getLookbackTimestamp(granularity?: Granularity, period?: UsagePeriod): number {
 	const resolved = resolvePeriodAndGranularity({ period, granularity });
-	const now = new Date();
-
-	if (resolved.granularity === 'month') {
-		// Include the current partial month plus (count - 1) preceding complete months.
-		// Start at UTC 00:00:00 on the 1st day of the starting month.
-		const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - (resolved.count - 1), 1, 0, 0, 0, 0));
-		return start.getTime();
-	}
-
-	if (resolved.granularity === 'hour') {
-		return now.getTime() - resolved.count * 60 * 60 * 1000;
-	}
-
-	return now.getTime() - resolved.count * 24 * 60 * 60 * 1000;
+	return resolved.startDate.getTime();
 }
 
 export function formatDate(date: Date, granularity: Granularity): string {

--- a/apps/backend/src/utils/date.ts
+++ b/apps/backend/src/utils/date.ts
@@ -1,4 +1,4 @@
-import type { Granularity, UsageRecord } from '../types/usage';
+import type { Granularity, UsagePeriod, UsageRecord } from '../types/usage';
 
 export function isValidIsoDateString(s: string): boolean {
 	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) {
@@ -9,24 +9,73 @@ export function isValidIsoDateString(s: string): boolean {
 	return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
 }
 
+export const PERIOD_CONFIG: Record<UsagePeriod, { count: number; granularity: Granularity }> = {
+	'24h': { count: 24, granularity: 'hour' },
+	'7d': { count: 7, granularity: 'day' },
+	'15d': { count: 15, granularity: 'day' },
+	'30d': { count: 30, granularity: 'day' },
+	'60d': { count: 60, granularity: 'day' },
+	'90d': { count: 90, granularity: 'day' },
+	'6m': { count: 6, granularity: 'month' },
+};
+
+export const DEFAULT_PERIOD_BY_GRANULARITY: Record<Granularity, UsagePeriod> = {
+	hour: '24h',
+	day: '15d',
+	month: '6m',
+};
+
 export const lookbackPeriods = {
 	hour: 24,
 	day: 15,
 	month: 6,
 };
 
-export function getLookbackTimestamp(granularity: Granularity): number {
-	const now = Date.now();
-	const periods = lookbackPeriods[granularity];
-
-	switch (granularity) {
-		case 'hour':
-			return now - periods * 60 * 60 * 1000;
-		case 'day':
-			return now - periods * 24 * 60 * 60 * 1000;
-		case 'month':
-			return now - periods * 30 * 24 * 60 * 60 * 1000;
+export function resolvePeriodAndGranularity(options?: { period?: UsagePeriod; granularity?: Granularity }): {
+	period: UsagePeriod;
+	granularity: Granularity;
+	count: number;
+} {
+	if (options?.period && PERIOD_CONFIG[options.period]) {
+		const config = PERIOD_CONFIG[options.period];
+		return {
+			period: options.period,
+			granularity: options.granularity ?? config.granularity,
+			count: config.count,
+		};
 	}
+	if (options?.granularity && DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]) {
+		const period = DEFAULT_PERIOD_BY_GRANULARITY[options.granularity];
+		const config = PERIOD_CONFIG[period];
+		return {
+			period,
+			granularity: options.granularity,
+			count: config.count,
+		};
+	}
+	return {
+		period: '15d',
+		granularity: 'day',
+		count: 15,
+	};
+}
+
+export function getLookbackTimestamp(granularity?: Granularity, period?: UsagePeriod): number {
+	const resolved = resolvePeriodAndGranularity({ period, granularity });
+	const now = new Date();
+
+	if (resolved.granularity === 'month') {
+		// Include the current partial month plus (count - 1) preceding complete months.
+		// Start at UTC 00:00:00 on the 1st day of the starting month.
+		const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - (resolved.count - 1), 1, 0, 0, 0, 0));
+		return start.getTime();
+	}
+
+	if (resolved.granularity === 'hour') {
+		return now.getTime() - resolved.count * 60 * 60 * 1000;
+	}
+
+	return now.getTime() - resolved.count * 24 * 60 * 60 * 1000;
 }
 
 export function formatDate(date: Date, granularity: Granularity): string {
@@ -45,15 +94,15 @@ export function formatDate(date: Date, granularity: Granularity): string {
 	}
 }
 
-export function generateDateSeries(granularity: Granularity): string[] {
+export function generateDateSeries(granularity?: Granularity, period?: UsagePeriod): string[] {
+	const resolved = resolvePeriodAndGranularity({ period, granularity });
 	const dates: string[] = [];
-	const periods = lookbackPeriods[granularity];
 	const now = new Date();
 
-	for (let i = periods - 1; i >= 0; i--) {
+	for (let i = resolved.count - 1; i >= 0; i--) {
 		const date = new Date(now);
 
-		switch (granularity) {
+		switch (resolved.granularity) {
 			case 'hour':
 				date.setUTCHours(date.getUTCHours() - i, 0, 0, 0);
 				break;
@@ -67,7 +116,7 @@ export function generateDateSeries(granularity: Granularity): string[] {
 				break;
 		}
 
-		dates.push(formatDate(date, granularity));
+		dates.push(formatDate(date, resolved.granularity));
 	}
 
 	return dates;
@@ -97,9 +146,14 @@ export function formatCurrentDate(timezone?: string): string {
 	return tz === 'UTC' ? `${formatted} (UTC)` : `${formatted} (${tz})`;
 }
 
-export function fillMissingDates(records: UsageRecord[], granularity: Granularity): UsageRecord[] {
+export function fillMissingDates(
+	records: UsageRecord[],
+	granularity?: Granularity,
+	period?: UsagePeriod,
+): UsageRecord[] {
+	const resolved = resolvePeriodAndGranularity({ period, granularity });
 	const dateSet = new Map(records.map((r) => [r.date, r]));
-	const allDates = generateDateSeries(granularity);
+	const allDates = generateDateSeries(resolved.granularity, resolved.period);
 
 	return allDates.map(
 		(date) =>

--- a/apps/backend/tests/usage-queries.test.ts
+++ b/apps/backend/tests/usage-queries.test.ts
@@ -189,5 +189,9 @@ describe('usage query results', () => {
 		expect(records6m).toHaveLength(6);
 		const currentMonth = formatDate(new Date(), 'month');
 		expect(records6m.map((r) => r.date)).toContain(currentMonth);
+
+		// Diverging period and granularity
+		const records6mDaily = await getMessagesUsage(PROJECT_ID, { period: '6m', granularity: 'day' });
+		expect(records6mDaily.length).toBeGreaterThan(150);
 	});
 });

--- a/apps/backend/tests/usage-queries.test.ts
+++ b/apps/backend/tests/usage-queries.test.ts
@@ -174,4 +174,20 @@ describe('usage query results', () => {
 			totalTokens: 45,
 		});
 	});
+
+	it('supports flexible time periods (30d, 60d, 90d, 6m)', async () => {
+		const records30d = await getMessagesUsage(PROJECT_ID, { period: '30d' });
+		expect(records30d).toHaveLength(30);
+
+		const records60d = await getMessagesUsage(PROJECT_ID, { period: '60d' });
+		expect(records60d).toHaveLength(60);
+
+		const records90d = await getMessagesUsage(PROJECT_ID, { period: '90d' });
+		expect(records90d).toHaveLength(90);
+
+		const records6m = await getMessagesUsage(PROJECT_ID, { period: '6m' });
+		expect(records6m).toHaveLength(6);
+		const currentMonth = formatDate(new Date(), 'month');
+		expect(records6m.map((r) => r.date)).toContain(currentMonth);
+	});
 });

--- a/apps/frontend/src/components/settings/usage-filters.tsx
+++ b/apps/frontend/src/components/settings/usage-filters.tsx
@@ -1,6 +1,6 @@
 import { Radio, ThumbsUp, Users, Wrench } from 'lucide-react';
 import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabel } from '@nao/shared/types';
-import { USAGE_SOURCES } from '@nao/backend/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG, USAGE_PERIODS, USAGE_SOURCES } from '@nao/backend/usage';
 import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
 import type {
 	ChatReplayFeedbackState,
@@ -21,21 +21,15 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
-export const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = [
-	{ value: '24h', label: 'Last 24 hours', granularity: 'hour' },
-	{ value: '7d', label: 'Last 7 days', granularity: 'day' },
-	{ value: '15d', label: 'Last 15 days', granularity: 'day' },
-	{ value: '30d', label: 'Last 30 days', granularity: 'day' },
-	{ value: '60d', label: 'Last 60 days', granularity: 'day' },
-	{ value: '90d', label: 'Last 90 days', granularity: 'day' },
-	{ value: '6m', label: 'Last 6 months', granularity: 'month' },
-];
+export const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = USAGE_PERIODS.map(
+	(value) => ({
+		value,
+		label: PERIOD_CONFIG[value].label,
+		granularity: PERIOD_CONFIG[value].granularity,
+	}),
+);
 
-export const periodByGranularity: Record<Granularity, UsagePeriod> = {
-	hour: '24h',
-	day: '15d',
-	month: '6m',
-};
+export const periodByGranularity: Record<Granularity, UsagePeriod> = DEFAULT_PERIOD_BY_GRANULARITY;
 
 export const dateFormats: Record<Granularity, string> = {
 	hour: 'MMM d, HH:00',
@@ -75,6 +69,9 @@ export function UsageFilters({
 	onSelectedSourcesChange,
 }: UsageFiltersProps) {
 	const currentPeriod = passedPeriod ?? periodByGranularity[granularity] ?? '15d';
+	const availableOptions = onPeriodChange
+		? periodOptions
+		: periodOptions.filter((o) => o.value === '24h' || o.value === '15d' || o.value === '6m');
 	const userOptions = (chatFacets?.userNames ?? []).map((name) => ({
 		value: name,
 		label: name,
@@ -106,7 +103,7 @@ export function UsageFilters({
 						value={currentPeriod}
 						onValueChange={(value) => {
 							const nextPeriod = value as UsagePeriod;
-							const option = periodOptions.find((o) => o.value === nextPeriod);
+							const option = availableOptions.find((o) => o.value === nextPeriod);
 							if (option) {
 								if (onPeriodChange) {
 									onPeriodChange(option.value, option.granularity);
@@ -120,7 +117,7 @@ export function UsageFilters({
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							{periodOptions.map((option) => (
+							{availableOptions.map((option) => (
 								<SelectItem key={option.value} value={option.value}>
 									{option.label}
 								</SelectItem>

--- a/apps/frontend/src/components/settings/usage-filters.tsx
+++ b/apps/frontend/src/components/settings/usage-filters.tsx
@@ -1,7 +1,7 @@
 import { Radio, ThumbsUp, Users, Wrench } from 'lucide-react';
 import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabel } from '@nao/shared/types';
 import { USAGE_SOURCES } from '@nao/backend/usage';
-import type { Granularity, UsageSource } from '@nao/backend/usage';
+import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
 import type {
 	ChatReplayFeedbackState,
 	ChatReplayToolState,
@@ -21,15 +21,17 @@ import {
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
-type UsagePeriod = '24h' | '15d' | '6m';
-
-const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = [
+export const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = [
 	{ value: '24h', label: 'Last 24 hours', granularity: 'hour' },
+	{ value: '7d', label: 'Last 7 days', granularity: 'day' },
 	{ value: '15d', label: 'Last 15 days', granularity: 'day' },
+	{ value: '30d', label: 'Last 30 days', granularity: 'day' },
+	{ value: '60d', label: 'Last 60 days', granularity: 'day' },
+	{ value: '90d', label: 'Last 90 days', granularity: 'day' },
 	{ value: '6m', label: 'Last 6 months', granularity: 'month' },
 ];
 
-const periodByGranularity: Record<Granularity, UsagePeriod> = {
+export const periodByGranularity: Record<Granularity, UsagePeriod> = {
 	hour: '24h',
 	day: '15d',
 	month: '6m',
@@ -45,6 +47,8 @@ interface UsageFiltersProps {
 	showUsageControls?: boolean;
 	provider: LlmProvider | 'all';
 	onProviderChange: (value: LlmProvider | 'all') => void;
+	period?: UsagePeriod;
+	onPeriodChange?: (period: UsagePeriod, granularity: Granularity) => void;
 	granularity: Granularity;
 	onGranularityChange: (value: Granularity) => void;
 	availableProviders: LlmProvider[] | undefined;
@@ -59,6 +63,8 @@ export function UsageFilters({
 	showUsageControls = true,
 	provider,
 	onProviderChange,
+	period: passedPeriod,
+	onPeriodChange,
 	granularity,
 	onGranularityChange,
 	availableProviders,
@@ -68,7 +74,7 @@ export function UsageFilters({
 	selectedSources,
 	onSelectedSourcesChange,
 }: UsageFiltersProps) {
-	const period = periodByGranularity[granularity];
+	const currentPeriod = passedPeriod ?? periodByGranularity[granularity] ?? '15d';
 	const userOptions = (chatFacets?.userNames ?? []).map((name) => ({
 		value: name,
 		label: name,
@@ -97,11 +103,16 @@ export function UsageFilters({
 						</SelectContent>
 					</Select>
 					<Select
-						value={period}
+						value={currentPeriod}
 						onValueChange={(value) => {
-							const option = periodOptions.find((o) => o.value === value);
+							const nextPeriod = value as UsagePeriod;
+							const option = periodOptions.find((o) => o.value === nextPeriod);
 							if (option) {
-								onGranularityChange(option.granularity);
+								if (onPeriodChange) {
+									onPeriodChange(option.value, option.granularity);
+								} else {
+									onGranularityChange(option.granularity);
+								}
 							}
 						}}
 					>

--- a/apps/frontend/src/components/settings/usage-route-search.ts
+++ b/apps/frontend/src/components/settings/usage-route-search.ts
@@ -1,5 +1,5 @@
 import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabels } from '@nao/shared/types';
-import { USAGE_SOURCES } from '@nao/backend/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG, USAGE_PERIODS, USAGE_SOURCES } from '@nao/backend/usage';
 import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
 import type { ChatReplayFeedbackState, ChatReplayToolState, LlmProvider } from '@nao/shared/types';
 import type { RecommendationTab } from '@/components/settings/recommendations-route-search';
@@ -44,27 +44,17 @@ export const DEFAULT_USAGE_SEARCH: UsageRouteSearch = {
 	recoTab: undefined,
 };
 
-const periods = ['24h', '7d', '15d', '30d', '60d', '90d', '6m'] as const satisfies readonly UsagePeriod[];
+const periods = USAGE_PERIODS;
 const granularities = ['hour', 'day', 'month'] as const satisfies readonly Granularity[];
 const tokenViews = ['tokens', 'dollars'] as const satisfies readonly TokenChartDisplayMode[];
 const filterSearchKeys = ['provider', 'period', 'granularity', 'users', 'feedback', 'tools', 'sources'] as const;
 const usageFiltersStorageKey = 'nao.usage-filters';
 
-export const PERIOD_TO_GRANULARITY: Record<UsagePeriod, Granularity> = {
-	'24h': 'hour',
-	'7d': 'day',
-	'15d': 'day',
-	'30d': 'day',
-	'60d': 'day',
-	'90d': 'day',
-	'6m': 'month',
-};
+export const PERIOD_TO_GRANULARITY: Record<UsagePeriod, Granularity> = Object.fromEntries(
+	USAGE_PERIODS.map((period) => [period, PERIOD_CONFIG[period].granularity]),
+) as Record<UsagePeriod, Granularity>;
 
-export const GRANULARITY_TO_PERIOD: Record<Granularity, UsagePeriod> = {
-	hour: '24h',
-	day: '15d',
-	month: '6m',
-};
+export const GRANULARITY_TO_PERIOD: Record<Granularity, UsagePeriod> = DEFAULT_PERIOD_BY_GRANULARITY;
 
 export function validateUsageSearchWithStoredFilters(search: Record<string, unknown>): UsageRouteSearch {
 	const hasSearchFilters = filterSearchKeys.some((key) => search[key] !== undefined);

--- a/apps/frontend/src/components/settings/usage-route-search.ts
+++ b/apps/frontend/src/components/settings/usage-route-search.ts
@@ -1,6 +1,6 @@
 import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabels } from '@nao/shared/types';
 import { USAGE_SOURCES } from '@nao/backend/usage';
-import type { Granularity, UsageSource } from '@nao/backend/usage';
+import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
 import type { ChatReplayFeedbackState, ChatReplayToolState, LlmProvider } from '@nao/shared/types';
 import type { RecommendationTab } from '@/components/settings/recommendations-route-search';
 import { RECOMMENDATION_TABS } from '@/components/settings/recommendations-route-search';
@@ -14,6 +14,7 @@ export type ReplayOrigin = 'recommendations';
 
 export type UsageRouteSearch = {
 	provider: LlmProvider | 'all';
+	period: UsagePeriod;
 	granularity: Granularity;
 	users: string[] | undefined;
 	feedback: ChatReplayFeedbackState[] | undefined;
@@ -29,6 +30,7 @@ export type UsageRouteSearch = {
 
 export const DEFAULT_USAGE_SEARCH: UsageRouteSearch = {
 	provider: 'all',
+	period: '15d',
 	granularity: 'day',
 	users: undefined,
 	feedback: undefined,
@@ -42,10 +44,27 @@ export const DEFAULT_USAGE_SEARCH: UsageRouteSearch = {
 	recoTab: undefined,
 };
 
+const periods = ['24h', '7d', '15d', '30d', '60d', '90d', '6m'] as const satisfies readonly UsagePeriod[];
 const granularities = ['hour', 'day', 'month'] as const satisfies readonly Granularity[];
 const tokenViews = ['tokens', 'dollars'] as const satisfies readonly TokenChartDisplayMode[];
-const filterSearchKeys = ['provider', 'granularity', 'users', 'feedback', 'tools', 'sources'] as const;
+const filterSearchKeys = ['provider', 'period', 'granularity', 'users', 'feedback', 'tools', 'sources'] as const;
 const usageFiltersStorageKey = 'nao.usage-filters';
+
+export const PERIOD_TO_GRANULARITY: Record<UsagePeriod, Granularity> = {
+	'24h': 'hour',
+	'7d': 'day',
+	'15d': 'day',
+	'30d': 'day',
+	'60d': 'day',
+	'90d': 'day',
+	'6m': 'month',
+};
+
+export const GRANULARITY_TO_PERIOD: Record<Granularity, UsagePeriod> = {
+	hour: '24h',
+	day: '15d',
+	month: '6m',
+};
 
 export function validateUsageSearchWithStoredFilters(search: Record<string, unknown>): UsageRouteSearch {
 	const hasSearchFilters = filterSearchKeys.some((key) => search[key] !== undefined);
@@ -72,9 +91,15 @@ const replayHighlights = ['tool-error', 'feedback'] as const satisfies readonly 
 const replayOrigins = ['recommendations'] as const satisfies readonly ReplayOrigin[];
 
 export function validateUsageSearch(search: Record<string, unknown>): UsageRouteSearch {
+	const rawPeriod = parseOneOf(search.period, periods);
+	const rawGranularity = parseOneOf(search.granularity, granularities);
+	const period = rawPeriod ?? (rawGranularity ? GRANULARITY_TO_PERIOD[rawGranularity] : '15d');
+	const granularity = rawGranularity ?? PERIOD_TO_GRANULARITY[period];
+
 	return {
 		provider: parseProvider(search.provider),
-		granularity: parseOneOf(search.granularity, granularities) ?? 'day',
+		period,
+		granularity,
 		users: parseStringArray(search.users),
 		feedback: parseArrayOf(search.feedback, CHAT_REPLAY_FEEDBACK_STATES),
 		tools: parseArrayOf(search.tools, CHAT_REPLAY_TOOL_STATES),

--- a/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { createFileRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
+import type { Granularity } from '@nao/backend/usage';
 import type { TokenChartDisplayMode, UsageRouteSearch } from '@/components/settings/usage-route-search';
 import type { displayChart } from '@nao/shared/tools';
 import { ChatsReplayPage } from '@/components/settings/chats-replay-page';
@@ -95,6 +96,14 @@ function UsagePage() {
 	);
 }
 
+function formatChartXAxisLabel(value: string, granularity: Granularity): string {
+	if (granularity === 'month' && /^\d{4}-\d{2}$/.test(value)) {
+		const [y, m] = value.split('-').map(Number);
+		return format(new Date(y, m - 1, 1), dateFormats.month);
+	}
+	return format(new Date(value), dateFormats[granularity]);
+}
+
 function UsageOverview({
 	usageSearch,
 	onUpdateSearch,
@@ -104,7 +113,7 @@ function UsageOverview({
 	onUpdateSearch: (next: Partial<UsageRouteSearch>) => void;
 	onOpenChatReplay: (chatId: string) => void;
 }) {
-	const { granularity, provider, users, feedback, tools, sources, tokenView } = usageSearch;
+	const { period, granularity, provider, users, feedback, tools, sources, tokenView } = usageSearch;
 	const { canViewUsage } = usePermissions();
 
 	const usedProviders = useQuery({
@@ -120,6 +129,7 @@ function UsageOverview({
 	});
 	const messagesUsage = useQuery({
 		...trpc.usage.getMessagesUsage.queryOptions({
+			period,
 			granularity,
 			provider: provider === 'all' ? undefined : provider,
 			userNames: users,
@@ -130,6 +140,7 @@ function UsageOverview({
 	});
 	const totalUsage = useQuery({
 		...trpc.usage.getTotalUsage.queryOptions({
+			period,
 			granularity,
 			provider: provider === 'all' ? undefined : provider,
 			userNames: users,
@@ -153,6 +164,10 @@ function UsageOverview({
 			showUsageControls={canViewUsage}
 			provider={provider}
 			onProviderChange={(value) => onUpdateSearch({ provider: value })}
+			period={period}
+			onPeriodChange={(nextPeriod, nextGranularity) =>
+				onUpdateSearch({ period: nextPeriod, granularity: nextGranularity })
+			}
 			granularity={granularity}
 			onGranularityChange={(value) => onUpdateSearch({ granularity: value })}
 			availableProviders={usedProviders.data}
@@ -202,7 +217,7 @@ function UsageOverview({
 								isError={messagesUsage.isError}
 								data={chartData}
 								chartType='stacked_bar'
-								xAxisLabelFormatter={(value) => format(new Date(value), dateFormats[granularity])}
+								xAxisLabelFormatter={(value) => formatChartXAxisLabel(value, granularity)}
 								titleAccessory={
 									<span className='text-xs text-muted-foreground'>Number of messages by source</span>
 								}
@@ -217,7 +232,7 @@ function UsageOverview({
 								isError={messagesUsage.isError}
 								data={chartData}
 								chartType='stacked_bar'
-								xAxisLabelFormatter={(value) => format(new Date(value), dateFormats[granularity])}
+								xAxisLabelFormatter={(value) => formatChartXAxisLabel(value, granularity)}
 								valueFormatter={showCost ? formatUsd : undefined}
 								series={showCost ? costSeries : tokenSeries}
 								titleAccessory={


### PR DESCRIPTION

Fixes #1482

### Summary of Changes

#### 1. Flexible Time Windows
- Added `Last 7 days`, `Last 30 days`, `Last 60 days`, and `Last 90 days` options to the usage analytics filter alongside existing `Last 24 hours`, `Last 15 days`, and `Last 6 months`.
- Decoupled `period` (time lookback window) from `granularity` (SQL aggregation bucket size).
- Sane default granularities are derived automatically from the chosen period (`24h -> hour`, `7d..90d -> day`, `6m -> month`), while still supporting independent granularity overrides if needed.

#### 2. Root Causes & Fix for Missing Current Month
- **Backend Lookback:** Previously, `getLookbackTimestamp('month')` subtracted an approximate 180 days (`now - 6 * 30 * 24 * 60 * 60 * 1000`), causing boundary cutoffs.
 It now calculates the 1st day of the month 5 months ago at `00:00:00 UTC`, covering the 5 preceding complete months plus the active current month (6 months total).
- **Client-Side Timezone Shift:** Earlier `format(new Date('YYYY-MM'), 'MMM yyyy')` was parsing month strings as UTC midnight (`2026-08-01T00:00:00Z`). In timezones with negative UTC offsets (e.g. US/Canada UTC-4 to UTC-8), this timestamp resolved to July 31st local time, shifting all 6 month labels backward by 1 month and dropping August. 
fix-Added local date component parsing (`formatChartXAxisLabel`) to preserve the exact month string.

#### 3. Backward Compatibility & Test Coverage
- Existing URLs and bookmarks using `?granularity=...` are seamlessly parsed and mapped to the corresponding `period`.
- Added unit tests in `@nao/backend` verifying `30d`, `60d`, `90d`, and `6m` lookback query outputs.

---

### Key Files Modified

- **`apps/backend/src/types/usage.ts`**: Added `usagePeriodSchema` (`'24h' | '7d' | '15d' | '30d' | '60d' | '90d' | '6m'`) and updated `usageFilterSchema`.
- **`apps/backend/src/utils/date.ts`**: Added `PERIOD_CONFIG`, `resolvePeriodAndGranularity`, updated `getLookbackTimestamp`, `generateDateSeries`, and `fillMissingDates`.
- **`apps/backend/src/queries/usage.queries.ts`**: Resolved `period` and `granularity` in `getMessagesUsage` and `getTotalUsage`.
- **`apps/backend/tests/usage-queries.test.ts`**: Added unit tests for 30d, 60d, 90d, and 6m lookbacks.
- **`apps/frontend/src/components/settings/usage-route-search.ts`**: Added `period` to search params, storage, and fallback validators.
- **`apps/frontend/src/components/settings/usage-filters.tsx`**: Added new period options to dropdown.
- **`apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx`**: Passed `period` to queries and added timezone-safe `formatChartXAxisLabel`.

### Testing & Verification

- [x] **Automated Tests:** Ran `npm run test -w @nao/backend -- tests/usage-queries.test.ts` — all 4 test suites passed.
- [x] **Lint & Type Checks:** Ran `npm run lint` across `@nao/backend`, `@nao/frontend`, and `@nao/shared` with 0 errors.
- [x] **Manual Local Verification:**
  - Tested all 7 options (`Last 24 hours`, `Last 7 days`, `Last 15 days`, `Last 30 days`, `Last 60 days`, `Last 90 days`, and `Last 6 months`) on `localhost:3000`.
  - Verified URL query search synchronization and filter persistence.
  - Verified that `Last 6 months` accurately renders the active current month (August) across different timezones without offset shifts.
 
---

### Screenshots / Proof of Fix

### **_Before:_**
- **Only 3 fixed options in dropdown:**
<img width="652" height="167" alt="bfusagedates" src="https://github.com/user-attachments/assets/534c6e1f-85fd-4b20-8649-f52529765e82" />

- **Last 6 Months _missing_ active current month (i.e. August):**
<img width="751" height="540" alt="last6monthsbefore" src="https://github.com/user-attachments/assets/c22f49e7-49b0-4d26-a6aa-543486a71ac6" />

---

### **_After:_**

- **All 7 Flexible Time Windows:**
<img width="342" height="301" alt="newdropdown" src="https://github.com/user-attachments/assets/a01d7ef2-fb43-4575-9cd9-f07b9c3c845b" />

- **Last 6 Months _cleanly rendering_ active current month (i.e. August):**
<img width="681" height="502" alt="new6monthsafter" src="https://github.com/user-attachments/assets/71221e44-5d6a-4155-82c2-70fc221861ee" />

- **Newly added Last 7 30 60 and  90 Days Daily Views:**
  
<img width="687" height="505" alt="last7days" src="https://github.com/user-attachments/assets/bd5ceeb4-88bf-4403-b148-db82f7cbe216" />

<img width="842" height="597" alt="last30daysafter" src="https://github.com/user-attachments/assets/05bc70e9-8103-4102-b61f-de8a09e9e9a2" />

<img width="721" height="530" alt="last60days" src="https://github.com/user-attachments/assets/8dac2e92-b6df-4652-bad7-30bb0ca5ae93" />

<img width="767" height="547" alt="last90daysafter" src="https://github.com/user-attachments/assets/39a9fc40-f57d-48e5-a0eb-175f4ff0d241" />

- **The 24h and 15 Days:**

<img width="672" height="512" alt="last24hourafter" src="https://github.com/user-attachments/assets/52ba11c0-b26e-4ce6-ba93-41c6be867f27" />

<img width="677" height="492" alt="last15daysafter" src="https://github.com/user-attachments/assets/f6264948-1b18-4886-83bb-7f3055fb88df" />

Tested Locally on the running frontend and backend.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

