### PR TITLE
fix/view sql in story even if env filter var is false 1505 + readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,43 @@ Docs on nao skills: https://docs.getnao.io/nao-agent/context-engineering/skills
 ## 👩🏻‍💻 Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commands, and guidelines.
+### Start nao locally
+
+Prerequisites: 
+- nvm
+- bun
+- uv
+
+Run the following commands:
+
+```
+npm run npm:pin
+npm install
+npm run db:migrate -w apps/backend
+```
+
+Create a .env file at the root of the repository and input environment variables
+
+Minimum variables necessary are:
+
+```
+BETTER_AUTH_SECRET=#run `openssl rand -base64 32` to generate
+# Public URL of your app (used for authentication, trusted origins, and Slack redirects)
+BETTER_AUTH_URL=http://localhost:3000
+
+# LLM providers
+OPENAI_API_KEY=12345678
+
+NAO_DEFAULT_PROJECT_PATH=#path to example folder
+```
+
+Run the following command:
+
+```
+npm run dev
+```
+
+Go to http://localhost:3000 on your browser
 
 ## 📒 Stack
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ Docs on nao skills: https://docs.getnao.io/nao-agent/context-engineering/skills
 ## 👩🏻‍💻 Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commands, and guidelines.
+
 ### Start nao locally
 
-Prerequisites: 
+Prerequisites:
+
 - nvm
 - bun
 - uv

--- a/apps/backend/src/trpc/shared-story.routes.ts
+++ b/apps/backend/src/trpc/shared-story.routes.ts
@@ -227,7 +227,6 @@ export const sharedStoryRoutes = {
 			}),
 		)
 		.query(async ({ input, ctx }) => {
-			assertStoryFiltersEnabled();
 			const shared = ctx.resource;
 			if (!shared.chatId) {
 				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Shared story has no chat.' });

--- a/apps/backend/src/trpc/story.routes.ts
+++ b/apps/backend/src/trpc/story.routes.ts
@@ -357,7 +357,6 @@ export const storyRoutes = {
 			}),
 		)
 		.query(async ({ input }) => {
-			assertStoryFiltersEnabled();
 			return getStoryQuerySql(input.chatId, input.storySlug, input.queryId, input.selections);
 		}),
 

--- a/apps/frontend/src/components/side-panel/story-preview.tsx
+++ b/apps/frontend/src/components/side-panel/story-preview.tsx
@@ -67,7 +67,10 @@ export const StoryPreview = memo(function StoryPreview({
 
 	const useLiveUnfiltered = isViewingLatest && isNoCacheMode && !storyFilters.hasActiveFilters;
 	const querySqlSource = useMemo(
-		() => (storyFilters.filtersEnabled ? { api: filterApi, selections: storyFilters.debouncedSelections } : null),
+		() => ({ 
+			api: filterApi,
+			selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
+		}),
 		[filterApi, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
 	);
 

--- a/apps/frontend/src/components/side-panel/story-preview.tsx
+++ b/apps/frontend/src/components/side-panel/story-preview.tsx
@@ -71,10 +71,10 @@ export const StoryPreview = memo(function StoryPreview({
 			filtersEnabled
 				? {
 						api: filterApi,
-						selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
+						selections: storyFilters.debouncedSelections,
 					}
 				: null,
-		[filterApi, filtersEnabled, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
+		[filterApi, filtersEnabled, storyFilters.debouncedSelections],
 	);
 
 	const renderChart = useCallback(

--- a/apps/frontend/src/components/side-panel/story-preview.tsx
+++ b/apps/frontend/src/components/side-panel/story-preview.tsx
@@ -67,11 +67,14 @@ export const StoryPreview = memo(function StoryPreview({
 
 	const useLiveUnfiltered = isViewingLatest && isNoCacheMode && !storyFilters.hasActiveFilters;
 	const querySqlSource = useMemo(
-		() => ({
-			api: filterApi,
-			selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
-		}),
-		[filterApi, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
+		() =>
+			filtersEnabled
+				? {
+						api: filterApi,
+						selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
+					}
+				: null,
+		[filterApi, filtersEnabled, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
 	);
 
 	const renderChart = useCallback(

--- a/apps/frontend/src/components/side-panel/story-preview.tsx
+++ b/apps/frontend/src/components/side-panel/story-preview.tsx
@@ -67,7 +67,7 @@ export const StoryPreview = memo(function StoryPreview({
 
 	const useLiveUnfiltered = isViewingLatest && isNoCacheMode && !storyFilters.hasActiveFilters;
 	const querySqlSource = useMemo(
-		() => ({ 
+		() => ({
 			api: filterApi,
 			selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
 		}),

--- a/apps/frontend/src/components/story-tabbed-content.tsx
+++ b/apps/frontend/src/components/story-tabbed-content.tsx
@@ -51,11 +51,11 @@ export function StoryTabbedContent({
 	});
 	const querySqlSource = useMemo(
 		() =>
-			filterApi ? 
-				{ 
-					api: filterApi,
-					selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {}
-				}
+			filterApi
+				? {
+						api: filterApi,
+						selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {},
+					}
 				: null,
 		[filterApi, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
 	);

--- a/apps/frontend/src/components/story-tabbed-content.tsx
+++ b/apps/frontend/src/components/story-tabbed-content.tsx
@@ -51,8 +51,11 @@ export function StoryTabbedContent({
 	});
 	const querySqlSource = useMemo(
 		() =>
-			filterApi && storyFilters.filtersEnabled
-				? { api: filterApi, selections: storyFilters.debouncedSelections }
+			filterApi ? 
+				{ 
+					api: filterApi,
+					selections: storyFilters.filtersEnabled ? storyFilters.debouncedSelections : {}
+				}
 				: null,
 		[filterApi, storyFilters.filtersEnabled, storyFilters.debouncedSelections],
 	);


### PR DESCRIPTION
- "see SQL behind chart" button in story view mode is now visible and displays the executed SQL even if the beta_story_filter_enabled var is false in the .env
- SQL in stories no longer depend on the variable and display either way
- readme includes a section that shows how to run nao locally

fixes #1505 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

