### PR TITLE
feat(stories): offer live mode after a story is created

### DIFF
--- a/apps/frontend/src/components/chat-input-suggestions.tsx
+++ b/apps/frontend/src/components/chat-input-suggestions.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { MessageSquare, X, ThumbsDown, ThumbsUp, Check, Plug } from 'lucide-react';
+import { Activity, MessageSquare, X, ThumbsDown, ThumbsUp, Check, Plug } from 'lucide-react';
 import { NegativeFeedbackDialog } from './chat-messages/assistant-message-actions';
 import { Button } from './ui/button';
 import StoryIcon from './ui/story-icon';
 import type { UIMessage, UIToolPart } from '@nao/backend/chat';
+import { useStoryViewerLiveSettings } from '@/components/side-panel/hooks/use-story-viewer-live-settings';
+import { LiveStorySettingsDialog } from '@/components/side-panel/live-story-settings-dialog';
 import { useAgentContext, useAgentMessages } from '@/contexts/agent.provider';
 import { useChatId } from '@/hooks/use-chat-id';
 import { useInactivityTrigger } from '@/hooks/use-inactivity-trigger';
@@ -25,6 +27,7 @@ const STORY_CHART_THRESHOLD = 2;
 const STORY_SUGGESTION_MESSAGE = 'Create a story from the charts in this conversation.';
 
 const storyProposalDisabledStorage = createLocalStorage<boolean>('nao-story-proposal-disabled', false);
