### PR TITLE
feat(story): export stories as Markdown (.md)

### DIFF
--- a/apps/backend/src/trpc/embed.routes.ts
+++ b/apps/backend/src/trpc/embed.routes.ts
@@ -1,3 +1,4 @@
+import { DOWNLOAD_FORMATS } from '@nao/shared/types';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
@@ -128,7 +129,7 @@ export const embedRoutes = router({
 	}),
 
 	downloadStory: publicProcedure
-		.input(tokenInput.extend({ storyId: z.string(), format: z.enum(['pdf', 'html']) }))
+		.input(tokenInput.extend({ storyId: z.string(), format: z.enum(DOWNLOAD_FORMATS) }))
 		.mutation(async ({ input }) => {
 			const story = await loadEmbedStoryContent(input.storyId, input.token);
 			logAnalyticsEvent({

--- a/apps/backend/src/utils/story-download.ts
+++ b/apps/backend/src/utils/story-download.ts
@@ -2,6 +2,7 @@ import type { DateFormatSettings } from '@nao/shared/date';
 import type { DownloadFormat } from '@nao/shared/types';
 
 import { generateStoryHtml } from './story-html';
+import { generateStoryMarkdown } from './story-markdown';
 import { generateStoryPdf } from './story-pdf';
 
 export type QueryDataMap = Record<string, { data: unknown[]; columns: string[] }>;
@@ -14,6 +15,7 @@ export interface StoryInput {
 const MIME_TYPES: Record<DownloadFormat, string> = {
 	pdf: 'application/pdf',
 	html: 'text/html',
+	md: 'text/markdown',
 };
 
 export async function buildStoryDownloadFile(
@@ -58,6 +60,8 @@ async function generateStoryBuffer(
 			return generateStoryPdf(story, queryData, dateFormat);
 		case 'html':
 			return Buffer.from(await generateStoryHtml(story, queryData, dateFormat));
+		case 'md':
+			return Buffer.from(generateStoryMarkdown(story, queryData, dateFormat));
 	}
 }
 

--- a/apps/backend/src/utils/story-markdown.ts
+++ b/apps/backend/src/utils/story-markdown.ts
@@ -1,0 +1,255 @@
+import { formatChartValue, labelize, resolveDataKey, resolveMapConfig } from '@nao/shared';
+import { type DateFormatSettings, DEFAULT_DATE_FORMAT_SETTINGS } from '@nao/shared/date';
+import type { ParsedChartBlock, ParsedMapBlock, ParsedTableBlock, Segment } from '@nao/shared/story-segments';
+import { mapBlockToInput, splitCodeIntoSegments } from '@nao/shared/story-segments';
+import { formatCellValue, isNumericColumn } from '@nao/shared/story-table-utils';
+import { flattenStoryTabs } from '@nao/shared/story-tabs';
+
+import type { QueryDataMap, StoryInput } from './story-download';
+
+export function generateStoryMarkdown(
+	story: StoryInput,
+	queryData: QueryDataMap | null,
+	dateFormat?: DateFormatSettings | null,
+): string {
+	const resolvedDateFormat = dateFormat ?? { ...DEFAULT_DATE_FORMAT_SETTINGS };
+	const flattenedTabs = flattenStoryTabs(story.code);
+	const flattenedCode = flattenedTabs.replace(/<\/?grid\b[^>]*>/gi, '');
+	const segments = splitCodeIntoSegments(flattenedCode);
+
+	const parts: string[] = [];
+
+	if (story.title?.trim()) {
+		parts.push(`# ${story.title.trim()}`);
+	}
+
+	for (const segment of segments) {
+		const rendered = renderSegmentToMarkdown(segment, queryData, resolvedDateFormat);
+		if (rendered.trim()) {
+			parts.push(rendered.trim());
+		}
+	}
+
+	return parts.join('\n\n') + '\n';
+}
+
+function renderSegmentToMarkdown(
+	segment: Segment,
+	queryData: QueryDataMap | null,
+	dateFormat: DateFormatSettings,
+): string {
+	switch (segment.type) {
+		case 'markdown':
+			return segment.content.trim();
+
+		case 'table':
+			return renderTableSegment(segment.table, queryData, dateFormat);
+
+		case 'chart':
+			return renderChartSegment(segment.chart, queryData, dateFormat);
+
+		case 'map':
+			return renderMapSegment(segment.map, queryData, dateFormat);
+
+		case 'grid':
+		case 'filter':
+			return '';
+	}
+}
+
+function renderTableSegment(
+	table: ParsedTableBlock,
+	queryData: QueryDataMap | null,
+	dateFormat: DateFormatSettings,
+): string {
+	const parts: string[] = [];
+	if (table.title?.trim()) {
+		parts.push(`### ${table.title.trim()}`);
+	}
+
+	const tableData = queryData?.[table.queryId];
+	if (!tableData || !tableData.columns || tableData.columns.length === 0) {
+		return parts.join('\n\n');
+	}
+
+	const columns = tableData.columns;
+	const rows = (tableData.data ?? []) as Record<string, unknown>[];
+
+	const headerRow = `| ${columns.map((col) => escapeMarkdownCell(labelize(col))).join(' | ')} |`;
+	const separatorRow = `| ${columns.map((col) => (isNumericColumn(rows, col) ? '---:' : '---')).join(' | ')} |`;
+
+	const dataRows = rows.map((row) => {
+		const cells = columns.map((col) => {
+			const rawVal = row[col];
+			const formatted = formatCellValue(rawVal, dateFormat);
+			return escapeMarkdownCell(formatted);
+		});
+		return `| ${cells.join(' | ')} |`;
+	});
+
+	parts.push([headerRow, separatorRow, ...dataRows].join('\n'));
+	return parts.join('\n\n');
+}
+
+function renderChartSegment(
+	chart: ParsedChartBlock,
+	queryData: QueryDataMap | null,
+	dateFormat: DateFormatSettings,
+): string {
+	const parts: string[] = [];
+	if (chart.title?.trim()) {
+		parts.push(`### ${chart.title.trim()}`);
+	}
+
+	const chartData = queryData?.[chart.queryId];
+
+	if (chart.chartType === 'kpi_card') {
+		if (chartData?.data?.length) {
+			const rows = chartData.data as Record<string, unknown>[];
+			const resolvedXAxisKey = resolveDataKey(rows, chart.xAxisKey);
+			const sortedRows = [...rows].sort((a, b) => {
+				const av = a[resolvedXAxisKey];
+				const bv = b[resolvedXAxisKey];
+				if (chart.xAxisType === 'date') {
+					return new Date(String(av)).getTime() - new Date(String(bv)).getTime();
+				}
+				return 0;
+			});
+			const lastRow = sortedRows[sortedRows.length - 1] ?? {};
+
+			const fallbackSeries = chartData.columns
+				.filter((col) => !resolvedXAxisKey || col.toLowerCase() !== resolvedXAxisKey.toLowerCase())
+				.map((data_key) => ({ data_key, label: labelize(data_key) }));
+
+			const seriesList = (chart.series && chart.series.length > 0 ? chart.series : fallbackSeries).map((s) => ({
+				...s,
+				data_key: resolveDataKey(rows, s.data_key),
+			}));
+
+			const kpiItems = seriesList
+				.map((s) => {
+					const rawVal = lastRow[s.data_key];
+					const value =
+						typeof rawVal === 'number'
+							? formatChartValue(rawVal, s.value_format)
+							: rawVal != null
+								? formatCellValue(rawVal, dateFormat)
+								: '';
+					const label = s.label ?? s.data_key;
+					const escapedLabel = escapeMarkdownCell(label);
+					const escapedValue = escapeMarkdownCell(value);
+					return seriesList.length === 1 && !s.label
+						? `**${escapedValue}**`
+						: `**${escapedLabel}:** ${escapedValue}`;
+				})
+				.filter((item) => item.trim().length > 0);
+
+			if (kpiItems.length > 0) {
+				parts.push(kpiItems.join(' · '));
+			}
+		}
+		return parts.join('\n\n');
+	}
+
+	const chartTypeLabel = labelize(chart.chartType.replace(/_/g, ' '));
+	parts.push(`*(Chart: ${chartTypeLabel})*`);
+
+	if (chartData && chartData.columns?.length && chartData.data?.length) {
+		const rows = chartData.data as Record<string, unknown>[];
+		const xAxisKey = resolveDataKey(rows, chart.xAxisKey) || chartData.columns[0];
+		const seriesList = (
+			chart.series && chart.series.length > 0
+				? chart.series
+				: chartData.columns
+						.filter((c) => c.toLowerCase() !== xAxisKey.toLowerCase())
+						.map((data_key) => ({ data_key, label: labelize(data_key) }))
+		).map((s) => ({
+			...s,
+			data_key: resolveDataKey(rows, s.data_key),
+		}));
+
+		if (seriesList.length > 0 && rows.length > 0) {
+			const headers = [
+				labelize(chart.xAxisLabel || xAxisKey),
+				...seriesList.map((s) => s.label || labelize(s.data_key)),
+			];
+			const headerRow = `| ${headers.map(escapeMarkdownCell).join(' | ')} |`;
+			const separatorRow = `| --- | ${seriesList.map(() => '---:').join(' | ')} |`;
+
+			const dataRows = rows.map((row) => {
+				const xVal = escapeMarkdownCell(formatCellValue(row[xAxisKey], dateFormat));
+				const seriesVals = seriesList.map((s) => {
+					const rawVal = row[s.data_key];
+					const formatted =
+						typeof rawVal === 'number'
+							? formatChartValue(rawVal, s.value_format)
+							: formatCellValue(rawVal, dateFormat);
+					return escapeMarkdownCell(formatted);
+				});
+				return `| ${[xVal, ...seriesVals].join(' | ')} |`;
+			});
+
+			parts.push([headerRow, separatorRow, ...dataRows].join('\n'));
+		}
+	}
+
+	return parts.join('\n\n');
+}
+
+function renderMapSegment(map: ParsedMapBlock, queryData: QueryDataMap | null, dateFormat: DateFormatSettings): string {
+	const parts: string[] = [];
+	if (map.title?.trim()) {
+		parts.push(`### ${map.title.trim()}`);
+	}
+	const mapTypeLabel = labelize(map.mapType.replace(/_/g, ' '));
+	parts.push(`*(Map: ${mapTypeLabel})*`);
+
+	const mapData = queryData?.[map.queryId];
+	if (mapData && mapData.columns?.length && mapData.data?.length) {
+		const rows = (mapData.data ?? []) as Record<string, unknown>[];
+		const config = resolveMapConfig(rows, mapBlockToInput(map));
+		const labelKey =
+			config.map_type === 'choropleth'
+				? config.region_key
+				: config.map_type === 'bubble'
+					? config.label_key || config.latitude_key
+					: config.label_key || config.latitude_key;
+		const valKey =
+			config.map_type === 'choropleth'
+				? config.value_key
+				: config.map_type === 'bubble'
+					? config.size_key || config.color_key
+					: config.color_key;
+
+		const resolvedLabelKey = resolveDataKey(rows, labelKey) || mapData.columns[0];
+		const resolvedValKey = resolveDataKey(rows, valKey) || mapData.columns.find((c) => c !== resolvedLabelKey);
+
+		if (resolvedLabelKey && resolvedValKey) {
+			const headers = [labelize(resolvedLabelKey), labelize(resolvedValKey)];
+			const headerRow = `| ${headers.map(escapeMarkdownCell).join(' | ')} |`;
+			const separatorRow = `| --- | ---: |`;
+			const dataRows = rows.map((row) => {
+				const lVal = escapeMarkdownCell(formatCellValue(row[resolvedLabelKey], dateFormat));
+				const vVal = escapeMarkdownCell(formatCellValue(row[resolvedValKey], dateFormat));
+				return `| ${lVal} | ${vVal} |`;
+			});
+			parts.push([headerRow, separatorRow, ...dataRows].join('\n'));
+		}
+	}
+
+	return parts.join('\n\n');
+}
+
+function escapeMarkdownCell(value: string): string {
+	return value
+		.replace(/\\/g, '\\\\')
+		.replace(/\|/g, '\\|')
+		.replace(/\*/g, '\\*')
+		.replace(/_/g, '\\_')
+		.replace(/`/g, '\\`')
+		.replace(/\[/g, '\\[')
+		.replace(/\]/g, '\\]')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/\r?\n/g, ' ');
+}

--- a/apps/backend/tests/story-markdown.test.ts
+++ b/apps/backend/tests/story-markdown.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/db/db', () => ({
+	db: {},
+}));
+
+import { buildStoryDownloadFile } from '../src/utils/story-download';
+import { generateStoryMarkdown } from '../src/utils/story-markdown';
+
+describe('generateStoryMarkdown', () => {
+	it('exports story title, text blocks, and headings as Markdown', () => {
+		const story = {
+			title: 'Sales Strategy Report',
+			code: `## Executive Summary\n\nOur sales grew by **25%** this quarter.\n\n- North America: Strong lead\n- EMEA: Steady growth\n- APAC: Emerging market`,
+		};
+
+		const md = generateStoryMarkdown(story, null);
+
+		expect(md).toContain('# Sales Strategy Report');
+		expect(md).toContain('## Executive Summary');
+		expect(md).toContain('Our sales grew by **25%** this quarter.');
+		expect(md).toContain('- North America: Strong lead');
+	});
+
+	it('flattens story tabs into markdown section headings', () => {
+		const story = {
+			title: 'Multi-Tab Story',
+			code: `<tabs>\n  <tab title="Overview">\n    This is the overview tab.\n  </tab>\n  <tab title="Details">\n    Here are the deep dive details.\n  </tab>\n</tabs>`,
+		};
+
+		const md = generateStoryMarkdown(story, null);
+
+		expect(md).toContain('# Multi-Tab Story');
+		expect(md).toContain('## Overview');
+		expect(md).toContain('This is the overview tab.');
+		expect(md).toContain('## Details');
+		expect(md).toContain('Here are the deep dive details.');
+	});
+
+	it('flattens nested grid blocks cleanly without leaving stray grid tags', () => {
+		const story = {
+			title: 'Nested Grid Story',
+			code: `<grid>\n  <grid>\n    ### Section in Grid\n\n    Inner text in nested grid.\n  </grid>\n</grid>`,
+		};
+
+		const md = generateStoryMarkdown(story, null);
+
+		expect(md).toContain('# Nested Grid Story');
+		expect(md).toContain('### Section in Grid');
+		expect(md).toContain('Inner text in nested grid.');
+		expect(md).not.toContain('<grid');
+		expect(md).not.toContain('</grid>');
+	});
+
+	it('renders table blocks as standard Markdown tables with escaped backslashes, pipes, and punctuation', () => {
+		const story = {
+			title: 'Financial Summary',
+			code: '<table query_id="q_revenue" title="Revenue By Department" />',
+		};
+
+		const queryData = {
+			q_revenue: {
+				columns: ['department', 'revenue', 'notes'],
+				data: [
+					{ department: 'Engineering', revenue: 150000, notes: 'Path C:\\proj | team A' },
+					{ department: 'Sales & Marketing', revenue: 320000, notes: 'Target *Q3* [Special]' },
+				],
+			},
+		};
+
+		const md = generateStoryMarkdown(story, queryData);
+
+		expect(md).toContain('### Revenue By Department');
+		expect(md).toContain('| Department | Revenue | Notes |');
+		expect(md).toContain('| --- | ---: | --- |');
+		expect(md).toContain('| Engineering | 150000 | Path C:\\\\proj \\| team A |');
+		expect(md).toContain('Target \\*Q3\\* \\[Special\\]');
+	});
+
+	it('resolves column casing and applies value_format to chart tables', () => {
+		const story = {
+			title: 'Analytics Dashboard',
+			code: `<chart query_id="q_monthly" chart_type="bar" x_axis_key="MONTH" series='[{"data_key":"REVENUE","label":"Monthly Revenue","value_format":{"prefix":"$"}}]' title="Monthly Growth" />`,
+		};
+
+		const queryData = {
+			q_monthly: {
+				columns: ['month', 'revenue'],
+				data: [
+					{ month: '2026-01', revenue: 10000 },
+					{ month: '2026-02', revenue: 15000 },
+				],
+			},
+		};
+
+		const md = generateStoryMarkdown(story, queryData);
+
+		expect(md).toContain('### Monthly Growth');
+		expect(md).toContain('*(Chart: Bar)*');
+		expect(md).toContain('| Month | Monthly Revenue |');
+		expect(md).toContain('| 2026-01 | $10,000 |');
+		expect(md).toContain('| 2026-02 | $15,000 |');
+	});
+
+	it('renders KPI cards selecting the latest date-sorted row, handling multiple series and value_format', () => {
+		const story = {
+			title: 'KPI Story',
+			code: `<chart query_id="q_kpi" chart_type="kpi_card" x_axis_key="DATE" x_axis_type="date" series='[{"data_key":"TOTAL_SALES","label":"Sales","value_format":{"prefix":"$"}},{"data_key":"ACTIVE_USERS","label":"Users"}]' title="Performance" />`,
+		};
+
+		const queryData = {
+			q_kpi: {
+				columns: ['date', 'total_sales', 'active_users'],
+				data: [
+					{ date: '2026-01-01', total_sales: 1000000, active_users: 50 },
+					{ date: '2026-03-01', total_sales: 1250000, active_users: 120 },
+					{ date: '2026-02-01', total_sales: 1100000, active_users: 80 },
+				],
+			},
+		};
+
+		const md = generateStoryMarkdown(story, queryData);
+
+		expect(md).toContain('### Performance');
+		expect(md).toContain('**Sales:** $1,250,000 · **Users:** 120');
+	});
+
+	it('renders fallback KPI series without explicit series configuration, excluding the date axis column', () => {
+		const story = {
+			title: 'Fallback KPI Story',
+			code: '<chart query_id="q_fallback_kpi" chart_type="kpi_card" x_axis_key="DATE" x_axis_type="date" title="Summary Metrics" />',
+		};
+
+		const queryData = {
+			q_fallback_kpi: {
+				columns: ['date', 'revenue', 'users_count'],
+				data: [
+					{ date: '2026-01-01', revenue: 50000, users_count: 300 },
+					{ date: '2026-02-01', revenue: 75000, users_count: 450 },
+				],
+			},
+		};
+
+		const md = generateStoryMarkdown(story, queryData);
+
+		expect(md).toContain('### Summary Metrics');
+		expect(md).toContain('**Revenue:** 75,000 · **Users Count:** 450');
+		expect(md).not.toContain('**Date:**');
+	});
+
+	it('renders map blocks with formatted dates and cells', () => {
+		const story = {
+			title: 'Map Story',
+			code: '<map query_id="q_map" map_type="choropleth" region_key="COUNTRY" value_key="POPULATION" title="Global Reach" />',
+		};
+
+		const queryData = {
+			q_map: {
+				columns: ['country', 'population'],
+				data: [
+					{ country: 'US', population: 330000000 },
+					{ country: 'FR', population: 67000000 },
+				],
+			},
+		};
+
+		const md = generateStoryMarkdown(story, queryData);
+
+		expect(md).toContain('### Global Reach');
+		expect(md).toContain('*(Map: Choropleth)*');
+		expect(md).toContain('| Country | Population |');
+		expect(md).toContain('| US | 330000000 |');
+	});
+
+	it('integrates with buildStoryDownloadFile for format md', async () => {
+		const result = await buildStoryDownloadFile(
+			'md',
+			'Q3 Executive Report',
+			'## Section 1\n\nReport body text.',
+			null,
+		);
+
+		expect(result.filename).toMatch(/^q3-executive-report-\d{4}-\d{2}-\d{2}\.md$/);
+		expect(result.mimeType).toBe('text/markdown');
+		expect(result.buffer.toString('utf8')).toContain('# Q3 Executive Report');
+		expect(result.buffer.toString('utf8')).toContain('## Section 1');
+	});
+});

--- a/apps/frontend/src/components/mcp-app/story-app-view.tsx
+++ b/apps/frontend/src/components/mcp-app/story-app-view.tsx
@@ -1,9 +1,7 @@
-import { Download, Loader2 } from 'lucide-react';
-import { useCallback, useState } from 'react';
-import { McpAppHeader } from './mcp-app-header';
-import { OpenInNaoButton } from './open-in-nao-button';
 import type { ParsedChartBlock, ParsedMapBlock, ParsedTableBlock } from '@nao/shared/story-segments';
 import type { DownloadFormat } from '@nao/shared/types';
+import { Download, Loader2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
 import type { QueryDataMap } from '@/components/story-embeds';
 import { StoryChartEmbed, StoryMapEmbed, StoryTableEmbed } from '@/components/story-embeds';
@@ -15,6 +13,9 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+
+import { McpAppHeader } from './mcp-app-header';
+import { OpenInNaoButton } from './open-in-nao-button';
 
 interface StoryAppViewProps {
 	title: string;
@@ -133,6 +134,7 @@ function StoryDownloadButton({ onDownload }: { onDownload: (format: DownloadForm
 			<DropdownMenuContent align='end'>
 				<DropdownMenuItem onClick={() => handleSelect('pdf')}>PDF</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => handleSelect('html')}>HTML</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => handleSelect('md')}>Markdown</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/apps/frontend/src/components/story-download.tsx
+++ b/apps/frontend/src/components/story-download.tsx
@@ -1,7 +1,7 @@
-import { Download, FileCode, FileText, Loader2 } from 'lucide-react';
+import type { DownloadFormat } from '@nao/shared/types';
+import { Download, FileCode, FileDown, FileText, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
-import type { DownloadFormat } from '@nao/shared/types';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -138,6 +138,9 @@ export function StoryDownload({ isAgentRunning, isSaving, iconOnly = false, ...d
 					</DropdownMenuItem>
 					<DropdownMenuItem onSelect={() => handleDownload('html')}>
 						<FileCode /> <span>HTML</span>
+					</DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => handleDownload('md')}>
+						<FileDown /> <span>Markdown</span>
 					</DropdownMenuItem>
 				</DropdownMenuContent>
 			</DropdownMenu>

--- a/apps/shared/src/types.ts
+++ b/apps/shared/src/types.ts
@@ -281,8 +281,8 @@ export type ProjectChatListItem = {
 	toolAvailableCount: number;
 };
 
-export type DownloadFormat = 'pdf' | 'html';
-export const DOWNLOAD_FORMATS = ['pdf', 'html'] as const satisfies readonly DownloadFormat[];
+export type DownloadFormat = 'pdf' | 'html' | 'md';
+export const DOWNLOAD_FORMATS = ['pdf', 'html', 'md'] as const satisfies readonly DownloadFormat[];
 
 export type ChatDownloadFormat = 'png' | 'csv' | 'xlsx' | 'other';
 export const CHAT_DOWNLOAD_FORMATS = ['png', 'csv', 'xlsx', 'other'] as const satisfies readonly ChatDownloadFormat[];


### PR DESCRIPTION
Fixes #1467

### Summary of Changes
Adds native Markdown (`.md`) story export support alongside existing PDF and HTML export formats, designed for direct ingestion into documentation tools like Notion without manual cleanup.

1. **Shared Types & Validation:**
   - Added `'md'` to `DownloadFormat` and `DOWNLOAD_FORMATS`.
   - Supports tRPC download endpoints with type-safe schema validation.

2. **Markdown Export Engine (`apps/backend/src/utils/story-markdown.ts`):**
   - Preserves story structure (title `# `, sections `## `, subheadings `### `, lists).
   - Flattens multi-tab stories into clean markdown section headers (`## Tab Title`).
   - Renders `<table ... />` results into formatted Markdown tables with numeric right-alignment (`---:`) and full punctuation escaping (`\`, `|`, `*`, `_`, `` ` ``, `[`, `]`, `<`, `>`).
   - Handles `<chart ... />` blocks with chart titles, type indicators `*(Chart: Type)*`, and underlying series data tables with custom `value_format` and column casing resolution (`resolveDataKey`).
   - Formats KPI cards with date-sorting (selecting latest date row), multi-series support, custom `value_format`, and excludes the date column in fallbacks.
   - Formats map blocks with `resolveMapConfig`, `resolveDataKey`, `formatCellValue`, and workspace `dateFormat`.
   - Strips nested `<grid>` tags cleanly without leftover tags.

3. **Frontend UI:**
   - Added `Markdown` option in story download dropdowns (`story-download.tsx` and `story-app-view.tsx`).

4. **Automated Tests:**
   - Added 9 unit tests in `story-markdown.test.ts` (100% passing).

---

### Verification
- **Automated Tests:** `vitest run tests/story-markdown.test.ts` (9/9 passed, 100%)
- **Lint & Format:** `npx eslint --max-warnings=0` & `npx prettier --check` (0 errors, 0 warnings)
- **Notion Import:** Tested & verified direct Markdown import into Notion.

### Screenshots
| Original Story in Nao | Exported & Rendered Markdown in Notion |
| :---: | :---: |
| <img width="1537" height="867" alt="ogstory" src="https://github.com/user-attachments/assets/7866e5e1-cfe5-4aea-a3e8-901ab50e7336" /> | <img width="971" height="852" alt="notion" src="https://github.com/user-attachments/assets/09c0d88a-4518-46b1-b119-effe23928174" /> |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

