### PR TITLE
fix/view sql in story even when env var for filters is false 1505 + readme update

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -85,3 +85,5 @@ joebordes pr
 thokich pr
 
 andrebaaij pr
+
+synthpieter pr

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,5 @@ routeTree.gen.ts
 
 # Helm YAML uses 2-space indent; Go templates aren't valid YAML
 helm/
+sandbox/
+.heal/

--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -209,6 +209,13 @@ export function SystemPrompt({
 						an "exact" count based on the number of rows a limited query returned. To count rows, run a
 						separate query using COUNT(*) (or COUNT over a subquery) without a LIMIT/TOP clause.
 					</ListItem>,
+					<ListItem>
+						Table documentation files (columns.md, preview.md, ai_summary.md, how_to_use.md, ...) are for
+						understanding schema and semantics only. Their statistics (row counts, previews, aggregates) are
+						stale profiling snapshots — never present them as the answer to a data question. Any number you
+						present as an answer to a data question must come from a query executed in this conversation, or
+						be computed from such results.
+					</ListItem>,
 					...dialectSqlQueryRules,
 				]}
 			</List>

--- a/apps/backend/src/mcp/chart-data-mode.ts
+++ b/apps/backend/src/mcp/chart-data-mode.ts
@@ -1,0 +1,63 @@
+import { displayChart } from '@nao/shared/tools';
+
+const MAX_INLINE_ROWS = 500;
+const MAX_INLINE_DATA_CHARS = 80_000;
+
+const DISPLAY_CHART_RETURNS =
+	'it returns the chart config and data rows with rendering instructions so you can render the chart ' +
+	'yourself as an interactive visualization (e.g. a recharts component in a code frame)';
+
+export const CHART_DATA_MODE_SERVER_INSTRUCTIONS =
+	' Chart workflow: when `ask_nao` returns `queries`, call `display_chart` with a `query_id` — ' +
+	`${DISPLAY_CHART_RETURNS} — do not just relay the embed link.`;
+
+export const CHART_DATA_MODE_ASK_NAO_ADDENDUM =
+	'\n\nCHARTS: when the result carries `queries` worth visualizing, follow up with `display_chart` on a ' +
+	`\`queries[].id\` — ${DISPLAY_CHART_RETURNS}.`;
+
+export const CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM =
+	'\n\nRENDERING: when the result includes the chart config, the data rows and recharts mapping instructions ' +
+	'and your platform can render code-based visualizations (React frames, artifacts, canvases…), render the ' +
+	'chart yourself as an interactive component from them instead of only sharing the embed link.';
+
+export const CHART_DATA_MODE_RESULT_NUDGE =
+	'If a visualization would help answer the question, call `display_chart` with a `query_id` from `queries` — ' +
+	`${DISPLAY_CHART_RETURNS}.`;
+
+export const CHART_DATA_MODE_FALLBACK_NOTE =
+	'Chart data not inlined (custom chart type, empty result, or too many rows to inline) — ' +
+	'share the embed link from this result instead of rendering the chart yourself.';
+
+const RENDER_INSTRUCTIONS = [
+	'RENDER THIS CHART for the user as an interactive visualization — do not answer with only links or a text list of the numbers. If your platform can render code-based visualizations (Dust interactive frames, Claude artifacts, canvases, React components…), build a single self-contained `recharts` component from the config and data below, inlining the data as a literal constant — never fetch it over the network. Only fall back to sharing the embed links from this result if no such rendering capability exists.',
+	'- Config mapping: `chart_type` → recharts component (`bar`→BarChart, `line`→LineChart, `area`→AreaChart, `pie`/`donut`→PieChart, `scatter`→ScatterChart, `radar`→RadarChart, `mixed`→ComposedChart with per-series `series_type`, `stacked_*`→shared `stackId`, `*_100`→stackOffset="expand", `kpi_card`→a stat card without a chart, `table`→a plain table).',
+	'- `x_axis_key` → XAxis dataKey (for `pie`/`donut` → `Pie` nameKey; for `radar` → PolarAngleAxis dataKey); each `series[].data_key` → one mark (Bar/Line/Area/…) with its `color` and `label`; `value_format` hints number formatting; `y_axis: "right"` → secondary YAxis.',
+	'- Omit series with `is_total: true` from `*_100` stacks — a pre-aggregated total would skew the percentages; render them normally in every other chart type.',
+	'- Respect the series colors. Add a Tooltip, and a Legend when there are multiple series.',
+	'- Along with the rendered chart, always include the `Open in nao` link from this result so the user can explore the underlying analysis in nao.',
+].join('\n');
+
+export function buildAgentRenderedChartText(args: {
+	config: displayChart.ChartInput;
+	columns: string[];
+	rows: Record<string, unknown>[];
+}): string | null {
+	const { config, columns, rows } = args;
+	if (!displayChart.isNativeDisplayType(config.chart_type) || rows.length === 0 || rows.length > MAX_INLINE_ROWS) {
+		return null;
+	}
+
+	const dataJson = JSON.stringify(rows);
+	if (dataJson.length > MAX_INLINE_DATA_CHARS) {
+		return null;
+	}
+
+	const { query_id: _queryId, ...renderConfig } = config;
+	return [
+		RENDER_INSTRUCTIONS,
+		'',
+		`Chart config: ${JSON.stringify(renderConfig)}`,
+		'',
+		`Data (${rows.length} rows, columns: ${columns.join(', ')}): ${dataJson}`,
+	].join('\n');
+}

--- a/apps/backend/src/mcp/logging.ts
+++ b/apps/backend/src/mcp/logging.ts
@@ -5,11 +5,14 @@ import type { ServerNotification, ServerRequest } from '@modelcontextprotocol/sd
 
 import { insertMcpCallLog } from '../queries/mcp-endpoint.queries';
 import type { McpEndpointSettings } from '../types/mcp-endpoint';
+import { truncateMiddle } from '../utils/utils';
 
 export interface McpContext {
 	userId: string;
 	projectId: string;
 	settings: McpEndpointSettings;
+	/** When true, chart tools return config + data rows for the client agent to render itself instead of embed links/apps only. */
+	chartDataMode: boolean;
 }
 
 export type ToolContent = { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string };
@@ -81,6 +84,8 @@ export function withLogging<T>(toolName: string, ctx: McpContext, handler: Logge
 	};
 }
 