+const liveStoryProposalDismissedStorage = createLocalStorage<string[]>('nao-live-story-proposal-dismissed', []);
 
 /**
  * A floating panel that sits above the chat input and surfaces a single
@@ -38,9 +41,10 @@ export function ChatInputSuggestions({ isHidden = false }: { isHidden?: boolean 
 	const { isReadonly } = useAgentContext();
 	const mcpAuth = useMcpAuthSuggestion();
 	const story = useStorySuggestion();
+	const liveStory = useLiveStorySuggestion();
 	const feedback = useConversationFeedback();
 
-	const content = renderSuggestion({ isReadonly, mcpAuth, story, feedback });
+	const content = renderSuggestion({ isReadonly, mcpAuth, story, liveStory, feedback });
 	const isCollapsed = isHidden || !content;
 	const { ref, height } = useMeasuredHeight();
 
@@ -83,11 +87,13 @@ function renderSuggestion({
 	isReadonly,
 	mcpAuth,
 	story,
+	liveStory,
 	feedback,
 }: {
 	isReadonly: boolean | undefined;
 	mcpAuth: McpAuthSuggestion;
 	story: StorySuggestion;
+	liveStory: LiveStorySuggestion;
 	feedback: ConversationFeedback;
 }) {
 	if (isReadonly) {
@@ -142,6 +148,36 @@ function renderSuggestion({
 					Yes
 				</Button>
 			</SuggestionCard>
+		);
+	}
+
+	if (liveStory.isVisible) {
+		return (
+			<>
+				<SuggestionCard
+					icon={<Activity className='size-4 text-primary' />}
+					message='Keep this story up to date?'
+					description='A live story re-runs its queries on a schedule, so its charts and numbers stay current instead of staying frozen at the moment it was created.'
+				>
+					<Button
+						variant='ghost'
+						size='sm'
+						className='rounded-full text-muted-foreground'
+						onClick={liveStory.dismiss}
+					>
+						Not now
+					</Button>
+					<Button variant='primary-gradient' size='sm' className='rounded-full' onClick={liveStory.accept}>
+						Make it live
+					</Button>
+				</SuggestionCard>
+				<LiveStorySettingsDialog
+					open={liveStory.isSettingsOpen}
+					onOpenChange={liveStory.setSettingsOpen}
+					proposeLive
+					{...liveStory.settings}
+				/>
+			</>
 		);
 	}
 
@@ -320,6 +356,115 @@ function useStorySuggestion(): StorySuggestion {
 	return { isVisible, accept, dismiss, neverPropose: handleNeverPropose };
 }
 
+interface LiveStorySuggestion {
+	isVisible: boolean;
+	isSettingsOpen: boolean;
+	setSettingsOpen: (open: boolean) => void;
+	settings: {
+		isLive: boolean;
+		isLiveTextDynamic: boolean;
+		cacheSchedule: string | null;
+		cacheScheduleDescription: string | null;
+		isUpdating: boolean;
+		onSaveSettings: (settings: {
+			isLive: boolean;
+			isLiveTextDynamic: boolean;
+			cacheSchedule: string | null;
+			cacheScheduleDescription: string | null;
+		}) => void;
+	};
+	accept: () => void;
+	dismiss: () => void;
+}
+
+/**
+ * Offers live mode for the story the agent just created. Live stories are otherwise only
+ * discoverable through the toggle on the story itself, so most stories stay static snapshots.
+ * Accepting opens the usual live settings dialog, already proposing a daily refresh.
+ */
+function useLiveStorySuggestion(): LiveStorySuggestion {
+	const { isRunning, isReadonly } = useAgentContext();
+	const messages = useAgentMessages();
+	const chatId = useChatId();
+
+	const [dismissedStories, setDismissedStories] = useState<ReadonlySet<string>>(
+		() => new Set(liveStoryProposalDismissedStorage.get() ?? []),
+	);
+	const [isSettingsOpen, setSettingsOpen] = useState(false);
+
+	const storySlug = useMemo(() => findLatestCreatedStorySlug(messages), [messages]);
+	const isPersistedChat = !!chatId && chatId !== NEW_CHAT_ID;
+	const dismissalKey = isPersistedChat && storySlug ? `${chatId}:${storySlug}` : null;
+
+	const {
+		storyId,
+		isLive,
+		isLiveTextDynamic,
+		cacheSchedule,
+		cacheScheduleDescription,
+		isUpdating,
+		handleSaveSettings,
+	} = useStoryViewerLiveSettings({
+		chatId: chatId ?? '',
+		storySlug: storySlug ?? '',
+		enabled: isPersistedChat && !!storySlug && !isReadonly,
+	});
+
+	useEffect(() => {
+		setSettingsOpen(false);
+	}, [chatId, storySlug]);
+
+	/** `storyId` is only set once the story query resolves, so it also guards against a premature `isLive` of false. */
+	const isVisible = !!dismissalKey && !isRunning && !dismissedStories.has(dismissalKey) && !!storyId && !isLive;
+
+	const dismiss = useCallback(() => {
+		if (!dismissalKey) {
+			return;
+		}
+		setDismissedStories((prev) => {
+			const next = new Set(prev).add(dismissalKey);
+			liveStoryProposalDismissedStorage.set([...next]);
+			return next;
+		});
+	}, [dismissalKey]);
+
+	const accept = useCallback(() => setSettingsOpen(true), []);
+
+	return {
+		isVisible,
+		isSettingsOpen,
+		setSettingsOpen,
+		settings: {
+			isLive,
+			isLiveTextDynamic,
+			cacheSchedule,
+			cacheScheduleDescription,
+			isUpdating,
+			onSaveSettings: handleSaveSettings,
+		},
+		accept,
+		dismiss,
+	};
+}
+
+/** Returns the slug of the most recently created story, ignoring later updates to it. */
+function findLatestCreatedStorySlug(messages: UIMessage[]): string | null {
+	for (let m = messages.length - 1; m >= 0; m--) {
+		const parts = messages[m]?.parts ?? [];
+
+		for (let p = parts.length - 1; p >= 0; p--) {
+			const part = parts[p];
+			if (part.type !== 'tool-story' || part.input?.action !== 'create') {
+				continue;
+			}
+			if (part.output?.success && part.output.version === 1) {
+				return part.output.id;
+			}
+		}
+	}
+	return null;
+}
+
 interface ConversationFeedback {
 	isVisible: boolean;
 	showThanks: boolean;
@@ -416,10 +561,12 @@ function useConversationFeedback(): ConversationFeedback {
 function SuggestionCard({
 	icon,
 	message,
+	description,
 	children,
 }: {
 	icon?: React.ReactNode;
 	message: string;
+	description?: string;
 	children?: React.ReactNode;
 }) {
 	return (
@@ -428,7 +575,10 @@ function SuggestionCard({
 			className='group flex items-center gap-1 rounded-2xl border border-muted-foreground/25 bg-background p-2'
 		>
 			{icon && <div className='flex size-9 shrink-0 items-center justify-center'>{icon}</div>}
-			<p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{message}</p>
+			<div className='min-w-0 flex-1'>
+				<p className='truncate text-sm font-medium text-foreground'>{message}</p>
+				{description && <p className='text-xs text-muted-foreground'>{description}</p>}
+			</div>
 			{children && <div className='flex shrink-0 items-center gap-1'>{children}</div>}
 		</div>
 	);

--- a/apps/frontend/src/components/side-panel/hooks/use-story-viewer-live-settings.ts
+++ b/apps/frontend/src/components/side-panel/hooks/use-story-viewer-live-settings.ts
@@ -6,11 +6,17 @@ interface UseStoryViewerLiveSettingsParams {
 	chatId: string;
 	storySlug: string;
 	shareId?: string;
+	enabled?: boolean;
 }
 
-export const useStoryViewerLiveSettings = ({ chatId, storySlug, shareId }: UseStoryViewerLiveSettingsParams) => {
+export const useStoryViewerLiveSettings = ({
+	chatId,
+	storySlug,
+	shareId,
+	enabled = true,
+}: UseStoryViewerLiveSettingsParams) => {
 	const queryClient = useQueryClient();
-	const { data } = useQuery(trpc.story.listVersions.queryOptions({ chatId, storySlug }));
+	const { data } = useQuery({ ...trpc.story.listVersions.queryOptions({ chatId, storySlug }), enabled });
 
 	const storyId = data?.id ?? null;
 	const isLive = data?.isLive ?? false;

--- a/apps/frontend/src/components/side-panel/live-story-settings-dialog.tsx
+++ b/apps/frontend/src/components/side-panel/live-story-settings-dialog.tsx
@@ -24,6 +24,7 @@ interface LiveStorySettingsDialogProps {
 	cacheSchedule: string | null;
 	cacheScheduleDescription: string | null;
 	isUpdating: boolean;
+	proposeLive?: boolean;
 	onSaveSettings: (settings: {
 		isLive: boolean;
 		isLiveTextDynamic: boolean;
@@ -43,9 +44,11 @@ const SCHEDULE_PRESETS = [
 	{ value: 'custom', label: 'Custom schedule...', cron: null },
 ] as const;
 
-function resolvePresetValue(cacheSchedule: string | null): string {
+const PROPOSED_SCHEDULE_PRESET = '0 0 * * *';
+
+function resolvePresetValue(cacheSchedule: string | null, fallbackPreset: string): string {
 	if (!cacheSchedule) {
-		return 'manual';
+		return fallbackPreset;
 	}
 	const match = SCHEDULE_PRESETS.find((p) => p.cron === cacheSchedule);
 	return match ? match.value : 'custom';
@@ -59,10 +62,12 @@ export function LiveStorySettingsDialog({
 	cacheSchedule,
 	cacheScheduleDescription,
 	isUpdating,
+	proposeLive = false,
 	onSaveSettings,
 }: LiveStorySettingsDialogProps) {
-	const [localIsLive, setLocalIsLive] = useState(isLive);
-	const [localPreset, setLocalPreset] = useState(() => resolvePresetValue(cacheSchedule));
+	const fallbackPreset = proposeLive ? PROPOSED_SCHEDULE_PRESET : 'manual';
+	const [localIsLive, setLocalIsLive] = useState(proposeLive || isLive);
+	const [localPreset, setLocalPreset] = useState(() => resolvePresetValue(cacheSchedule, fallbackPreset));
 	const [localCustomCron, setLocalCustomCron] = useState(localPreset === 'custom' ? (cacheSchedule ?? '') : '');
 	const [localTextBlocksDynamic, setLocalTextBlocksDynamic] = useState(isLiveTextDynamic);
 	const [nlInput, setNlInput] = useState(cacheScheduleDescription ?? '');
@@ -70,15 +75,15 @@ export function LiveStorySettingsDialog({
 
 	useEffect(() => {
 		if (open) {
-			setLocalIsLive(isLive);
+			setLocalIsLive(proposeLive || isLive);
 			setLocalTextBlocksDynamic(isLiveTextDynamic);
-			const preset = resolvePresetValue(cacheSchedule);
+			const preset = resolvePresetValue(cacheSchedule, fallbackPreset);
 			setLocalPreset(preset);
 			setLocalCustomCron(preset === 'custom' ? (cacheSchedule ?? '') : '');
 			setNlInput(preset === 'custom' ? (cacheScheduleDescription ?? '') : '');
 			setSavedNlInput(preset === 'custom' ? (cacheScheduleDescription ?? '') : '');
 		}
-	}, [open, isLive, isLiveTextDynamic, cacheSchedule, cacheScheduleDescription]);
+	}, [open, isLive, isLiveTextDynamic, cacheSchedule, cacheScheduleDescription, proposeLive, fallbackPreset]);
 
 	const resolvedCron =
 		localPreset === 'manual' ? null : localPreset === 'custom' ? localCustomCron || null : localPreset;


### PR DESCRIPTION
Closes #1471

Live stories only surfaced through the small toggle in the story header, so unless you already knew the feature existed you'd never find it. This adds the offer at the point where it makes sense — right after the agent builds you a story.

I put the card in the existing `ChatInputSuggestions` panel rather than adding a modal, since that panel already does exactly this job for MCP auth, the "create a story" prompt, and conversation feedback. It's non-modal and already collapses when you start typing, which fits the "declining is non blocking" requirement.

**What changed**

- `chat-input-suggestions.tsx` — a `useLiveStorySuggestion` hook plus a fourth suggestion card. Visible when the chat contains a story created by the agent (`action: 'create'`, `output.version === 1`) that isn't live yet and hasn't been dismissed. Dismissal persists in localStorage, keyed `chatId:storySlug`.
- `live-story-settings-dialog.tsx` — a new optional `proposeLive` prop that only affects the dialog's initial state. All copy, controls and save behaviour are unchanged, and the header toggle doesn't pass it, so that path is untouched.
- `use-story-viewer-live-settings.ts` — an optional `enabled` flag (defaults true, so the four existing call sites are unaffected) so the suggestion can reuse the hook's mutation and invalidation set without firing a query in chats with no story.

No backend, schema or migration changes — everything from `updateLiveSettings` down already existed and was simply unreachable unless you found the toggle.

**On the schedule default**

`proposeLive` preselects a daily refresh rather than letting the dialog fall back to "Manual refresh only". With `cacheSchedule: null`, `syncStoryRefreshJob` creates no recurring job and `isCacheExpired` never returns true, so the story fetches once and never refreshes again — live in name only, which is the exact thing the issue is about.

**One deliberate deviation**

The issue says accepting should convert "without sending the user to settings". The discovery and the offer both happen in the card, so the user never navigates anywhere, but accepting does open the live settings dialog rather than converting
silently. I chose that because each scheduled refresh runs real SQL against the user's warehouse and makes an LLM call when `isLiveTextDynamic` is on, and enrolling someone in that without showing the cadence felt wrong. Happy to make
it one-click if you'd rather.

**Testing**

Tested locally against a Postgres project: created a story from chat, accepted the offer, confirmed the story row updates, a recurring `scheduled_job` is created, and the header pill flips on. `npm run lint` passes.


https://github.com/user-attachments/assets/aeb52781-8a75-4655-8517-8fd20a5ab126



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

