### PR TITLE
feat: add nao project delete command

### DIFF
--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -87,6 +87,19 @@ export const updateProjectMemberRole = async (projectId: string, userId: string,
 		.execute();
 };
 
+export const listScheduledJobIdsForProject = async (projectId: string): Promise<string[]> => {
+	const automations = await db
+		.select({ scheduledJobId: s.automation.scheduledJobId })
+		.from(s.automation)
+		.where(eq(s.automation.projectId, projectId))
+		.execute();
+	return automations.map((a) => a.scheduledJobId).filter((id): id is string => id !== null);
+};
+
+export const deleteProject = async (projectId: string): Promise<void> => {
+	await db.delete(s.project).where(eq(s.project.id, projectId)).execute();
+};
+
 export const listProjectMembershipsForUser = async (
 	userId: string,
 ): Promise<Array<{ projectId: string; projectPath: string | null; role: UserRole }>> => {

--- a/apps/backend/src/routes/deploy.ts
+++ b/apps/backend/src/routes/deploy.ts
@@ -7,9 +7,13 @@ import yaml from 'js-yaml';
 
 import type { App } from '../app';
 import { env } from '../env';
-import { ensureContextRecommendationsScheduleForNewProject } from '../handlers/context-recommendations.handler';
+import {
+	contextRecommendationsJobUniqueKey,
+	ensureContextRecommendationsScheduleForNewProject,
+} from '../handlers/context-recommendations.handler';
 import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
+import * as scheduledJobQueries from '../queries/scheduled-job.queries';
 import { validateApiKey } from '../services/api-key.service';
 
 export const deployRoutes = async (app: App) => {
@@ -99,6 +103,42 @@ export const deployRoutes = async (app: App) => {
 		} finally {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		}
+	});
+
+	app.delete('/deploy', async (request, reply) => {
+		const authHeader = request.headers.authorization;
+		if (!authHeader?.startsWith('Bearer ')) {
+			return reply.status(401).send({ error: 'Missing or invalid Authorization header' });
+		}
+
+		const org = await validateApiKey(authHeader.slice(7));
+		if (!org) {
+			return reply.status(401).send({ error: 'Invalid API key' });
+		}
+
+		const projectName = (request.query as { project?: string }).project;
+		if (!projectName) {
+			return reply.status(400).send({ error: 'Missing required query parameter "project"' });
+		}
+
+		const project = await projectQueries.getProjectByOrgAndName(org.id, projectName);
+		if (!project) {
+			return reply.status(404).send({ error: `No project named "${projectName}" found` });
+		}
+
+		const scheduledJobIds = await projectQueries.listScheduledJobIdsForProject(project.id);
+		for (const jobId of scheduledJobIds) {
+			await scheduledJobQueries.deleteJob(jobId);
+		}
+		await scheduledJobQueries.deleteJobByUniqueKey(contextRecommendationsJobUniqueKey(project.id));
+
+		await projectQueries.deleteProject(project.id);
+
+		if (project.path && fs.existsSync(project.path)) {
+			fs.rmSync(project.path, { recursive: true, force: true });
+		}
+
+		return reply.send({ projectId: project.id, projectName: project.name, status: 'deleted' });
 	});
 };
 

--- a/cli/nao_core/commands/__init__.py
+++ b/cli/nao_core/commands/__init__.py
@@ -1,5 +1,6 @@
 from nao_core.commands.chat import chat
 from nao_core.commands.debug import debug
+from nao_core.commands.delete import delete
 from nao_core.commands.deploy import deploy
 from nao_core.commands.docs import docs
 from nao_core.commands.init import init
