### PR TITLE
Fix Chat not found issue when browser loses network.

### DIFF
--- a/apps/frontend/src/components/chat-access-error.tsx
+++ b/apps/frontend/src/components/chat-access-error.tsx
@@ -4,12 +4,7 @@ import { Lock, SearchX, TriangleAlert, WifiOff } from 'lucide-react';
 import { MobileHeader } from '@/components/mobile-header';
 import { Button } from '@/components/ui/button';
 import { getSafeRedirectPath } from '@/lib/safe-redirect';
-import {
-	isForbiddenError,
-	isInternalServerError,
-	isNotFoundError,
-	isUnauthorizedError,
-} from '@/lib/trpc-error';
+import { isForbiddenError, isInternalServerError, isNotFoundError, isUnauthorizedError } from '@/lib/trpc-error';
 
 export function ChatAccessError({
 	error,

--- a/apps/frontend/src/components/chat-access-error.tsx
+++ b/apps/frontend/src/components/chat-access-error.tsx
@@ -1,0 +1,118 @@
+import { Link } from '@tanstack/react-router';
+import { Lock, SearchX, TriangleAlert, WifiOff } from 'lucide-react';
+
+import { MobileHeader } from '@/components/mobile-header';
+import { Button } from '@/components/ui/button';
+import { getSafeRedirectPath } from '@/lib/safe-redirect';
+import {
+	isForbiddenError,
+	isInternalServerError,
+	isNotFoundError,
+	isUnauthorizedError,
+} from '@/lib/trpc-error';
+
+export function ChatAccessError({
+	error,
+	onRetry,
+	chatId,
+}: {
+	error?: unknown;
+	onRetry?: () => void;
+	chatId?: string;
+}) {
+	if (isNotFoundError(error)) {
+		return (
+			<ChatErrorLayout
+				icon={<SearchX className='size-4' aria-hidden />}
+				title='Chat not found'
+				description='This chat may have been deleted, moved, or you may not have access to it.'
+			>
+				<Button asChild variant='secondary'>
+					<Link to='/'>Start a new chat</Link>
+				</Button>
+			</ChatErrorLayout>
+		);
+	}
+
+	if (isUnauthorizedError(error)) {
+		const redirect = getSafeRedirectPath(chatId ? `/${chatId}` : undefined) ?? undefined;
+		return (
+			<ChatErrorLayout
+				icon={<Lock className='size-4' aria-hidden />}
+				title='Session expired'
+				description='Sign in again to continue where you left off.'
+			>
+				<Button asChild>
+					<Link to='/login' search={{ error: undefined, redirect }}>
+						Sign in
+					</Link>
+				</Button>
+			</ChatErrorLayout>
+		);
+	}
+
+	if (isForbiddenError(error)) {
+		return (
+			<ChatErrorLayout
+				icon={<Lock className='size-4' aria-hidden />}
+				title="You don't have access to this chat"
+				description='Ask the owner to share it with you if you need access.'
+			>
+				<Button asChild variant='secondary'>
+					<Link to='/'>Go home</Link>
+				</Button>
+			</ChatErrorLayout>
+		);
+	}
+
+	const isServerError = isInternalServerError(error);
+	return (
+		<ChatErrorLayout
+			icon={
+				isServerError ? (
+					<TriangleAlert className='size-4' aria-hidden />
+				) : (
+					<WifiOff className='size-4' aria-hidden />
+				)
+			}
+			title={isServerError ? 'Something went wrong' : "Can't reach nao"}
+			description={
+				isServerError
+					? "We couldn't load this chat. This is likely a temporary problem, so please try again."
+					: 'Check your connection and try again.'
+			}
+		>
+			{onRetry ? <Button onClick={onRetry}>Retry</Button> : null}
+		</ChatErrorLayout>
+	);
+}
+
+function ChatErrorLayout({
+	icon,
+	title,
+	description,
+	children,
+}: {
+	icon: React.ReactNode;
+	title: string;
+	description: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className='flex h-full flex-1 flex-col min-w-0 overflow-hidden justify-center bg-panel'>
+			<MobileHeader />
+			<div className='flex flex-1 items-center justify-center p-6'>
+				<div className='flex max-w-sm flex-col items-center gap-4 text-center'>
+					<div className='flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground'>
+						{icon}
+					</div>
+					<div className='space-y-2'>
+						<h1 className='text-lg font-medium tracking-tight'>{title}</h1>
+						<p className='text-sm text-muted-foreground'>{description}</p>
+					</div>
+					<div className='flex items-center gap-2'>{children}</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/src/components/chat-access-error.tsx
+++ b/apps/frontend/src/components/chat-access-error.tsx
@@ -71,7 +71,7 @@ export function ChatAccessError({
 			</ChatErrorLayout>
 		);
 	}
-	
+
 	return (
 		<ChatErrorLayout
 			icon={<WifiOff className='size-4' aria-hidden />}

--- a/apps/frontend/src/components/chat-access-error.tsx
+++ b/apps/frontend/src/components/chat-access-error.tsx
@@ -60,22 +60,23 @@ export function ChatAccessError({
 		);
 	}
 
-	const isServerError = isInternalServerError(error);
+	if (isInternalServerError(error)) {
+		return (
+			<ChatErrorLayout
+				icon={<TriangleAlert className='size-4' aria-hidden />}
+				title='Something went wrong'
+				description="We couldn't load this chat. This is likely a temporary problem, so please try again."
+			>
+				{onRetry ? <Button onClick={onRetry}>Retry</Button> : null}
+			</ChatErrorLayout>
+		);
+	}
+	
 	return (
 		<ChatErrorLayout
-			icon={
-				isServerError ? (
-					<TriangleAlert className='size-4' aria-hidden />
-				) : (
-					<WifiOff className='size-4' aria-hidden />
-				)
-			}
-			title={isServerError ? 'Something went wrong' : "Can't reach nao"}
-			description={
-				isServerError
-					? "We couldn't load this chat. This is likely a temporary problem, so please try again."
-					: 'Check your connection and try again.'
-			}
+			icon={<WifiOff className='size-4' aria-hidden />}
+			title="Can't reach nao"
+			description='Check your connection and try again.'
 		>
 			{onRetry ? <Button onClick={onRetry}>Retry</Button> : null}
 		</ChatErrorLayout>

--- a/apps/frontend/src/lib/trpc-error.ts
+++ b/apps/frontend/src/lib/trpc-error.ts
@@ -13,3 +13,11 @@ export function isForbiddenError(error: unknown): boolean {
 export function isNotFoundError(error: unknown): boolean {
 	return getTrpcErrorCode(error) === 'NOT_FOUND';
 }
+
+export function isUnauthorizedError(error: unknown): boolean {
+	return getTrpcErrorCode(error) === 'UNAUTHORIZED';
+}
+
+export function isInternalServerError(error: unknown): boolean {
+	return getTrpcErrorCode(error) === 'INTERNAL_SERVER_ERROR';
+}

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -8,6 +8,7 @@ import { NEW_CHAT_ID } from '@/lib/ai';
 import { StoryOpenButton } from '@/components/story-open-button';
 import { StoryViewer } from '@/components/side-panel/story-viewer';
 import { DEFAULT_USAGE_SEARCH } from '@/components/settings/usage-route-search';
+import { ChatAccessError } from '@/components/chat-access-error';
 import { ChatInput } from '@/components/chat-input';
 import { ChatMessages } from '@/components/chat-messages/chat-messages';
 import { HighlightBubble } from '@/components/highlight-bubble';
@@ -78,6 +79,17 @@ function ChatPage() {
 		}
 	}, [shouldRedirectToReplay, chatId, router]);
 
+	useEffect(() => {
+		if (!chat.isError) {
+			return;
+		}
+		const onOnline = () => {
+			void chat.refetch();
+		};
+		window.addEventListener('online', onOnline);
+		return () => window.removeEventListener('online', onOnline);
+	}, [chat.isError, chat.refetch]);
+
 	const shareQuery = useQuery({
 		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
 		enabled: chat.isSuccess,
@@ -136,7 +148,7 @@ function ChatPage() {
 		if (shouldRedirectToReplay || isResolvingReplayRedirect) {
 			return null;
 		}
-		return <ChatNotFoundState />;
+		return <ChatAccessError error={chat.error} onRetry={() => chat.refetch()} chatId={chatId} />;
 	}
 
 	return (
@@ -289,27 +301,6 @@ function ChatPage() {
 				chatId={chatId}
 			/>
 		</SidePanelProvider>
-	);
-}
-
-function ChatNotFoundState() {
-	return (
-		<div className='flex h-full flex-1 flex-col min-w-0 overflow-hidden justify-center bg-panel'>
-			<MobileHeader />
-			<div className='flex flex-1 items-center justify-center p-6'>
-				<div className='flex max-w-sm flex-col items-center gap-4 text-center'>
-					<div className='space-y-2'>
-						<h1 className='text-lg font-medium tracking-tight'>Chat not found</h1>
-						<p className='text-sm text-muted-foreground'>
-							This chat may have been deleted, moved, or you may not have access to it.
-						</p>
-					</div>
-					<Button asChild variant='secondary'>
-						<Link to='/'>Start a new chat</Link>
-					</Button>
-				</div>
-			</div>
-		</div>
 	);
 }
 

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -79,19 +79,6 @@ function ChatPage() {
 		}
 	}, [shouldRedirectToReplay, chatId, router]);
 
-	const { isError: isChatError, refetch: refetchChat } = chat;
-
-	useEffect(() => {
-		if (!isChatError) {
-			return;
-		}
-		const onOnline = () => {
-			void refetchChat();
-		};
-		window.addEventListener('online', onOnline);
-		return () => window.removeEventListener('online', onOnline);
-	}, [isChatError, refetchChat]);
-
 	const shareQuery = useQuery({
 		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
 		enabled: chat.isSuccess,
@@ -150,7 +137,7 @@ function ChatPage() {
 		if (shouldRedirectToReplay || isResolvingReplayRedirect) {
 			return null;
 		}
-		return <ChatAccessError error={chat.error} onRetry={() => refetchChat()} chatId={chatId} />;
+		return <ChatAccessError error={chat.error} onRetry={() => chat.refetch()} chatId={chatId} />;
 	}
 
 	return (

--- a/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout._chat-layout.$chatId.tsx
@@ -79,16 +79,18 @@ function ChatPage() {
 		}
 	}, [shouldRedirectToReplay, chatId, router]);
 
+	const { isError: isChatError, refetch: refetchChat } = chat;
+
 	useEffect(() => {
-		if (!chat.isError) {
+		if (!isChatError) {
 			return;
 		}
 		const onOnline = () => {
-			void chat.refetch();
+			void refetchChat();
 		};
 		window.addEventListener('online', onOnline);
 		return () => window.removeEventListener('online', onOnline);
-	}, [chat.isError, chat.refetch]);
+	}, [isChatError, refetchChat]);
 
 	const shareQuery = useQuery({
 		...trpc.sharedChat.getShareOptionsByChatId.queryOptions({ chatId }),
@@ -148,7 +150,7 @@ function ChatPage() {
 		if (shouldRedirectToReplay || isResolvingReplayRedirect) {
 			return null;
 		}
-		return <ChatAccessError error={chat.error} onRetry={() => chat.refetch()} chatId={chatId} />;
+		return <ChatAccessError error={chat.error} onRetry={() => refetchChat()} chatId={chatId} />;
 	}
 
 	return (


### PR DESCRIPTION
Creates a better distinction between different chat errors when the network is suddenly lost. It used to display "Chat not found. This chat may have been deleted".

- UNAUTHORIZED Error (401)
- INTERNAL SERVER ERROR (500)

The point is to prevent the user from assuming data loss when the issue is only front-end related. With those error codes, the user can click a retry button to reload the page.

Closes #1491 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

