### PR TITLE
feat: add Compact Mode for non-technical business stakeholders

### DIFF
--- a/apps/backend/src/components/ai/system-prompt.tsx
+++ b/apps/backend/src/components/ai/system-prompt.tsx
@@ -41,6 +41,8 @@ type SystemPromptProps = {
 type SystemPromptOptions = {
 	/** False when the storage backend has no real filesystem (`s3`), so grep cannot look inside saved files. */
 	canGrepSavedFiles?: boolean;
+	/** Injects a business-friendly, non-technical tone into the persona. */
+	compactMode?: boolean;
 };
 
 export const MEMORY_TOKEN_LIMIT = 1000;
@@ -59,7 +61,7 @@ export function SystemPrompt({
 	toolNames,
 	options = {},
 }: SystemPromptProps) {
-	const { canGrepSavedFiles = true } = options;
+	const { canGrepSavedFiles = true, compactMode } = options;
 	const hasTool = (name: string) => !toolNames || toolNames.includes(name);
 	const visibleMemories = getMemoriesInTokenRange(memories, MEMORY_TOKEN_LIMIT);
 	const dialectToolCallRules = getDialectToolCallRules(connections);
@@ -88,6 +90,12 @@ export function SystemPrompt({
 			<NaoContextStructure />
 			<Title level={2}>Persona</Title>
 			<List>
+				{compactMode && (
+					<ListItem>
+						<Bold>Compact Mode</Bold>: The user selected compact mode. Be business friendly in your answers.
+						Business tone, not technical tone. Shorter answers, plain language, no technical detour.
+					</ListItem>
+				)}
 				<ListItem>
 					<Bold>Efficient & Proactive</Bold>: Value the user's time. Be concise. Anticipate needs and act
 					without unnecessary hesitation.

--- a/apps/backend/src/handlers/agent.ts
+++ b/apps/backend/src/handlers/agent.ts
@@ -28,7 +28,7 @@ interface HandleAgentMessageResult {
 }
 
 export const handleAgentRoute = async (opts: HandleAgentMessageInput): Promise<HandleAgentMessageResult> => {
-	const { userId, message, messageToEditId, model, mentions, projectId, adminMode } = opts;
+	const { userId, message, messageToEditId, model, mentions, projectId, adminMode, compactMode } = opts;
 
 	if (!projectId) {
 		throw new HandlerError('BAD_REQUEST', noProjectMessage());
@@ -67,17 +67,17 @@ export const handleAgentRoute = async (opts: HandleAgentMessageInput): Promise<H
 	await mcpService.initializeMcpState(projectId);
 	await skillService.initializeSkills(projectId);
 
-	const agent = await agentService.create(
-		{ ...chat, userId, projectId },
-		model,
-		adminMode
-			? {
-					tools: adminAgentTools,
-					systemPrompt: renderAdminSystemPrompt({ timezone: opts.timezone }),
-					adminMode: true,
-				}
-			: undefined,
-	);
+	const agentOptions: Parameters<typeof agentService.create>[2] = {};
+	if (adminMode) {
+		agentOptions.tools = adminAgentTools;
+		agentOptions.systemPrompt = renderAdminSystemPrompt({ timezone: opts.timezone });
+		agentOptions.adminMode = true;
+	}
+	if (compactMode) {
+		agentOptions.compactMode = true;
+	}
+
+	const agent = await agentService.create({ ...chat, userId, projectId }, model, agentOptions);
 
 	const isForkedFirstMessage =
 		!isNewChat && !!chat.forkMetadata && chat.messages.filter((m) => m.role === 'user' && !m.isForked).length === 1;

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -251,6 +251,7 @@ export class AgentService {
 			adminMode?: boolean;
 			/** Enables project-defined charts that render only in the web client. */
 			supportsCustomCharts?: boolean;
+			compactMode?: boolean;
 		} = {},
 	): Promise<AgentManager> {
 		this._disposeAgent(chat.id);
@@ -287,6 +288,7 @@ export class AgentService {
 			toolContext,
 			stopWhen,
 			options.systemPrompt,
+			options.compactMode,
 		);
 		this._agents.set(chat.id, agent);
 		return agent;
@@ -376,6 +378,7 @@ class AgentManager {
 		private readonly _toolContext: ToolContext,
 		stopWhen: StopCondition<AgentTools>[] = [hasToolCall('suggest_follow_ups'), hasToolCall('clarification')],
 		private readonly _systemPromptOverride?: string,
+		private readonly _compactMode?: boolean,
 	) {
 		this._finished = new Promise((resolve) => {
 			this._resolveFinished = resolve;
@@ -618,7 +621,7 @@ class AgentManager {
 				timezone,
 				testMode: this.chat.testMode,
 				toolNames: Object.keys(this._agentTools),
-				options: { canGrepSavedFiles: canGrepUserFiles() },
+				options: { canGrepSavedFiles: canGrepUserFiles(), compactMode: this._compactMode },
 			}),
 		);
 		const renderedPrompt = provider

--- a/apps/backend/src/types/chat.ts
+++ b/apps/backend/src/types/chat.ts
@@ -200,4 +200,6 @@ export const AgentRequestSchema = z.object({
 	timezone: z.string().optional(),
 	/** When true, the message runs in admin mode: it queries nao's own usage database instead of the warehouse. */
 	adminMode: z.boolean().optional(),
+	/** When true, the agent uses a business-friendly, non-technical tone and tool calls are collapsed in the UI. */
+	compactMode: z.boolean().optional(),
 });

--- a/apps/frontend/src/components/chat-input.tsx
+++ b/apps/frontend/src/components/chat-input.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useLayoutEffect, useRef, useCallback, useId } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
-import { Plus, PencilRuler, Database, Paperclip, AlertTriangle, Shield, Check } from 'lucide-react';
+import { Plus, PencilRuler, Database, Paperclip, AlertTriangle, Shield, Check, Briefcase } from 'lucide-react';
 import { ATTACHMENT_ACCEPT } from '@nao/shared/attachments';
 import { Button, ChatButton, MicButton } from './ui/button';
 import { SlidingWaveform } from './chat-input-sliding-waveform';
@@ -107,6 +107,8 @@ function ChatInputBase({
 		isLoadingMessages,
 		adminMode,
 		setAdminMode,
+		compactMode,
+		setCompactMode,
 		setMentions,
 		submitQueuedMessageNow,
 		error,
@@ -421,6 +423,8 @@ function ChatInputBase({
 								isAdminMode={isAdminMode}
 								adminModeLocked={adminModeLocked}
 								onSelectAdminMode={handleSelectAdminMode}
+								isCompactMode={compactMode}
+								onSelectCompactMode={() => setCompactMode(!compactMode)}
 								onAddAttachment={attachmentUpload.openFilePicker}
 								onAddStory={() => {
 									promptRef.current?.appendMention(
@@ -630,6 +634,8 @@ function ChatInputPlusMenu({
 	isAdminMode,
 	adminModeLocked,
 	onSelectAdminMode,
+	isCompactMode,
+	onSelectCompactMode,
 	onAddAttachment,
 	onAddStory,
 	onOpenSkills,
@@ -642,6 +648,8 @@ function ChatInputPlusMenu({
 	isAdminMode: boolean;
 	adminModeLocked: boolean;
 	onSelectAdminMode: () => void;
+	isCompactMode: boolean;
+	onSelectCompactMode: () => void;
 	onAddAttachment: () => void;
 	onAddStory: () => void;
 	onOpenSkills: () => void;
@@ -700,6 +708,11 @@ function ChatInputPlusMenu({
 							<Shield className='size-4' />
 							<span>Admin mode</span>
 							{isAdminMode && <Check className='size-4 ml-auto' />}
+						</DropdownMenuItem>
+						<DropdownMenuItem onSelect={onSelectCompactMode}>
+							<Briefcase className='size-4' />
+							<span>Compact mode</span>
+							{isCompactMode && <Check className='size-4 ml-auto' />}
 						</DropdownMenuItem>
 					</>
 				)}

--- a/apps/frontend/src/components/tool-calls/tool-calls-group.tsx
+++ b/apps/frontend/src/components/tool-calls/tool-calls-group.tsx
@@ -5,6 +5,7 @@ import type { GroupablePart } from '@/types/ai';
 import { Expandable } from '@/components/ui/expandable';
 import { AssistantReasoning } from '@/components/chat-messages/assistant-reasoning';
 import { useChatView } from '@/contexts/chat-view';
+import { useOptionalAgentContext } from '@/contexts/agent.provider';
 import { ToolGroupProvider } from '@/contexts/tool-group';
 import { isReasoningPart } from '@/lib/ai';
 import { groupMcpToolCalls } from '@/lib/mcp';
@@ -19,13 +20,21 @@ export const ToolCallsGroup = memo(({ parts, isSettled }: Props) => {
 	const isLoading = !isSettled;
 	const hasError = parts.some((p) => !isReasoningPart(p) && p.state === 'output-error');
 	const { expandOnError } = useChatView();
-	const [isExpanded, setIsExpanded] = useState(isLoading || (expandOnError && hasError));
+	const agent = useOptionalAgentContext();
+	const compactMode = agent?.compactMode ?? false;
+	const [isExpanded, setIsExpanded] = useState(!compactMode && (isLoading || (expandOnError && hasError)));
 
 	useEffect(() => {
+		if (compactMode) {
+			if (isSettled) {
+				setIsExpanded(false);
+			}
+			return;
+		}
 		if (isLoading || (expandOnError && hasError)) {
 			setIsExpanded(true);
 		}
-	}, [isLoading, expandOnError, hasError]);
+	}, [isLoading, expandOnError, hasError, compactMode, isSettled]);
 
 	const title = useToolGroupSummaryTitle({ parts, isLoading });
 	const groupedParts = useMemo(() => groupMcpToolCalls(parts), [parts]);

--- a/apps/frontend/src/contexts/agent.provider.tsx
+++ b/apps/frontend/src/contexts/agent.provider.tsx
@@ -63,6 +63,8 @@ export const AgentProvider = ({ children, disableNavigation }: Props) => {
 			setMentions: agent.setMentions,
 			adminMode: agent.adminMode,
 			setAdminMode: agent.setAdminMode,
+			compactMode: agent.compactMode,
+			setCompactMode: agent.setCompactMode,
 		}),
 		[
 			agent.chatId,
@@ -83,6 +85,8 @@ export const AgentProvider = ({ children, disableNavigation }: Props) => {
 			agent.setMentions,
 			agent.adminMode,
 			agent.setAdminMode,
+			agent.compactMode,
+			agent.setCompactMode,
 		],
 	);
 
@@ -138,6 +142,8 @@ export const ReadonlyAgentMessagesProvider = ({
 			setMentions: noop,
 			adminMode: false,
 			setAdminMode: noop,
+			compactMode: false,
+			setCompactMode: noop,
 			isReadonly: true,
 		}),
 		[chatId],

--- a/apps/frontend/src/hooks/use-agent.ts
+++ b/apps/frontend/src/hooks/use-agent.ts
@@ -60,6 +60,8 @@ export interface AgentHelpers {
 	setMentions: (mentions: MentionOption[]) => void;
 	adminMode: boolean;
 	setAdminMode: (enabled: boolean) => void;
+	compactMode: boolean;
+	setCompactMode: (enabled: boolean) => void;
 	isReadonly?: boolean;
 }
 
@@ -83,6 +85,7 @@ const agentAdminModeStore = new WeakMap<Agent<UIMessage>, boolean>();
 
 interface AgentSendRefs {
 	adminModeRef: { current: boolean };
+	compactModeRef: { current: boolean };
 	selectedModelRef: { current: LlmSelectedModel | null };
 	mentionsRef: { current: MentionOption[] };
 }
@@ -104,6 +107,8 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 	const mentionsRef = useRef<MentionOption[]>([]);
 	const [adminMode, setAdminModeState] = useState(false);
 	const adminModeRef = useRef(false);
+	const [compactMode, setCompactModeState] = useState(false);
+	const compactModeRef = useRef(false);
 	/** Set to the server id of a chat that was just created, so the upcoming chatId change is treated as the same conversation continuing rather than opening a different chat. */
 	const continuationChatIdRef = useRef<string | undefined>(undefined);
 
@@ -114,6 +119,11 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 	const setAdminMode = useCallback((enabled: boolean) => {
 		adminModeRef.current = enabled;
 		setAdminModeState(enabled);
+	}, []);
+
+	const setCompactMode = useCallback((enabled: boolean) => {
+		compactModeRef.current = enabled;
+		setCompactModeState(enabled);
 	}, []);
 
 	const agentInstance = useMemo(() => {
@@ -183,6 +193,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 					const activeMentionsRef = liveRefs?.mentionsRef ?? mentionsRef;
 					const activeSelectedModelRef = liveRefs?.selectedModelRef ?? selectedModelRef;
 					const activeAdminModeRef = liveRefs?.adminModeRef ?? adminModeRef;
+					const activeCompactModeRef = liveRefs?.compactModeRef ?? compactModeRef;
 
 					const mentions = activeMentionsRef.current;
 					activeMentionsRef.current = [];
@@ -190,6 +201,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 					const images = extractImagesFromMessage(messageToSend);
 					const documents = extractDocumentPathsFromMessage(messageToSend);
 					const adminModeAtSend = activeAdminModeRef.current;
+					const compactModeAtSend = activeCompactModeRef.current;
 					agentAdminModeStore.set(newAgent, adminModeAtSend);
 					return {
 						headers: getActiveProjectId() ? { 'x-nao-project-id': getActiveProjectId()! } : undefined,
@@ -206,6 +218,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 							mentions: mentions.length > 0 ? mentions : undefined,
 							timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 							adminMode: adminModeAtSend || undefined,
+							compactMode: compactModeAtSend || undefined,
 						},
 					};
 				},
@@ -241,7 +254,7 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 		return agentService.registerAgent(agentId, newAgent);
 	}, [chatId, disableNavigation, navigate, setChat, queryClient]);
 
-	agentSendRefsStore.set(agentInstance, { adminModeRef, selectedModelRef, mentionsRef });
+	agentSendRefsStore.set(agentInstance, { adminModeRef, compactModeRef, selectedModelRef, mentionsRef });
 
 	const { status, error, clearError, sendMessage, setMessages, messages } = useChat({
 		chat: agentInstance,
@@ -514,6 +527,8 @@ export const useAgent = ({ disableNavigation = false }: { disableNavigation?: bo
 		setMentions,
 		adminMode,
 		setAdminMode,
+		compactMode,
+		setCompactMode,
 	});
 };
 


### PR DESCRIPTION
fix: #1483 

This PR introduces the requested "Compact Mode" toggle for business stakeholders to receive shorter, plainer, non-technical answers.

<img width="695" height="344" alt="Screenshot 2026-09-02 at 1 25 53 AM" src="https://github.com/user-attachments/assets/4c7a0b71-5f57-4ec1-917a-d0e7560495e2" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