@@ -13,6 +14,7 @@ from nao_core.commands.upgrade import upgrade
 __all__ = [
     "chat",
     "debug",
+    "delete",
     "deploy",
     "docs",
     "init",

--- a/cli/nao_core/commands/delete.py
+++ b/cli/nao_core/commands/delete.py
@@ -1,0 +1,61 @@
+from typing import Annotated
+
+import httpx
+from cyclopts import Parameter
+
+from nao_core.tracking import track_command
+from nao_core.ui import UI, ask_confirm
+
+
+@track_command("delete")
+def delete(
+    project: Annotated[str, Parameter(help="Name of the project to delete", name=["--project", "-p"])],
+    url: Annotated[str, Parameter(help="Remote nao instance URL")],
+    api_key: Annotated[str, Parameter(help="API key for authentication", name=["--api-key", "-k"])],
+    yes: Annotated[bool, Parameter(help="Skip the confirmation prompt", name=["--yes", "-y"])] = False,
+) -> None:
+    """Permanently delete a project from a remote nao instance."""
+    if not yes and not ask_confirm(
+        f"Permanently delete project [cyan]{project}[/cyan] from [cyan]{url}[/cyan]?", default=False
+    ):
+        UI.print("Delete cancelled.")
+        return
+
+    delete_url = f"{url.rstrip('/')}/api/deploy"
+
+    UI.print(f"\n[dim]Deleting {project}...[/dim]")
+    try:
+        response = httpx.delete(
+            delete_url,
+            headers={"Authorization": f"Bearer {api_key}"},
+            params={"project": project},
+            timeout=30.0,
+        )
+    except httpx.ConnectError:
+        UI.error(f"Could not connect to {url}")
+        UI.print("[dim]Check the URL and ensure the nao instance is running.[/dim]")
+        return
+    except httpx.TimeoutException:
+        UI.error("Request timed out")
+        return
+
+    if response.status_code == 401:
+        UI.error("Authentication failed. Check your API key.")
+        return
+
+    if response.status_code == 404:
+        UI.error(f"No project named [cyan]{project}[/cyan] found")
+        return
+
+    if response.status_code != 200:
+        UI.error(f"Delete failed ({response.status_code})")
+        try:
+            error = response.json().get("error", response.text)
+        except Exception:
+            error = response.text
+        UI.print(f"[red]{error}[/red]")
+        return
+
+    result = response.json()
+    UI.success(f"Project [cyan]{result.get('projectName', project)}[/cyan] deleted")
+    UI.print(f"[dim]Project ID: {result.get('projectId')}[/dim]")

--- a/cli/nao_core/main.py
+++ b/cli/nao_core/main.py
@@ -11,6 +11,7 @@ from nao_core.branding import banner, should_show_banner  # noqa: E402
 from nao_core.commands import (  # noqa: E402
     chat,
     debug,
+    delete,
     deploy,
     docs,
     init,
@@ -28,6 +29,7 @@ app = App(version=__version__)
 
 app.command(chat)
 app.command(debug)
+app.command(delete)
 app.command(deploy)
 app.command(docs)
 app.command(init)


### PR DESCRIPTION
Closes #1382

## What
Adds `nao delete --project <name> --url <url> --api-key <key>` to the CLI,
and a matching `DELETE /api/deploy?project=<name>` endpoint on the backend,
symmetric with the existing `nao deploy` / `POST /api/deploy`.

## Why
There was no supported way to remove a project from a self-hosted
multi-project instance — only create/update via `nao deploy`.

## What gets deleted
- The project row and everything cascaded via its `onDelete: 'cascade'`
  foreign keys (project_member, chat, automation, story, etc.)
- Scheduled jobs tied to the project — context-recommendations and
  per-automation jobs — which are NOT covered by the DB cascade
  (`automation.scheduledJobId` is `onDelete: 'set null'`, not cascade),
  so these are cleaned up explicitly before the project row is deleted
- The project's directory on disk (`NAO_PROJECTS_DIR/<id>`)

It does not delete user accounts or API keys — those are org-scoped,
independent of any project.

<details>
<summary>Manual test output</summary>

piyush@nao: cd cli
uv run nao deploy --url http://localhost:5005 --api-key "$NAO_API_KEY" --path ../example

Deploying example to http://localhost:5005

Packaging project files...
Package size: 0.0 MB
Uploading...
✓ Project example created
Project ID: 6f180b56-cc84-4b2a-bffb-9ae7c5efb430
piyush@cli: uv run nao delete --project example --url http://localhost:5005 --api-key "$NAO_API_KEY" --yes


Deleting example...
✓ Project example deleted
Project ID: 6f180b56-cc84-4b2a-bffb-9ae7c5efb430
piyush@cli: 

</details>


## Testing
Tested manually end-to-end against both SQLite and Postgres:
- Deployed a project, confirmed the project row, project_member row, and
  disk directory all exist, deleted it, confirmed all three are gone
- Created a real recurring automation on a project and confirmed its
  scheduled_job row is removed on delete, not just orphaned
- Repeat delete on an already-deleted project returns a clean 404
- An invalid API key returns a clean 401
- `npm run lint` and `cd cli && make lint` both pass

This PR was written using Claude Sonnet 5 (claude-sonnet-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

