### PR TITLE
feat(usage): add flexible time windows and include current month in usage analytics

### DIFF
--- a/apps/backend/src/queries/usage.queries.ts
+++ b/apps/backend/src/queries/usage.queries.ts
@@ -7,7 +7,7 @@ import { db } from '../db/db';
 import dbConfig, { Dialect } from '../db/dbConfig';
 import type { ModelCosts } from '../types/llm';
 import type { Granularity, TotalUsageRecord, UsageFilter, UsageRecord, UsageSource } from '../types/usage';
-import { fillMissingDates, getLookbackTimestamp } from '../utils/date';
+import { fillMissingDates, resolvePeriodAndGranularity } from '../utils/date';
 import { getProjectDeclaredModels } from '../utils/llm';
 
 const COST_COLS = [
@@ -108,10 +108,18 @@ const INFERENCE_USAGE_SOURCE_EXPR = sql<UsageSource | null>`(
 )`;
 
 export const getMessagesUsage = async (projectId: string, filter: UsageFilter): Promise<UsageRecord[]> => {
-	const { granularity, provider } = filter;
+	const now = new Date();
+	const resolved = resolvePeriodAndGranularity(
+		{
+			period: filter.period,
+			granularity: filter.granularity,
+		},
+		now,
+	);
+	const { granularity, startDate } = resolved;
 	const messageDateExpr = getDateExpr(s.chatMessage.createdAt, granularity);
 	const inferenceDateExpr = getDateExpr(s.llmInference.createdAt, granularity);
-	const lookbackTs = getLookbackTimestamp(granularity);
+	const lookbackTs = startDate.getTime();
 	const messageLookbackFilter =
 		dbConfig.dialect === Dialect.Postgres
 			? sql`${s.chatMessage.createdAt} >= ${new Date(lookbackTs).toISOString()}`
@@ -123,9 +131,9 @@ export const getMessagesUsage = async (projectId: string, filter: UsageFilter): 
 
 	const messageWhereConditions = [eq(s.chat.projectId, projectId), messageLookbackFilter];
 	const inferenceWhereConditions = [eq(s.llmInference.projectId, projectId), inferenceLookbackFilter];
-	if (provider) {
-		messageWhereConditions.push(sql`${MESSAGE_USAGE_PROVIDER_EXPR} = ${provider}`);
-		inferenceWhereConditions.push(eq(s.llmInference.llmProvider, provider));
+	if (filter.provider) {
+		messageWhereConditions.push(sql`${MESSAGE_USAGE_PROVIDER_EXPR} = ${filter.provider}`);
+		inferenceWhereConditions.push(eq(s.llmInference.llmProvider, filter.provider));
 	}
 	addUserNameFilter(messageWhereConditions, filter.userNames);
 	addUserNameFilter(inferenceWhereConditions, filter.userNames);
@@ -259,12 +267,20 @@ export const getMessagesUsage = async (projectId: string, filter: UsageFilter): 
 		.from(combinedUsage)
 		.groupBy(({ date }) => date);
 
-	return fillMissingDates(rows.map(normalizeMessageUsageRow), granularity);
+	return fillMissingDates(rows.map(normalizeMessageUsageRow), resolved);
 };
 
 export const getTotalUsage = async (projectId: string, filter: UsageFilter): Promise<TotalUsageRecord> => {
-	const { granularity, provider } = filter;
-	const lookbackTs = getLookbackTimestamp(granularity);
+	const now = new Date();
+	const resolved = resolvePeriodAndGranularity(
+		{
+			period: filter.period,
+			granularity: filter.granularity,
+		},
+		now,
+	);
+	const { provider } = filter;
+	const lookbackTs = resolved.startDate.getTime();
 	const lookbackFilter =
 		dbConfig.dialect === Dialect.Postgres
 			? sql`${s.chatMessage.createdAt} >= ${new Date(lookbackTs).toISOString()}`

--- a/apps/backend/src/types/usage.ts
+++ b/apps/backend/src/types/usage.ts
@@ -6,11 +6,32 @@ import { llmProviderSchema } from './llm';
 export const granularitySchema = z.enum(['hour', 'day', 'month']);
 export type Granularity = z.infer<typeof granularitySchema>;
 
+export const USAGE_PERIODS = ['24h', '7d', '15d', '30d', '60d', '90d', '6m'] as const;
+export const usagePeriodSchema = z.enum(USAGE_PERIODS);
+export type UsagePeriod = z.infer<typeof usagePeriodSchema>;
+
+export const PERIOD_CONFIG: Record<UsagePeriod, { count: number; granularity: Granularity; label: string }> = {
+	'24h': { count: 24, granularity: 'hour', label: 'Last 24 hours' },
+	'7d': { count: 7, granularity: 'day', label: 'Last 7 days' },
+	'15d': { count: 15, granularity: 'day', label: 'Last 15 days' },
+	'30d': { count: 30, granularity: 'day', label: 'Last 30 days' },
+	'60d': { count: 60, granularity: 'day', label: 'Last 60 days' },
+	'90d': { count: 90, granularity: 'day', label: 'Last 90 days' },
+	'6m': { count: 6, granularity: 'month', label: 'Last 6 months' },
+};
+
+export const DEFAULT_PERIOD_BY_GRANULARITY: Record<Granularity, UsagePeriod> = {
+	hour: '24h',
+	day: '15d',
+	month: '6m',
+};
+
 export const USAGE_SOURCES = MESSAGE_SOURCES;
 export type UsageSource = (typeof USAGE_SOURCES)[number];
 
 export const usageFilterSchema = z.object({
-	granularity: granularitySchema.default('day'),
+	granularity: granularitySchema.optional(),
+	period: usagePeriodSchema.optional(),
 	provider: llmProviderSchema.optional(),
 	userNames: z.array(z.string()).optional(),
 	sources: z.array(z.enum(USAGE_SOURCES)).optional(),

--- a/apps/backend/src/utils/date.ts
+++ b/apps/backend/src/utils/date.ts
@@ -1,4 +1,15 @@
-import type { Granularity, UsageRecord } from '../types/usage';
+import type { Granularity, UsagePeriod, UsageRecord } from '../types/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG } from '../types/usage';
+
+export { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG };
+
+export interface ResolvedPeriod {
+	period: UsagePeriod;
+	granularity: Granularity;
+	count: number;
+	startDate: Date;
+	now: Date;
+}
 
 export function isValidIsoDateString(s: string): boolean {
 	if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) {
@@ -9,24 +20,69 @@ export function isValidIsoDateString(s: string): boolean {
 	return date.getUTCFullYear() === y && date.getUTCMonth() === m - 1 && date.getUTCDate() === d;
 }
 
-export const lookbackPeriods = {
-	hour: 24,
-	day: 15,
-	month: 6,
-};
+export function getPeriodStartDate(period: UsagePeriod, now: Date = new Date()): Date {
+	const config = PERIOD_CONFIG[period] ?? PERIOD_CONFIG['15d'];
+	const date = new Date(now);
 
-export function getLookbackTimestamp(granularity: Granularity): number {
-	const now = Date.now();
-	const periods = lookbackPeriods[granularity];
-
-	switch (granularity) {
-		case 'hour':
-			return now - periods * 60 * 60 * 1000;
-		case 'day':
-			return now - periods * 24 * 60 * 60 * 1000;
-		case 'month':
-			return now - periods * 30 * 24 * 60 * 60 * 1000;
+	if (config.granularity === 'month') {
+		return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - (config.count - 1), 1, 0, 0, 0, 0));
 	}
+
+	if (config.granularity === 'hour') {
+		date.setUTCHours(date.getUTCHours() - (config.count - 1), 0, 0, 0);
+		return date;
+	}
+
+	date.setUTCDate(date.getUTCDate() - (config.count - 1));
+	date.setUTCHours(0, 0, 0, 0);
+	return date;
+}
+
+export function resolvePeriodAndGranularity(
+	options?: { period?: UsagePeriod; granularity?: Granularity },
+	now: Date = new Date(),
+): ResolvedPeriod {
+	const period =
+		options?.period && PERIOD_CONFIG[options.period]
+			? options.period
+			: options?.granularity && DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]
+				? DEFAULT_PERIOD_BY_GRANULARITY[options.granularity]
+				: '15d';
+
+	const defaultGranularity = PERIOD_CONFIG[period].granularity;
+	const granularity = options?.granularity ?? defaultGranularity;
+	const startDate = getPeriodStartDate(period, now);
+
+	let count: number;
+	if (granularity === defaultGranularity) {
+		count = PERIOD_CONFIG[period].count;
+	} else if (granularity === 'month') {
+		count =
+			(now.getUTCFullYear() - startDate.getUTCFullYear()) * 12 +
+			(now.getUTCMonth() - startDate.getUTCMonth()) +
+			1;
+	} else if (granularity === 'day') {
+		const currentDayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+		const startDayUtc = Date.UTC(startDate.getUTCFullYear(), startDate.getUTCMonth(), startDate.getUTCDate());
+		count = Math.floor((currentDayUtc - startDayUtc) / (24 * 60 * 60 * 1000)) + 1;
+	} else {
+		const currentHourUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours());
+		const startHourUtc = Date.UTC(
+			startDate.getUTCFullYear(),
+			startDate.getUTCMonth(),
+			startDate.getUTCDate(),
+			startDate.getUTCHours(),
+		);
+		count = Math.floor((currentHourUtc - startHourUtc) / (60 * 60 * 1000)) + 1;
+	}
+
+	return {
+		period,
+		granularity,
+		count,
+		startDate,
+		now,
+	};
 }
 
 export function formatDate(date: Date, granularity: Granularity): string {
@@ -45,15 +101,18 @@ export function formatDate(date: Date, granularity: Granularity): string {
 	}
 }
 
-export function generateDateSeries(granularity: Granularity): string[] {
+export function generateDateSeries(granularity?: Granularity | ResolvedPeriod, period?: UsagePeriod): string[] {
+	const resolved =
+		typeof granularity === 'object' && granularity !== null
+			? granularity
+			: resolvePeriodAndGranularity({ period, granularity });
 	const dates: string[] = [];
-	const periods = lookbackPeriods[granularity];
-	const now = new Date();
+	const now = resolved.now;
 
-	for (let i = periods - 1; i >= 0; i--) {
+	for (let i = resolved.count - 1; i >= 0; i--) {
 		const date = new Date(now);
 
-		switch (granularity) {
+		switch (resolved.granularity) {
 			case 'hour':
 				date.setUTCHours(date.getUTCHours() - i, 0, 0, 0);
 				break;
@@ -67,7 +126,7 @@ export function generateDateSeries(granularity: Granularity): string[] {
 				break;
 		}
 
-		dates.push(formatDate(date, granularity));
+		dates.push(formatDate(date, resolved.granularity));
 	}
 
 	return dates;
@@ -97,9 +156,17 @@ export function formatCurrentDate(timezone?: string): string {
 	return tz === 'UTC' ? `${formatted} (UTC)` : `${formatted} (${tz})`;
 }
 
-export function fillMissingDates(records: UsageRecord[], granularity: Granularity): UsageRecord[] {
+export function fillMissingDates(
+	records: UsageRecord[],
+	granularity?: Granularity | ResolvedPeriod,
+	period?: UsagePeriod,
+): UsageRecord[] {
+	const resolved =
+		typeof granularity === 'object' && granularity !== null
+			? granularity
+			: resolvePeriodAndGranularity({ period, granularity });
 	const dateSet = new Map(records.map((r) => [r.date, r]));
-	const allDates = generateDateSeries(granularity);
+	const allDates = generateDateSeries(resolved);
 
 	return allDates.map(
 		(date) =>

--- a/apps/backend/tests/usage-queries.test.ts
+++ b/apps/backend/tests/usage-queries.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import s from '../src/db/abstractSchema';
 import { db } from '../src/db/db';
 import { getMessagesUsage, getTotalUsage } from '../src/queries/usage.queries';
-import { formatDate } from '../src/utils/date';
+import { formatDate, resolvePeriodAndGranularity } from '../src/utils/date';
 
 vi.mock('../src/db/db', async () => {
 	const { default: Database } = await import('better-sqlite3');
@@ -175,5 +175,87 @@ describe('usage query results', () => {
 			outputTotalTokens: 5,
 			totalTokens: 45,
 		});
+	});
+
+	it('supports flexible time periods (30d, 60d, 90d, 6m)', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-28T12:00:00.000Z'));
+		try {
+			// Insert rows near boundaries:
+			// 1. One ms before 6m start boundary (2026-02-28 23:59:59.999 UTC) -> should be excluded
+			// 2. Exactly at 6m start boundary (2026-03-01 00:00:00.000 UTC) -> should be included in 2026-03
+			// 3. In the current active month (2026-08-28 10:00:00.000 UTC) -> should be included in 2026-08
+			await db.insert(s.chatMessage).values([
+				{
+					id: 'out-of-range-before-6m',
+					chatId: CHAT_ID,
+					role: 'user',
+					createdAt: new Date('2026-02-28T23:59:59.999Z'),
+				},
+				{
+					id: 'exact-boundary-6m',
+					chatId: CHAT_ID,
+					role: 'user',
+					createdAt: new Date('2026-03-01T00:00:00.000Z'),
+				},
+				{
+					id: 'current-month-active',
+					chatId: CHAT_ID,
+					role: 'user',
+					createdAt: new Date('2026-08-28T10:00:00.000Z'),
+				},
+			]);
+
+			const records30d = await getMessagesUsage(PROJECT_ID, { period: '30d' });
+			expect(records30d).toHaveLength(30);
+			expect(records30d.find((r) => r.date === '2026-08-28')?.messageCount).toBe(1);
+			expect(records30d.reduce((sum, r) => sum + r.messageCount, 0)).toBe(1);
+
+			const records60d = await getMessagesUsage(PROJECT_ID, { period: '60d' });
+			expect(records60d).toHaveLength(60);
+			expect(records60d.find((r) => r.date === '2026-08-28')?.messageCount).toBe(1);
+			expect(records60d.reduce((sum, r) => sum + r.messageCount, 0)).toBe(1);
+
+			const records90d = await getMessagesUsage(PROJECT_ID, { period: '90d' });
+			expect(records90d).toHaveLength(90);
+			expect(records90d.find((r) => r.date === '2026-08-28')?.messageCount).toBe(1);
+			expect(records90d.reduce((sum, r) => sum + r.messageCount, 0)).toBe(1);
+
+			const records6m = await getMessagesUsage(PROJECT_ID, { period: '6m' });
+			expect(records6m).toHaveLength(6);
+			expect(records6m.map((r) => r.date)).toEqual([
+				'2026-03',
+				'2026-04',
+				'2026-05',
+				'2026-06',
+				'2026-07',
+				'2026-08',
+			]);
+			expect(records6m.find((r) => r.date === '2026-03')?.messageCount).toBe(1);
+			expect(records6m.find((r) => r.date === '2026-08')?.messageCount).toBe(1);
+			expect(records6m.find((r) => r.date === '2026-04')?.messageCount).toBe(0);
+			expect(records6m.reduce((sum, r) => sum + r.messageCount, 0)).toBe(2);
+
+			// Diverging period and granularity
+			const records6mDaily = await getMessagesUsage(PROJECT_ID, { period: '6m', granularity: 'day' });
+			expect(records6mDaily).toHaveLength(181);
+			expect(records6mDaily[0].date).toBe('2026-03-01');
+			expect(records6mDaily[0].messageCount).toBe(1);
+			expect(records6mDaily[records6mDaily.length - 1].date).toBe('2026-08-28');
+			expect(records6mDaily[records6mDaily.length - 1].messageCount).toBe(1);
+			expect(records6mDaily.reduce((sum, r) => sum + r.messageCount, 0)).toBe(2);
+
+			// Verify that advancing past midnight UTC increments the daily bucket count by exactly 1
+			const beforeMidnight = new Date('2026-08-28T23:59:59.000Z');
+			const afterMidnight = new Date('2026-08-29T00:00:01.000Z');
+			const resolvedBefore = resolvePeriodAndGranularity({ period: '6m', granularity: 'day' }, beforeMidnight);
+			const resolvedAfter = resolvePeriodAndGranularity({ period: '6m', granularity: 'day' }, afterMidnight);
+			expect(resolvedBefore.count).toBe(181);
+			expect(resolvedAfter.count).toBe(182);
+			expect(resolvedBefore.startDate.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+			expect(resolvedAfter.startDate.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/apps/frontend/src/components/settings/usage-filters.tsx
+++ b/apps/frontend/src/components/settings/usage-filters.tsx
@@ -1,15 +1,16 @@
-import { useState } from 'react';
-import { CheckIcon, Radio, ThumbsUp, Users, Wrench } from 'lucide-react';
-import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabel } from '@nao/shared/types';
-import { USAGE_SOURCES } from '@nao/backend/usage';
-import type { Granularity, UsageSource } from '@nao/backend/usage';
+import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG, USAGE_PERIODS, USAGE_SOURCES } from '@nao/backend/usage';
 import type {
 	ChatReplayFeedbackState,
 	ChatReplayToolState,
 	LlmProvider,
 	ProjectChatReplayFacets,
 } from '@nao/shared/types';
+import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabel } from '@nao/shared/types';
 import type { LucideIcon } from 'lucide-react';
+import { CheckIcon, Radio, ThumbsUp, Users, Wrench } from 'lucide-react';
+import { useState } from 'react';
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
@@ -17,19 +18,15 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 
-type UsagePeriod = '24h' | '15d' | '6m';
+export const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = USAGE_PERIODS.map(
+	(value) => ({
+		value,
+		label: PERIOD_CONFIG[value].label,
+		granularity: PERIOD_CONFIG[value].granularity,
+	}),
+);
 
-const periodOptions: { value: UsagePeriod; label: string; granularity: Granularity }[] = [
-	{ value: '24h', label: 'Last 24 hours', granularity: 'hour' },
-	{ value: '15d', label: 'Last 15 days', granularity: 'day' },
-	{ value: '6m', label: 'Last 6 months', granularity: 'month' },
-];
-
-const periodByGranularity: Record<Granularity, UsagePeriod> = {
-	hour: '24h',
-	day: '15d',
-	month: '6m',
-};
+export const periodByGranularity: Record<Granularity, UsagePeriod> = DEFAULT_PERIOD_BY_GRANULARITY;
 
 export const dateFormats: Record<Granularity, string> = {
 	hour: 'MMM d, HH:00',
@@ -41,8 +38,10 @@ interface UsageFiltersProps {
 	showUsageControls?: boolean;
 	provider: LlmProvider | 'all';
 	onProviderChange: (value: LlmProvider | 'all') => void;
+	period?: UsagePeriod;
+	onPeriodChange?: (period: UsagePeriod, granularity: Granularity) => void;
 	granularity: Granularity;
-	onGranularityChange: (value: Granularity) => void;
+	onGranularityChange?: (value: Granularity) => void;
 	availableProviders: LlmProvider[] | undefined;
 	chatFacets: ProjectChatReplayFacets | undefined;
 	selectedUserNames: string[] | undefined;
@@ -55,6 +54,8 @@ export function UsageFilters({
 	showUsageControls = true,
 	provider,
 	onProviderChange,
+	period: passedPeriod,
+	onPeriodChange,
 	granularity,
 	onGranularityChange,
 	availableProviders,
@@ -64,7 +65,10 @@ export function UsageFilters({
 	selectedSources,
 	onSelectedSourcesChange,
 }: UsageFiltersProps) {
-	const period = periodByGranularity[granularity];
+	const currentPeriod = passedPeriod ?? periodByGranularity[granularity] ?? '15d';
+	const availableOptions = onPeriodChange
+		? periodOptions
+		: periodOptions.filter((o) => o.value === '24h' || o.value === '15d' || o.value === '6m');
 	const userOptions = (chatFacets?.userNames ?? []).map((name) => ({
 		value: name,
 		label: name,
@@ -93,11 +97,16 @@ export function UsageFilters({
 						</SelectContent>
 					</Select>
 					<Select
-						value={period}
+						value={currentPeriod}
 						onValueChange={(value) => {
-							const option = periodOptions.find((o) => o.value === value);
+							const nextPeriod = value as UsagePeriod;
+							const option = availableOptions.find((o) => o.value === nextPeriod);
 							if (option) {
-								onGranularityChange(option.granularity);
+								if (onPeriodChange) {
+									onPeriodChange(option.value, option.granularity);
+								} else {
+									onGranularityChange(option.granularity);
+								}
 							}
 						}}
 					>
@@ -105,7 +114,7 @@ export function UsageFilters({
 							<SelectValue />
 						</SelectTrigger>
 						<SelectContent>
-							{periodOptions.map((option) => (
+							{availableOptions.map((option) => (
 								<SelectItem key={option.value} value={option.value}>
 									{option.label}
 								</SelectItem>

--- a/apps/frontend/src/components/settings/usage-route-search.ts
+++ b/apps/frontend/src/components/settings/usage-route-search.ts
@@ -1,7 +1,8 @@
-import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabels } from '@nao/shared/types';
-import { USAGE_SOURCES } from '@nao/backend/usage';
-import type { Granularity, UsageSource } from '@nao/backend/usage';
+import type { Granularity, UsagePeriod, UsageSource } from '@nao/backend/usage';
+import { DEFAULT_PERIOD_BY_GRANULARITY, PERIOD_CONFIG, USAGE_PERIODS, USAGE_SOURCES } from '@nao/backend/usage';
 import type { ChatReplayFeedbackState, ChatReplayToolState, LlmProvider } from '@nao/shared/types';
+import { CHAT_REPLAY_FEEDBACK_STATES, CHAT_REPLAY_TOOL_STATES, providerLabels } from '@nao/shared/types';
+
 import type { RecommendationTab } from '@/components/settings/recommendations-route-search';
 import { RECOMMENDATION_TABS } from '@/components/settings/recommendations-route-search';
 import { getActiveProjectId } from '@/lib/active-project';
@@ -14,6 +15,7 @@ export type ReplayOrigin = 'recommendations';
 
 export type UsageRouteSearch = {
 	provider: LlmProvider | 'all';
+	period: UsagePeriod;
 	granularity: Granularity;
 	users: string[] | undefined;
 	feedback: ChatReplayFeedbackState[] | undefined;
@@ -29,6 +31,7 @@ export type UsageRouteSearch = {
 
 export const DEFAULT_USAGE_SEARCH: UsageRouteSearch = {
 	provider: 'all',
+	period: '15d',
 	granularity: 'day',
 	users: undefined,
 	feedback: undefined,
@@ -42,10 +45,17 @@ export const DEFAULT_USAGE_SEARCH: UsageRouteSearch = {
 	recoTab: undefined,
 };
 
+const periods = USAGE_PERIODS;
 const granularities = ['hour', 'day', 'month'] as const satisfies readonly Granularity[];
 const tokenViews = ['tokens', 'dollars'] as const satisfies readonly TokenChartDisplayMode[];
-const filterSearchKeys = ['provider', 'granularity', 'users', 'feedback', 'tools', 'sources'] as const;
+const filterSearchKeys = ['provider', 'period', 'granularity', 'users', 'feedback', 'tools', 'sources'] as const;
 const usageFiltersStorageKey = 'nao.usage-filters';
+
+export const PERIOD_TO_GRANULARITY: Record<UsagePeriod, Granularity> = Object.fromEntries(
+	USAGE_PERIODS.map((period) => [period, PERIOD_CONFIG[period].granularity]),
+) as Record<UsagePeriod, Granularity>;
+
+export const GRANULARITY_TO_PERIOD: Record<Granularity, UsagePeriod> = DEFAULT_PERIOD_BY_GRANULARITY;
 
 export function validateUsageSearchWithStoredFilters(search: Record<string, unknown>): UsageRouteSearch {
 	const hasSearchFilters = filterSearchKeys.some((key) => search[key] !== undefined);
@@ -72,9 +82,15 @@ const replayHighlights = ['tool-error', 'feedback'] as const satisfies readonly 
 const replayOrigins = ['recommendations'] as const satisfies readonly ReplayOrigin[];
 
 export function validateUsageSearch(search: Record<string, unknown>): UsageRouteSearch {
+	const rawPeriod = parseOneOf(search.period, periods);
+	const rawGranularity = parseOneOf(search.granularity, granularities);
+	const period = rawPeriod ?? (rawGranularity ? GRANULARITY_TO_PERIOD[rawGranularity] : '15d');
+	const granularity = rawGranularity ?? PERIOD_TO_GRANULARITY[period];
+
 	return {
 		provider: parseProvider(search.provider),
-		granularity: parseOneOf(search.granularity, granularities) ?? 'day',
+		period,
+		granularity,
 		users: parseStringArray(search.users),
 		feedback: parseArrayOf(search.feedback, CHAT_REPLAY_FEEDBACK_STATES),
 		tools: parseArrayOf(search.tools, CHAT_REPLAY_TOOL_STATES),

--- a/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
+++ b/apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx
@@ -1,17 +1,19 @@
-import { useEffect } from 'react';
-import { createFileRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { format } from 'date-fns';
-import type { TokenChartDisplayMode, UsageRouteSearch } from '@/components/settings/usage-route-search';
+import type { Granularity } from '@nao/backend/usage';
 import type { displayChart } from '@nao/shared/tools';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { createFileRoute, Outlet, useNavigate, useRouterState } from '@tanstack/react-router';
+import { format } from 'date-fns';
+import { useEffect } from 'react';
+
 import { ChatsReplayPage } from '@/components/settings/chats-replay-page';
 import { UsageChartCard } from '@/components/settings/usage-chart-card';
-import { ReplayFilters, UsageFilters, dateFormats } from '@/components/settings/usage-filters';
+import { dateFormats, ReplayFilters, UsageFilters } from '@/components/settings/usage-filters';
+import type { TokenChartDisplayMode, UsageRouteSearch } from '@/components/settings/usage-route-search';
 import { saveUsageFilters, validateUsageSearchWithStoredFilters } from '@/components/settings/usage-route-search';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { usePermissions } from '@/hooks/use-permissions';
-import { trpc } from '@/main';
 import { requireContextAdminOrAdmin } from '@/lib/require-admin';
+import { trpc } from '@/main';
 
 export const Route = createFileRoute('/_sidebar-layout/settings/usage')({
 	beforeLoad: requireContextAdminOrAdmin,
@@ -95,6 +97,29 @@ function UsagePage() {
 	);
 }
 
+function formatChartXAxisLabel(value: string, granularity: Granularity): string {
+	if (/^\d{4}-\d{2}$/.test(value)) {
+		const [y, m] = value.split('-').map(Number);
+		return format(new Date(y, m - 1, 1), dateFormats.month);
+	}
+	if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		const [y, m, d] = value.split('-').map(Number);
+		return format(new Date(y, m - 1, d), dateFormats.day);
+	}
+	if (/^\d{4}-\d{2}-\d{2} \d{2}:00$/.test(value)) {
+		const [datePart, timePart] = value.split(' ');
+		const [y, m, d] = datePart.split('-').map(Number);
+		const [h] = timePart.split(':').map(Number);
+		const dateStr = format(new Date(y, m - 1, d, 12), dateFormats.day);
+		return `${dateStr}, ${String(h).padStart(2, '0')}:00`;
+	}
+	try {
+		return format(new Date(value), dateFormats[granularity]);
+	} catch {
+		return value;
+	}
+}
+
 function UsageOverview({
 	usageSearch,
 	onUpdateSearch,
@@ -104,7 +129,7 @@ function UsageOverview({
 	onUpdateSearch: (next: Partial<UsageRouteSearch>) => void;
 	onOpenChatReplay: (chatId: string) => void;
 }) {
-	const { granularity, provider, users, feedback, tools, sources, tokenView } = usageSearch;
+	const { period, granularity, provider, users, feedback, tools, sources, tokenView } = usageSearch;
 	const { canViewUsage } = usePermissions();
 
 	const usedProviders = useQuery({
@@ -120,6 +145,7 @@ function UsageOverview({
 	});
 	const messagesUsage = useQuery({
 		...trpc.usage.getMessagesUsage.queryOptions({
+			period,
 			granularity,
 			provider: provider === 'all' ? undefined : provider,
 			userNames: users,
@@ -130,6 +156,7 @@ function UsageOverview({
 	});
 	const totalUsage = useQuery({
 		...trpc.usage.getTotalUsage.queryOptions({
+			period,
 			granularity,
 			provider: provider === 'all' ? undefined : provider,
 			userNames: users,
@@ -153,8 +180,11 @@ function UsageOverview({
 			showUsageControls={canViewUsage}
 			provider={provider}
 			onProviderChange={(value) => onUpdateSearch({ provider: value })}
+			period={period}
+			onPeriodChange={(nextPeriod, nextGranularity) =>
+				onUpdateSearch({ period: nextPeriod, granularity: nextGranularity })
+			}
 			granularity={granularity}
-			onGranularityChange={(value) => onUpdateSearch({ granularity: value })}
 			availableProviders={usedProviders.data}
 			chatFacets={chatFacets.data?.facets}
 			selectedUserNames={users}
@@ -202,7 +232,7 @@ function UsageOverview({
 								isError={messagesUsage.isError}
 								data={chartData}
 								chartType='stacked_bar'
-								xAxisLabelFormatter={(value) => format(new Date(value), dateFormats[granularity])}
+								xAxisLabelFormatter={(value) => formatChartXAxisLabel(value, granularity)}
 								titleAccessory={
 									<span className='text-xs text-muted-foreground'>Number of messages by source</span>
 								}
@@ -217,7 +247,7 @@ function UsageOverview({
 								isError={messagesUsage.isError}
 								data={chartData}
 								chartType='stacked_bar'
-								xAxisLabelFormatter={(value) => format(new Date(value), dateFormats[granularity])}
+								xAxisLabelFormatter={(value) => formatChartXAxisLabel(value, granularity)}
 								valueFormatter={showCost ? formatUsd : undefined}
 								series={showCost ? costSeries : tokenSeries}
 								titleAccessory={


### PR DESCRIPTION
Fixes #1482 

### Summary of Changes

#### 1. Flexible Time Windows
- Added `Last 7 days`, `Last 30 days`, `Last 60 days`, and `Last 90 days` options to the usage analytics filter alongside existing `Last 24 hours`, `Last 15 days`, and `Last 6 months`.
- Decoupled `period` (time lookback window) from `granularity` (SQL aggregation bucket size).
- Sane default granularities are derived automatically from the chosen period (`24h` -> hour, `7d`..`90d` -> day, `6m` -> month), while still supporting independent granularity overrides if needed (e.g. 6 months with daily granularity).

#### 2. Root Causes & Fix for Missing Current Month
- **Backend Lookback:** Previously, month lookback subtracted an approximate 180 days (`now - 6 * 30 * 24 * 60 * 60 * 1000`), causing boundary cutoffs. It now calculates the 1st day of the month 5 months ago at 00:00:00 UTC, covering the 5 preceding complete months plus the active current month (6 months total).
- **Client-Side Timezone Shift:** Earlier `format(new Date('YYYY-MM'), 'MMM yyyy')` was parsing month strings as UTC midnight (`2026-08-01T00:00:00Z`). In timezones with negative UTC offsets (e.g. US/Canada UTC-4 to UTC-8), this timestamp resolved to the previous month in local time. Added value-shape parsing in `formatChartXAxisLabel` to preserve the exact date string across all timezones and loading transitions.

#### 3. Backward Compatibility & Test Coverage
- Existing URLs and bookmarks using `?granularity=...` are seamlessly parsed and mapped to the corresponding period.
- Added deterministic unit tests in `usage-queries.test.ts` with frozen timers asserting exact 30d, 60d, 90d, and 6m lookback date arrays and daily bucket counts.

---

### Key Files Modified
- `apps/backend/src/types/usage.ts`: Added `usagePeriodSchema` (`'24h' | '7d' | '15d' | '30d' | '60d' | '90d' | '6m'`) and updated `usageFilterSchema`.
- `apps/backend/src/utils/date.ts`: Added `PERIOD_CONFIG`, `resolvePeriodAndGranularity`, `generateDateSeries`, and `fillMissingDates`.
- `apps/backend/src/queries/usage.queries.ts`: Resolved period and granularity in `getMessagesUsage` and `getTotalUsage`.
- `apps/backend/tests/usage-queries.test.ts`: Added unit tests for 30d, 60d, 90d, and 6m lookbacks.
- `apps/frontend/src/components/settings/usage-route-search.ts`: Added period to search params, storage, and fallback validators.
- `apps/frontend/src/components/settings/usage-filters.tsx`: Added new period options to dropdown.
- `apps/frontend/src/routes/_sidebar-layout.settings.usage.tsx`: Passed period to queries and added timezone-safe `formatChartXAxisLabel`.

---

### Testing & Verification
- **Automated Tests:** Ran `vitest` across backend and frontend (32 suites, 218/218 frontend tests passing).
- **Lint & Type Checks:** Ran ESLint and Prettier across all workspaces with 0 errors and 0 warnings.
- **Manual Local Verification:**
  - Tested all 7 options (`Last 24 hours`, `Last 7 days`, `Last 15 days`, `Last 30 days`, `Last 60 days`, `Last 90 days`, `Last 6 months`) on localhost.
  - Verified URL query search synchronization and filter persistence.
  - Verified that `Last 6 months` accurately renders the active current month across different timezones without offset shifts.

### Screenshots / Proof of Fix

### **_Before:_**
- **Only 3 fixed options in dropdown:**
<img width="652" height="167" alt="bfusagedates" src="https://github.com/user-attachments/assets/534c6e1f-85fd-4b20-8649-f52529765e82" />

- **Last 6 Months _missing_ active current month (i.e. August):**
<img width="751" height="540" alt="last6monthsbefore" src="https://github.com/user-attachments/assets/c22f49e7-49b0-4d26-a6aa-543486a71ac6" />

---

### **_After:_**

- **All 7 Flexible Time Windows:**
<img width="342" height="301" alt="newdropdown" src="https://github.com/user-attachments/assets/a01d7ef2-fb43-4575-9cd9-f07b9c3c845b" />

- **Last 6 Months _cleanly rendering_ active current month (i.e. August):**
<img width="681" height="502" alt="new6monthsafter" src="https://github.com/user-attachments/assets/71221e44-5d6a-4155-82c2-70fc221861ee" />

- **Newly added Last 7 30 60 and  90 Days Daily Views:**
  
<img width="687" height="505" alt="last7days" src="https://github.com/user-attachments/assets/bd5ceeb4-88bf-4403-b148-db82f7cbe216" />

<img width="842" height="597" alt="last30daysafter" src="https://github.com/user-attachments/assets/05bc70e9-8103-4102-b61f-de8a09e9e9a2" />

<img width="721" height="530" alt="last60days" src="https://github.com/user-attachments/assets/8dac2e92-b6df-4652-bad7-30bb0ca5ae93" />

<img width="767" height="547" alt="last90daysafter" src="https://github.com/user-attachments/assets/39a9fc40-f57d-48e5-a0eb-175f4ff0d241" />

- **The 24h and 15 Days:**

<img width="672" height="512" alt="last24hourafter" src="https://github.com/user-attachments/assets/52ba11c0-b26e-4ce6-ba93-41c6be867f27" />

<img width="677" height="492" alt="last15daysafter" src="https://github.com/user-attachments/assets/f6264948-1b18-4886-83bb-7f3055fb88df" />

Tested Locally on the running frontend and backend.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