+const MAX_LOGGED_OUTPUT_CHARS = 10_000;
+
 function extractLoggableOutput(result: ToolResult | undefined): unknown {
 	if (!result) {
 		return undefined;
@@ -89,10 +94,20 @@ function extractLoggableOutput(result: ToolResult | undefined): unknown {
 		.filter((part): part is { type: 'text'; text: string } => part.type === 'text')
 		.map((part) => part.text)
 		.join('\n');
+	if (text.length <= MAX_LOGGED_OUTPUT_CHARS && (text.startsWith('{') || text.startsWith('['))) {
+		const parsed = tryParseJson(text);
+		if (parsed !== undefined) {
+			return parsed;
+		}
+	}
+	return truncateMiddle(text, MAX_LOGGED_OUTPUT_CHARS, ' … [truncated] … ');
+}
+
+function tryParseJson(text: string): unknown {
 	try {
 		return JSON.parse(text);
 	} catch {
-		return text;
+		return undefined;
 	}
 }
 

--- a/apps/backend/src/mcp/routes.ts
+++ b/apps/backend/src/mcp/routes.ts
@@ -61,7 +61,12 @@ async function handleMcpRequest(request: FastifyRequest, reply: FastifyReply): P
 		return;
 	}
 
-	const server = await createMcpServer(request.mcpUserId, request.mcpProjectId, settings);
+	const server = await createMcpServer(
+		request.mcpUserId,
+		request.mcpProjectId,
+		settings,
+		isChartDataModeRequest(request),
+	);
 	const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 
 	reply.raw.on('close', () => {
@@ -72,6 +77,11 @@ async function handleMcpRequest(request: FastifyRequest, reply: FastifyReply): P
 	await server.connect(transport);
 	await transport.handleRequest(request.raw, reply.raw, request.body as Record<string, unknown>);
 	reply.hijack();
+}
+
+function isChartDataModeRequest(request: FastifyRequest): boolean {
+	const { chart_output } = request.query as { chart_output?: string };
+	return chart_output?.toLowerCase() === 'data';
 }
 
 function replyMethodNotAllowed(reply: FastifyReply) {

--- a/apps/backend/src/mcp/server.ts
+++ b/apps/backend/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { getCustomBoundaries, listUserProjects } from '../queries/project.queries';
 import type { McpEndpointSettings } from '../types/mcp-endpoint';
+import { CHART_DATA_MODE_SERVER_INSTRUCTIONS } from './chart-data-mode';
 import { registerNaoMcpApps } from './embed/ui-resources';
 import { registerAssetTools } from './tools/asset-tools';
 import { registerContextLayerTools } from './tools/context-layer';
@@ -24,9 +25,16 @@ export async function createMcpServer(
 	userId: string,
 	projectId: string,
 	settings: McpEndpointSettings,
+	chartDataMode = false,
 ): Promise<McpServer> {
-	const server = new McpServer({ name: 'nao', version: '0.1.0' }, { capabilities: { tools: {}, resources: {} } });
-	const ctx = { userId, projectId, settings };
+	const server = new McpServer(
+		{ name: 'nao', version: '0.1.0' },
+		{
+			capabilities: { tools: {}, resources: {} },
+			instructions: chartDataMode ? DATA_MODE_SERVER_INSTRUCTIONS : BASE_SERVER_INSTRUCTIONS,
+		},
+	);
+	const ctx = { userId, projectId, settings, chartDataMode };
 
 	if (settings.subAgentModeEnabled) {
 		registerSubAgentTools(server, ctx);
@@ -44,3 +52,9 @@ export async function createMcpServer(
 
 	return server;
 }
+
+const BASE_SERVER_INSTRUCTIONS =
+	'nao answers analytics questions backed by SQL queries on the connected data sources. ' +
+	'Default to `ask_nao` for analytics questions; prefer showing results as charts over text tables when the data suits it.';
+
+const DATA_MODE_SERVER_INSTRUCTIONS = BASE_SERVER_INSTRUCTIONS + CHART_DATA_MODE_SERVER_INSTRUCTIONS;

--- a/apps/backend/src/mcp/tools/asset-tools.ts
+++ b/apps/backend/src/mcp/tools/asset-tools.ts
@@ -7,6 +7,11 @@ import zodV3 from 'zod/v3';
 import displayChartTool from '../../agents/tools/display-chart';
 import * as storyQueries from '../../queries/story.queries';
 import {
+	buildAgentRenderedChartText,
+	CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM,
+	CHART_DATA_MODE_FALLBACK_NOTE,
+} from '../chart-data-mode';
+import {
 	buildChartToolResult,
 	buildMapToolResult,
 	STORY_OUTPUT_SCHEMA,
@@ -35,6 +40,8 @@ const DISPLAY_CHART_DESCRIPTION =
 	'both the SQL and the chart in one shot. Also skip when you just called `create_story` or ' +
 	'`update_story` — the story embed already renders all its `<chart>` blocks; calling ' +
 	'`display_chart` again would duplicate them.';
+
+const DISPLAY_CHART_DATA_MODE_DESCRIPTION = DISPLAY_CHART_DESCRIPTION + CHART_DATA_MODE_DISPLAY_CHART_ADDENDUM;
 
 const LIST_STORIES_DESCRIPTION = 'List nao stories.';
 
@@ -82,7 +89,7 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 		name: 'display_chart',
 		agentTool: displayChartTool,
 		title: 'Display Chart',
-		description: DISPLAY_CHART_DESCRIPTION,
+		description: ctx.chartDataMode ? DISPLAY_CHART_DATA_MODE_DESCRIPTION : DISPLAY_CHART_DESCRIPTION,
 		inputSchema: displayChart.ChartInputObjectSchema.extend({
 			chat_id: zodV3
 				.string()
@@ -119,22 +126,7 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 		mapInput: ({ chat_id: _chatId, ...input }) => input,
 		resolveChatId: (input) => input.chat_id ?? null,
 		formatResult: async ({ input, output, callLogId }) => {
-			const {
-				query_id,
-				chart_type,
-				x_axis_key,
-				x_axis_type,
-				x_axis_label,
-				series,
-				y_axis_min,
-				y_axis_max,
-				y_axis_label,
-				y_axis_right_min,
-				y_axis_right_max,
-				y_axis_right_label,
-				title,
-				chat_id,
-			} = input;
+			const { chat_id, ...artifact } = input;
 			if (!output.success) {
 				return {
 					content: [{ type: 'text' as const, text: output.error ?? 'Chart config is invalid.' }],
@@ -143,35 +135,35 @@ function registerDisplayChart(server: McpServer, ctx: McpContext): void {
 			}
 
 			const validatedChatId = await resolveChartChatId(chat_id, ctx);
-			const result = await buildChartEmbedFromArtifact(
-				{
-					query_id,
-					chart_type,
-					x_axis_key,
-					x_axis_type,
-					x_axis_label,
-					series,
-					y_axis_min,
-					y_axis_max,
-					y_axis_label,
-					y_axis_right_min,
-					y_axis_right_max,
-					y_axis_right_label,
-					title,
-				},
-				ctx,
-				{ chatId: validatedChatId ?? null, callLogId },
-			);
+			const result = await buildChartEmbedFromArtifact(artifact, ctx, {
+				chatId: validatedChatId ?? null,
+				callLogId,
+			});
 
 			if (!result) {
-				return buildMissingQueryDataResult({ queryId: query_id, chatIdInput: chat_id, validatedChatId });
+				return buildMissingQueryDataResult({
+					queryId: artifact.query_id,
+					chatIdInput: chat_id,
+					validatedChatId,
+				});
 			}
 
 			if ('keyError' in result) {
 				return buildInvalidKeysResult(result.keyError);
 			}
 
-			return buildChartToolResult(result.payload, { sandboxChartHtml: result.sandboxChartHtml });
+			const toolResult = buildChartToolResult(result.payload, { sandboxChartHtml: result.sandboxChartHtml });
+
+			if (ctx.chartDataMode) {
+				const chartText = buildAgentRenderedChartText({
+					config: artifact,
+					columns: result.queryData.columns,
+					rows: result.queryData.data,
+				});
+				toolResult.content.unshift({ type: 'text', text: chartText ?? CHART_DATA_MODE_FALLBACK_NOTE });
+			}
+
+			return toolResult;
 		},
 	});
 }

--- a/apps/backend/src/mcp/tools/helpers.ts
+++ b/apps/backend/src/mcp/tools/helpers.ts
@@ -134,7 +134,11 @@ export async function buildChartEmbedFromArtifact(
 	artifact: displayChart.ChartInput,
 	ctx: McpContext,
 	opts: { chatId: string | null; callLogId: string },
-): Promise<{ payload: ChartToolPayload; sandboxChartHtml: string | null } | { keyError: ChartKeyError } | null> {
+): Promise<
+	| { payload: ChartToolPayload; sandboxChartHtml: string | null; queryData: ChartQueryData }
+	| { keyError: ChartKeyError }
+	| null
+> {
 	const {
 		query_id,
 		chart_type,
@@ -219,17 +223,19 @@ export async function buildChartEmbedFromArtifact(
 
 	const naoChatUrl = effectiveChatId ? chatUrl(effectiveChatId) : null;
 	let sandboxChartHtml: string | null = null;
-	try {
-		sandboxChartHtml = await buildChartSandboxHtml({
-			title,
-			chartBlock: block,
-			queryId: query_id,
-			columns: queryData.columns,
-			data: queryData.data,
-			naoChatUrl,
-		});
-	} catch (sandboxErr) {
-		logger.warn(`MCP sandbox HTML failed: ${String(sandboxErr)}`, { source: 'tool' });
+	if (!ctx.chartDataMode) {
+		try {
+			sandboxChartHtml = await buildChartSandboxHtml({
+				title,
+				chartBlock: block,
+				queryId: query_id,
+				columns: queryData.columns,
+				data: queryData.data,
+				naoChatUrl,
+			});
+		} catch (sandboxErr) {
+			logger.warn(`MCP sandbox HTML failed: ${String(sandboxErr)}`, { source: 'tool' });
+		}
 	}
 
 	const payload: ChartToolPayload = {
@@ -240,7 +246,7 @@ export async function buildChartEmbedFromArtifact(
 		title,
 		chatId: effectiveChatId,
 	};
-	return { payload, sandboxChartHtml };
+	return { payload, sandboxChartHtml, queryData };
 }
 
 type MapKeyError = { invalidKeys: string[]; availableColumns: string[] };

--- a/apps/backend/src/mcp/tools/sub-agent.ts
+++ b/apps/backend/src/mcp/tools/sub-agent.ts
@@ -9,6 +9,7 @@ import { agentService, defaultAgentToolsExcluding } from '../../services/agent';
 import { mcpService } from '../../services/mcp';
 import { skillService } from '../../services/skill';
 import type { UIMessage, UIMessagePart } from '../../types/chat';
+import { CHART_DATA_MODE_ASK_NAO_ADDENDUM, CHART_DATA_MODE_RESULT_NUDGE } from '../chart-data-mode';
 import type { McpContext, ToolResult } from '../logging';
 import { chatUrl } from '../urls';
 import { type AskNaoClarification, type AskNaoResult, askNaoRuns } from './ask-nao-runs';
@@ -42,6 +43,8 @@ const ASK_NAO_DESCRIPTION =
 	"CLARIFICATIONS: if the question is ambiguous, this returns `status: 'needs_clarification'` " +
 	'with a `clarification.question` (and optional `clarification.options`). Relay the question to the user, ' +
 	'then call `ask_nao` again with the SAME `chatId` and their answer as `question`.';
+
+const ASK_NAO_DATA_MODE_DESCRIPTION = ASK_NAO_DESCRIPTION + CHART_DATA_MODE_ASK_NAO_ADDENDUM;
 
 const GET_NAO_ANSWER_DESCRIPTION =
 	'Fetch the result of an `ask_nao` run that is still in progress. ' +
@@ -81,7 +84,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 	registerMcpTool(server, ctx, {
 		name: 'ask_nao',
 		title: 'Ask Nao',
-		description: ASK_NAO_DESCRIPTION,
+		description: ctx.chartDataMode ? ASK_NAO_DATA_MODE_DESCRIPTION : ASK_NAO_DESCRIPTION,
 		inputSchema: {
 			question: z
 				.string()
@@ -141,7 +144,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 				throw new Error(outcome.error);
 			}
 			if (outcome.kind === 'complete') {
-				return answerCompletePayload(outcome.result);
+				return answerCompletePayload(outcome.result, ctx);
 			}
 			return runningPayload(chat.id, naoChatUrl);
 		},
@@ -167,7 +170,7 @@ export function registerSubAgentTools(server: McpServer, ctx: McpContext): void 
 		errorMessage: () => 'Failed to fetch the nao answer.',
 		handler: async ({ chatId }) => {
 			await assertChatAccess(ctx, chatId);
-			return resolveAnswerPayload(chatId);
+			return resolveAnswerPayload(chatId, ctx);
 		},
 	});
 }
@@ -222,13 +225,13 @@ async function waitForResultOrBudget(runPromise: Promise<AskNaoResult>, budgetMs
 	}
 }
 
-async function resolveAnswerPayload(chatId: string): Promise<ToolResult> {
+async function resolveAnswerPayload(chatId: string, ctx: McpContext): Promise<ToolResult> {
 	const state = askNaoRuns.get(chatId);
 	if (!state) {
-		return reconstructAnswerFromDb(chatId);
+		return reconstructAnswerFromDb(chatId, ctx);
 	}
 	if (state.status === 'complete') {
-		return answerCompletePayload(state.result);
+		return answerCompletePayload(state.result, ctx);
 	}
 	if (state.status === 'error') {
 		return answerErrorPayload(chatId, state.error);
@@ -241,16 +244,19 @@ async function resolveAnswerPayload(chatId: string): Promise<ToolResult> {
  * restart): rebuild the final answer from the persisted chat. Query/story metadata is
  * not reconstructed since it only lives on the in-memory run.
  */
-async function reconstructAnswerFromDb(chatId: string): Promise<ToolResult> {
+async function reconstructAnswerFromDb(chatId: string, ctx: McpContext): Promise<ToolResult> {
 	const answer = await extractAnswerFromChat(chatId);
-	return answerCompletePayload({
-		chatId,
-		chatUrl: chatUrl(chatId),
-		text: answer.text,
-		...(answer.clarification ? { clarification: answer.clarification } : {}),
-		queries: [],
-		story_ids: [],
-	});
+	return answerCompletePayload(
+		{
+			chatId,
+			chatUrl: chatUrl(chatId),
+			text: answer.text,
+			...(answer.clarification ? { clarification: answer.clarification } : {}),
+			queries: [],
+			story_ids: [],
+		},
+		ctx,
+	);
 }
 
 async function extractAnswerFromChat(chatId: string): Promise<AskNaoAnswer> {
@@ -282,19 +288,24 @@ function runningPayload(chatId: string, naoChatUrl: string): ToolResult {
 	};
 }
 
-function answerCompletePayload(result: AskNaoResult): ToolResult {
+function answerCompletePayload(result: AskNaoResult, ctx: McpContext): ToolResult {
 	if (result.clarification) {
 		return clarificationPayload(result, result.clarification);
 	}
 
+	const content: ToolResult['content'] = [
+		{
+			type: 'text' as const,
+			text: `${result.text}\n\n[chatId: ${result.chatId}]\n[chatUrl: ${result.chatUrl}]`,
+		},
+		{ type: 'text' as const, text: JSON.stringify({ queries: result.queries, story_ids: result.story_ids }) },
+	];
+	if (ctx.chartDataMode && result.queries.length > 0 && result.story_ids.length === 0) {
+		content.push({ type: 'text' as const, text: CHART_DATA_MODE_RESULT_NUDGE });
+	}
+
 	return {
-		content: [
-			{
-				type: 'text' as const,
-				text: `${result.text}\n\n[chatId: ${result.chatId}]\n[chatUrl: ${result.chatUrl}]`,
-			},
-			{ type: 'text' as const, text: JSON.stringify({ queries: result.queries, story_ids: result.story_ids }) },
-		],
+		content,
 		structuredContent: { status: 'complete', ...result },
 	};
 }

--- a/apps/backend/src/queries/organization.queries.ts
+++ b/apps/backend/src/queries/organization.queries.ts
@@ -374,12 +374,13 @@ export const listOrgProjectsWithAccess = async (orgId: string, userId: string): 
 		.select({
 			id: s.project.id,
 			name: s.project.name,
-			role: sql<UserRole>`coalesce(${s.projectMember.role}, 'viewer')`,
+			role: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role}, 'viewer')`,
 			createdAt: s.project.createdAt,
 			updatedAt: s.project.updatedAt,
 		})
 		.from(s.project)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.projectId, s.project.id), eq(s.projectMember.userId, userId)))
+		.leftJoin(s.orgMember, and(eq(s.orgMember.orgId, s.project.orgId), eq(s.orgMember.userId, userId)))
 		.where(eq(s.project.orgId, orgId))
 		.orderBy(asc(s.project.name))
 		.execute();
@@ -452,20 +453,10 @@ const ensureDefaultProject = async (org: DBOrganization): Promise<void> => {
 	}
 
 	const projectName = projectPath.split('/').pop() || 'Default Project';
-	const project = await projectQueries.createProject({
+	await projectQueries.createProject({
 		name: projectName,
 		type: 'local',
 		path: projectPath,
 		orgId: org.id,
 	});
-
-	// Add all org members to the new project
-	const orgMembers = await db.select().from(s.orgMember).where(eq(s.orgMember.orgId, org.id)).execute();
-	for (const member of orgMembers) {
-		await projectQueries.addProjectMember({
-			projectId: project.id,
-			userId: member.userId,
-			role: member.role,
-		});
-	}
 };

--- a/apps/backend/src/queries/project.queries.ts
+++ b/apps/backend/src/queries/project.queries.ts
@@ -106,7 +106,7 @@ export const listUserProjectsWithRoles = async (userId: string): Promise<UserPro
 	const results = await db
 		.select({
 			project: s.project,
-			userRole: sql<UserRole>`coalesce(${s.projectMember.role}, 'viewer')`,
+			userRole: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role}, 'viewer')`,
 		})
 		.from(s.project)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.projectId, s.project.id), eq(s.projectMember.userId, userId)))
@@ -150,7 +150,6 @@ export const listProjectMembersWithRoles = async (projectId: string): Promise<Us
 			name: s.user.name,
 			email: s.user.email,
 			role: s.projectMember.role,
-			messagingProviderCode: s.user.messagingProviderCode,
 		})
 		.from(s.user)
 		.innerJoin(s.projectMember, eq(s.projectMember.userId, s.user.id))
@@ -168,7 +167,6 @@ export const listUsersWithProjectAccess = async (projectId: string): Promise<Use
 			name: s.user.name,
 			email: s.user.email,
 			role: sql<UserRole>`coalesce(${s.projectMember.role}, ${s.orgMember.role})`,
-			messagingProviderCode: s.user.messagingProviderCode,
 		})
 		.from(s.user)
 		.leftJoin(s.projectMember, and(eq(s.projectMember.userId, s.user.id), eq(s.projectMember.projectId, projectId)))
@@ -209,8 +207,8 @@ export const getProjectByUserId = async (
 		return null;
 	}
 
-	const membership = await getProjectMember(project.id, userId);
-	return membership ? project : null;
+	const role = await getUserRoleInProject(project.id, userId);
+	return role ? project : null;
 };
 
 export const checkProjectHasMoreThanOneAdmin = async (projectId: string): Promise<boolean> => {

--- a/apps/backend/src/routes/deploy.ts
+++ b/apps/backend/src/routes/deploy.ts
@@ -8,7 +8,6 @@ import yaml from 'js-yaml';
 import type { App } from '../app';
 import { env } from '../env';
 import { ensureContextRecommendationsScheduleForNewProject } from '../handlers/context-recommendations.handler';
-import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
 import { validateApiKey } from '../services/api-key.service';
 
@@ -84,14 +83,6 @@ export const deployRoutes = async (app: App) => {
 				projectId = project.id;
 				status = 'created';
 
-				const orgMembers = await orgQueries.listOrgMembersWithUsers(org.id);
-				for (const member of orgMembers) {
-					await projectQueries.addProjectMember({
-						projectId,
-						userId: member.id,
-						role: member.role,
-					});
-				}
 				await ensureContextRecommendationsScheduleForNewProject(projectId);
 			}
 

--- a/apps/backend/src/routes/test.ts
+++ b/apps/backend/src/routes/test.ts
@@ -40,6 +40,7 @@ export const testRoutes = async (app: App) => {
 					prompt: z.string(),
 					model: llmSelectedModelSchema,
 					sql: z.string(),
+					databaseId: z.string().optional(),
 					meta: z
 						.object({
 							costs: customModelCostSchema,
@@ -51,7 +52,7 @@ export const testRoutes = async (app: App) => {
 		async (request, reply) => {
 			const projectId = request.project?.id;
 			const userId = request.user.id;
-			const { prompt, model, sql, meta } = request.body;
+			const { prompt, model, sql, databaseId, meta } = request.body;
 
 			const costs = meta?.costs;
 
@@ -67,7 +68,7 @@ export const testRoutes = async (app: App) => {
 				let verification;
 				if (sql) {
 					const { data: expectedData, columns: expectedColumns } = await executeQuery(
-						{ sql_query: sql },
+						{ sql_query: sql, database_id: databaseId },
 						{
 							projectFolder: project.path!,
 							chatId: '',

--- a/apps/backend/src/services/duckdb.service.ts
+++ b/apps/backend/src/services/duckdb.service.ts
@@ -7,7 +7,6 @@ import type { executeSql } from '@nao/shared/tools';
 
 import { env } from '../env';
 import type { QueryResult } from '../types/tools';
-import { validateReadOnlyAllowlistedSql } from '../utils/sql-allowlist';
 import { isReadOnlySqlQuery } from '../utils/sql-filter';
 
 type DuckDBModule = typeof import('@duckdb/node-api');
@@ -178,14 +177,14 @@ export async function runSqlOverQueryResults(
 	queryResults: Map<string, QueryResult>,
 	sql: string,
 ): Promise<QueryResult> {
-	await assertSafeQueryResultsSql(sql, [...queryResults.keys()]);
-
 	const duckdb = await loadDuckDB();
 	const workspace = await mkdtemp(join(tmpdir(), 'nao-query-results-'));
 	const instance = await duckdb.DuckDBInstance.create(':memory:');
 	const connection = await instance.connect();
 
 	try {
+		await assertSafeQueryResultsSql(connection, sql, [...queryResults.keys()]);
+
 		for (const [queryId, queryResult] of queryResults) {
 			await createQueryResultTable(connection, workspace, queryId, queryResult);
 		}
@@ -268,14 +267,95 @@ async function loadDuckDB(): Promise<DuckDBModule> {
 	}
 }
 
-async function assertSafeQueryResultsSql(sql: string, allowedTables: string[]): Promise<void> {
-	const verdict = await validateReadOnlyAllowlistedSql(sql, {
-		allowedTables,
-		parserDialect: 'postgresql',
-		dialectName: 'DuckDB',
-	});
-	if (!verdict.ok) {
-		throw new Error(verdict.reason);
+/**
+ * Enforces the read-only, table-allowlisted policy on the untrusted SQL. The query is parsed with
+ * DuckDB's own parser (json_serialize_sql) so the dialect checked is exactly the dialect it will
+ * run under — an external parser would reject valid DuckDB syntax like TRY_CAST or QUALIFY.
+ */
+async function assertSafeQueryResultsSql(
+	connection: DuckDBConnection,
+	sql: string,
+	allowedTables: string[],
+): Promise<void> {
+	if (!(await isReadOnlySqlQuery(sql))) {
+		throw new Error('Only read-only SELECT/WITH queries are allowed.');
+	}
+
+	const referenced = await referencedBaseTables(connection, sql);
+	const allowed = new Set(allowedTables);
+	const disallowed = [...new Set(referenced)].filter((name) => !allowed.has(name));
+	if (disallowed.length > 0) {
+		throw new Error(
+			`Query references objects outside the allowlist: ${disallowed.join(', ')}. Allowed: ${allowedTables.join(', ') || '(none)'}.`,
+		);
+	}
+}
+
+async function referencedBaseTables(connection: DuckDBConnection, sql: string): Promise<string[]> {
+	const reader = await connection.runAndReadAll('SELECT json_serialize_sql(?::VARCHAR) AS ast', [sql]);
+	const ast = JSON.parse(reader.getRowObjectsJson()[0]!.ast as string) as SerializedSqlAst;
+
+	if (ast.error) {
+		throw new Error(
+			`Could not parse the query as DuckDB; rejected for safety. Rewrite it in DuckDB syntax. ${ast.error_message ?? ''}`.trim(),
+		);
+	}
+
+	const scan = scanSerializedAst(ast.statements);
+	return scan.tables.filter((name) => !scan.cteNames.has(name));
+}
+
+interface SerializedSqlAst {
+	error: boolean;
+	error_message?: string;
+	statements?: unknown[];
+}
+
+interface AstScan {
+	tables: string[];
+	cteNames: Set<string>;
+}
+
+/** Walks the serialized AST collecting referenced base tables and declared CTE names. */
+function scanSerializedAst(node: unknown, scan: AstScan = { tables: [], cteNames: new Set() }): AstScan {
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			scanSerializedAst(child, scan);
+		}
+		return scan;
+	}
+
+	if (!node || typeof node !== 'object') {
+		return scan;
+	}
+
+	const record = node as Record<string, unknown>;
+	if (record.type === 'BASE_TABLE' && typeof record.table_name === 'string') {
+		scan.tables.push(record.table_name);
+	}
+
+	for (const [key, value] of Object.entries(record)) {
+		if (key === 'cte_map') {
+			collectCteNames(value, scan.cteNames);
+		}
+		scanSerializedAst(value, scan);
+	}
+
+	return scan;
+}
+
+/** A cte_map is serialized as `{ map: [{ key: <cte name>, value: <definition> }] }`. */
+function collectCteNames(cteMap: unknown, names: Set<string>): void {
+	const entries = (cteMap as { map?: unknown[] } | null)?.map;
+	if (!Array.isArray(entries)) {
+		return;
+	}
+
+	for (const entry of entries) {
+		const name = (entry as { key?: unknown } | null)?.key;
+		if (typeof name === 'string') {
+			names.add(name);
+		}
 	}
 }
 

--- a/apps/backend/src/services/sandbox-runtime.ts
+++ b/apps/backend/src/services/sandbox-runtime.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 /**
  * The sandbox runtime is an optional native dependency, so whether a deployment can run code at
  * all is decided here, once, at startup. It lives apart from the tool that uses it because other
@@ -6,12 +8,31 @@
  */
 let boxlite: typeof import('@boxlite-ai/boxlite') | null = null;
 
-try {
-	boxlite = await import('@boxlite-ai/boxlite');
-} catch {
-	console.warn('⚠ sandbox runtime not installed — execute_sandboxed_code tool disabled (run `nao chat --sandbox`)');
+if (isSandboxHostSupported()) {
+	try {
+		boxlite = await import('@boxlite-ai/boxlite');
+	} catch {
+		console.warn(
+			'⚠ sandbox runtime not installed — execute_sandboxed_code tool disabled (run `nao chat --sandbox`)',
+		);
+	}
+} else {
+	console.warn('⚠ sandbox runtime unavailable on this host; execute_sandboxed_code tool disabled');
 }
 
 export const sandboxRuntime = boxlite;
 
 export const isSandboxAvailable = boxlite !== null;
+
+function isSandboxHostSupported(): boolean {
+	if (process.platform !== 'linux') {
+		return true;
+	}
+
+	try {
+		fs.accessSync('/dev/kvm', fs.constants.R_OK | fs.constants.W_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/apps/backend/src/services/story-template-validation.ts
+++ b/apps/backend/src/services/story-template-validation.ts
@@ -1,17 +1,59 @@
 import { findUnreferencedStoryFilters, validateSqlFilterTemplate } from '@nao/shared/sql-template';
-import { getStoryFiltersFromCode } from '@nao/shared/story-segments';
+import { extractQueryIds, getStoryFiltersFromCode } from '@nao/shared/story-segments';
+import { QueryIdSchema } from '@nao/shared/tools';
 
 import { env } from '../env';
-import * as storyQueries from '../queries/story.queries';
+import * as executeSqlQueries from '../queries/execute-sql.queries';
+
+type SqlQueryMap = Record<string, { sqlQuery: string; databaseId?: string }>;
 
 export async function getStoryTemplateWarnings(chatId: string, code: string): Promise<string[]> {
-	if (!env.BETA_STORY_FILTERS_ENABLED) {
-		return [];
+	const warnings: string[] = [];
+	const { wellFormedIds, malformedWarnings } = partitionReferencedQueryIds(code);
+	warnings.push(...malformedWarnings);
+
+	const sqlQueries =
+		wellFormedIds.size > 0 ? await executeSqlQueries.getLatestSqlQueriesByIds(chatId, wellFormedIds) : {};
+
+	warnings.push(...getMissingQueryWarnings(wellFormedIds, sqlQueries));
+
+	if (env.BETA_STORY_FILTERS_ENABLED) {
+		warnings.push(...getFilterWarnings(code, sqlQueries));
 	}
 
+	return warnings;
+}
+
+function partitionReferencedQueryIds(code: string): { wellFormedIds: Set<string>; malformedWarnings: string[] } {
+	const wellFormedIds = new Set<string>();
+	const malformedWarnings: string[] = [];
+	for (const queryId of extractQueryIds(code)) {
+		if (QueryIdSchema.safeParse(queryId).success) {
+			wellFormedIds.add(queryId);
+		} else {
+			malformedWarnings.push(
+				`Story references query_id "${queryId}", which is not a valid query id. Use the exact id returned in an execute_sql tool output (the "id" field, which looks like "query_..."); a chart/table/map block with an invalid query_id renders empty.`,
+			);
+		}
+	}
+	return { wellFormedIds, malformedWarnings };
+}
+
+function getMissingQueryWarnings(wellFormedIds: Set<string>, sqlQueries: SqlQueryMap): string[] {
+	const warnings: string[] = [];
+	for (const queryId of wellFormedIds) {
+		if (!sqlQueries[queryId]) {
+			warnings.push(
+				`Story references query_id "${queryId}", which was not produced by any execute_sql call in this chat. Run execute_sql first and use the exact id returned in its output (the "id" field); a chart/table/map block with an unknown query_id renders empty.`,
+			);
+		}
+	}
+	return warnings;
+}
+
+function getFilterWarnings(code: string, sqlQueries: SqlQueryMap): string[] {
 	const filters = getStoryFiltersFromCode(code);
 	const knownFilterIds = filters.map((filter) => filter.id);
-	const sqlQueries = await storyQueries.getSqlQueriesFromCode(chatId, code);
 	const warnings: string[] = [];
 
 	for (const duplicateId of findDuplicateFilterIds(knownFilterIds)) {

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -793,6 +793,10 @@ export const projectRoutes = {
 		return projectQueries.listProjectMembersWithRoles(ctx.project.id);
 	}),
 
+	listUsersWithAccess: projectProtectedProcedure.query(async ({ ctx }) => {
+		return projectQueries.listUsersWithProjectAccess(ctx.project.id);
+	}),
+
 	getProjectMembersByChatId: protectedProcedure
 		.input(z.object({ chatId: z.string() }))
 		.query(async ({ ctx, input }) => {

--- a/apps/backend/src/types/project.ts
+++ b/apps/backend/src/types/project.ts
@@ -5,7 +5,6 @@ export interface UserWithRole {
 	name: string;
 	email: string;
 	role: UserRole;
-	messagingProviderCode: string | null;
 }
 
 export type ProjectChatsFacetKey = 'userName' | 'userRole' | 'toolState' | 'feedback' | 'source';

--- a/apps/backend/src/utils/project-import.utils.ts
+++ b/apps/backend/src/utils/project-import.utils.ts
@@ -7,7 +7,6 @@ import yaml from 'js-yaml';
 import type { DBProject } from '../db/abstractSchema';
 import { env } from '../env';
 import { ensureContextRecommendationsScheduleForNewProject } from '../handlers/context-recommendations.handler';
-import * as orgQueries from '../queries/organization.queries';
 import * as projectQueries from '../queries/project.queries';
 
 export function createTempProjectDir(prefix: string): string {
@@ -90,14 +89,6 @@ export async function createNewProject({
 		orgId,
 	});
 
-	const orgMembers = await orgQueries.listOrgMembersWithUsers(orgId);
-	for (const member of orgMembers) {
-		await projectQueries.addProjectMember({
-			projectId: project.id,
-			userId: member.id,
-			role: member.role,
-		});
-	}
 	await ensureContextRecommendationsScheduleForNewProject(project.id);
 
 	return { projectId: project.id, projectName, status: 'created' as const };

--- a/apps/backend/tests/duckdb-query-results.test.ts
+++ b/apps/backend/tests/duckdb-query-results.test.ts
@@ -92,6 +92,31 @@ describe('runSqlOverQueryResults', () => {
 		).rejects.toThrow(/allowlist/i);
 	});
 
+	it('accepts DuckDB-specific syntax such as TRY_CAST', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([['query_orders', orders]]),
+			'SELECT SUM(TRY_CAST(customer_id AS BIGINT)) AS total FROM query_orders',
+		);
+
+		expect(result.data).toEqual([{ total: 105 }]);
+	});
+
+	it('accepts DuckDB-specific syntax such as QUALIFY', async () => {
+		const result = await runSqlOverQueryResults(
+			new Map([['query_orders', orders]]),
+			`SELECT customer_id, SUM(total_amount) AS revenue FROM query_orders GROUP BY customer_id
+			 QUALIFY ROW_NUMBER() OVER (ORDER BY revenue DESC) = 1`,
+		);
+
+		expect(result.data).toEqual([{ customer_id: 51, revenue: 100 }]);
+	});
+
+	it('rejects unparseable SQL, naming DuckDB and the parser error', async () => {
+		await expect(
+			runSqlOverQueryResults(new Map([['query_orders', orders]]), 'SELECT FROM WHERE )('),
+		).rejects.toThrow(/Could not parse the query as DuckDB.*syntax error/s);
+	});
+
 	it('allows CTEs that only read allowlisted tables', async () => {
 		const result = await runSqlOverQueryResults(
 			new Map([['query_orders', orders]]),

--- a/apps/backend/tests/project-accessible-users.test.ts
+++ b/apps/backend/tests/project-accessible-users.test.ts
@@ -1,13 +1,26 @@
-import '../src/env';
-
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.hoisted(() => {
+	process.env.MODE = 'test';
+	process.env.NAO_MODE = 'self-hosted';
+});
+
+import '../src/env';
+
 import { db as appDb } from '../src/db/db';
 import * as sqliteSchema from '../src/db/sqlite-schema';
 import { organization, orgMember, project, projectMember, user } from '../src/db/sqlite-schema';
-import { listProjectMembersWithRoles, listUsersWithProjectAccess } from '../src/queries/project.queries';
+import { env, isCloud } from '../src/env';
+import { listOrgProjectsWithAccess } from '../src/queries/organization.queries';
+import {
+	getProjectByUserId,
+	getUserRoleInProject,
+	listProjectMembersWithRoles,
+	listUserProjectsWithRoles,
+	listUsersWithProjectAccess,
+} from '../src/queries/project.queries';
 
 vi.mock('../src/db/db', async () => {
 	const { drizzle } = await import('drizzle-orm/better-sqlite3');
@@ -26,30 +39,41 @@ async function cleanup() {
 	await db.delete(organization).where(eq(organization.id, 'pau-org'));
 	await db.delete(user).where(eq(user.id, 'pau-direct'));
 	await db.delete(user).where(eq(user.id, 'pau-org-only'));
+	await db.delete(user).where(eq(user.id, 'pau-org-admin'));
 	await db.delete(user).where(eq(user.id, 'pau-both'));
 	await db.delete(user).where(eq(user.id, 'pau-ctx'));
+	await db.delete(user).where(eq(user.id, 'pau-none'));
 }
 
 describe('project accessible users', () => {
+	const originalDefaultProjectPath = env.NAO_DEFAULT_PROJECT_PATH;
+
 	beforeEach(async () => {
 		await cleanup();
+		env.NAO_DEFAULT_PROJECT_PATH = '/tmp/pau';
 		await db.insert(organization).values({ id: 'pau-org', name: 'PAU', slug: 'pau-org' });
 		await db.insert(project).values([
 			{ id: 'pau-proj', orgId: 'pau-org', name: 'PAU', type: 'local', path: '/tmp/pau' },
 			{ id: 'pau-solo', orgId: null, name: 'PAU Solo', type: 'local', path: '/tmp/pau-solo' },
 		]);
 		db.$client
-			.prepare('insert into user (id, name, email) values (?, ?, ?)')
-			.run('pau-direct', 'PAU Direct', 'pau-direct@example.com');
+			.prepare('insert into user (id, name, email, messaging_provider_code) values (?, ?, ?, ?)')
+			.run('pau-direct', 'PAU Direct', 'pau-direct@example.com', 'pau-secret-code');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-org-only', 'PAU Org Only', 'pau-org-only@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-org-admin', 'PAU Org Admin', 'pau-org-admin@example.com');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-both', 'PAU Both', 'pau-both@example.com');
 		db.$client
 			.prepare('insert into user (id, name, email) values (?, ?, ?)')
 			.run('pau-ctx', 'PAU Ctx', 'pau-ctx@example.com');
+		db.$client
+			.prepare('insert into user (id, name, email) values (?, ?, ?)')
+			.run('pau-none', 'PAU None', 'pau-none@example.com');
 		await db.insert(projectMember).values([
 			{ projectId: 'pau-proj', userId: 'pau-direct', role: 'admin' },
 			{ projectId: 'pau-proj', userId: 'pau-both', role: 'viewer' },
@@ -58,11 +82,15 @@ describe('project accessible users', () => {
 		]);
 		await db.insert(orgMember).values([
 			{ orgId: 'pau-org', userId: 'pau-org-only', role: 'user' },
+			{ orgId: 'pau-org', userId: 'pau-org-admin', role: 'admin' },
 			{ orgId: 'pau-org', userId: 'pau-both', role: 'admin' },
 		]);
 	});
 
-	afterEach(cleanup);
+	afterEach(async () => {
+		env.NAO_DEFAULT_PROJECT_PATH = originalDefaultProjectPath;
+		await cleanup();
+	});
 
 	afterAll(() => {
 		appDb.$client.close();
@@ -73,9 +101,16 @@ describe('project accessible users', () => {
 		const users = await listUsersWithProjectAccess('pau-proj');
 		const rolesById = new Map(users.map(({ id, role }) => [id, role]));
 
-		expect([...rolesById.keys()].sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct', 'pau-org-only']);
+		expect([...rolesById.keys()].sort()).toEqual([
+			'pau-both',
+			'pau-ctx',
+			'pau-direct',
+			'pau-org-admin',
+			'pau-org-only',
+		]);
 		expect(rolesById.get('pau-direct')).toBe('admin');
 		expect(rolesById.get('pau-org-only')).toBe('user');
+		expect(rolesById.get('pau-org-admin')).toBe('admin');
 		expect(rolesById.get('pau-both')).toBe('viewer');
 		expect(rolesById.get('pau-ctx')).toBe('context_admin');
 	});
@@ -86,9 +121,73 @@ describe('project accessible users', () => {
 		expect(teamUsers.map(({ id }) => id).sort()).toEqual(['pau-both', 'pau-ctx', 'pau-direct']);
 	});
 
+	it('omits messaging provider codes from user listings', async () => {
+		const accessibleUsers = await listUsersWithProjectAccess('pau-proj');
+		const teamUsers = await listProjectMembersWithRoles('pau-proj');
+
+		expect(accessibleUsers.every((accessibleUser) => !('messagingProviderCode' in accessibleUser))).toBe(true);
+		expect(teamUsers.every((teamUser) => !('messagingProviderCode' in teamUser))).toBe(true);
+	});
+
 	it('self-hosted project without org returns only direct members', async () => {
 		const soloUsers = await listUsersWithProjectAccess('pau-solo');
 
 		expect(soloUsers.map(({ id }) => id).sort()).toEqual(['pau-direct']);
+	});
+
+	it('returns the self-hosted project for an org-only member', async () => {
+		expect(isCloud).toBe(false);
+
+		const result = await getProjectByUserId('pau-org-only');
+
+		expect(result?.id).toBe('pau-proj');
+	});
+
+	it('resolves an org-only member role from the organization', async () => {
+		const role = await getUserRoleInProject('pau-proj', 'pau-org-only');
+
+		expect(role).toBe('user');
+	});
+
+	it('prefers a project member role over the organization role', async () => {
+		const role = await getUserRoleInProject('pau-proj', 'pau-both');
+
+		expect(role).toBe('viewer');
+	});
+
+	it('returns inherited organization roles in user project listings', async () => {
+		const userProjects = await listUserProjectsWithRoles('pau-org-only');
+		const adminProjects = await listUserProjectsWithRoles('pau-org-admin');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.userRole).toBe('user');
+		expect(adminProjects).toHaveLength(1);
+		expect(adminProjects[0]?.userRole).toBe('admin');
+	});
+
+	it('returns inherited organization roles in organization project listings', async () => {
+		const userProjects = await listOrgProjectsWithAccess('pau-org', 'pau-org-only');
+		const adminProjects = await listOrgProjectsWithAccess('pau-org', 'pau-org-admin');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.role).toBe('user');
+		expect(adminProjects).toHaveLength(1);
+		expect(adminProjects[0]?.role).toBe('admin');
+	});
+
+	it('prefers explicit roles in both project listings', async () => {
+		const userProjects = await listUserProjectsWithRoles('pau-both');
+		const orgProjects = await listOrgProjectsWithAccess('pau-org', 'pau-both');
+
+		expect(userProjects).toHaveLength(1);
+		expect(userProjects[0]?.userRole).toBe('viewer');
+		expect(orgProjects).toHaveLength(1);
+		expect(orgProjects[0]?.role).toBe('viewer');
+	});
+
+	it('returns null for a user without project or organization membership', async () => {
+		const result = await getProjectByUserId('pau-none');
+
+		expect(result).toBeNull();
 	});
 });

--- a/apps/backend/tests/sandbox-runtime.test.ts
+++ b/apps/backend/tests/sandbox-runtime.test.ts
@@ -1,0 +1,119 @@
+import { constants } from 'fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentSettings } from '../src/types/agent-settings';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+
+type KvmAccess = 'missing' | 'denied' | 'usable';
+
+const sandboxEnabledSettings = {
+	experimental: { sandboxes: true },
+} as AgentSettings;
+
+async function loadSandboxModules(kvmAccess: KvmAccess, platform = 'linux') {
+	vi.resetModules();
+	Object.defineProperty(process, 'platform', { ...originalPlatform, value: platform });
+
+	const accessSync = vi.fn(() => {
+		if (kvmAccess !== 'usable') {
+			const error = new Error(kvmAccess === 'missing' ? 'ENOENT' : 'EACCES') as NodeJS.ErrnoException;
+			error.code = kvmAccess === 'missing' ? 'ENOENT' : 'EACCES';
+			throw error;
+		}
+	});
+
+	vi.doMock('fs', async (importOriginal) => {
+		const actual = await importOriginal<typeof import('fs')>();
+		return {
+			...actual,
+			accessSync,
+			default: { ...actual.default, accessSync },
+		};
+	});
+	vi.doMock('@boxlite-ai/boxlite', () => ({
+		CodeBox: class FakeCodeBox {},
+		ExecError: class FakeExecError extends Error {},
+		TimeoutError: class FakeTimeoutError extends Error {},
+	}));
+	vi.doMock('../src/db/db', () => ({ db: {} }));
+
+	const runtime = await import('../src/services/sandbox-runtime');
+	const sandboxTool = await import('../src/agents/tools/execute-sandboxed-code');
+	const { getTools } = await import('../src/agents/tools');
+	const { default: loadSkillTool } = await import('../src/agents/tools/load-skill');
+
+	return { accessSync, getTools, loadSkillTool, runtime, sandboxTool: sandboxTool.default };
+}
+
+async function loadPdfSkill(loadSkillTool: Awaited<ReturnType<typeof loadSandboxModules>>['loadSkillTool']) {
+	return (await loadSkillTool.execute!(
+		{ name: 'pdf-handling' },
+		{
+			experimental_context: { agentSettings: sandboxEnabledSettings },
+			toolCallId: 'sandbox-capability-test',
+			messages: [],
+		},
+	)) as { body: string };
+}
+
+afterEach(() => {
+	Object.defineProperty(process, 'platform', originalPlatform);
+	vi.restoreAllMocks();
+	vi.resetModules();
+	vi.doUnmock('fs');
+	vi.doUnmock('@boxlite-ai/boxlite');
+	vi.doUnmock('../src/db/db');
+});
+
+describe('sandbox runtime host capability', () => {
+	it.each(['missing', 'denied'] as const)(
+		'should not expose the sandbox when /dev/kvm is %s - regression for ENG-9189',
+		async (kvmAccess) => {
+			// Arrange
+			const modules = await loadSandboxModules(kvmAccess);
+
+			// Act
+			const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+			const pdfSkill = await loadPdfSkill(modules.loadSkillTool);
+
+			// Assert
+			expect(modules.accessSync).toHaveBeenCalledWith('/dev/kvm', constants.R_OK | constants.W_OK);
+			expect(modules.runtime.sandboxRuntime).toBeNull();
+			expect(modules.runtime.isSandboxAvailable).toBe(false);
+			expect(modules.sandboxTool).toBeNull();
+			expect(tools).not.toHaveProperty('execute_sandboxed_code');
+			expect(pdfSkill.body).not.toContain('pdfplumber');
+		},
+	);
+
+	it('should expose the sandbox when /dev/kvm is usable', async () => {
+		// Arrange
+		const modules = await loadSandboxModules('usable');
+
+		// Act
+		const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+		const pdfSkill = await loadPdfSkill(modules.loadSkillTool);
+
+		// Assert
+		expect(modules.accessSync).toHaveBeenCalledWith('/dev/kvm', constants.R_OK | constants.W_OK);
+		expect(modules.runtime.sandboxRuntime).not.toBeNull();
+		expect(modules.runtime.isSandboxAvailable).toBe(true);
+		expect(modules.sandboxTool).not.toBeNull();
+		expect(tools).toHaveProperty('execute_sandboxed_code');
+		expect(pdfSkill.body).toContain('pdfplumber');
+	});
+
+	it('should preserve the native runtime check on non-Linux hosts', async () => {
+		// Arrange
+		const modules = await loadSandboxModules('missing', 'darwin');
+
+		// Act
+		const tools = modules.getTools(sandboxEnabledSettings, undefined, { mcpEnabled: false });
+
+		// Assert
+		expect(modules.accessSync).not.toHaveBeenCalled();
+		expect(modules.runtime.isSandboxAvailable).toBe(true);
+		expect(tools).toHaveProperty('execute_sandboxed_code');
+	});
+});

--- a/apps/backend/tests/system-prompt.test.ts
+++ b/apps/backend/tests/system-prompt.test.ts
@@ -293,6 +293,17 @@ describe('SystemPrompt built-in skills', () => {
 	});
 });
 
+describe('SystemPrompt SQL query rules', () => {
+	it('forbids citing table documentation statistics as answers to data questions', () => {
+		const markdown = renderToMarkdown(SystemPrompt({}));
+
+		expect(markdown).toContain('never present them as the answer to a data question');
+		expect(markdown).toContain(
+			'must come from a query executed in this conversation, or be computed from such results',
+		);
+	});
+});
+
 describe('SystemPrompt display_map rules', () => {
 	it('includes the display_map rule by default', () => {
 		expect(renderToMarkdown(SystemPrompt({}))).toContain('display_map');

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -388,7 +388,7 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		pageLabel: 'MCP Endpoint',
 		title: 'MCP Server Endpoint',
 		description: 'Allow external AI clients to connect to this workspace via MCP.',
-		keywords: ['model context protocol', 'claude desktop', 'cursor', 'external', 'api', 'bearer'],
+		keywords: ['model context protocol', 'claude desktop', 'cursor', 'dust', 'external', 'api', 'bearer'],
 	},
 	{
 		page: '/settings/mcp-endpoint',

--- a/apps/frontend/src/components/settings/experimental.tsx
+++ b/apps/frontend/src/components/settings/experimental.tsx
@@ -150,7 +150,7 @@ export function SettingsExperimental({ isAdmin }: SettingsExperimentalProps) {
 						</a>
 						.
 						{!sandboxAvailable &&
-							' The runtime is not installed — on macOS or Linux, run `nao chat --sandbox` and restart nao.'}
+							' The sandbox runtime is unavailable on this host. Install it with `nao chat --sandbox` on a supported host.'}
 					</span>
 				}
 				control={

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -264,6 +264,21 @@ function ConnectionCard() {
 			],
 		},
 		{
+			id: 'dust',
+			label: 'Dust',
+			methods: [
+				{
+					steps: [
+						'Open {Spaces > Tools} and click `Add Tool > Add MCP Server`.',
+						'Paste the URL below into the `MCP server URL` field — keep the `?chart_output=data` parameter: it returns chart config and data so Dust agents can render charts as interactive frames.',
+						'Authenticate in your browser when prompted.',
+					],
+					config: `${endpointUrl}?chart_output=data`,
+					configLabel: 'MCP Endpoint URL',
+				},
+			],
+		},
+		{
 			id: 'cli',
 			label: 'CLI',
 			methods: [

--- a/apps/frontend/src/hooks/use-share-dialog.ts
+++ b/apps/frontend/src/hooks/use-share-dialog.ts
@@ -2,19 +2,11 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { trpc } from '@/main';
 
-export function useMemberPicker(currentUserId: string | undefined, initialIds?: string[], chatId?: string) {
+export function useMemberPicker(currentUserId: string | undefined, initialIds: string[] | undefined, chatId: string) {
 	const [selectedUserIds, setSelectedUserIds] = useState<Set<string>>(() => new Set(initialIds));
 	const [search, setSearch] = useState('');
 
-	const membersByChatQuery = useQuery({
-		...trpc.project.getProjectMembersByChatId.queryOptions({ chatId: chatId! }),
-		enabled: !!chatId,
-	});
-	const membersDefaultQuery = useQuery({
-		...trpc.project.listAllUsersWithRoles.queryOptions(),
-		enabled: !chatId,
-	});
-	const membersQuery = chatId ? membersByChatQuery : membersDefaultQuery;
+	const membersQuery = useQuery(trpc.project.getProjectMembersByChatId.queryOptions({ chatId }));
 
 	const otherMembers = useMemo(() => {
 		return (membersQuery.data ?? []).filter((m) => m.id !== currentUserId);

--- a/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.project.budgets.tsx
@@ -138,7 +138,7 @@ function RouteComponent() {
 		enabled: perUserSpendEnabled,
 	});
 	const projectMembers = useQuery({
-		...trpc.project.listAllUsersWithRoles.queryOptions(),
+		...trpc.project.listUsersWithAccess.queryOptions(),
 		enabled: perUserSpendEnabled,
 	});
 

--- a/apps/shared/src/story-segments.ts
+++ b/apps/shared/src/story-segments.ts
@@ -683,10 +683,14 @@ function extractSeriesFromRawAttrs(attrString: string): ParsedChartBlock['series
 
 export function extractQueryIds(code: string): Set<string> {
 	const ids = new Set<string>();
-	const regex = /<(?:chart|table|map)\s+[^>]*?\bquery_id\s*=\s*"([^"]+)"/g;
-	let match: RegExpExecArray | null;
-	while ((match = regex.exec(code)) !== null) {
-		ids.add(match[1]);
+	for (const tagRegex of [chartTagRegex('g'), tableTagRegex('g'), mapTagRegex('g')]) {
+		let match: RegExpExecArray | null;
+		while ((match = tagRegex.exec(code)) !== null) {
+			const { query_id } = parseChartAttributes(match[1]);
+			if (query_id) {
+				ids.add(query_id);
+			}
+		}
 	}
 	return ids;
 }

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -24,7 +24,7 @@ const ChartTypeNameSchema = z
 	.string()
 	.regex(/^[a-z][a-z0-9_-]*$/, 'Chart type must use lowercase letters, numbers, underscores, or hyphens.');
 const CustomChartTypeSchema = ChartTypeNameSchema.refine(
-	(type) => type !== 'table' && !(BUILTIN_CHART_TYPES as readonly string[]).includes(type),
+	(type) => !isNativeDisplayType(type),
 ).brand<'CustomChartType'>();
 const ChartTypeSchema = z.union([ChartTypeEnum, CustomChartTypeSchema]);
 
@@ -345,6 +345,11 @@ export type BuiltinChartInput = Omit<ChartInput, 'chart_type'> & { chart_type: C
 
 export function isBuiltinChartType(type: string): type is ChartType {
 	return (BUILTIN_CHART_TYPES as readonly string[]).includes(type);
+}
+
+/** Display types nao renders natively (as opposed to project-defined custom charts): builtins plus `table`. */
+export function isNativeDisplayType(type: string): boolean {
+	return type === 'table' || isBuiltinChartType(type);
 }
 
 export function isTableInput(input: Input): input is TableInput {

--- a/apps/shared/src/tools/index.ts
+++ b/apps/shared/src/tools/index.ts
@@ -10,6 +10,7 @@ export * as list from './list';
 export * as loadSkill from './load-skill';
 export * as mcpCall from './mcp-call';
 export * as mcpConnect from './mcp-connect';
+export { QueryIdSchema } from './query-id';
 export * as readFile from './read';
 export * as readQueryResult from './read-query-result';
 export * as searchFiles from './search';

--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -244,13 +244,13 @@ def extract_page_title(page: dict[str, Any], page_id: str) -> str:
     """Read a page's title from its properties, falling back to its ID."""
     properties = page.get("properties", {})
 
-    for prop_name in ["title", "Title", "Name", "name", "Page"]:
-        if prop_name in properties:
-            title_prop = properties[prop_name]
-            if title_prop.get("type") == "title":
-                title_array = title_prop.get("title", [])
-                if title_array:
-                    return "".join(t.get("plain_text", "") for t in title_array)
+    # Database rows name their title property freely (e.g. "Topic"), so match on the
+    # property type rather than a list of conventional names.
+    for title_prop in properties.values():
+        if title_prop.get("type") == "title":
+            title_array = title_prop.get("title", [])
+            if title_array:
+                return "".join(t.get("plain_text", "") for t in title_array)
 
     return page_id
 

--- a/cli/nao_core/commands/test/case.py
+++ b/cli/nao_core/commands/test/case.py
@@ -16,6 +16,7 @@ class TestCase:
     prompt: str
     file_path: Path
     sql: str
+    database: str | None = None
 
     @classmethod
     def from_yaml(cls, file_path: Path) -> "TestCase":
@@ -27,6 +28,7 @@ class TestCase:
             name=data.get("name", file_path.stem),
             prompt=data["prompt"],
             sql=data.get("sql"),
+            database=data.get("database"),
             file_path=file_path,
         )
 

--- a/cli/nao_core/commands/test/client.py
+++ b/cli/nao_core/commands/test/client.py
@@ -131,6 +131,9 @@ class AgentClient:
             "sql": test_case.sql,
         }
 
+        if test_case.database:
+            payload["databaseId"] = test_case.database
+
         cost_payload = serialize_model_costs(costs)
         if cost_payload is not None:
             payload["meta"] = {"costs": cost_payload}

--- a/cli/tests/nao_core/commands/sync/test_notion_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_provider.py
@@ -12,6 +12,7 @@ from nao_core.commands.sync.providers.notion.database import DatabaseExportError
 from nao_core.commands.sync.providers.notion.provider import (
     NotionSyncProvider,
     extract_notion_id,
+    extract_page_title,
     extract_view_id,
     markdown_filename,
     render_document,
@@ -111,6 +112,23 @@ def test_extract_notion_id_prefers_the_object_over_the_view():
     url = "https://notion.so/ws/marts-35e5f0e8a00080c69a81ef456a2b174b?v=" + "a" * 32
 
     assert extract_notion_id(url) == "35e5f0e8a00080c69a81ef456a2b174b"
+
+
+def test_extract_page_title_reads_a_custom_named_title_property():
+    page = {
+        "properties": {
+            "Owner": {"type": "people", "people": []},
+            "Topic": {"type": "title", "title": [{"plain_text": "Basic "}, {"plain_text": "Knowledge"}]},
+        }
+    }
+
+    assert extract_page_title(page, "35e5f0e8a00080c69a81ef456a2b174b") == "Basic Knowledge"
+
+
+def test_extract_page_title_falls_back_to_the_id_when_the_title_is_empty():
+    page = {"properties": {"Topic": {"type": "title", "title": []}}}
+
+    assert extract_page_title(page, "35e5f0e8a00080c69a81ef456a2b174b") == "35e5f0e8a00080c69a81ef456a2b174b"
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/nao_core/commands/test_case.py
+++ b/cli/tests/nao_core/commands/test_case.py
@@ -1,3 +1,4 @@
+from nao_core.commands.test.case import TestCase as NaoTestCase
 from nao_core.commands.test.case import discover_tests
 
 
@@ -11,6 +12,24 @@ def test_discover_tests_is_recursive(tmp_path):
 
     names = {c.name for c in cases}
     assert names == {"mrr", "uptime"}
+
+
+def test_from_yaml_reads_the_database_field(tmp_path):
+    test_file = tmp_path / "revenue.yml"
+    test_file.write_text("prompt: total revenue\nsql: select 1\ndatabase: bigquery-prod\n")
+
+    case = NaoTestCase.from_yaml(test_file)
+
+    assert case.database == "bigquery-prod"
+
+
+def test_from_yaml_leaves_database_unset_when_absent(tmp_path):
+    test_file = tmp_path / "revenue.yml"
+    test_file.write_text("prompt: total revenue\nsql: select 1\n")
+
+    case = NaoTestCase.from_yaml(test_file)
+
+    assert case.database is None
 
 
 def test_discover_tests_ignores_outputs_dir(tmp_path):

--- a/cli/tests/nao_core/commands/test_runner.py
+++ b/cli/tests/nao_core/commands/test_runner.py
@@ -8,6 +8,7 @@ import pytest
 
 from nao_core.commands.test.case import TestCase as NaoTestCase
 from nao_core.commands.test.client import (
+    AgentClient,
     AgentClientError,
     TokenCost,
     TokenUsage,
@@ -162,6 +163,47 @@ def test_serialize_model_costs_uses_backend_field_names():
         "inputCacheWrite": 1.25,
         "output": 2.0,
     }
+
+
+def _successful_run_response() -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "text": "",
+        "toolCalls": [],
+        "usage": {"totalTokens": 0},
+        "cost": {"totalCost": 0},
+        "finishReason": "stop",
+    }
+    return response
+
+
+def test_client_sends_the_test_case_database_as_database_id(monkeypatch):
+    test_case = NaoTestCase(
+        name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1", database="bigquery-prod"
+    )
+    client = AgentClient(backend_url="http://backend")
+    session = Mock()
+    session.post.return_value = _successful_run_response()
+    monkeypatch.setattr(client, "_get_session", lambda: session)
+
+    client.run_test(test_case)
+
+    payload = session.post.call_args.kwargs["json"]
+    assert payload["databaseId"] == "bigquery-prod"
+
+
+def test_client_omits_database_id_when_the_test_case_has_none(monkeypatch):
+    test_case = NaoTestCase(name="orders", prompt="p1", file_path=Path("tests/orders.yml"), sql="select 1")
+    client = AgentClient(backend_url="http://backend")
+    session = Mock()
+    session.post.return_value = _successful_run_response()
+    monkeypatch.setattr(client, "_get_session", lambda: session)
+
+    client.run_test(test_case)
+
+    payload = session.post.call_args.kwargs["json"]
+    assert "databaseId" not in payload
 
 
 def test_run_test_passes_configured_costs_to_client(monkeypatch):

--- a/skills/create-context-tests/templates/test.yaml
+++ b/skills/create-context-tests/templates/test.yaml
@@ -22,6 +22,7 @@ sql: |
     );
 
 # Optional fields:
+# database: <database name from nao_config.yaml — required when several databases are configured>
 # category: revenue | activity | conversion | churn | retention | ...
 # difficulty: easy | medium | hard
 # notes: why this test matters / what failure mode it catches


### PR DESCRIPTION
- "see SQL behind chart" button in story view mode is now visible and displays the executed SQL even if the beta_story_filter_enabled var is false in the .env
- SQL in stories no longer depend on the variable and display either way
- readme includes a section that shows how to run nao locally

Fixes #1505 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

