### PR TITLE
Add auto save story edits to fix bugs and avoid lost changes

### DIFF
--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -20,6 +20,7 @@ import StoryIcon from './ui/story-icon';
 import type { PromptHandle, SelectedMention } from 'prompt-mentions';
 import type { FormEvent } from 'react';
 import type { AgentHelpers } from '@/hooks/use-agent';
+import type { BeforeAgentSendResult } from '@/contexts/story-before-agent-send';
 import { ContextWindowRing } from '@/components/ui/chat-input-context-window-ring';
 import { SimpleTooltip } from '@/components/ui/tooltip';
 
@@ -277,7 +278,10 @@ function ChatInputBase({
 				return;
 			}
 
-			if (chatId && !(await storyBeforeAgentSend.run(chatId))) {
+			const beforeAgentSendResult: BeforeAgentSendResult = chatId
+				? await storyBeforeAgentSend.run(chatId)
+				: { canSend: true };
+			if (!beforeAgentSendResult.canSend) {
 				return;
 			}
 
@@ -300,7 +304,9 @@ function ChatInputBase({
 			const { images, documents } = attachmentUpload.getPayload();
 			attachmentUpload.clearAttachments();
 
-			await onSubmitMessage({ text: trimmedInput, images, documents, citation });
+			const submitPromise = onSubmitMessage({ text: trimmedInput, images, documents, citation });
+			beforeAgentSendResult.afterSend?.();
+			await submitPromise;
 		},
 		[
 			onSubmitMessage,

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -20,7 +20,6 @@ import StoryIcon from './ui/story-icon';
 import type { PromptHandle, SelectedMention } from 'prompt-mentions';
 import type { FormEvent } from 'react';
 import type { AgentHelpers } from '@/hooks/use-agent';
-import type { BeforeAgentSendResult } from '@/contexts/story-before-agent-send';
 import { ContextWindowRing } from '@/components/ui/chat-input-context-window-ring';
 import { SimpleTooltip } from '@/components/ui/tooltip';
 
@@ -43,7 +42,7 @@ import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useChatPendingCitation } from '@/hooks/use-chat-pending-citation';
 import { SelectionCitationBanner } from '@/components/selection-citation-banner';
 import { ChatInputSuggestions } from '@/components/chat-input-suggestions';
-import { useStoryBeforeAgentSend } from '@/contexts/story-before-agent-send';
+import { runWithStoryBeforeAgentSend, useStoryBeforeAgentSend } from '@/contexts/story-before-agent-send';
 
 const cycleModelShortcut = getShortcut('cycle-model').shortcut;
 
@@ -253,6 +252,22 @@ function ChatInputBase({
 		micWarningTimer.current = window.setTimeout(() => setMicWarning(false), 5000);
 	}, []);
 
+	const runGuardedAgentSend = useCallback(
+		(send: () => Promise<void>) =>
+			runWithStoryBeforeAgentSend({
+				beforeSend: () => (chatId ? storyBeforeAgentSend.run(chatId) : Promise.resolve({ canSend: true })),
+				send,
+			}),
+		[chatId, storyBeforeAgentSend],
+	);
+
+	const submitQueuedMessageWithGuard = useCallback(
+		async (messageId: string) => {
+			await runGuardedAgentSend(() => submitQueuedMessageNow(messageId));
+		},
+		[runGuardedAgentSend, submitQueuedMessageNow],
+	);
+
 	const submitMessage = useCallback(
 		async (text: string, currentMentions: SelectedMention[] = []) => {
 			const trimmedInput = text.trim();
@@ -263,7 +278,7 @@ function ChatInputBase({
 				if (isRunning && allowQueueing) {
 					const queue = messageQueueStore.getSnapshot(chatId);
 					if (queue?.length) {
-						await submitQueuedMessageNow(queue[0].id);
+						await submitQueuedMessageWithGuard(queue[0].id);
 					}
 				}
 				return;
@@ -278,35 +293,28 @@ function ChatInputBase({
 				return;
 			}
 
-			const beforeAgentSendResult: BeforeAgentSendResult = chatId
-				? await storyBeforeAgentSend.run(chatId)
-				: { canSend: true };
-			if (!beforeAgentSendResult.canSend) {
-				return;
-			}
+			await runGuardedAgentSend(() => {
+				const citation = hasCitation
+					? {
+							start: citationSnapshot.start,
+							end: citationSnapshot.end,
+							text: citationSnapshot.text,
+							storySlug: citationSnapshot.storySlug,
+						}
+					: undefined;
+				if (hasCitation) {
+					chatPendingCitationStore.clear();
+				}
 
-			const citation = hasCitation
-				? {
-						start: citationSnapshot.start,
-						end: citationSnapshot.end,
-						text: citationSnapshot.text,
-						storySlug: citationSnapshot.storySlug,
-					}
-				: undefined;
-			if (hasCitation) {
-				chatPendingCitationStore.clear();
-			}
+				setMentions(currentMentions.map((m) => ({ id: m.id, label: m.label, trigger: m.trigger })));
+				promptRef.current?.clear();
+				setInputText('');
 
-			setMentions(currentMentions.map((m) => ({ id: m.id, label: m.label, trigger: m.trigger })));
-			promptRef.current?.clear();
-			setInputText('');
+				const { images, documents } = attachmentUpload.getPayload();
+				attachmentUpload.clearAttachments();
 
-			const { images, documents } = attachmentUpload.getPayload();
-			attachmentUpload.clearAttachments();
-
-			const submitPromise = onSubmitMessage({ text: trimmedInput, images, documents, citation });
-			beforeAgentSendResult.afterSend?.();
-			await submitPromise;
+				return onSubmitMessage({ text: trimmedInput, images, documents, citation });
+			});
 		},
 		[
 			onSubmitMessage,
@@ -317,8 +325,8 @@ function ChatInputBase({
 			promptRef,
 			attachmentUpload,
 			chatId,
-			storyBeforeAgentSend,
-			submitQueuedMessageNow,
+			runGuardedAgentSend,
+			submitQueuedMessageWithGuard,
 		],
 	);
 
@@ -384,7 +392,7 @@ function ChatInputBase({
 
 	return (
 		<div ref={dropZoneRef} className={cn('px-3 pb-3 pt-0 md:px-4 md:pb-4 max-w-3xl w-full mx-auto', className)}>
-			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageNow} />
+			<ChatInputMessageQueue onEditMessage={handleEditQueuedMessage} onSubmitNow={submitQueuedMessageWithGuard} />
 			<SelectionCitationBanner />
 			<BudgetBanner />
 			{allowQueueing && !isAdminMode && <ChatInputSuggestions isHidden={inputText.trim().length > 0} />}

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -42,6 +42,7 @@ import { chatPendingCitationStore } from '@/stores/chat-pending-citation';
 import { useChatPendingCitation } from '@/hooks/use-chat-pending-citation';
 import { SelectionCitationBanner } from '@/components/selection-citation-banner';
 import { ChatInputSuggestions } from '@/components/chat-input-suggestions';
+import { useStoryBeforeAgentSend } from '@/contexts/story-before-agent-send';
 
 const cycleModelShortcut = getShortcut('cycle-model').shortcut;
 
@@ -115,6 +116,7 @@ function ChatInputBase({
 	const navigate = useNavigate();
 	const { canChatWithNaoData } = usePermissions();
 	const chatId = useChatId();
+	const storyBeforeAgentSend = useStoryBeforeAgentSend();
 
 	const isAdminMode = canChatWithNaoData && adminMode;
 	const adminModeLocked = useAgentMessagesSelector((messages) => messages.some((message) => message.role === 'user'));
@@ -275,6 +277,10 @@ function ChatInputBase({
 				return;
 			}
 
+			if (chatId && !(await storyBeforeAgentSend.run(chatId))) {
+				return;
+			}
+
 			const citation = hasCitation
 				? {
 						start: citationSnapshot.start,
@@ -305,6 +311,7 @@ function ChatInputBase({
 			promptRef,
 			attachmentUpload,
 			chatId,
+			storyBeforeAgentSend,
 			submitQueuedMessageNow,
 		],
 	);

--- a/apps/frontend/src/components/side-panel/hooks/story-editor-content-sync.test.ts
+++ b/apps/frontend/src/components/side-panel/hooks/story-editor-content-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { shouldSyncStoryEditorContent } from './story-editor-content-sync';
+
+describe('shouldSyncStoryEditorContent', () => {
+	it('skips a tabbed prop echo of Markdown emitted by the editor', () => {
+		expect(
+			shouldSyncStoryEditorContent({
+				editorMarkdown: '# Overview updated',
+				incomingCode: '\n# Overview updated\n',
+				lastEmittedMarkdown: '# Overview updated',
+			}),
+		).toBe(false);
+	});
+
+	it('syncs genuine external and other-tab content changes', () => {
+		expect(
+			shouldSyncStoryEditorContent({
+				editorMarkdown: '# Local edit',
+				incomingCode: '\n# Externally loaded version\n',
+				lastEmittedMarkdown: '# Local edit',
+			}),
+		).toBe(true);
+		expect(
+			shouldSyncStoryEditorContent({
+				editorMarkdown: '# Overview',
+				incomingCode: '\n# Details\n',
+				lastEmittedMarkdown: '# Overview',
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/frontend/src/components/side-panel/hooks/story-editor-content-sync.ts
+++ b/apps/frontend/src/components/side-panel/hooks/story-editor-content-sync.ts
@@ -1,0 +1,25 @@
+export function shouldSyncStoryEditorContent({
+	editorMarkdown,
+	incomingCode,
+	lastEmittedMarkdown,
+}: {
+	editorMarkdown: string;
+	incomingCode: string;
+	lastEmittedMarkdown: string | null;
+}): boolean {
+	if (editorMarkdown === incomingCode) {
+		return false;
+	}
+	if (lastEmittedMarkdown === null || !hasStructuralOuterBlankLines(incomingCode)) {
+		return true;
+	}
+	return stripStructuralOuterBlankLines(incomingCode) !== stripStructuralOuterBlankLines(lastEmittedMarkdown);
+}
+
+function hasStructuralOuterBlankLines(code: string): boolean {
+	return /^(?:[ \t]*\r?\n)+/.test(code) && /(?:\r?\n[ \t]*)+$/.test(code);
+}
+
+function stripStructuralOuterBlankLines(code: string): string {
+	return code.replace(/^(?:[ \t]*\r?\n)+/, '').replace(/(?:\r?\n[ \t]*)+$/, '');
+}

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -23,6 +23,7 @@ import {
 	preprocessForEditor,
 	removeCardFromOrigin,
 } from '../story-editor-utils';
+import { shouldSyncStoryEditorContent } from './story-editor-content-sync';
 import type { GridDragSource, StoryBlockDragSource } from '../story-editor-drag-context';
 import type { DragUnit, GridColumnRef } from '../story-block-selection';
 import type { Node as PMNode } from '@tiptap/pm/model';
@@ -46,6 +47,7 @@ export function useStoryEditor({ code, editorRef, onSave, onChange }: UseStoryEd
 	const processedContent = useMemo(() => preprocessForEditor(code), [code]);
 	const onSaveRef = useRef(onSave);
 	const onChangeRef = useRef(onChange);
+	const lastEmittedMarkdownRef = useRef<string | null>(null);
 	const gridDragSourceRef = useRef<GridDragSource | null>(null);
 	const storyBlockSourceRef = useRef<StoryBlockDragSource | null>(null);
 	const multiSelectionDragRef = useRef<DragUnit[] | null>(null);
@@ -406,7 +408,11 @@ export function useStoryEditor({ code, editorRef, onSave, onChange }: UseStoryEd
 		if (!editor) {
 			return;
 		}
-		const handleUpdate = () => onChangeRef.current?.(editor.getMarkdown());
+		const handleUpdate = () => {
+			const markdown = editor.getMarkdown();
+			lastEmittedMarkdownRef.current = markdown;
+			onChangeRef.current?.(markdown);
+		};
 		editor.on('update', handleUpdate);
 		return () => {
 			editor.off('update', handleUpdate);
@@ -417,9 +423,17 @@ export function useStoryEditor({ code, editorRef, onSave, onChange }: UseStoryEd
 		if (!editor) {
 			return;
 		}
-		if (editor.getMarkdown() === code) {
+		if (
+			!shouldSyncStoryEditorContent({
+				editorMarkdown: editor.getMarkdown(),
+				incomingCode: code,
+				lastEmittedMarkdown: lastEmittedMarkdownRef.current,
+			})
+		) {
+			lastEmittedMarkdownRef.current = null;
 			return;
 		}
+		lastEmittedMarkdownRef.current = null;
 		editor.commands.setContent(processedContent, { emitUpdate: false, contentType: 'markdown' });
 	}, [editor, code, processedContent]);
 

--- a/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-editor.ts
@@ -34,6 +34,7 @@ interface UseStoryEditorParams {
 	code: string;
 	editorRef: MutableRefObject<Editor | null>;
 	onSave?: () => void;
+	onChange?: (code: string) => void;
 }
 
 /**
@@ -41,9 +42,10 @@ interface UseStoryEditorParams {
  * block extensions, the save shortcut, and the drag-and-drop handlers that move
  * story blocks and grid columns around the document.
  */
-export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams) {
+export function useStoryEditor({ code, editorRef, onSave, onChange }: UseStoryEditorParams) {
 	const processedContent = useMemo(() => preprocessForEditor(code), [code]);
 	const onSaveRef = useRef(onSave);
+	const onChangeRef = useRef(onChange);
 	const gridDragSourceRef = useRef<GridDragSource | null>(null);
 	const storyBlockSourceRef = useRef<StoryBlockDragSource | null>(null);
 	const multiSelectionDragRef = useRef<DragUnit[] | null>(null);
@@ -89,6 +91,7 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 		handleNodePosRef.current = node ? pos : null;
 	}, []);
 	onSaveRef.current = onSave;
+	onChangeRef.current = onChange;
 
 	const extensions = useMemo(
 		() => [
@@ -398,6 +401,17 @@ export function useStoryEditor({ code, editorRef, onSave }: UseStoryEditorParams
 			editorRef.current = null;
 		};
 	}, [editor, editorRef]);
+
+	useEffect(() => {
+		if (!editor) {
+			return;
+		}
+		const handleUpdate = () => onChangeRef.current?.(editor.getMarkdown());
+		editor.on('update', handleUpdate);
+		return () => {
+			editor.off('update', handleUpdate);
+		};
+	}, [editor]);
 
 	useEffect(() => {
 		if (!editor) {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.test.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStoryViewerVersionActions } from './use-story-viewer-version-actions';
+import type { StoryCodeViewHandle } from '../story-code-view';
+import type { MutableRefObject } from 'react';
+
+interface CreateVersionInput {
+	chatId: string;
+	storySlug: string;
+	title: string;
+	code: string;
+	action: 'replace';
+}
+
+const mocks = vi.hoisted(() => ({
+	invalidateQueries: vi.fn(async () => {}),
+	mutate: vi.fn(),
+	mutateAsync: vi.fn(async (_input: CreateVersionInput) => {}),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+	useMutation: () => ({
+		isPending: false,
+		mutate: mocks.mutate,
+		mutateAsync: mocks.mutateAsync,
+	}),
+	useQueryClient: () => ({
+		invalidateQueries: mocks.invalidateQueries,
+	}),
+}));
+
+vi.mock('@/main', () => ({
+	trpc: {
+		story: {
+			createVersion: {
+				mutationOptions: () => ({}),
+			},
+			getLatest: {
+				queryKey: ({ chatId, storySlug }: { chatId: string; storySlug: string }) => [
+					'latest',
+					chatId,
+					storySlug,
+				],
+			},
+			listAll: {
+				queryKey: () => ['all'],
+			},
+			listVersions: {
+				queryKey: ({ chatId, storySlug }: { chatId: string; storySlug: string }) => [
+					'versions',
+					chatId,
+					storySlug,
+				],
+			},
+		},
+	},
+}));
+
+interface HookProps {
+	chatId: string;
+	storySlug: string;
+	storyTitle: string;
+	persistedCode: string;
+	currentCode: string;
+	onVersionSaved: (code: string) => void;
+}
+
+const codeViewRef = { current: null } as MutableRefObject<StoryCodeViewHandle | null>;
+
+describe('useStoryViewerVersionActions', () => {
+	beforeEach(() => {
+		mocks.invalidateQueries.mockReset();
+		mocks.invalidateQueries.mockResolvedValue(undefined);
+		mocks.mutate.mockClear();
+		mocks.mutateAsync.mockReset();
+		mocks.mutateAsync.mockResolvedValue(undefined);
+	});
+
+	it('does not let an old save continue into a newly rendered Story', async () => {
+		const firstMutation = deferred<void>();
+		mocks.mutateAsync.mockImplementationOnce(() => firstMutation.promise);
+		const onStoryASaved = vi.fn();
+		const onStoryBSaved = vi.fn();
+		const { result, rerender } = renderHook(
+			(props: HookProps) =>
+				useStoryViewerVersionActions({
+					chatId: props.chatId,
+					storySlug: props.storySlug,
+					storyTitle: props.storyTitle,
+					currentVersionCode: props.persistedCode,
+					isViewingLatest: true,
+					goToLatestVersion: vi.fn(),
+					codeViewRef,
+					getCurrentCode: () => props.currentCode,
+					viewMode: 'edit',
+					setViewMode: vi.fn(),
+					onVersionSaved: props.onVersionSaved,
+				}),
+			{
+				initialProps: {
+					chatId: 'chat-a',
+					storySlug: 'story-a',
+					storyTitle: 'Story A',
+					persistedCode: '# Story A',
+					currentCode: '# Story A edit',
+					onVersionSaved: onStoryASaved,
+				},
+			},
+		);
+
+		let savePromise!: Promise<string>;
+		act(() => {
+			savePromise = result.current.saveCurrentVersion();
+		});
+		await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledOnce());
+
+		rerender({
+			chatId: 'chat-b',
+			storySlug: 'story-b',
+			storyTitle: 'Story B',
+			persistedCode: '# Story B',
+			currentCode: '# Story B',
+			onVersionSaved: onStoryBSaved,
+		});
+
+		await act(async () => {
+			firstMutation.resolve();
+			expect(await savePromise).toBe('unavailable');
+		});
+
+		expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+		expect(mocks.mutateAsync).toHaveBeenCalledWith({
+			chatId: 'chat-a',
+			storySlug: 'story-a',
+			title: 'Story A',
+			code: '# Story A edit',
+			action: 'replace',
+		});
+		expect(mocks.invalidateQueries).not.toHaveBeenCalled();
+		expect(onStoryASaved).not.toHaveBeenCalled();
+		expect(onStoryBSaved).not.toHaveBeenCalled();
+
+		rerender({
+			chatId: 'chat-b',
+			storySlug: 'story-b',
+			storyTitle: 'Story B',
+			persistedCode: '# Story B',
+			currentCode: '# Story B edit',
+			onVersionSaved: onStoryBSaved,
+		});
+
+		await act(async () => {
+			expect(await result.current.saveCurrentVersion()).toBe('saved');
+		});
+
+		expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
+		expect(mocks.mutateAsync).toHaveBeenLastCalledWith({
+			chatId: 'chat-b',
+			storySlug: 'story-b',
+			title: 'Story B',
+			code: '# Story B edit',
+			action: 'replace',
+		});
+		expect(onStoryBSaved).toHaveBeenCalledOnce();
+		expect(onStoryBSaved).toHaveBeenCalledWith('# Story B edit');
+	});
+
+	it('persists newer edits made to the same Story while saving', async () => {
+		const firstMutation = deferred<void>();
+		const refresh = deferred<void>();
+		mocks.mutateAsync.mockImplementationOnce(() => firstMutation.promise);
+		mocks.invalidateQueries.mockImplementationOnce(() => refresh.promise);
+		const onVersionSaved = vi.fn();
+		const { result, rerender } = renderHook(
+			(props: HookProps) =>
+				useStoryViewerVersionActions({
+					chatId: props.chatId,
+					storySlug: props.storySlug,
+					storyTitle: props.storyTitle,
+					currentVersionCode: props.persistedCode,
+					isViewingLatest: true,
+					goToLatestVersion: vi.fn(),
+					codeViewRef,
+					getCurrentCode: () => props.currentCode,
+					viewMode: 'edit',
+					setViewMode: vi.fn(),
+					onVersionSaved: props.onVersionSaved,
+				}),
+			{
+				initialProps: {
+					chatId: 'chat-a',
+					storySlug: 'story-a',
+					storyTitle: 'Story A',
+					persistedCode: '# Story A',
+					currentCode: '# First edit',
+					onVersionSaved,
+				},
+			},
+		);
+
+		let savePromise!: Promise<string>;
+		act(() => {
+			savePromise = result.current.saveCurrentVersion();
+		});
+		await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledOnce());
+
+		rerender({
+			chatId: 'chat-a',
+			storySlug: 'story-a',
+			storyTitle: 'Story A',
+			persistedCode: '# Story A',
+			currentCode: '# Newer edit',
+			onVersionSaved,
+		});
+
+		act(() => {
+			firstMutation.resolve();
+		});
+		await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(2));
+		await waitFor(() => expect(mocks.invalidateQueries).toHaveBeenCalledTimes(3));
+
+		expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
+		expect(mocks.mutateAsync.mock.calls.map(([input]) => input.code)).toEqual(['# First edit', '# Newer edit']);
+		expect(result.current.isSaving).toBe(true);
+		expect(onVersionSaved).not.toHaveBeenCalled();
+
+		await act(async () => {
+			refresh.resolve();
+			expect(await savePromise).toBe('saved');
+		});
+
+		expect(onVersionSaved).toHaveBeenCalledOnce();
+		expect(onVersionSaved).toHaveBeenCalledWith('# Newer edit');
+	});
+});
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((promiseResolve) => {
+		resolve = promiseResolve;
+	});
+	return { promise, resolve };
+}

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -1,10 +1,12 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getEditorMarkdown } from '../story-editor';
 import type { MutableRefObject } from 'react';
 import type { Editor as TiptapEditor } from '@tiptap/react';
 import type { StoryViewMode } from '../story-viewer.types';
 import type { StoryCodeViewHandle } from '../story-code-view';
+import type { StorySaveResult } from '@/lib/story-save';
+import { saveStoryCodeIfChanged } from '@/lib/story-save';
 import { trpc } from '@/main';
 
 interface UseStoryViewerVersionActionsParams {
@@ -19,6 +21,7 @@ interface UseStoryViewerVersionActionsParams {
 	getEditModeCode?: () => string | null;
 	viewMode: StoryViewMode;
 	setViewMode: (mode: StoryViewMode) => void;
+	onVersionSaved?: (code: string) => void;
 }
 
 export const useStoryViewerVersionActions = ({
@@ -33,114 +36,145 @@ export const useStoryViewerVersionActions = ({
 	getEditModeCode,
 	viewMode,
 	setViewMode,
+	onVersionSaved,
 }: UseStoryViewerVersionActionsParams) => {
 	const queryClient = useQueryClient();
 	const latestStoryQueryKey = trpc.story.getLatest.queryKey({ chatId, storySlug });
 	const listVersionsQueryKey = trpc.story.listVersions.queryKey({ chatId, storySlug });
-
-	const createVersionMutation = useMutation(
-		trpc.story.createVersion.mutationOptions({
-			onMutate: async (variables) => {
-				const previousLatestStory = queryClient.getQueryData(latestStoryQueryKey);
-				const previousVersions = queryClient.getQueryData(listVersionsQueryKey);
-				queryClient.setQueryData(latestStoryQueryKey, (latestStory) =>
-					latestStory && typeof latestStory === 'object'
-						? { ...latestStory, code: variables.code }
-						: latestStory,
-				);
-				queryClient.setQueryData(listVersionsQueryKey, (data) => {
-					if (!data || !Array.isArray(data.versions) || data.versions.length === 0) {
-						return data;
-					}
-					const lastVersion = data.versions[data.versions.length - 1];
-					return {
-						...data,
-						versions: [...data.versions, { ...lastVersion, code: variables.code }],
-					};
-				});
-
-				await queryClient.cancelQueries({ queryKey: latestStoryQueryKey });
-				await queryClient.cancelQueries({ queryKey: listVersionsQueryKey });
-
-				return { previousLatestStory, previousVersions };
-			},
-			onError: (_error, _variables, context) => {
-				if (context?.previousLatestStory !== undefined) {
-					queryClient.setQueryData(latestStoryQueryKey, context.previousLatestStory);
-				}
-				if (context?.previousVersions !== undefined) {
-					queryClient.setQueryData(listVersionsQueryKey, context.previousVersions);
-				}
-			},
-			onSuccess: () => {
-				void queryClient.invalidateQueries({
-					queryKey: trpc.story.listVersions.queryKey({ chatId, storySlug }),
-				});
-				void queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() });
-				void queryClient.invalidateQueries({ queryKey: latestStoryQueryKey });
-			},
-		}),
-	);
-
-	const handleSave = useCallback(() => {
-		const hasVersionData = storyTitle !== undefined && currentVersionCode !== undefined;
-		if (!hasVersionData) {
-			return;
-		}
-
-		let newCode: string | null = null;
-		if (viewMode === 'edit') {
-			const override = getEditModeCode?.();
-			if (override != null) {
-				newCode = override;
-			} else {
-				const editor = tiptapEditorRef.current;
-				if (!editor) {
-					return;
-				}
-				newCode = getEditorMarkdown(editor);
-			}
-		} else if (viewMode === 'code') {
-			const codeView = codeViewRef.current;
-			if (!codeView) {
-				return;
-			}
-			if (codeView.getErrors().length > 0) {
-				return;
-			}
-			newCode = codeView.getCode();
-		}
-
-		if (newCode === null) {
-			return;
-		}
-
-		if (newCode === currentVersionCode) {
-			setViewMode('preview');
-			return;
-		}
-
-		createVersionMutation.mutate({
-			chatId,
-			storySlug,
-			title: storyTitle,
-			code: newCode,
-			action: 'replace',
-		});
-
-		setViewMode('preview');
-	}, [
+	const identity = `${chatId}:${storySlug}`;
+	const baselineRef = useRef({ identity, code: currentVersionCode });
+	const savePromiseRef = useRef<Promise<StorySaveResult> | null>(null);
+	const [isSavingVersion, setIsSavingVersion] = useState(false);
+	const paramsRef = useRef({
 		chatId,
 		storySlug,
 		storyTitle,
 		currentVersionCode,
-		tiptapEditorRef,
-		codeViewRef,
 		getEditModeCode,
 		viewMode,
-		createVersionMutation,
-		setViewMode,
-	]);
+		onVersionSaved,
+	});
+
+	if (baselineRef.current.identity !== identity) {
+		baselineRef.current = { identity, code: currentVersionCode };
+	}
+	paramsRef.current = {
+		chatId,
+		storySlug,
+		storyTitle,
+		currentVersionCode,
+		getEditModeCode,
+		viewMode,
+		onVersionSaved,
+	};
+
+	const createVersionMutation = useMutation(trpc.story.createVersion.mutationOptions());
+	const mutationRef = useRef(createVersionMutation);
+	mutationRef.current = createVersionMutation;
+	const refreshQueries = useCallback(async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: listVersionsQueryKey }),
+			queryClient.invalidateQueries({ queryKey: trpc.story.listAll.queryKey() }),
+			queryClient.invalidateQueries({ queryKey: latestStoryQueryKey }),
+		]);
+	}, [latestStoryQueryKey, listVersionsQueryKey, queryClient]);
+	const refreshQueriesRef = useRef(refreshQueries);
+	refreshQueriesRef.current = refreshQueries;
+
+	useEffect(() => {
+		if (currentVersionCode !== undefined && savePromiseRef.current === null) {
+			baselineRef.current = { identity, code: currentVersionCode };
+		}
+	}, [currentVersionCode, identity]);
+
+	const readCurrentCode = useCallback((): { code: string } | StorySaveResult => {
+		const params = paramsRef.current;
+		if (params.storyTitle === undefined || params.currentVersionCode === undefined) {
+			return 'unavailable';
+		}
+		if (params.viewMode === 'edit') {
+			const trackedCode = params.getEditModeCode?.();
+			if (trackedCode != null) {
+				return { code: trackedCode };
+			}
+			const editor = tiptapEditorRef.current;
+			return editor ? { code: getEditorMarkdown(editor) } : 'unavailable';
+		}
+		if (params.viewMode === 'code') {
+			const codeView = codeViewRef.current;
+			if (!codeView) {
+				return 'unavailable';
+			}
+			if (codeView.getErrors().length > 0) {
+				return 'invalid';
+			}
+			return { code: codeView.getCode() };
+		}
+		return 'unavailable';
+	}, [codeViewRef, tiptapEditorRef]);
+
+	const saveCurrentVersion = useCallback(() => {
+		if (savePromiseRef.current) {
+			return savePromiseRef.current;
+		}
+
+		const save = async (): Promise<StorySaveResult> => {
+			let saved = false;
+			while (true) {
+				const snapshot = readCurrentCode();
+				if (typeof snapshot === 'string') {
+					return snapshot;
+				}
+				const params = paramsRef.current;
+				const result = await saveStoryCodeIfChanged({
+					baselineCode: baselineRef.current.code,
+					code: snapshot.code,
+					persist: async () => {
+						await mutationRef.current.mutateAsync({
+							chatId: params.chatId,
+							storySlug: params.storySlug,
+							title: params.storyTitle!,
+							code: snapshot.code,
+							action: 'replace',
+						});
+					},
+				});
+				if (result !== 'saved') {
+					if (saved && result === 'unchanged') {
+						await refreshQueriesRef.current();
+						const refreshedSnapshot = readCurrentCode();
+						if (typeof refreshedSnapshot === 'string') {
+							return refreshedSnapshot;
+						}
+						if (refreshedSnapshot.code !== baselineRef.current.code) {
+							continue;
+						}
+						return 'saved';
+					}
+					return result;
+				}
+
+				baselineRef.current = { identity: `${params.chatId}:${params.storySlug}`, code: snapshot.code };
+				params.onVersionSaved?.(snapshot.code);
+				saved = true;
+			}
+		};
+
+		setIsSavingVersion(true);
+		const promise = save().finally(() => {
+			savePromiseRef.current = null;
+			setIsSavingVersion(false);
+		});
+		savePromiseRef.current = promise;
+		return promise;
+	}, [readCurrentCode]);
+
+	const handleSave = useCallback(async () => {
+		const result = await saveCurrentVersion();
+		if (result === 'saved' || result === 'unchanged') {
+			setViewMode('preview');
+		}
+	}, [saveCurrentVersion, setViewMode]);
 
 	const handleRestore = useCallback(() => {
 		const hasVersionData = storyTitle !== undefined && currentVersionCode !== undefined;
@@ -156,13 +190,28 @@ export const useStoryViewerVersionActions = ({
 				code: currentVersionCode,
 				action: 'replace',
 			},
-			{ onSuccess: () => goToLatestVersion() },
+			{
+				onSuccess: async () => {
+					await refreshQueries();
+					goToLatestVersion();
+				},
+			},
 		);
-	}, [chatId, storySlug, storyTitle, currentVersionCode, isViewingLatest, createVersionMutation, goToLatestVersion]);
+	}, [
+		chatId,
+		storySlug,
+		storyTitle,
+		currentVersionCode,
+		isViewingLatest,
+		createVersionMutation,
+		refreshQueries,
+		goToLatestVersion,
+	]);
 
 	return {
 		handleSave,
+		saveCurrentVersion,
 		handleRestore,
-		isSaving: createVersionMutation.isPending,
+		isSaving: createVersionMutation.isPending || isSavingVersion,
 	};
 };

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { getEditorMarkdown } from '../story-editor';
 import type { MutableRefObject } from 'react';
-import type { Editor as TiptapEditor } from '@tiptap/react';
 import type { StoryViewMode } from '../story-viewer.types';
 import type { StoryCodeViewHandle } from '../story-code-view';
 import type { StorySaveResult } from '@/lib/story-save';
@@ -16,9 +14,8 @@ interface UseStoryViewerVersionActionsParams {
 	currentVersionCode?: string;
 	isViewingLatest: boolean;
 	goToLatestVersion: () => void;
-	tiptapEditorRef: MutableRefObject<TiptapEditor | null>;
 	codeViewRef: MutableRefObject<StoryCodeViewHandle | null>;
-	getEditModeCode?: () => string | null;
+	getCurrentCode: () => string;
 	viewMode: StoryViewMode;
 	setViewMode: (mode: StoryViewMode) => void;
 	onVersionSaved?: (code: string) => void;
@@ -31,9 +28,8 @@ export const useStoryViewerVersionActions = ({
 	currentVersionCode,
 	isViewingLatest,
 	goToLatestVersion,
-	tiptapEditorRef,
 	codeViewRef,
-	getEditModeCode,
+	getCurrentCode,
 	viewMode,
 	setViewMode,
 	onVersionSaved,
@@ -50,7 +46,7 @@ export const useStoryViewerVersionActions = ({
 		storySlug,
 		storyTitle,
 		currentVersionCode,
-		getEditModeCode,
+		getCurrentCode,
 		viewMode,
 		onVersionSaved,
 	});
@@ -63,7 +59,7 @@ export const useStoryViewerVersionActions = ({
 		storySlug,
 		storyTitle,
 		currentVersionCode,
-		getEditModeCode,
+		getCurrentCode,
 		viewMode,
 		onVersionSaved,
 	};
@@ -92,14 +88,6 @@ export const useStoryViewerVersionActions = ({
 		if (params.storyTitle === undefined || params.currentVersionCode === undefined) {
 			return 'unavailable';
 		}
-		if (params.viewMode === 'edit') {
-			const trackedCode = params.getEditModeCode?.();
-			if (trackedCode != null) {
-				return { code: trackedCode };
-			}
-			const editor = tiptapEditorRef.current;
-			return editor ? { code: getEditorMarkdown(editor) } : 'unavailable';
-		}
 		if (params.viewMode === 'code') {
 			const codeView = codeViewRef.current;
 			if (!codeView) {
@@ -108,10 +96,9 @@ export const useStoryViewerVersionActions = ({
 			if (codeView.getErrors().length > 0) {
 				return 'invalid';
 			}
-			return { code: codeView.getCode() };
 		}
-		return 'unavailable';
-	}, [codeViewRef, tiptapEditorRef]);
+		return { code: params.getCurrentCode() };
+	}, [codeViewRef]);
 
 	const saveCurrentVersion = useCallback(() => {
 		if (savePromiseRef.current) {

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-version-actions.ts
@@ -21,6 +21,11 @@ interface UseStoryViewerVersionActionsParams {
 	onVersionSaved?: (code: string) => void;
 }
 
+interface StoryIdentity {
+	chatId: string;
+	storySlug: string;
+}
+
 export const useStoryViewerVersionActions = ({
 	chatId,
 	storySlug,
@@ -37,11 +42,13 @@ export const useStoryViewerVersionActions = ({
 	const queryClient = useQueryClient();
 	const latestStoryQueryKey = trpc.story.getLatest.queryKey({ chatId, storySlug });
 	const listVersionsQueryKey = trpc.story.listVersions.queryKey({ chatId, storySlug });
-	const identity = `${chatId}:${storySlug}`;
+	const identity = { chatId, storySlug };
+	const currentIdentityRef = useRef(identity);
 	const baselineRef = useRef({ identity, code: currentVersionCode });
-	const savePromiseRef = useRef<Promise<StorySaveResult> | null>(null);
+	const savePromiseRef = useRef<{ identity: StoryIdentity; promise: Promise<StorySaveResult> } | null>(null);
 	const [isSavingVersion, setIsSavingVersion] = useState(false);
 	const paramsRef = useRef({
+		identity,
 		chatId,
 		storySlug,
 		storyTitle,
@@ -51,10 +58,12 @@ export const useStoryViewerVersionActions = ({
 		onVersionSaved,
 	});
 
-	if (baselineRef.current.identity !== identity) {
+	currentIdentityRef.current = identity;
+	if (!isSameStoryIdentity(baselineRef.current.identity, identity)) {
 		baselineRef.current = { identity, code: currentVersionCode };
 	}
 	paramsRef.current = {
+		identity,
 		chatId,
 		storySlug,
 		storyTitle,
@@ -78,81 +87,143 @@ export const useStoryViewerVersionActions = ({
 	refreshQueriesRef.current = refreshQueries;
 
 	useEffect(() => {
-		if (currentVersionCode !== undefined && savePromiseRef.current === null) {
-			baselineRef.current = { identity, code: currentVersionCode };
+		const activeSave = savePromiseRef.current;
+		const hasActiveSaveForStory =
+			activeSave !== null && isSameStoryIdentity(activeSave.identity, { chatId, storySlug });
+		if (currentVersionCode !== undefined && !hasActiveSaveForStory) {
+			baselineRef.current = { identity: { chatId, storySlug }, code: currentVersionCode };
 		}
-	}, [currentVersionCode, identity]);
+	}, [chatId, currentVersionCode, storySlug]);
 
-	const readCurrentCode = useCallback((): { code: string } | StorySaveResult => {
-		const params = paramsRef.current;
-		if (params.storyTitle === undefined || params.currentVersionCode === undefined) {
-			return 'unavailable';
-		}
-		if (params.viewMode === 'code') {
-			const codeView = codeViewRef.current;
-			if (!codeView) {
+	const readCurrentCode = useCallback(
+		(saveIdentity: StoryIdentity): { code: string } | StorySaveResult => {
+			if (!isSameStoryIdentity(currentIdentityRef.current, saveIdentity)) {
 				return 'unavailable';
 			}
-			if (codeView.getErrors().length > 0) {
-				return 'invalid';
+			const params = paramsRef.current;
+			if (!isSameStoryIdentity(params.identity, saveIdentity)) {
+				return 'unavailable';
 			}
-		}
-		return { code: params.getCurrentCode() };
-	}, [codeViewRef]);
+			if (params.storyTitle === undefined || params.currentVersionCode === undefined) {
+				return 'unavailable';
+			}
+			if (params.viewMode === 'code') {
+				const codeView = codeViewRef.current;
+				if (!codeView) {
+					return 'unavailable';
+				}
+				if (codeView.getErrors().length > 0) {
+					return 'invalid';
+				}
+			}
+			return { code: params.getCurrentCode() };
+		},
+		[codeViewRef],
+	);
 
 	const saveCurrentVersion = useCallback(() => {
-		if (savePromiseRef.current) {
-			return savePromiseRef.current;
+		const params = paramsRef.current;
+		const saveIdentity = params.identity;
+		const activeSave = savePromiseRef.current;
+		if (activeSave) {
+			return isSameStoryIdentity(activeSave.identity, saveIdentity)
+				? activeSave.promise
+				: Promise.resolve<StorySaveResult>('unavailable');
 		}
+
+		if (params.storyTitle === undefined || params.currentVersionCode === undefined) {
+			return Promise.resolve<StorySaveResult>('unavailable');
+		}
+
+		const saveTarget = {
+			identity: saveIdentity,
+			chatId: params.chatId,
+			storySlug: params.storySlug,
+			storyTitle: params.storyTitle,
+			onVersionSaved: params.onVersionSaved,
+			persist: mutationRef.current.mutateAsync,
+			refreshQueries: refreshQueriesRef.current,
+		};
+		const isSaveIdentityActive = () => isSameStoryIdentity(currentIdentityRef.current, saveTarget.identity);
 
 		const save = async (): Promise<StorySaveResult> => {
 			let saved = false;
 			while (true) {
-				const snapshot = readCurrentCode();
+				if (!isSaveIdentityActive()) {
+					return 'unavailable';
+				}
+
+				const snapshot = readCurrentCode(saveTarget.identity);
 				if (typeof snapshot === 'string') {
 					return snapshot;
 				}
-				const params = paramsRef.current;
+				if (!isSameStoryIdentity(baselineRef.current.identity, saveTarget.identity)) {
+					return 'unavailable';
+				}
+
 				const result = await saveStoryCodeIfChanged({
 					baselineCode: baselineRef.current.code,
 					code: snapshot.code,
 					persist: async () => {
-						await mutationRef.current.mutateAsync({
-							chatId: params.chatId,
-							storySlug: params.storySlug,
-							title: params.storyTitle!,
+						if (!isSaveIdentityActive()) {
+							return;
+						}
+						await saveTarget.persist({
+							chatId: saveTarget.chatId,
+							storySlug: saveTarget.storySlug,
+							title: saveTarget.storyTitle,
 							code: snapshot.code,
 							action: 'replace',
 						});
+						if (!isSaveIdentityActive()) {
+							return;
+						}
 					},
 				});
+				if (!isSaveIdentityActive()) {
+					return 'unavailable';
+				}
+
 				if (result !== 'saved') {
 					if (saved && result === 'unchanged') {
-						await refreshQueriesRef.current();
-						const refreshedSnapshot = readCurrentCode();
+						if (!isSaveIdentityActive()) {
+							return 'unavailable';
+						}
+						await saveTarget.refreshQueries();
+						if (!isSaveIdentityActive()) {
+							return 'unavailable';
+						}
+
+						const refreshedSnapshot = readCurrentCode(saveTarget.identity);
 						if (typeof refreshedSnapshot === 'string') {
 							return refreshedSnapshot;
+						}
+						if (!isSameStoryIdentity(baselineRef.current.identity, saveTarget.identity)) {
+							return 'unavailable';
 						}
 						if (refreshedSnapshot.code !== baselineRef.current.code) {
 							continue;
 						}
+						saveTarget.onVersionSaved?.(refreshedSnapshot.code);
 						return 'saved';
 					}
 					return result;
 				}
 
-				baselineRef.current = { identity: `${params.chatId}:${params.storySlug}`, code: snapshot.code };
-				params.onVersionSaved?.(snapshot.code);
+				baselineRef.current = { identity: saveTarget.identity, code: snapshot.code };
 				saved = true;
 			}
 		};
 
 		setIsSavingVersion(true);
 		const promise = save().finally(() => {
+			if (savePromiseRef.current?.promise !== promise) {
+				return;
+			}
 			savePromiseRef.current = null;
 			setIsSavingVersion(false);
 		});
-		savePromiseRef.current = promise;
+		savePromiseRef.current = { identity: saveIdentity, promise };
 		return promise;
 	}, [readCurrentCode]);
 
@@ -202,3 +273,7 @@ export const useStoryViewerVersionActions = ({
 		isSaving: createVersionMutation.isPending || isSavingVersion,
 	};
 };
+
+function isSameStoryIdentity(first: StoryIdentity, second: StoryIdentity): boolean {
+	return first.chatId === second.chatId && first.storySlug === second.storySlug;
+}

--- a/apps/frontend/src/components/side-panel/story-code-view.tsx
+++ b/apps/frontend/src/components/side-panel/story-code-view.tsx
@@ -29,6 +29,7 @@ interface StoryCodeViewProps {
 	readOnly?: boolean;
 	codeRef?: React.MutableRefObject<StoryCodeViewHandle | null>;
 	onDirtyChange?: (dirty: boolean) => void;
+	onCodeChange?: (code: string) => void;
 	onValidChange?: (valid: boolean) => void;
 	onSave?: () => void;
 }
@@ -40,20 +41,26 @@ export const StoryCodeView = memo(function StoryCodeView({
 	readOnly = false,
 	codeRef,
 	onDirtyChange,
+	onCodeChange,
 	onValidChange,
 	onSave,
 }: StoryCodeViewProps) {
 	const editorTheme = useEditorTheme();
 	const [draft, setDraft] = useState(code);
 	const [errors, setErrors] = useState<StoryValidationError[]>(() => (readOnly ? [] : validateStoryCode(code)));
+	const draftRef = useRef(draft);
+	const errorsRef = useRef(errors);
 	const editorInstanceRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 	const monacoRef = useRef<Monaco | null>(null);
 	const onSaveRef = useRef(onSave);
 	onSaveRef.current = onSave;
 
 	useEffect(() => {
+		const nextErrors = readOnly ? [] : validateStoryCode(code);
+		draftRef.current = code;
+		errorsRef.current = nextErrors;
 		setDraft(code);
-		setErrors(readOnly ? [] : validateStoryCode(code));
+		setErrors(nextErrors);
 	}, [code, readOnly]);
 
 	useEffect(() => {
@@ -69,13 +76,13 @@ export const StoryCodeView = memo(function StoryCodeView({
 			return;
 		}
 		codeRef.current = {
-			getCode: () => draft,
-			getErrors: () => errors,
+			getCode: () => draftRef.current,
+			getErrors: () => errorsRef.current,
 		};
 		return () => {
 			codeRef.current = null;
 		};
-	}, [codeRef, draft, errors]);
+	}, [codeRef]);
 
 	useEffect(() => {
 		const monaco = monacoRef.current;
@@ -123,10 +130,14 @@ export const StoryCodeView = memo(function StoryCodeView({
 	const handleChange = useCallback(
 		(value: string | undefined) => {
 			const next = value ?? '';
+			const nextErrors = readOnly ? [] : validateStoryCode(next);
+			draftRef.current = next;
+			errorsRef.current = nextErrors;
 			setDraft(next);
-			setErrors(readOnly ? [] : validateStoryCode(next));
+			setErrors(nextErrors);
+			onCodeChange?.(next);
 		},
-		[readOnly],
+		[onCodeChange, readOnly],
 	);
 
 	const options = useMemo(

--- a/apps/frontend/src/components/side-panel/story-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-editor.tsx
@@ -15,9 +15,10 @@ interface StoryEditorProps {
 	code: string;
 	editorRef: React.MutableRefObject<Editor | null>;
 	onSave?: () => void;
+	onChange?: (code: string) => void;
 }
 
-export const StoryEditor = memo(function StoryEditor({ code, editorRef, onSave }: StoryEditorProps) {
+export const StoryEditor = memo(function StoryEditor({ code, editorRef, onSave, onChange }: StoryEditorProps) {
 	const {
 		editor,
 		gridDragSourceRef,
@@ -30,7 +31,7 @@ export const StoryEditor = memo(function StoryEditor({ code, editorRef, onSave }
 		onElementDragStart,
 		onElementDragEnd,
 		onDragHandleClick,
-	} = useStoryEditor({ code, editorRef, onSave });
+	} = useStoryEditor({ code, editorRef, onSave, onChange });
 
 	const hideFloatingHandle =
 		handleNodeType === 'gridBlock' || handleNodeType === 'chartBlock' || handleNodeType === 'tableBlock';

--- a/apps/frontend/src/components/side-panel/story-header.test.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StoryHeader } from './story-header';
+import type { StoryHeaderProps } from './story-header';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+vi.mock('@tanstack/react-query', () => ({
+	useQuery: () => ({ data: undefined }),
+}));
+
+vi.mock('@/components/editable-story-title', () => ({
+	EditableStoryTitle: ({ title }: { title: string }) => <span>{title}</span>,
+}));
+
+vi.mock('@/components/story-download', () => ({
+	StoryDownload: () => null,
+}));
+
+vi.mock('@/components/story-page-header', () => ({
+	LiveStoryTimestamp: () => null,
+	StoryRefreshFailureBanner: () => null,
+}));
+
+vi.mock('@/hooks/use-is-mobile', () => ({
+	useIsMobile: () => false,
+}));
+
+vi.mock('@/hooks/use-toggle-favorite', () => ({
+	useToggleFavorite: () => ({ toggle: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/main', () => ({
+	trpc: {
+		favorite: {
+			list: {
+				queryOptions: () => ({}),
+			},
+		},
+		story: {
+			listStories: {
+				queryOptions: () => ({}),
+			},
+		},
+	},
+}));
+
+describe('StoryHeader editing subheader', () => {
+	afterEach(cleanup);
+
+	it('shows save controls whenever visual Edit mode is active', () => {
+		renderHeader({ viewMode: 'edit' });
+
+		expect(screen.getByText('Editing')).toBeDefined();
+		expect(screen.getByRole('button', { name: /save/i })).toBeDefined();
+	});
+
+	it('hides save controls in Preview mode', () => {
+		renderHeader({ viewMode: 'preview' });
+
+		expect(screen.queryByText('Editing')).toBeNull();
+		expect(screen.queryByRole('button', { name: /save/i })).toBeNull();
+	});
+
+	it('keeps save controls for dirty code', () => {
+		renderHeader({ viewMode: 'code', isCodeDirty: true });
+
+		expect(screen.getByText('Editing code')).toBeDefined();
+		expect(screen.getByRole('button', { name: /save/i })).toBeDefined();
+	});
+});
+
+function renderHeader(overrides: Partial<StoryHeaderProps>) {
+	const props: StoryHeaderProps = {
+		title: 'Revenue',
+		chatId: 'chat-1',
+		storySlug: 'revenue',
+		allStories: [],
+		onSwitchStory: vi.fn(),
+		viewMode: 'preview',
+		onViewModeChange: vi.fn(),
+		currentVersion: 1,
+		totalVersions: 1,
+		onPreviousVersion: vi.fn(),
+		onNextVersion: vi.fn(),
+		isViewingLatest: true,
+		onRestore: vi.fn(),
+		onSave: vi.fn(),
+		onCancel: vi.fn(),
+		onShare: vi.fn(),
+		onOpenAnalytics: vi.fn(),
+		onEnlarge: vi.fn(),
+		isShared: false,
+		isAgentRunning: false,
+		isStoryUpdating: false,
+		isReadonlyMode: false,
+		isLive: false,
+		isRefreshing: false,
+		onRefreshData: vi.fn(),
+		onOpenLiveSettings: vi.fn(),
+		onClose: vi.fn(),
+		...overrides,
+	};
+
+	return render(
+		<TooltipProvider>
+			<StoryHeader {...props} />
+		</TooltipProvider>,
+	);
+}

--- a/apps/frontend/src/components/side-panel/story-header.tsx
+++ b/apps/frontend/src/components/side-panel/story-header.tsx
@@ -59,6 +59,7 @@ export interface StoryHeaderProps {
 	isViewingLatest: boolean;
 	onRestore: () => void;
 	onSave: () => void;
+	onCancel: () => void;
 	onShare: () => void;
 	onOpenAnalytics: () => void;
 	onEnlarge: () => void;
@@ -110,6 +111,7 @@ export const StoryHeader = memo(function StoryHeader({
 	isViewingLatest,
 	onRestore,
 	onSave,
+	onCancel,
 	onShare,
 	onOpenAnalytics,
 	onEnlarge,
@@ -220,6 +222,7 @@ export const StoryHeader = memo(function StoryHeader({
 				className={cn(viewMode === 'preview' && 'bg-accent rounded-full', 'hover:rounded-full')}
 				size='icon-xs'
 				onClick={() => onViewModeChange('preview')}
+				disabled={isSaving}
 			>
 				<Eye className='size-3' strokeWidth={2.25} />
 			</Button>
@@ -229,7 +232,7 @@ export const StoryHeader = memo(function StoryHeader({
 					className={cn(viewMode === 'edit' && 'bg-accent rounded-full', 'hover:rounded-full')}
 					size='icon-xs'
 					onClick={() => onViewModeChange('edit')}
-					disabled={isAgentRunning}
+					disabled={isAgentRunning || isSaving}
 				>
 					<Pencil className='size-3' strokeWidth={2.25} />
 				</Button>
@@ -239,6 +242,7 @@ export const StoryHeader = memo(function StoryHeader({
 				className={cn(viewMode === 'code' && 'bg-accent rounded-full', 'hover:rounded-full')}
 				size='icon-xs'
 				onClick={() => onViewModeChange('code')}
+				disabled={isSaving}
 			>
 				<Code className='size-3' strokeWidth={2.25} />
 			</Button>
@@ -404,10 +408,17 @@ export const StoryHeader = memo(function StoryHeader({
 						<>
 							<span className='text-xs text-muted-foreground'>Editing</span>
 							<div className='flex items-center gap-2'>
-								<Button variant='outline' size='sm' onClick={() => onViewModeChange('preview')}>
+								<Button variant='outline' size='sm' onClick={onCancel} disabled={isSaving}>
 									Cancel
 								</Button>
-								<Button variant='primary-gradient' size='sm' onClick={onSave} className='gap-1.5'>
+								<Button
+									variant='primary-gradient'
+									size='sm'
+									onClick={onSave}
+									disabled={isSaving}
+									isLoading={isSaving}
+									className='gap-1.5'
+								>
 									<Save className='size-3' strokeWidth={2.25} />
 									<span>Save</span>
 									<kbd className='text-[10px] opacity-60 font-sans'>⌘S</kbd>
@@ -420,14 +431,15 @@ export const StoryHeader = memo(function StoryHeader({
 								{isCodeValid ? 'Editing code' : 'Fix validation errors to save'}
 							</span>
 							<div className='flex items-center gap-2'>
-								<Button variant='outline' size='sm' onClick={() => onViewModeChange('preview')}>
+								<Button variant='outline' size='sm' onClick={onCancel} disabled={isSaving}>
 									Cancel
 								</Button>
 								<Button
 									variant='primary-gradient'
 									size='sm'
 									onClick={onSave}
-									disabled={!isCodeValid}
+									disabled={isSaving || !isCodeValid}
+									isLoading={isSaving}
 									className='gap-1.5'
 								>
 									<Save className='size-3' strokeWidth={2.25} />

--- a/apps/frontend/src/components/side-panel/story-tabbed-editor.tsx
+++ b/apps/frontend/src/components/side-panel/story-tabbed-editor.tsx
@@ -8,7 +8,7 @@ import {
 	stripStoryTabsMarkup,
 } from '@nao/shared/story-tabs';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { getEditorMarkdown, StoryEditor } from './story-editor';
+import { StoryEditor } from './story-editor';
 import { StoryTabsBar } from './story-tabs-bar';
 import type { MutableRefObject } from 'react';
 import type { Editor as TiptapEditor } from '@tiptap/react';
@@ -17,6 +17,7 @@ interface StoryTabbedEditorProps {
 	code: string;
 	editorRef: MutableRefObject<TiptapEditor | null>;
 	onSave?: () => void;
+	onChange?: (code: string) => void;
 	getCodeRef: MutableRefObject<(() => string) | null>;
 	barContentClassName?: string;
 	contentClassName?: string;
@@ -26,6 +27,7 @@ export function StoryTabbedEditor({
 	code,
 	editorRef,
 	onSave,
+	onChange,
 	getCodeRef,
 	barContentClassName,
 	contentClassName,
@@ -36,49 +38,49 @@ export function StoryTabbedEditor({
 	const active = tabs.length ? Math.min(activeIndex, tabs.length - 1) : 0;
 	const bufferRef = useRef(bufferCode);
 	const activeRef = useRef(active);
+	const onChangeRef = useRef(onChange);
 
 	bufferRef.current = bufferCode;
 	activeRef.current = active;
+	onChangeRef.current = onChange;
 
 	useEffect(() => {
+		bufferRef.current = code;
 		setBufferCode(code);
 	}, [code]);
 
 	useEffect(() => {
-		getCodeRef.current = () => {
-			const currentCode = bufferRef.current;
-			const currentActive = activeRef.current;
-			const editor = editorRef.current;
-			const parsed = parseStoryTabs(currentCode);
-			const inner = editor ? getEditorMarkdown(editor) : (parsed?.[currentActive]?.innerCode ?? '');
-			if (!parsed?.length) {
-				return inner;
-			}
-			return replaceStoryTabInner(currentCode, currentActive, inner);
-		};
+		getCodeRef.current = () => bufferRef.current;
 		return () => {
 			getCodeRef.current = null;
 		};
-	}, [editorRef, getCodeRef]);
+	}, [getCodeRef]);
 
-	const handleSelect = useCallback(
-		(nextIndex: number) => {
-			const editor = editorRef.current;
-			const spliced = editor ? replaceStoryTabInner(bufferCode, active, getEditorMarkdown(editor)) : bufferCode;
-			setBufferCode(spliced);
-			setActiveIndex(nextIndex);
+	const updateBuffer = useCallback((nextCode: string) => {
+		bufferRef.current = nextCode;
+		setBufferCode(nextCode);
+		onChangeRef.current?.(nextCode);
+	}, []);
+
+	const handleSelect = useCallback((nextIndex: number) => {
+		setActiveIndex(nextIndex);
+	}, []);
+
+	const handleEditorChange = useCallback(
+		(innerCode: string) => {
+			const currentCode = bufferRef.current;
+			const parsed = parseStoryTabs(currentCode);
+			const nextCode = parsed?.length
+				? replaceStoryTabInner(currentCode, activeRef.current, innerCode)
+				: innerCode;
+			updateBuffer(nextCode);
 		},
-		[active, bufferCode, editorRef],
+		[updateBuffer],
 	);
-
-	const spliceCurrent = () => {
-		const editor = editorRef.current;
-		return editor ? replaceStoryTabInner(bufferCode, active, getEditorMarkdown(editor)) : bufferCode;
-	};
 
 	if (tabs.length === 0) {
 		const plainCode = stripStoryTabsMarkup(bufferCode).trim();
-		return <StoryEditor code={plainCode} editorRef={editorRef} onSave={onSave} />;
+		return <StoryEditor code={plainCode} editorRef={editorRef} onSave={onSave} onChange={handleEditorChange} />;
 	}
 
 	return (
@@ -90,17 +92,15 @@ export function StoryTabbedEditor({
 					onSelect={handleSelect}
 					contentClassName={barContentClassName}
 					editable={{
-						onRename: (index, title) => setBufferCode(renameStoryTab(spliceCurrent(), index, title)),
+						onRename: (index, title) => updateBuffer(renameStoryTab(bufferRef.current, index, title)),
 						onDelete: (index) => {
-							const spliced = spliceCurrent();
 							setActiveIndex((current) =>
 								Math.max(0, current > index ? current - 1 : Math.min(current, tabs.length - 2)),
 							);
-							setBufferCode(deleteStoryTab(spliced, index));
+							updateBuffer(deleteStoryTab(bufferRef.current, index));
 						},
 						onMove: (fromIndex, toIndex) => {
-							const spliced = spliceCurrent();
-							setBufferCode(moveStoryTab(spliced, fromIndex, toIndex));
+							updateBuffer(moveStoryTab(bufferRef.current, fromIndex, toIndex));
 							setActiveIndex((current) => {
 								if (current === fromIndex) {
 									return toIndex;
@@ -113,15 +113,19 @@ export function StoryTabbedEditor({
 							});
 						},
 						onAdd: () => {
-							const spliced = spliceCurrent();
-							setBufferCode(addStoryTab(spliced));
+							updateBuffer(addStoryTab(bufferRef.current));
 							setActiveIndex(tabs.length);
 						},
 					}}
 				/>
 			</div>
 			<div className={contentClassName}>
-				<StoryEditor code={tabs[active]?.innerCode ?? ''} editorRef={editorRef} onSave={onSave} />
+				<StoryEditor
+					code={tabs[active]?.innerCode ?? ''}
+					editorRef={editorRef}
+					onSave={onSave}
+					onChange={handleEditorChange}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -136,19 +136,8 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 	const tabs = useMemo(() => parseStoryTabs(storyCode ?? ''), [storyCode]);
 	const isTabbedStory = Boolean(tabs?.length);
 	const activeTab = tabs?.length ? Math.min(activeTabIndex, tabs.length - 1) : 0;
-	const editBuffer = useStoryEditBuffer(storyCode ?? '');
-	const codeBuffer = useStoryEditBuffer(storyCode ?? '');
-	const isCodeDirty = codeBuffer.isDirty;
-	const handleVersionSaved = useCallback(
-		(savedCode: string) => {
-			if (viewMode === 'edit') {
-				editBuffer.markSaved(savedCode);
-			} else if (viewMode === 'code') {
-				codeBuffer.markSaved(savedCode);
-			}
-		},
-		[codeBuffer, editBuffer, viewMode],
-	);
+	const storyBuffer = useStoryEditBuffer(storyCode ?? '');
+	const isCodeDirty = storyBuffer.isDirty;
 	useTrackViewDuration({
 		assetType: 'story',
 		chatId,
@@ -164,32 +153,24 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		currentVersionCode: currentVersion?.code ?? storyCode,
 		isViewingLatest,
 		goToLatestVersion,
-		tiptapEditorRef,
 		codeViewRef,
-		getEditModeCode: editBuffer.getCode,
+		getCurrentCode: storyBuffer.getCode,
 		viewMode,
 		setViewMode,
-		onVersionSaved: handleVersionSaved,
+		onVersionSaved: storyBuffer.markSaved,
 	});
-	const isDirty = viewMode === 'edit' ? editBuffer.isDirty : viewMode === 'code' && isCodeDirty;
-	const discardChanges = useCallback(() => {
-		if (viewMode === 'edit') {
-			editBuffer.discard();
-		} else {
-			codeBuffer.discard();
-		}
-	}, [codeBuffer, editBuffer, viewMode]);
+	const isDirty = storyBuffer.isDirty;
 	const exitGuard = useStoryExitGuard({
 		isDirty,
 		canSave: viewMode !== 'code' || isCodeValid,
 		save: saveCurrentVersion,
-		discard: discardChanges,
+		discard: storyBuffer.discard,
 	});
 	const transitions = useStoryEditTransitions({
 		viewMode,
 		setViewMode,
-		isEditDirty: editBuffer.isDirty,
-		isCodeDirty,
+		isDirty,
+		isCodeValid,
 		isSaving,
 		save: saveCurrentVersion,
 		requestExit: exitGuard.requestExit,
@@ -197,14 +178,20 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 	useEffect(() => registerBeforeChange(exitGuard.requestExit), [exitGuard.requestExit, registerBeforeChange]);
 	const handleBeforeAgentSend = useCallback(async () => {
 		if (!isDirty) {
-			return true;
+			return { canSend: true };
 		}
 		if (viewMode === 'code' && !isCodeValid) {
-			return false;
+			return { canSend: false };
 		}
 		const result = await saveCurrentVersion();
-		return result === 'saved' || result === 'unchanged';
-	}, [isCodeValid, isDirty, saveCurrentVersion, viewMode]);
+		if (result !== 'saved' && result !== 'unchanged') {
+			return { canSend: false };
+		}
+		return {
+			canSend: true,
+			afterSend: () => setViewMode('preview'),
+		};
+	}, [isCodeValid, isDirty, saveCurrentVersion, setViewMode, viewMode]);
 	useRegisterStoryBeforeAgentSend({
 		chatId,
 		enabled: !isReadonlyMode && isSidePanelVisible && currentStorySlug === resolvedStorySlug,
@@ -291,14 +278,16 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 
 	const editCode = selectStoryEditorCode({
 		persistedCode: storyCode,
-		bufferCode: editBuffer.getCode(),
-		isDirty: editBuffer.isDirty,
+		bufferCode: storyBuffer.getCode(),
+		isDirty: storyBuffer.isDirty,
 		isSaving,
 	});
+	const editTabs = parseStoryTabs(editCode);
+	const isEditTabbedStory = Boolean(editTabs?.length);
 	const codeDraft = selectStoryEditorCode({
 		persistedCode: storyCode,
-		bufferCode: codeBuffer.getCode(),
-		isDirty: codeBuffer.isDirty,
+		bufferCode: storyBuffer.getCode(),
+		isDirty: storyBuffer.isDirty,
 		isSaving,
 	});
 	const content = (
@@ -384,12 +373,12 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 						)
 					) : viewMode === 'edit' ? (
 						<StoryEmbedDataProvider value={versionQueryData}>
-							{isTabbedStory ? (
+							{isEditTabbedStory ? (
 								<StoryTabbedEditor
 									code={editCode}
 									editorRef={tiptapEditorRef}
 									onSave={handleSave}
-									onChange={editBuffer.handleCodeChange}
+									onChange={storyBuffer.handleCodeChange}
 									getCodeRef={tabbedEditCodeRef}
 									barContentClassName='px-6'
 									contentClassName='p-6'
@@ -399,7 +388,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 									code={editCode}
 									editorRef={tiptapEditorRef}
 									onSave={handleSave}
-									onChange={editBuffer.handleCodeChange}
+									onChange={storyBuffer.handleCodeChange}
 								/>
 							)}
 						</StoryEmbedDataProvider>
@@ -408,7 +397,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 							code={codeDraft}
 							readOnly={isReadonlyMode}
 							codeRef={codeViewRef}
-							onCodeChange={codeBuffer.handleCodeChange}
+							onCodeChange={storyBuffer.handleCodeChange}
 							onValidChange={setIsCodeValid}
 							onSave={handleSave}
 						/>

--- a/apps/frontend/src/components/side-panel/story-viewer.tsx
+++ b/apps/frontend/src/components/side-panel/story-viewer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { useQuery } from '@tanstack/react-query';
 import { parseStoryTabs, stripStoryTabsMarkup } from '@nao/shared/story-tabs';
 import { ShareStoryDialog } from '../share-dialog.story';
+import { StoryUnsavedChangesDialog } from '../story-unsaved-changes-dialog';
 import { StoryEditor } from './story-editor';
 import { LiveStorySettingsDialog } from './live-story-settings-dialog';
 import { ArchivedBanner } from './story-archived-banner';
@@ -28,6 +29,9 @@ import { useSidePanel } from '@/contexts/side-panel';
 import { useDragAutoScroll } from '@/hooks/use-drag-auto-scroll';
 import { useStoryVersionQueryData } from '@/hooks/use-story-version-query-data';
 import { useTrackViewDuration } from '@/hooks/use-track-view-duration';
+import { selectStoryEditorCode, useStoryEditBuffer } from '@/hooks/use-story-edit-buffer';
+import { useStoryEditTransitions } from '@/hooks/use-story-edit-transitions';
+import { useStoryExitGuard } from '@/hooks/use-story-exit-guard';
 import { ReadonlyAgentMessagesProvider, useOptionalAgentContext } from '@/contexts/agent.provider';
 import { StoryChartEditProvider } from '@/contexts/story-chart-edit';
 import { StoryMapEditProvider } from '@/contexts/story-map-edit';
@@ -35,6 +39,7 @@ import { StoryTableEditProvider } from '@/contexts/story-table-edit';
 import { StoryEmbedDataProvider } from '@/contexts/story-embed-data';
 import { Spinner } from '@/components/ui/spinner';
 import { chatActivityStore } from '@/stores/chat-activity';
+import { useRegisterStoryBeforeAgentSend } from '@/contexts/story-before-agent-send';
 import { trpc } from '@/main';
 
 interface StoryViewerProps {
@@ -48,14 +53,15 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 	const tiptapEditorRef = useRef<TiptapEditor | null>(null);
 	const codeViewRef = useRef<StoryCodeViewHandle | null>(null);
 	const tabbedEditCodeRef = useRef<(() => string) | null>(null);
-	const getEditModeCode = useCallback(() => tabbedEditCodeRef.current?.() ?? null, []);
-	const [isCodeDirty, setIsCodeDirty] = useState(false);
 	const [isCodeValid, setIsCodeValid] = useState(true);
 	const [activeTabIndex, setActiveTabIndex] = useState(initialTabIndex ?? 0);
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	const {
 		close: closeSidePanel,
+		isVisible: isSidePanelVisible,
+		currentStorySlug,
 		isReadonlyMode: contextReadonlyMode,
+		registerBeforeChange,
 		shareId,
 		shareType,
 		setCurrentStorySlug,
@@ -130,6 +136,19 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 	const tabs = useMemo(() => parseStoryTabs(storyCode ?? ''), [storyCode]);
 	const isTabbedStory = Boolean(tabs?.length);
 	const activeTab = tabs?.length ? Math.min(activeTabIndex, tabs.length - 1) : 0;
+	const editBuffer = useStoryEditBuffer(storyCode ?? '');
+	const codeBuffer = useStoryEditBuffer(storyCode ?? '');
+	const isCodeDirty = codeBuffer.isDirty;
+	const handleVersionSaved = useCallback(
+		(savedCode: string) => {
+			if (viewMode === 'edit') {
+				editBuffer.markSaved(savedCode);
+			} else if (viewMode === 'code') {
+				codeBuffer.markSaved(savedCode);
+			}
+		},
+		[codeBuffer, editBuffer, viewMode],
+	);
 	useTrackViewDuration({
 		assetType: 'story',
 		chatId,
@@ -138,18 +157,58 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		versionNumber: storedVersionNumber > 0 ? storedVersionNumber : undefined,
 	});
 
-	const { handleSave, handleRestore, isSaving } = useStoryViewerVersionActions({
+	const { handleSave, saveCurrentVersion, handleRestore, isSaving } = useStoryViewerVersionActions({
 		chatId,
 		storySlug: resolvedStorySlug,
-		storyTitle: storedTitle,
-		currentVersionCode: currentVersion?.code,
+		storyTitle,
+		currentVersionCode: currentVersion?.code ?? storyCode,
 		isViewingLatest,
 		goToLatestVersion,
 		tiptapEditorRef,
 		codeViewRef,
-		getEditModeCode,
+		getEditModeCode: editBuffer.getCode,
 		viewMode,
 		setViewMode,
+		onVersionSaved: handleVersionSaved,
+	});
+	const isDirty = viewMode === 'edit' ? editBuffer.isDirty : viewMode === 'code' && isCodeDirty;
+	const discardChanges = useCallback(() => {
+		if (viewMode === 'edit') {
+			editBuffer.discard();
+		} else {
+			codeBuffer.discard();
+		}
+	}, [codeBuffer, editBuffer, viewMode]);
+	const exitGuard = useStoryExitGuard({
+		isDirty,
+		canSave: viewMode !== 'code' || isCodeValid,
+		save: saveCurrentVersion,
+		discard: discardChanges,
+	});
+	const transitions = useStoryEditTransitions({
+		viewMode,
+		setViewMode,
+		isEditDirty: editBuffer.isDirty,
+		isCodeDirty,
+		isSaving,
+		save: saveCurrentVersion,
+		requestExit: exitGuard.requestExit,
+	});
+	useEffect(() => registerBeforeChange(exitGuard.requestExit), [exitGuard.requestExit, registerBeforeChange]);
+	const handleBeforeAgentSend = useCallback(async () => {
+		if (!isDirty) {
+			return true;
+		}
+		if (viewMode === 'code' && !isCodeValid) {
+			return false;
+		}
+		const result = await saveCurrentVersion();
+		return result === 'saved' || result === 'unchanged';
+	}, [isCodeValid, isDirty, saveCurrentVersion, viewMode]);
+	useRegisterStoryBeforeAgentSend({
+		chatId,
+		enabled: !isReadonlyMode && isSidePanelVisible && currentStorySlug === resolvedStorySlug,
+		guard: handleBeforeAgentSend,
 	});
 	const { isShareDialogOpen, setIsShareDialogOpen, isShared } = useStoryViewerSharing({
 		chatId,
@@ -180,10 +239,14 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		[chatId, readonlyProp],
 	);
 	const { switchStory } = useStoryViewerSwitchStory({ renderStoryViewer });
+	const handlePreviousVersion = useCallback(
+		() => exitGuard.requestExit(goToPreviousVersion),
+		[exitGuard, goToPreviousVersion],
+	);
+	const handleNextVersion = useCallback(() => exitGuard.requestExit(goToNextVersion), [exitGuard, goToNextVersion]);
 
 	useEffect(() => {
 		if (viewMode !== 'code') {
-			setIsCodeDirty(false);
 			setIsCodeValid(true);
 		}
 	}, [viewMode]);
@@ -226,6 +289,18 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 		);
 	}
 
+	const editCode = selectStoryEditorCode({
+		persistedCode: storyCode,
+		bufferCode: editBuffer.getCode(),
+		isDirty: editBuffer.isDirty,
+		isSaving,
+	});
+	const codeDraft = selectStoryEditorCode({
+		persistedCode: storyCode,
+		bufferCode: codeBuffer.getCode(),
+		isDirty: codeBuffer.isDirty,
+		isSaving,
+	});
 	const content = (
 		<div className='flex h-full flex-col'>
 			<StoryHeader
@@ -238,15 +313,16 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 				allStories={allStories}
 				onSwitchStory={switchStory}
 				viewMode={viewMode}
-				onViewModeChange={setViewMode}
+				onViewModeChange={transitions.requestViewMode}
 				currentVersion={currentVersionNumber}
 				totalVersions={versions.length}
 				versionNumber={currentVersion?.version}
-				onPreviousVersion={goToPreviousVersion}
-				onNextVersion={goToNextVersion}
+				onPreviousVersion={handlePreviousVersion}
+				onNextVersion={handleNextVersion}
 				isViewingLatest={isViewingLatest}
 				onRestore={handleRestore}
 				onSave={handleSave}
+				onCancel={transitions.requestCancel}
 				onShare={handleOpenShare}
 				onOpenAnalytics={handleOpenAnalytics}
 				onEnlarge={handleEnlarge}
@@ -310,23 +386,29 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 						<StoryEmbedDataProvider value={versionQueryData}>
 							{isTabbedStory ? (
 								<StoryTabbedEditor
-									code={storyCode}
+									code={editCode}
 									editorRef={tiptapEditorRef}
 									onSave={handleSave}
+									onChange={editBuffer.handleCodeChange}
 									getCodeRef={tabbedEditCodeRef}
 									barContentClassName='px-6'
 									contentClassName='p-6'
 								/>
 							) : (
-								<StoryEditor code={storyCode} editorRef={tiptapEditorRef} onSave={handleSave} />
+								<StoryEditor
+									code={editCode}
+									editorRef={tiptapEditorRef}
+									onSave={handleSave}
+									onChange={editBuffer.handleCodeChange}
+								/>
 							)}
 						</StoryEmbedDataProvider>
 					) : (
 						<StoryCodeView
-							code={storyCode}
+							code={codeDraft}
 							readOnly={isReadonlyMode}
 							codeRef={codeViewRef}
-							onDirtyChange={setIsCodeDirty}
+							onCodeChange={codeBuffer.handleCodeChange}
 							onValidChange={setIsCodeValid}
 							onSave={handleSave}
 						/>
@@ -359,6 +441,7 @@ export function StoryViewer({ chatId, storySlug, isReadonlyMode: readonlyProp, i
 				isUpdating={isLiveUpdating}
 				onSaveSettings={handleSaveSettings}
 			/>
+			<StoryUnsavedChangesDialog {...exitGuard.dialogProps} />
 		</div>
 	);
 

--- a/apps/frontend/src/components/story-page-body.tsx
+++ b/apps/frontend/src/components/story-page-body.tsx
@@ -8,57 +8,77 @@ import { useDragAutoScroll } from '@/hooks/use-drag-auto-scroll';
 import { StoryCodeView } from '@/components/side-panel/story-code-view';
 import { StoryEditor } from '@/components/side-panel/story-editor';
 import { StoryTabbedEditor } from '@/components/side-panel/story-tabbed-editor';
+import { StoryUnsavedChangesDialog } from '@/components/story-unsaved-changes-dialog';
 import { StoryEmbedDataProvider } from '@/contexts/story-embed-data';
 
 interface StoryPageBodyProps {
-	code: string;
 	editor: ReturnType<typeof useStoryPageEditor>;
 	preview: ReactNode;
 	queryData?: QueryDataMap | null;
 }
 
-export function StoryPageBody({ code, editor, preview, queryData }: StoryPageBodyProps) {
+export function StoryPageBody({ editor, preview, queryData }: StoryPageBodyProps) {
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 	useDragAutoScroll(scrollContainerRef);
+	const unsavedChangesDialog = <StoryUnsavedChangesDialog {...editor.exitDialog} />;
 
 	if (editor.viewMode === 'edit') {
-		const tabs = parseStoryTabs(code);
+		const editCode = editor.editCode;
+		const tabs = parseStoryTabs(editCode);
 		const isTabbed = Boolean(tabs?.length);
 		return (
-			<StoryEmbedDataProvider value={queryData ?? null}>
-				<div ref={scrollContainerRef} className='flex-1 min-h-0 overflow-auto'>
-					{isTabbed ? (
-						<StoryTabbedEditor
-							code={code}
-							editorRef={editor.tiptapEditorRef}
-							onSave={editor.handleSave}
-							getCodeRef={editor.tabbedEditCodeRef}
-							barContentClassName='mx-auto w-full max-w-5xl px-4 md:px-8'
-							contentClassName='max-w-5xl mx-auto p-4 md:p-8'
-						/>
-					) : (
-						<div className='max-w-5xl mx-auto p-4 md:p-8'>
-							<StoryEditor code={code} editorRef={editor.tiptapEditorRef} onSave={editor.handleSave} />
-						</div>
-					)}
-				</div>
-			</StoryEmbedDataProvider>
+			<>
+				<StoryEmbedDataProvider value={queryData ?? null}>
+					<div ref={scrollContainerRef} className='flex-1 min-h-0 overflow-auto'>
+						{isTabbed ? (
+							<StoryTabbedEditor
+								code={editCode}
+								editorRef={editor.tiptapEditorRef}
+								onSave={editor.handleSave}
+								onChange={editor.onEditCodeChange}
+								getCodeRef={editor.tabbedEditCodeRef}
+								barContentClassName='mx-auto w-full max-w-5xl px-4 md:px-8'
+								contentClassName='max-w-5xl mx-auto p-4 md:p-8'
+							/>
+						) : (
+							<div className='max-w-5xl mx-auto p-4 md:p-8'>
+								<StoryEditor
+									code={editCode}
+									editorRef={editor.tiptapEditorRef}
+									onSave={editor.handleSave}
+									onChange={editor.onEditCodeChange}
+								/>
+							</div>
+						)}
+					</div>
+				</StoryEmbedDataProvider>
+				{unsavedChangesDialog}
+			</>
 		);
 	}
 
 	if (editor.viewMode === 'code') {
+		const codeDraft = editor.codeDraft;
 		return (
-			<div className='flex-1 min-h-0'>
-				<StoryCodeView
-					code={code}
-					codeRef={editor.codeViewRef}
-					onDirtyChange={editor.setIsCodeDirty}
-					onValidChange={editor.setIsCodeValid}
-					onSave={editor.handleSave}
-				/>
-			</div>
+			<>
+				<div className='flex-1 min-h-0'>
+					<StoryCodeView
+						code={codeDraft}
+						codeRef={editor.codeViewRef}
+						onCodeChange={editor.onCodeChange}
+						onValidChange={editor.setIsCodeValid}
+						onSave={editor.handleSave}
+					/>
+				</div>
+				{unsavedChangesDialog}
+			</>
 		);
 	}
 
-	return <>{preview}</>;
+	return (
+		<>
+			{preview}
+			{unsavedChangesDialog}
+		</>
+	);
 }

--- a/apps/frontend/src/components/story-page-header.tsx
+++ b/apps/frontend/src/components/story-page-header.tsx
@@ -68,6 +68,8 @@ interface ViewModeControls {
 	isCodeDirty?: boolean;
 	isCodeValid?: boolean;
 	onSave?: () => void;
+	onCancel?: () => void;
+	isSaving?: boolean;
 }
 
 interface VersionControls {
@@ -231,7 +233,7 @@ function VersionNav({ controls }: { controls: VersionControls }) {
 }
 
 function ViewModeToggle({ controls }: { controls: ViewModeControls }) {
-	const { viewMode, onViewModeChange, canEdit = false, isAgentRunning = false } = controls;
+	const { viewMode, onViewModeChange, canEdit = false, isAgentRunning = false, isSaving = false } = controls;
 
 	return (
 		<div className='flex items-center gap-1.5 rounded-full border p-0.5'>
@@ -240,6 +242,7 @@ function ViewModeToggle({ controls }: { controls: ViewModeControls }) {
 				size='icon-xs'
 				className={cn(viewMode === 'preview' && 'bg-accent rounded-full', 'hover:rounded-full')}
 				onClick={() => onViewModeChange('preview')}
+				disabled={isSaving}
 				aria-label='Preview'
 			>
 				<Eye className='size-3' strokeWidth={2.25} />
@@ -250,7 +253,7 @@ function ViewModeToggle({ controls }: { controls: ViewModeControls }) {
 					size='icon-xs'
 					className={cn(viewMode === 'edit' && 'bg-accent rounded-full', 'hover:rounded-full')}
 					onClick={() => onViewModeChange('edit')}
-					disabled={isAgentRunning}
+					disabled={isAgentRunning || isSaving}
 					aria-label='Edit'
 				>
 					<Pencil className='size-3' strokeWidth={2.25} />
@@ -261,6 +264,7 @@ function ViewModeToggle({ controls }: { controls: ViewModeControls }) {
 				size='icon-xs'
 				className={cn(viewMode === 'code' && 'bg-accent rounded-full', 'hover:rounded-full')}
 				onClick={() => onViewModeChange('code')}
+				disabled={isSaving}
 				aria-label='Code'
 			>
 				<Code className='size-3' strokeWidth={2.25} />
@@ -281,7 +285,7 @@ function StorySubHeader({
 	const isEditing = viewMode === 'edit' || (viewMode === 'code' && isCodeDirty);
 
 	if (viewModeControls && isEditing) {
-		const { onViewModeChange, isCodeValid = true, onSave } = viewModeControls;
+		const { onViewModeChange, onCancel, isCodeValid = true, onSave, isSaving = false } = viewModeControls;
 		const isEditingCode = viewMode === 'code' && isCodeDirty;
 		return (
 			<div className='flex items-center justify-between border-b bg-muted/40 px-4 py-2 md:px-6'>
@@ -289,14 +293,20 @@ function StorySubHeader({
 					{viewMode === 'edit' ? 'Editing' : isCodeValid ? 'Editing code' : 'Fix validation errors to save'}
 				</span>
 				<div className='flex items-center gap-2'>
-					<Button variant='outline' size='sm' onClick={() => onViewModeChange('preview')}>
+					<Button
+						variant='outline'
+						size='sm'
+						onClick={onCancel ?? (() => onViewModeChange('preview'))}
+						disabled={isSaving}
+					>
 						Cancel
 					</Button>
 					<Button
 						variant='primary-gradient'
 						size='sm'
 						onClick={onSave}
-						disabled={isEditingCode && !isCodeValid}
+						disabled={isSaving || (isEditingCode && !isCodeValid)}
+						isLoading={isSaving}
 						className='gap-1.5'
 					>
 						<Save className='size-3' strokeWidth={2.25} />

--- a/apps/frontend/src/components/story-unsaved-changes-dialog.tsx
+++ b/apps/frontend/src/components/story-unsaved-changes-dialog.tsx
@@ -1,0 +1,70 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+export interface StoryUnsavedChangesDialogProps {
+	open: boolean;
+	canSave: boolean;
+	isSaving: boolean;
+	saveFailed: boolean;
+	onKeepEditing: () => void;
+	onSaveAndContinue: () => void;
+	onLeaveWithoutSaving: () => void;
+}
+
+export function StoryUnsavedChangesDialog({
+	open,
+	canSave,
+	isSaving,
+	saveFailed,
+	onKeepEditing,
+	onSaveAndContinue,
+	onLeaveWithoutSaving,
+}: StoryUnsavedChangesDialogProps) {
+	return (
+		<AlertDialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen && !isSaving) {
+					onKeepEditing();
+				}
+			}}
+		>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Save Story changes?</AlertDialogTitle>
+					<AlertDialogDescription>
+						You have unsaved changes. Save them before continuing, or leave without saving.
+					</AlertDialogDescription>
+					{saveFailed && (
+						<p className='text-sm text-destructive'>Could not save your changes. Please try again.</p>
+					)}
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={isSaving}>Keep editing</AlertDialogCancel>
+					<AlertDialogAction
+						variant='destructive'
+						disabled={isSaving}
+						onClick={(event) => {
+							event.preventDefault();
+							onLeaveWithoutSaving();
+						}}
+					>
+						Leave without saving
+					</AlertDialogAction>
+					<Button onClick={onSaveAndContinue} disabled={!canSave || isSaving} isLoading={isSaving}>
+						Save and continue
+					</Button>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/frontend/src/contexts/side-panel.test.tsx
+++ b/apps/frontend/src/contexts/side-panel.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useEffect } from 'react';
+import { SidePanelProvider, useSidePanel } from './side-panel';
+
+function GuardedStoryOpen({ guard, storySlug }: { guard: (continueChange: () => void) => void; storySlug: string }) {
+	const sidePanel = useSidePanel();
+	useEffect(() => sidePanel.registerBeforeChange(guard), [guard, sidePanel]);
+	return <button onClick={() => sidePanel.open(<div />, storySlug)}>Open Story</button>;
+}
+
+describe('SidePanelProvider', () => {
+	afterEach(cleanup);
+
+	it.each([
+		['switching Stories', 'story-b'],
+		['reopening the same Story', 'story-a'],
+	])('guards %s initiated outside the open Story', (_label, storySlug) => {
+		let continueChange: () => void = () => {};
+		const guard = vi.fn((continuation: () => void) => {
+			continueChange = continuation;
+		});
+		const open = vi.fn();
+
+		render(
+			<SidePanelProvider
+				isVisible
+				currentStorySlug='story-a'
+				setCurrentStorySlug={vi.fn()}
+				currentStoryTabIndex={0}
+				setCurrentStoryTabIndex={vi.fn()}
+				chatId='chat-1'
+				open={open}
+				close={vi.fn()}
+			>
+				<GuardedStoryOpen guard={guard} storySlug={storySlug} />
+			</SidePanelProvider>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Open Story' }));
+		expect(guard).toHaveBeenCalledOnce();
+		expect(open).not.toHaveBeenCalled();
+
+		continueChange();
+		expect(open).toHaveBeenCalledWith(expect.anything(), storySlug);
+	});
+});

--- a/apps/frontend/src/contexts/side-panel.tsx
+++ b/apps/frontend/src/contexts/side-panel.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef } from 'react';
 
 type ShareType = 'chat' | 'story';
 
@@ -14,6 +14,7 @@ interface SidePanelContext {
 	isReadonlyMode: boolean;
 	open: (content: React.ReactNode, storySlug?: string) => void;
 	close: () => void;
+	registerBeforeChange: (guard: (continueChange: () => void) => void) => () => void;
 }
 
 const SidePanelContext = createContext<SidePanelContext | null>(null);
@@ -30,6 +31,7 @@ const noopSidePanel: SidePanelContext = {
 	isReadonlyMode: false,
 	open: () => {},
 	close: () => {},
+	registerBeforeChange: () => () => {},
 };
 
 export const useSidePanel = () => {
@@ -63,6 +65,32 @@ export const SidePanelProvider = ({
 	open: (content: React.ReactNode, storySlug?: string) => void;
 	close: () => void;
 }) => {
+	const beforeChangeRef = useRef<((continueChange: () => void) => void) | null>(null);
+	const registerBeforeChange = useCallback((guard: (continueChange: () => void) => void) => {
+		beforeChangeRef.current = guard;
+		return () => {
+			if (beforeChangeRef.current === guard) {
+				beforeChangeRef.current = null;
+			}
+		};
+	}, []);
+	const guardedOpen = useCallback(
+		(content: React.ReactNode, storySlug?: string) => {
+			if (isVisible && currentStorySlug && beforeChangeRef.current) {
+				beforeChangeRef.current(() => open(content, storySlug));
+				return;
+			}
+			open(content, storySlug);
+		},
+		[currentStorySlug, isVisible, open],
+	);
+	const guardedClose = useCallback(() => {
+		if (isVisible && currentStorySlug && beforeChangeRef.current) {
+			beforeChangeRef.current(close);
+			return;
+		}
+		close();
+	}, [close, currentStorySlug, isVisible]);
 	const value = useMemo(
 		() => ({
 			isVisible,
@@ -74,8 +102,9 @@ export const SidePanelProvider = ({
 			shareId,
 			shareType,
 			isReadonlyMode,
-			open,
-			close,
+			open: guardedOpen,
+			close: guardedClose,
+			registerBeforeChange,
 		}),
 		[
 			isVisible,
@@ -87,8 +116,9 @@ export const SidePanelProvider = ({
 			shareId,
 			shareType,
 			isReadonlyMode,
-			open,
-			close,
+			guardedOpen,
+			guardedClose,
+			registerBeforeChange,
 		],
 	);
 	return <SidePanelContext.Provider value={value}>{children}</SidePanelContext.Provider>;

--- a/apps/frontend/src/contexts/story-before-agent-send.test.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.test.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+	runWithStoryBeforeAgentSend,
 	StoryBeforeAgentSendProvider,
 	useRegisterStoryBeforeAgentSend,
 	useStoryBeforeAgentSend,
@@ -16,13 +17,10 @@ function SendHarness({ guard, send }: { guard: () => Promise<BeforeAgentSendResu
 	return (
 		<button
 			onClick={async () => {
-				const result = await beforeAgentSend.run('chat-1');
-				if (!result.canSend) {
-					return;
-				}
-				const sendPromise = send();
-				result.afterSend?.();
-				await sendPromise;
+				await runWithStoryBeforeAgentSend({
+					beforeSend: () => beforeAgentSend.run('chat-1'),
+					send,
+				});
 			}}
 		>
 			Send
@@ -131,5 +129,46 @@ describe('StoryBeforeAgentSendProvider', () => {
 		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 		await waitFor(() => expect(send).toHaveBeenCalledOnce());
 		expect(preview).not.toHaveBeenCalled();
+	});
+});
+
+describe('runWithStoryBeforeAgentSend', () => {
+	it('invokes an allowed queued send once before afterSend', async () => {
+		const events: string[] = [];
+		let finishSend = () => {};
+		const submitQueuedMessageNow = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					events.push('send invoked');
+					finishSend = resolve;
+				}),
+		);
+		const promise = runWithStoryBeforeAgentSend({
+			beforeSend: async () => ({
+				canSend: true,
+				afterSend: () => events.push('after send'),
+			}),
+			send: () => submitQueuedMessageNow(),
+		});
+
+		await waitFor(() => expect(events).toEqual(['send invoked', 'after send']));
+		expect(submitQueuedMessageNow).toHaveBeenCalledOnce();
+
+		finishSend();
+		await promise;
+	});
+
+	it('does not invoke a blocked queued send or afterSend', async () => {
+		const afterSend = vi.fn();
+		const submitQueuedMessageNow = vi.fn(async () => {});
+
+		const sent = await runWithStoryBeforeAgentSend({
+			beforeSend: async () => ({ canSend: false, afterSend }),
+			send: submitQueuedMessageNow,
+		});
+
+		expect(sent).toBe(false);
+		expect(submitQueuedMessageNow).not.toHaveBeenCalled();
+		expect(afterSend).not.toHaveBeenCalled();
 	});
 });

--- a/apps/frontend/src/contexts/story-before-agent-send.test.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	StoryBeforeAgentSendProvider,
+	useRegisterStoryBeforeAgentSend,
+	useStoryBeforeAgentSend,
+} from './story-before-agent-send';
+
+function SendHarness({ guard, send }: { guard: () => Promise<boolean>; send: () => void }) {
+	const beforeAgentSend = useStoryBeforeAgentSend();
+	useRegisterStoryBeforeAgentSend({ chatId: 'chat-1', enabled: true, guard });
+
+	return (
+		<button
+			onClick={async () => {
+				if (await beforeAgentSend.run('chat-1')) {
+					send();
+				}
+			}}
+		>
+			Send
+		</button>
+	);
+}
+
+describe('StoryBeforeAgentSendProvider', () => {
+	afterEach(cleanup);
+
+	it('awaits the active Story save before sending', async () => {
+		let finishSave: (saved: boolean) => void = () => {};
+		const guard = vi.fn(
+			() =>
+				new Promise<boolean>((resolve) => {
+					finishSave = resolve;
+				}),
+		);
+		const send = vi.fn();
+		render(
+			<StoryBeforeAgentSendProvider>
+				<SendHarness guard={guard} send={send} />
+			</StoryBeforeAgentSendProvider>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+		expect(guard).toHaveBeenCalledOnce();
+		expect(send).not.toHaveBeenCalled();
+
+		finishSave(true);
+		await waitFor(() => expect(send).toHaveBeenCalledOnce());
+	});
+
+	it('does not send when the Story save fails', async () => {
+		const guard = vi.fn(async () => false);
+		const send = vi.fn();
+		render(
+			<StoryBeforeAgentSendProvider>
+				<SendHarness guard={guard} send={send} />
+			</StoryBeforeAgentSendProvider>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+		await waitFor(() => expect(guard).toHaveBeenCalledOnce());
+		expect(send).not.toHaveBeenCalled();
+	});
+});

--- a/apps/frontend/src/contexts/story-before-agent-send.test.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.test.tsx
@@ -7,17 +7,22 @@ import {
 	useRegisterStoryBeforeAgentSend,
 	useStoryBeforeAgentSend,
 } from './story-before-agent-send';
+import type { BeforeAgentSendResult } from './story-before-agent-send';
 
-function SendHarness({ guard, send }: { guard: () => Promise<boolean>; send: () => void }) {
+function SendHarness({ guard, send }: { guard: () => Promise<BeforeAgentSendResult>; send: () => Promise<void> }) {
 	const beforeAgentSend = useStoryBeforeAgentSend();
 	useRegisterStoryBeforeAgentSend({ chatId: 'chat-1', enabled: true, guard });
 
 	return (
 		<button
 			onClick={async () => {
-				if (await beforeAgentSend.run('chat-1')) {
-					send();
+				const result = await beforeAgentSend.run('chat-1');
+				if (!result.canSend) {
+					return;
 				}
+				const sendPromise = send();
+				result.afterSend?.();
+				await sendPromise;
 			}}
 		>
 			Send
@@ -28,15 +33,35 @@ function SendHarness({ guard, send }: { guard: () => Promise<boolean>; send: () 
 describe('StoryBeforeAgentSendProvider', () => {
 	afterEach(cleanup);
 
-	it('awaits the active Story save before sending', async () => {
-		let finishSave: (saved: boolean) => void = () => {};
-		const guard = vi.fn(
+	it('awaits a successful dirty Story save before continuing the send', async () => {
+		const events: string[] = [];
+		let finishSave = () => {};
+		let finishSend = () => {};
+		const save = vi.fn(
 			() =>
-				new Promise<boolean>((resolve) => {
-					finishSave = resolve;
+				new Promise<void>((resolve) => {
+					finishSave = () => resolve();
 				}),
 		);
-		const send = vi.fn();
+		const guard = vi.fn(async () => {
+			events.push('save started');
+			await save();
+			events.push('save finished');
+			return {
+				canSend: true,
+				afterSend: () => events.push('preview'),
+			};
+		});
+		const send = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					events.push('send invoked');
+					finishSend = () => {
+						events.push('send finished');
+						resolve();
+					};
+				}),
+		);
 		render(
 			<StoryBeforeAgentSendProvider>
 				<SendHarness guard={guard} send={send} />
@@ -45,15 +70,42 @@ describe('StoryBeforeAgentSendProvider', () => {
 
 		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 		expect(guard).toHaveBeenCalledOnce();
+		expect(save).toHaveBeenCalledOnce();
 		expect(send).not.toHaveBeenCalled();
+		expect(events).toEqual(['save started']);
 
-		finishSave(true);
-		await waitFor(() => expect(send).toHaveBeenCalledOnce());
+		finishSave();
+		await waitFor(() => expect(events).toEqual(['save started', 'save finished', 'send invoked', 'preview']));
+		expect(send).toHaveBeenCalledOnce();
+
+		finishSend();
+		await waitFor(() =>
+			expect(events).toEqual(['save started', 'save finished', 'send invoked', 'preview', 'send finished']),
+		);
 	});
 
 	it('does not send when the Story save fails', async () => {
-		const guard = vi.fn(async () => false);
-		const send = vi.fn();
+		const save = vi.fn(async (): Promise<'saved' | 'failed'> => 'failed');
+		const preview = vi.fn();
+		const guard = vi.fn(async () => ({ canSend: (await save()) === 'saved', afterSend: preview }));
+		const send = vi.fn(async () => {});
+		render(
+			<StoryBeforeAgentSendProvider>
+				<SendHarness guard={guard} send={send} />
+			</StoryBeforeAgentSendProvider>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+		await waitFor(() => expect(guard).toHaveBeenCalledOnce());
+		expect(save).toHaveBeenCalledOnce();
+		expect(send).not.toHaveBeenCalled();
+		expect(preview).not.toHaveBeenCalled();
+	});
+
+	it('does not send or change modes when the Story code is invalid', async () => {
+		const preview = vi.fn();
+		const guard = vi.fn(async () => ({ canSend: false, afterSend: preview }));
+		const send = vi.fn(async () => {});
 		render(
 			<StoryBeforeAgentSendProvider>
 				<SendHarness guard={guard} send={send} />
@@ -63,5 +115,21 @@ describe('StoryBeforeAgentSendProvider', () => {
 		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
 		await waitFor(() => expect(guard).toHaveBeenCalledOnce());
 		expect(send).not.toHaveBeenCalled();
+		expect(preview).not.toHaveBeenCalled();
+	});
+
+	it('sends normally without changing modes when the Story is clean', async () => {
+		const preview = vi.fn();
+		const guard = vi.fn(async () => ({ canSend: true }));
+		const send = vi.fn(async () => {});
+		render(
+			<StoryBeforeAgentSendProvider>
+				<SendHarness guard={guard} send={send} />
+			</StoryBeforeAgentSendProvider>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+		await waitFor(() => expect(send).toHaveBeenCalledOnce());
+		expect(preview).not.toHaveBeenCalled();
 	});
 });

--- a/apps/frontend/src/contexts/story-before-agent-send.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.tsx
@@ -1,0 +1,72 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+
+type BeforeAgentSendGuard = () => Promise<boolean>;
+
+interface RegisteredGuard {
+	chatId: string;
+	guard: BeforeAgentSendGuard;
+}
+
+interface StoryBeforeAgentSendContextValue {
+	run: (chatId: string) => Promise<boolean>;
+	register: (registration: RegisteredGuard) => () => void;
+}
+
+const StoryBeforeAgentSendContext = createContext<StoryBeforeAgentSendContextValue | null>(null);
+
+export function StoryBeforeAgentSendProvider({ children }: { children: React.ReactNode }) {
+	const guardRef = useRef<RegisteredGuard | null>(null);
+
+	const register = useCallback((registration: RegisteredGuard) => {
+		guardRef.current = registration;
+		return () => {
+			if (guardRef.current === registration) {
+				guardRef.current = null;
+			}
+		};
+	}, []);
+
+	const run = useCallback(async (chatId: string) => {
+		const registration = guardRef.current;
+		if (!registration || registration.chatId !== chatId) {
+			return true;
+		}
+		return registration.guard();
+	}, []);
+
+	const value = useMemo(() => ({ run, register }), [register, run]);
+
+	return <StoryBeforeAgentSendContext.Provider value={value}>{children}</StoryBeforeAgentSendContext.Provider>;
+}
+
+export function useStoryBeforeAgentSend() {
+	const context = useContext(StoryBeforeAgentSendContext);
+	if (!context) {
+		return { run: async () => true };
+	}
+	return context;
+}
+
+export function useRegisterStoryBeforeAgentSend({
+	chatId,
+	enabled,
+	guard,
+}: {
+	chatId: string;
+	enabled: boolean;
+	guard: BeforeAgentSendGuard;
+}) {
+	const context = useContext(StoryBeforeAgentSendContext);
+	const guardRef = useRef(guard);
+	guardRef.current = guard;
+
+	useEffect(() => {
+		if (!context || !enabled) {
+			return;
+		}
+		return context.register({
+			chatId,
+			guard: () => guardRef.current(),
+		});
+	}, [chatId, context, enabled]);
+}

--- a/apps/frontend/src/contexts/story-before-agent-send.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.tsx
@@ -1,6 +1,11 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 
-type BeforeAgentSendGuard = () => Promise<boolean>;
+export interface BeforeAgentSendResult {
+	canSend: boolean;
+	afterSend?: () => void;
+}
+
+type BeforeAgentSendGuard = () => Promise<BeforeAgentSendResult>;
 
 interface RegisteredGuard {
 	chatId: string;
@@ -8,7 +13,7 @@ interface RegisteredGuard {
 }
 
 interface StoryBeforeAgentSendContextValue {
-	run: (chatId: string) => Promise<boolean>;
+	run: (chatId: string) => Promise<BeforeAgentSendResult>;
 	register: (registration: RegisteredGuard) => () => void;
 }
 
@@ -29,7 +34,7 @@ export function StoryBeforeAgentSendProvider({ children }: { children: React.Rea
 	const run = useCallback(async (chatId: string) => {
 		const registration = guardRef.current;
 		if (!registration || registration.chatId !== chatId) {
-			return true;
+			return { canSend: true };
 		}
 		return registration.guard();
 	}, []);
@@ -39,10 +44,10 @@ export function StoryBeforeAgentSendProvider({ children }: { children: React.Rea
 	return <StoryBeforeAgentSendContext.Provider value={value}>{children}</StoryBeforeAgentSendContext.Provider>;
 }
 
-export function useStoryBeforeAgentSend() {
+export function useStoryBeforeAgentSend(): Pick<StoryBeforeAgentSendContextValue, 'run'> {
 	const context = useContext(StoryBeforeAgentSendContext);
 	if (!context) {
-		return { run: async () => true };
+		return { run: async () => ({ canSend: true }) };
 	}
 	return context;
 }

--- a/apps/frontend/src/contexts/story-before-agent-send.tsx
+++ b/apps/frontend/src/contexts/story-before-agent-send.tsx
@@ -7,6 +7,24 @@ export interface BeforeAgentSendResult {
 
 type BeforeAgentSendGuard = () => Promise<BeforeAgentSendResult>;
 
+export async function runWithStoryBeforeAgentSend({
+	beforeSend,
+	send,
+}: {
+	beforeSend: BeforeAgentSendGuard;
+	send: () => Promise<void>;
+}): Promise<boolean> {
+	const result = await beforeSend();
+	if (!result.canSend) {
+		return false;
+	}
+
+	const sendPromise = send();
+	result.afterSend?.();
+	await sendPromise;
+	return true;
+}
+
 interface RegisteredGuard {
 	chatId: string;
 	guard: BeforeAgentSendGuard;

--- a/apps/frontend/src/hooks/use-story-edit-buffer.ts
+++ b/apps/frontend/src/hooks/use-story-edit-buffer.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function isStoryCodeDirty(baselineCode: string, currentCode: string) {
+	return baselineCode !== currentCode;
+}
+
+export function selectStoryEditorCode({
+	persistedCode,
+	bufferCode,
+	isDirty,
+	isSaving,
+}: {
+	persistedCode: string;
+	bufferCode: string;
+	isDirty: boolean;
+	isSaving: boolean;
+}) {
+	return isDirty || isSaving ? bufferCode : persistedCode;
+}
+
+export function useStoryEditBuffer(baselineCode: string) {
+	const baselineCodeRef = useRef(baselineCode);
+	const currentCodeRef = useRef(baselineCode);
+	const isDirtyRef = useRef(false);
+	const [isDirty, setIsDirty] = useState(false);
+
+	const updateDirty = useCallback((dirty: boolean) => {
+		isDirtyRef.current = dirty;
+		setIsDirty(dirty);
+	}, []);
+
+	useEffect(() => {
+		baselineCodeRef.current = baselineCode;
+		if (!isDirtyRef.current) {
+			currentCodeRef.current = baselineCode;
+		}
+		updateDirty(isStoryCodeDirty(baselineCode, currentCodeRef.current));
+	}, [baselineCode, updateDirty]);
+
+	const handleCodeChange = useCallback(
+		(code: string) => {
+			currentCodeRef.current = code;
+			updateDirty(isStoryCodeDirty(baselineCodeRef.current, code));
+		},
+		[updateDirty],
+	);
+
+	const markSaved = useCallback(
+		(code: string) => {
+			baselineCodeRef.current = code;
+			updateDirty(isStoryCodeDirty(code, currentCodeRef.current));
+		},
+		[updateDirty],
+	);
+
+	const discard = useCallback(() => {
+		currentCodeRef.current = baselineCodeRef.current;
+		updateDirty(false);
+	}, [updateDirty]);
+
+	const getCode = useCallback(() => currentCodeRef.current, []);
+
+	return {
+		isDirty,
+		getCode,
+		handleCodeChange,
+		markSaved,
+		discard,
+	};
+}

--- a/apps/frontend/src/hooks/use-story-edit-transitions.ts
+++ b/apps/frontend/src/hooks/use-story-edit-transitions.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import type { StoryViewMode } from '@/components/side-panel/story-viewer.types';
+import type { StorySaveResult } from '@/lib/story-save';
+
+function didSaveSucceed(result: StorySaveResult) {
+	return result === 'saved' || result === 'unchanged';
+}
+
+export function useStoryEditTransitions({
+	viewMode,
+	setViewMode,
+	isEditDirty,
+	isCodeDirty,
+	isSaving,
+	save,
+	requestExit,
+}: {
+	viewMode: StoryViewMode;
+	setViewMode: (mode: StoryViewMode) => void;
+	isEditDirty: boolean;
+	isCodeDirty: boolean;
+	isSaving: boolean;
+	save: () => Promise<StorySaveResult>;
+	requestExit: (action: () => void) => void;
+}) {
+	const requestViewMode = useCallback(
+		async (targetMode: StoryViewMode) => {
+			if (targetMode === viewMode || isSaving) {
+				return;
+			}
+			if (viewMode === 'edit') {
+				const result = await save();
+				if (didSaveSucceed(result)) {
+					setViewMode(targetMode);
+				}
+				return;
+			}
+			if (viewMode === 'code' && isCodeDirty) {
+				requestExit(() => setViewMode(targetMode));
+				return;
+			}
+			setViewMode(targetMode);
+		},
+		[isCodeDirty, isSaving, requestExit, save, setViewMode, viewMode],
+	);
+
+	const requestCancel = useCallback(() => {
+		const isDirty = viewMode === 'edit' ? isEditDirty : viewMode === 'code' && isCodeDirty;
+		if (!isDirty) {
+			setViewMode('preview');
+			return;
+		}
+		requestExit(() => setViewMode('preview'));
+	}, [isCodeDirty, isEditDirty, requestExit, setViewMode, viewMode]);
+
+	return {
+		requestViewMode,
+		requestCancel,
+	};
+}

--- a/apps/frontend/src/hooks/use-story-edit-transitions.ts
+++ b/apps/frontend/src/hooks/use-story-edit-transitions.ts
@@ -9,16 +9,16 @@ function didSaveSucceed(result: StorySaveResult) {
 export function useStoryEditTransitions({
 	viewMode,
 	setViewMode,
-	isEditDirty,
-	isCodeDirty,
+	isDirty,
+	isCodeValid,
 	isSaving,
 	save,
 	requestExit,
 }: {
 	viewMode: StoryViewMode;
 	setViewMode: (mode: StoryViewMode) => void;
-	isEditDirty: boolean;
-	isCodeDirty: boolean;
+	isDirty: boolean;
+	isCodeValid: boolean;
 	isSaving: boolean;
 	save: () => Promise<StorySaveResult>;
 	requestExit: (action: () => void) => void;
@@ -28,30 +28,40 @@ export function useStoryEditTransitions({
 			if (targetMode === viewMode || isSaving) {
 				return;
 			}
-			if (viewMode === 'edit') {
+
+			const isSwitchingEditors =
+				(viewMode === 'edit' && targetMode === 'code') || (viewMode === 'code' && targetMode === 'edit');
+			if (isSwitchingEditors) {
+				if (viewMode === 'code' && !isCodeValid) {
+					return;
+				}
+				setViewMode(targetMode);
+				return;
+			}
+
+			if ((viewMode === 'edit' || viewMode === 'code') && targetMode === 'preview') {
+				if (viewMode === 'code' && !isCodeValid) {
+					return;
+				}
 				const result = await save();
 				if (didSaveSucceed(result)) {
 					setViewMode(targetMode);
 				}
 				return;
 			}
-			if (viewMode === 'code' && isCodeDirty) {
-				requestExit(() => setViewMode(targetMode));
-				return;
-			}
+
 			setViewMode(targetMode);
 		},
-		[isCodeDirty, isSaving, requestExit, save, setViewMode, viewMode],
+		[isCodeValid, isSaving, save, setViewMode, viewMode],
 	);
 
 	const requestCancel = useCallback(() => {
-		const isDirty = viewMode === 'edit' ? isEditDirty : viewMode === 'code' && isCodeDirty;
 		if (!isDirty) {
 			setViewMode('preview');
 			return;
 		}
 		requestExit(() => setViewMode('preview'));
-	}, [isCodeDirty, isEditDirty, requestExit, setViewMode, viewMode]);
+	}, [isDirty, requestExit, setViewMode]);
 
 	return {
 		requestViewMode,

--- a/apps/frontend/src/hooks/use-story-editing.test.ts
+++ b/apps/frontend/src/hooks/use-story-editing.test.ts
@@ -1,11 +1,20 @@
 // @vitest-environment jsdom
 
-import { renameStoryTab } from '@nao/shared/story-tabs';
+import {
+	addStoryTab,
+	deleteStoryTab,
+	moveStoryTab,
+	renameStoryTab,
+	replaceStoryTabInner,
+} from '@nao/shared/story-tabs';
 import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { selectStoryEditorCode, useStoryEditBuffer } from './use-story-edit-buffer';
 import { useStoryEditTransitions } from './use-story-edit-transitions';
 import { getStoryNavigationBlockerOptions } from './use-story-exit-guard';
+import type { StoryViewMode } from '@/components/side-panel/story-viewer.types';
+import type { StorySaveResult } from '@/lib/story-save';
 
 const tabbedStory = [
 	'<tab title="Overview">',
@@ -58,39 +67,85 @@ describe('Story editing', () => {
 		).toBe('# Saved Story');
 	});
 
-	it('awaits Edit to Preview persistence before changing mode', async () => {
-		let finishSave: (result: 'saved') => void = () => {};
+	it('switches dirty Edit to Code without saving or losing the buffer', async () => {
+		const save = vi.fn(async (): Promise<StorySaveResult> => 'saved');
+		const { result } = renderEditingSession({ initialMode: 'edit', save });
+
+		act(() => result.current.changeCode('# Unsaved visual edit'));
+		await act(() => result.current.requestViewMode('code'));
+
+		expect(save).not.toHaveBeenCalled();
+		expect(result.current.viewMode).toBe('code');
+		expect(result.current.code).toBe('# Unsaved visual edit');
+		expect(result.current.isDirty).toBe(true);
+	});
+
+	it('switches dirty valid Code to Edit without saving or losing the buffer', async () => {
+		const save = vi.fn(async (): Promise<StorySaveResult> => 'saved');
+		const { result } = renderEditingSession({ initialMode: 'code', save });
+
+		act(() => result.current.changeCode('# Unsaved code edit'));
+		await act(() => result.current.requestViewMode('edit'));
+
+		expect(save).not.toHaveBeenCalled();
+		expect(result.current.viewMode).toBe('edit');
+		expect(result.current.code).toBe('# Unsaved code edit');
+		expect(result.current.isDirty).toBe(true);
+	});
+
+	it('keeps invalid Code active with its buffer intact', async () => {
+		const save = vi.fn(async (): Promise<StorySaveResult> => 'saved');
+		const { result } = renderEditingSession({ initialMode: 'code', isCodeValid: false, save });
+
+		act(() => result.current.changeCode('<invalid>'));
+		await act(() => result.current.requestViewMode('edit'));
+
+		expect(save).not.toHaveBeenCalled();
+		expect(result.current.viewMode).toBe('code');
+		expect(result.current.code).toBe('<invalid>');
+		expect(result.current.isDirty).toBe(true);
+	});
+
+	it.each<StoryViewMode>(['edit', 'code'])('awaits dirty %s persistence before Preview', async (initialMode) => {
+		let finishSave: (result: StorySaveResult) => void = () => {};
 		const save = vi.fn(
 			() =>
-				new Promise<'saved'>((resolve) => {
+				new Promise<StorySaveResult>((resolve) => {
 					finishSave = resolve;
 				}),
 		);
-		const setViewMode = vi.fn();
-		const { result } = renderHook(() =>
-			useStoryEditTransitions({
-				viewMode: 'edit',
-				setViewMode,
-				isEditDirty: true,
-				isCodeDirty: false,
-				isSaving: false,
-				save,
-				requestExit: vi.fn(),
-			}),
-		);
+		const { result } = renderEditingSession({ initialMode, save });
+
+		act(() => result.current.changeCode('# Dirty Story'));
 
 		let transition!: Promise<void>;
 		act(() => {
 			transition = result.current.requestViewMode('preview');
 		});
 		expect(save).toHaveBeenCalledOnce();
-		expect(setViewMode).not.toHaveBeenCalled();
+		expect(result.current.viewMode).toBe(initialMode);
 
 		await act(async () => {
 			finishSave('saved');
 			await transition;
 		});
-		expect(setViewMode).toHaveBeenCalledWith('preview');
+		expect(result.current.viewMode).toBe('preview');
+	});
+
+	it('keeps complete tabbed Story operations across Edit and Code', async () => {
+		const contentEditedStory = replaceStoryTabInner(tabbedStory, 0, '# Updated overview');
+		const addedStory = addStoryTab(contentEditedStory);
+		const renamedStory = renameStoryTab(addedStory, 2, 'Forecast');
+		const reorderedStory = moveStoryTab(renamedStory, 2, 0);
+		const changedStory = deleteStoryTab(reorderedStory, 2);
+		const { result } = renderEditingSession({ initialMode: 'edit', initialCode: tabbedStory });
+
+		act(() => result.current.changeCode(changedStory));
+		await act(() => result.current.requestViewMode('code'));
+		await act(() => result.current.requestViewMode('edit'));
+
+		expect(result.current.code).toBe(changedStory);
+		expect(result.current.isDirty).toBe(true);
 	});
 
 	it('only enables route and unload blocking while dirty', () => {
@@ -104,3 +159,38 @@ describe('Story editing', () => {
 		});
 	});
 });
+
+function renderEditingSession({
+	initialMode,
+	initialCode = '# Story',
+	isCodeValid = true,
+	save = async () => 'saved',
+}: {
+	initialMode: StoryViewMode;
+	initialCode?: string;
+	isCodeValid?: boolean;
+	save?: () => Promise<StorySaveResult>;
+}) {
+	const requestExit = vi.fn();
+	return renderHook(() => {
+		const [viewMode, setViewMode] = useState<StoryViewMode>(initialMode);
+		const buffer = useStoryEditBuffer(initialCode);
+		const transitions = useStoryEditTransitions({
+			viewMode,
+			setViewMode,
+			isDirty: buffer.isDirty,
+			isCodeValid,
+			isSaving: false,
+			save,
+			requestExit,
+		});
+
+		return {
+			viewMode,
+			code: buffer.getCode(),
+			isDirty: buffer.isDirty,
+			changeCode: buffer.handleCodeChange,
+			requestViewMode: transitions.requestViewMode,
+		};
+	});
+}

--- a/apps/frontend/src/hooks/use-story-editing.test.ts
+++ b/apps/frontend/src/hooks/use-story-editing.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { renameStoryTab } from '@nao/shared/story-tabs';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { selectStoryEditorCode, useStoryEditBuffer } from './use-story-edit-buffer';
+import { useStoryEditTransitions } from './use-story-edit-transitions';
+import { getStoryNavigationBlockerOptions } from './use-story-exit-guard';
+
+const tabbedStory = [
+	'<tab title="Overview">',
+	'# Overview',
+	'</tab>',
+	'',
+	'<tab title="Details">',
+	'Details',
+	'</tab>',
+].join('\n');
+
+describe('Story editing', () => {
+	it('marks changes in any tab metadata as dirty', () => {
+		const { result } = renderHook(() => useStoryEditBuffer(tabbedStory));
+
+		act(() => result.current.handleCodeChange(renameStoryTab(tabbedStory, 1, 'Revenue')));
+
+		expect(result.current.isDirty).toBe(true);
+	});
+
+	it('keeps newer edits dirty when an earlier save finishes', () => {
+		const { result } = renderHook(() => useStoryEditBuffer('# Story'));
+
+		act(() => {
+			result.current.handleCodeChange('# First edit');
+			result.current.handleCodeChange('# Newer edit');
+			result.current.markSaved('# First edit');
+		});
+
+		expect(result.current.getCode()).toBe('# Newer edit');
+		expect(result.current.isDirty).toBe(true);
+	});
+
+	it('keeps rendering the buffer while a clean save is still finishing', () => {
+		expect(
+			selectStoryEditorCode({
+				persistedCode: '# Old persisted Story',
+				bufferCode: '# Saved Story',
+				isDirty: false,
+				isSaving: true,
+			}),
+		).toBe('# Saved Story');
+		expect(
+			selectStoryEditorCode({
+				persistedCode: '# Saved Story',
+				bufferCode: '# Saved Story',
+				isDirty: false,
+				isSaving: false,
+			}),
+		).toBe('# Saved Story');
+	});
+
+	it('awaits Edit to Preview persistence before changing mode', async () => {
+		let finishSave: (result: 'saved') => void = () => {};
+		const save = vi.fn(
+			() =>
+				new Promise<'saved'>((resolve) => {
+					finishSave = resolve;
+				}),
+		);
+		const setViewMode = vi.fn();
+		const { result } = renderHook(() =>
+			useStoryEditTransitions({
+				viewMode: 'edit',
+				setViewMode,
+				isEditDirty: true,
+				isCodeDirty: false,
+				isSaving: false,
+				save,
+				requestExit: vi.fn(),
+			}),
+		);
+
+		let transition!: Promise<void>;
+		act(() => {
+			transition = result.current.requestViewMode('preview');
+		});
+		expect(save).toHaveBeenCalledOnce();
+		expect(setViewMode).not.toHaveBeenCalled();
+
+		await act(async () => {
+			finishSave('saved');
+			await transition;
+		});
+		expect(setViewMode).toHaveBeenCalledWith('preview');
+	});
+
+	it('only enables route and unload blocking while dirty', () => {
+		expect(getStoryNavigationBlockerOptions(false)).toMatchObject({
+			disabled: true,
+			enableBeforeUnload: false,
+		});
+		expect(getStoryNavigationBlockerOptions(true)).toMatchObject({
+			disabled: false,
+			enableBeforeUnload: true,
+		});
+	});
+});

--- a/apps/frontend/src/hooks/use-story-editing.test.ts
+++ b/apps/frontend/src/hooks/use-story-editing.test.ts
@@ -59,12 +59,12 @@ describe('Story editing', () => {
 		).toBe('# Saved Story');
 		expect(
 			selectStoryEditorCode({
-				persistedCode: '# Saved Story',
-				bufferCode: '# Saved Story',
+				persistedCode: '# Refreshed persisted Story',
+				bufferCode: '# Stale buffer Story',
 				isDirty: false,
 				isSaving: false,
 			}),
-		).toBe('# Saved Story');
+		).toBe('# Refreshed persisted Story');
 	});
 
 	it('switches dirty Edit to Code without saving or losing the buffer', async () => {

--- a/apps/frontend/src/hooks/use-story-exit-guard.ts
+++ b/apps/frontend/src/hooks/use-story-exit-guard.ts
@@ -1,0 +1,96 @@
+import { useBlocker } from '@tanstack/react-router';
+import { useCallback, useState } from 'react';
+import type { StoryUnsavedChangesDialogProps } from '@/components/story-unsaved-changes-dialog';
+import type { StorySaveResult } from '@/lib/story-save';
+
+type ExitAction = () => void;
+
+export function getStoryNavigationBlockerOptions(isDirty: boolean) {
+	return {
+		shouldBlockFn: () => isDirty,
+		enableBeforeUnload: isDirty,
+		disabled: !isDirty,
+		withResolver: true as const,
+	};
+}
+
+export function useStoryExitGuard({
+	isDirty,
+	canSave,
+	save,
+	discard,
+}: {
+	isDirty: boolean;
+	canSave: boolean;
+	save: () => Promise<StorySaveResult>;
+	discard: () => void;
+}) {
+	const [pendingExit, setPendingExit] = useState<ExitAction | null>(null);
+	const [isSavingForExit, setIsSavingForExit] = useState(false);
+	const [saveFailed, setSaveFailed] = useState(false);
+	const navigationBlocker = useBlocker(getStoryNavigationBlockerOptions(isDirty));
+
+	const requestExit = useCallback(
+		(action: ExitAction) => {
+			if (!isDirty) {
+				action();
+				return;
+			}
+			setSaveFailed(false);
+			setPendingExit(() => action);
+		},
+		[isDirty],
+	);
+
+	const clearPendingExit = useCallback(() => {
+		setPendingExit(null);
+		setSaveFailed(false);
+		if (navigationBlocker.status === 'blocked') {
+			navigationBlocker.reset();
+		}
+	}, [navigationBlocker]);
+
+	const continueExit = useCallback(() => {
+		if (navigationBlocker.status === 'blocked') {
+			navigationBlocker.proceed();
+		} else {
+			pendingExit?.();
+		}
+		setPendingExit(null);
+	}, [navigationBlocker, pendingExit]);
+
+	const saveAndContinue = useCallback(async () => {
+		if (!canSave || isSavingForExit) {
+			return;
+		}
+		setIsSavingForExit(true);
+		setSaveFailed(false);
+		const result = await save();
+		setIsSavingForExit(false);
+		if (result === 'failed' || result === 'invalid' || result === 'unavailable') {
+			setSaveFailed(result === 'failed' || result === 'unavailable');
+			return;
+		}
+		continueExit();
+	}, [canSave, continueExit, isSavingForExit, save]);
+
+	const leaveWithoutSaving = useCallback(() => {
+		discard();
+		continueExit();
+	}, [continueExit, discard]);
+
+	const dialogProps: StoryUnsavedChangesDialogProps = {
+		open: pendingExit !== null || navigationBlocker.status === 'blocked',
+		canSave,
+		isSaving: isSavingForExit,
+		saveFailed,
+		onKeepEditing: clearPendingExit,
+		onSaveAndContinue: () => void saveAndContinue(),
+		onLeaveWithoutSaving: leaveWithoutSaving,
+	};
+
+	return {
+		requestExit,
+		dialogProps,
+	};
+}

--- a/apps/frontend/src/hooks/use-story-page-editor.ts
+++ b/apps/frontend/src/hooks/use-story-page-editor.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Editor as TiptapEditor } from '@tiptap/react';
 
 import type { StoryCodeViewHandle } from '@/components/side-panel/story-code-view';
@@ -45,19 +45,8 @@ export function useStoryPageEditor({
 	const codeViewRef = useRef<StoryCodeViewHandle | null>(null);
 	const tabbedEditCodeRef = useRef<(() => string) | null>(null);
 	const [isCodeValid, setIsCodeValid] = useState(true);
-	const editBuffer = useStoryEditBuffer(code);
-	const codeBuffer = useStoryEditBuffer(code);
-	const isCodeDirty = codeBuffer.isDirty;
-	const handleVersionSaved = useCallback(
-		(savedCode: string) => {
-			if (viewMode === 'edit') {
-				editBuffer.markSaved(savedCode);
-			} else if (viewMode === 'code') {
-				codeBuffer.markSaved(savedCode);
-			}
-		},
-		[codeBuffer, editBuffer, viewMode],
-	);
+	const storyBuffer = useStoryEditBuffer(code);
+	const isCodeDirty = storyBuffer.isDirty;
 
 	const { handleSave, saveCurrentVersion, handleRestore, isSaving } = useStoryViewerVersionActions({
 		chatId,
@@ -66,32 +55,24 @@ export function useStoryPageEditor({
 		currentVersionCode: code,
 		isViewingLatest,
 		goToLatestVersion,
-		tiptapEditorRef,
 		codeViewRef,
-		getEditModeCode: editBuffer.getCode,
+		getCurrentCode: storyBuffer.getCode,
 		viewMode,
 		setViewMode,
-		onVersionSaved: handleVersionSaved,
+		onVersionSaved: storyBuffer.markSaved,
 	});
-	const isDirty = viewMode === 'edit' ? editBuffer.isDirty : viewMode === 'code' && isCodeDirty;
-	const discardChanges = useCallback(() => {
-		if (viewMode === 'edit') {
-			editBuffer.discard();
-		} else {
-			codeBuffer.discard();
-		}
-	}, [codeBuffer, editBuffer, viewMode]);
+	const isDirty = storyBuffer.isDirty;
 	const exitGuard = useStoryExitGuard({
 		isDirty,
 		canSave: viewMode !== 'code' || isCodeValid,
 		save: saveCurrentVersion,
-		discard: discardChanges,
+		discard: storyBuffer.discard,
 	});
 	const transitions = useStoryEditTransitions({
 		viewMode,
 		setViewMode,
-		isEditDirty: editBuffer.isDirty,
-		isCodeDirty,
+		isDirty,
+		isCodeValid,
 		isSaving,
 		save: saveCurrentVersion,
 		requestExit: exitGuard.requestExit,
@@ -112,22 +93,22 @@ export function useStoryPageEditor({
 		tiptapEditorRef,
 		codeViewRef,
 		tabbedEditCodeRef,
-		isEditDirty: editBuffer.isDirty,
+		isEditDirty: storyBuffer.isDirty,
 		editCode: selectStoryEditorCode({
 			persistedCode: code,
-			bufferCode: editBuffer.getCode(),
-			isDirty: editBuffer.isDirty,
+			bufferCode: storyBuffer.getCode(),
+			isDirty: storyBuffer.isDirty,
 			isSaving,
 		}),
-		onEditCodeChange: editBuffer.handleCodeChange,
+		onEditCodeChange: storyBuffer.handleCodeChange,
 		isCodeDirty,
 		codeDraft: selectStoryEditorCode({
 			persistedCode: code,
-			bufferCode: codeBuffer.getCode(),
-			isDirty: codeBuffer.isDirty,
+			bufferCode: storyBuffer.getCode(),
+			isDirty: storyBuffer.isDirty,
 			isSaving,
 		}),
-		onCodeChange: codeBuffer.handleCodeChange,
+		onCodeChange: storyBuffer.handleCodeChange,
 		isCodeValid,
 		setIsCodeValid,
 		handleSave,

--- a/apps/frontend/src/hooks/use-story-page-editor.ts
+++ b/apps/frontend/src/hooks/use-story-page-editor.ts
@@ -5,6 +5,9 @@ import type { StoryCodeViewHandle } from '@/components/side-panel/story-code-vie
 import { useStoryViewerVersionActions } from '@/components/side-panel/hooks/use-story-viewer-version-actions';
 import { useStoryViewerVersions } from '@/components/side-panel/hooks/use-story-viewer-versions';
 import { useStoryViewerViewMode } from '@/components/side-panel/hooks/use-story-viewer-view-mode';
+import { selectStoryEditorCode, useStoryEditBuffer } from '@/hooks/use-story-edit-buffer';
+import { useStoryEditTransitions } from '@/hooks/use-story-edit-transitions';
+import { useStoryExitGuard } from '@/hooks/use-story-exit-guard';
 
 interface UseStoryPageEditorParams {
 	chatId: string;
@@ -41,11 +44,22 @@ export function useStoryPageEditor({
 	const tiptapEditorRef = useRef<TiptapEditor | null>(null);
 	const codeViewRef = useRef<StoryCodeViewHandle | null>(null);
 	const tabbedEditCodeRef = useRef<(() => string) | null>(null);
-	const getEditModeCode = useCallback(() => tabbedEditCodeRef.current?.() ?? null, []);
-	const [isCodeDirty, setIsCodeDirty] = useState(false);
 	const [isCodeValid, setIsCodeValid] = useState(true);
+	const editBuffer = useStoryEditBuffer(code);
+	const codeBuffer = useStoryEditBuffer(code);
+	const isCodeDirty = codeBuffer.isDirty;
+	const handleVersionSaved = useCallback(
+		(savedCode: string) => {
+			if (viewMode === 'edit') {
+				editBuffer.markSaved(savedCode);
+			} else if (viewMode === 'code') {
+				codeBuffer.markSaved(savedCode);
+			}
+		},
+		[codeBuffer, editBuffer, viewMode],
+	);
 
-	const { handleSave, handleRestore } = useStoryViewerVersionActions({
+	const { handleSave, saveCurrentVersion, handleRestore, isSaving } = useStoryViewerVersionActions({
 		chatId,
 		storySlug,
 		storyTitle,
@@ -54,39 +68,79 @@ export function useStoryPageEditor({
 		goToLatestVersion,
 		tiptapEditorRef,
 		codeViewRef,
-		getEditModeCode,
+		getEditModeCode: editBuffer.getCode,
 		viewMode,
 		setViewMode,
+		onVersionSaved: handleVersionSaved,
+	});
+	const isDirty = viewMode === 'edit' ? editBuffer.isDirty : viewMode === 'code' && isCodeDirty;
+	const discardChanges = useCallback(() => {
+		if (viewMode === 'edit') {
+			editBuffer.discard();
+		} else {
+			codeBuffer.discard();
+		}
+	}, [codeBuffer, editBuffer, viewMode]);
+	const exitGuard = useStoryExitGuard({
+		isDirty,
+		canSave: viewMode !== 'code' || isCodeValid,
+		save: saveCurrentVersion,
+		discard: discardChanges,
+	});
+	const transitions = useStoryEditTransitions({
+		viewMode,
+		setViewMode,
+		isEditDirty: editBuffer.isDirty,
+		isCodeDirty,
+		isSaving,
+		save: saveCurrentVersion,
+		requestExit: exitGuard.requestExit,
 	});
 
 	useEffect(() => {
 		if (viewMode !== 'code') {
-			setIsCodeDirty(false);
 			setIsCodeValid(true);
 		}
 	}, [viewMode]);
 
 	return {
 		viewMode,
-		setViewMode,
+		setViewMode: transitions.requestViewMode,
+		handleCancel: transitions.requestCancel,
 		code,
 		storyId,
 		tiptapEditorRef,
 		codeViewRef,
 		tabbedEditCodeRef,
+		isEditDirty: editBuffer.isDirty,
+		editCode: selectStoryEditorCode({
+			persistedCode: code,
+			bufferCode: editBuffer.getCode(),
+			isDirty: editBuffer.isDirty,
+			isSaving,
+		}),
+		onEditCodeChange: editBuffer.handleCodeChange,
 		isCodeDirty,
-		setIsCodeDirty,
+		codeDraft: selectStoryEditorCode({
+			persistedCode: code,
+			bufferCode: codeBuffer.getCode(),
+			isDirty: codeBuffer.isDirty,
+			isSaving,
+		}),
+		onCodeChange: codeBuffer.handleCodeChange,
 		isCodeValid,
 		setIsCodeValid,
 		handleSave,
 		handleRestore,
+		isSaving,
+		exitDialog: exitGuard.dialogProps,
 		versionNav: {
 			currentVersion: currentVersionNumber,
 			storedVersionNumber,
 			totalVersions: versions.length,
 			isViewingLatest,
-			goToPrevious: goToPreviousVersion,
-			goToNext: goToNextVersion,
+			goToPrevious: () => exitGuard.requestExit(goToPreviousVersion),
+			goToNext: () => exitGuard.requestExit(goToNextVersion),
 		},
 	};
 }

--- a/apps/frontend/src/lib/story-save.test.ts
+++ b/apps/frontend/src/lib/story-save.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { saveStoryCodeIfChanged } from './story-save';
+
+describe('saveStoryCodeIfChanged', () => {
+	it('does not persist unchanged code', async () => {
+		const persist = vi.fn(async () => {});
+
+		const result = await saveStoryCodeIfChanged({
+			baselineCode: '# Story',
+			code: '# Story',
+			persist,
+		});
+
+		expect(result).toBe('unchanged');
+		expect(persist).not.toHaveBeenCalled();
+	});
+
+	it('reports a failed persistence without treating it as saved', async () => {
+		const persist = vi.fn(async () => {
+			throw new Error('save failed');
+		});
+
+		const result = await saveStoryCodeIfChanged({
+			baselineCode: '# Story',
+			code: '# Updated Story',
+			persist,
+		});
+
+		expect(result).toBe('failed');
+		expect(persist).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/frontend/src/lib/story-save.ts
+++ b/apps/frontend/src/lib/story-save.ts
@@ -1,0 +1,21 @@
+export type StorySaveResult = 'saved' | 'unchanged' | 'invalid' | 'unavailable' | 'failed';
+
+export async function saveStoryCodeIfChanged({
+	baselineCode,
+	code,
+	persist,
+}: {
+	baselineCode: string | undefined;
+	code: string;
+	persist: () => Promise<void>;
+}): Promise<StorySaveResult> {
+	if (code === baselineCode) {
+		return 'unchanged';
+	}
+	try {
+		await persist();
+		return 'saved';
+	} catch {
+		return 'failed';
+	}
+}

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { AgentProvider } from '@/contexts/agent.provider';
 import { SetChatInputCallbackProvider } from '@/contexts/set-chat-input-callback';
+import { StoryBeforeAgentSendProvider } from '@/contexts/story-before-agent-send';
 
 export const Route = createFileRoute('/_sidebar-layout/_chat-layout')({
 	component: RouteComponent,
@@ -9,9 +10,11 @@ export const Route = createFileRoute('/_sidebar-layout/_chat-layout')({
 function RouteComponent() {
 	return (
 		<SetChatInputCallbackProvider>
-			<AgentProvider>
-				<Outlet />
-			</AgentProvider>
+			<StoryBeforeAgentSendProvider>
+				<AgentProvider>
+					<Outlet />
+				</AgentProvider>
+			</StoryBeforeAgentSendProvider>
 		</SetChatInputCallbackProvider>
 	);
 }

--- a/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.preview.$chatId.$storySlug.tsx
@@ -128,6 +128,8 @@ function StoryPreviewPage() {
 					isCodeDirty: editor.isCodeDirty,
 					isCodeValid: editor.isCodeValid,
 					onSave: editor.handleSave,
+					onCancel: editor.handleCancel,
+					isSaving: editor.isSaving,
 				}}
 				versionControls={{
 					currentVersion: editor.versionNav.currentVersion,
@@ -156,7 +158,6 @@ function StoryPreviewPage() {
 			)}
 
 			<StoryPageBody
-				code={editor.code}
 				editor={editor}
 				queryData={queryData}
 				preview={

--- a/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.shared.$shareId.tsx
@@ -124,6 +124,8 @@ function SharedStoryPage() {
 					isCodeDirty: editor.isCodeDirty,
 					isCodeValid: editor.isCodeValid,
 					onSave: editor.handleSave,
+					onCancel: editor.handleCancel,
+					isSaving: editor.isSaving,
 				}}
 				versionControls={{
 					currentVersion: editor.versionNav.currentVersion,
@@ -179,7 +181,6 @@ function SharedStoryPage() {
 					<div className='flex flex-1 min-h-0 min-w-0'>
 						<div ref={contentAreaRef} className='flex flex-col flex-1 min-w-0 min-h-0'>
 							<StoryPageBody
-								code={editor.code}
 								editor={editor}
 								queryData={queryData}
 								preview={

--- a/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.stories.standalone.$storyId.tsx
@@ -228,6 +228,8 @@ function StandaloneEditableStory({
 					isCodeDirty: editor.isCodeDirty,
 					isCodeValid: editor.isCodeValid,
 					onSave: editor.handleSave,
+					onCancel: editor.handleCancel,
+					isSaving: editor.isSaving,
 				}}
 				versionControls={{
 					currentVersion: editor.versionNav.currentVersion,
@@ -240,7 +242,6 @@ function StandaloneEditableStory({
 			/>
 
 			<StoryPageBody
-				code={editor.code}
 				editor={editor}
 				queryData={versionQueryData}
 				preview={

--- a/apps/frontend/tests/hooks/use-debounced-callback.test.ts
+++ b/apps/frontend/tests/hooks/use-debounced-callback.test.ts
@@ -3,7 +3,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useDebouncedCallback } from './use-debounced-callback';
+import { useDebouncedCallback } from '@/hooks/use-debounced-callback';
 
 describe('useDebouncedCallback', () => {
 	afterEach(() => {

--- a/apps/frontend/tests/hooks/use-story-editing.test.ts
+++ b/apps/frontend/tests/hooks/use-story-editing.test.ts
@@ -10,10 +10,10 @@ import {
 import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { selectStoryEditorCode, useStoryEditBuffer } from './use-story-edit-buffer';
-import { useStoryEditTransitions } from './use-story-edit-transitions';
-import { getStoryNavigationBlockerOptions } from './use-story-exit-guard';
 import type { StoryViewMode } from '@/components/side-panel/story-viewer.types';
+import { selectStoryEditorCode, useStoryEditBuffer } from '@/hooks/use-story-edit-buffer';
+import { useStoryEditTransitions } from '@/hooks/use-story-edit-transitions';
+import { getStoryNavigationBlockerOptions } from '@/hooks/use-story-exit-guard';
 import type { StorySaveResult } from '@/lib/story-save';
 
 const tabbedStory = [

--- a/apps/frontend/tests/hooks/use-story-editing.test.ts
+++ b/apps/frontend/tests/hooks/use-story-editing.test.ts
@@ -11,10 +11,10 @@ import { act, renderHook } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { StoryViewMode } from '@/components/side-panel/story-viewer.types';
+import type { StorySaveResult } from '@/lib/story-save';
 import { selectStoryEditorCode, useStoryEditBuffer } from '@/hooks/use-story-edit-buffer';
 import { useStoryEditTransitions } from '@/hooks/use-story-edit-transitions';
 import { getStoryNavigationBlockerOptions } from '@/hooks/use-story-exit-guard';
-import type { StorySaveResult } from '@/lib/story-save';
 
 const tabbedStory = [
 	'<tab title="Overview">',

--- a/apps/frontend/tests/hooks/use-throttled-value.test.ts
+++ b/apps/frontend/tests/hooks/use-throttled-value.test.ts
@@ -3,7 +3,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useThrottledValue } from './use-throttled-value';
+import { useThrottledValue } from '@/hooks/use-throttled-value';
 
 describe('useThrottledValue', () => {
 	afterEach(() => {


### PR DESCRIPTION
## Summary

- Saves manual Story edits before the agent starts working.
- Auto-saves when switching from Edit(or Code) to View.
- Warns before leaving or switching Stories with unsaved changes.
- Protects normal, tabbed, and code edits.

Closes #1443

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

