### PR TITLE
fix(chat): show a recoverable state when a tool output never arrives

### DIFF
--- a/apps/frontend/src/components/tool-calls/execute-python.tsx
+++ b/apps/frontend/src/components/tool-calls/execute-python.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Code, Copy, Terminal } from 'lucide-react';
 import { ToolCallWrapper } from './tool-call-wrapper';
+import { ToolOutputFallback } from './tool-output-fallback';
 import type { ToolCallComponentProps } from '.';
 import { useToolCallContext } from '@/contexts/tool-call';
 
@@ -81,7 +82,7 @@ export const ExecutePythonToolCall = ({ toolPart: { output, input } }: ToolCallC
 					</div>
 				</div>
 			) : (
-				<div className='p-4 text-center text-foreground/50 text-sm'>Executing Python...</div>
+				<ToolOutputFallback runningLabel='Executing Python...' />
 			)}
 		</ToolCallWrapper>
 	);

--- a/apps/frontend/src/components/tool-calls/execute-sql.tsx
+++ b/apps/frontend/src/components/tool-calls/execute-sql.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { Code, Copy, Download, Palette, Pencil, Table as TableIcon } from 'lucide-react';
 import { ToolCallWrapper } from './tool-call-wrapper';
+import { ToolOutputFallback } from './tool-output-fallback';
 import { TableFormatEditDialog } from './display-table-edit-dialog';
 import { SqlQueryDisplay } from './sql-query-display';
 import { SqlResultDisplay } from './sql-result-display';
@@ -132,7 +133,7 @@ export const ExecuteSqlToolCall = ({
 					/>
 				</>
 			) : (
-				<div className='p-4 text-center text-foreground/50 text-sm'>Executing query...</div>
+				<ToolOutputFallback runningLabel='Executing query...' />
 			)}
 		</ToolCallWrapper>
 	);

--- a/apps/frontend/src/components/tool-calls/query-app-db.tsx
+++ b/apps/frontend/src/components/tool-calls/query-app-db.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Streamdown } from 'streamdown';
 import { Code, Copy, Table as TableIcon } from 'lucide-react';
 import { ToolCallWrapper } from './tool-call-wrapper';
+import { ToolOutputFallback } from './tool-output-fallback';
 import { TableDisplay } from './display-table';
 import type { ToolCallComponentProps } from '.';
 import { useToolCallContext } from '@/contexts/tool-call';
@@ -78,7 +79,7 @@ export const QueryAppDbToolCall = ({ toolPart }: ToolCallComponentProps) => {
 					showRowCount={false}
 				/>
 			) : (
-				<div className='p-4 text-center text-foreground/50 text-sm'>Executing query...</div>
+				<ToolOutputFallback runningLabel='Executing query...' />
 			)}
 		</ToolCallWrapper>
 	);

--- a/apps/frontend/src/components/tool-calls/tool-output-fallback.test.tsx
+++ b/apps/frontend/src/components/tool-calls/tool-output-fallback.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+/**
+ * A tool call with no output must not look the same when it is running and when its output is
+ * never going to arrive. Every SQL/Python/app-db body rendered the in-flight placeholder for
+ * both, so a dropped stream showed "Executing query..." forever and the only way out was a
+ * manual reload — see the header comment in `tool-output-fallback.tsx`.
+ *
+ * The per-component tests below are the non-vacuous half: each one renders the real component
+ * with `isSettled: true` and no output, and fails if its running label comes back.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ToolOutputFallback } from './tool-output-fallback';
+import { ExecuteSqlToolCall } from './execute-sql';
+import { QueryAppDbToolCall } from './query-app-db';
+import { ExecutePythonToolCall } from './execute-python';
+import type { ToolCallComponentProps } from '.';
+import { ToolCallProvider } from '@/contexts/tool-call';
+
+vi.mock('@/contexts/side-panel', () => ({
+	useSidePanel: () => ({ open: vi.fn(), currentStorySlug: null, isVisible: false }),
+}));
+
+// `TableDisplay` reaches `@/hooks/use-date-format`, which imports `@/main` and would execute the
+// real app bootstrap (it mounts on a `#app` element that does not exist under jsdom).
+vi.mock('@/hooks/use-date-format', () => ({
+	useDateFormat: () => ({ preset: 'european' }),
+}));
+vi.mock('@/main', () => ({
+	trpc: {
+		analyticsEvent: { logChatDownload: { mutationOptions: () => ({ mutationFn: async () => undefined }) } },
+	},
+}));
+
+const MISSING_TEXT = /No result reached this tab/;
+
+type AnyToolPart = ToolCallComponentProps['toolPart'];
+
+const partWithoutOutput = (type: string, input: Record<string, unknown>): AnyToolPart =>
+	({
+		type,
+		toolCallId: 'call-1',
+		state: 'input-available',
+		input,
+	}) as unknown as AnyToolPart;
+
+const renderIn = (node: React.ReactNode, toolPart: AnyToolPart, isSettled: boolean) =>
+	render(
+		<QueryClientProvider client={new QueryClient()}>
+			<ToolCallProvider value={{ toolPart, isSettled }}>{node}</ToolCallProvider>
+		</QueryClientProvider>,
+	);
+
+describe('ToolOutputFallback', () => {
+	afterEach(cleanup);
+
+	it('shows the running label while the call is in flight', () => {
+		renderIn(
+			<ToolOutputFallback runningLabel='Executing query...' />,
+			partWithoutOutput('tool-execute_sql', {}),
+			false,
+		);
+
+		expect(screen.getByText('Executing query...')).toBeDefined();
+		expect(screen.queryByText(MISSING_TEXT)).toBeNull();
+		expect(screen.queryByRole('button', { name: /Reload page/ })).toBeNull();
+	});
+
+	it('replaces the running label with a recoverable state once the message has settled', () => {
+		renderIn(
+			<ToolOutputFallback runningLabel='Executing query...' />,
+			partWithoutOutput('tool-execute_sql', {}),
+			true,
+		);
+
+		expect(screen.queryByText('Executing query...')).toBeNull();
+		expect(screen.getByText(MISSING_TEXT)).toBeDefined();
+		expect(screen.getByRole('button', { name: /Reload page/ })).toBeDefined();
+	});
+});
+
+// Each entry: the component, the tool part it needs, and the label that must NOT survive a
+// settled-without-output render. `viewMode` defaults to results in all three, so an input with no
+// SQL/code keeps the render on the branch under test.
+const cases = [
+	{
+		name: 'ExecuteSqlToolCall',
+		runningLabel: 'Executing query...',
+		render: (toolPart: AnyToolPart) => <ExecuteSqlToolCall toolPart={toolPart as never} />,
+		toolPart: partWithoutOutput('tool-execute_sql', { name: 'Revenue by product' }),
+	},
+	{
+		name: 'QueryAppDbToolCall',
+		runningLabel: 'Executing query...',
+		render: (toolPart: AnyToolPart) => <QueryAppDbToolCall toolPart={toolPart} />,
+		toolPart: partWithoutOutput('tool-query_app_db', {}),
+	},
+	{
+		name: 'ExecutePythonToolCall',
+		runningLabel: 'Executing Python...',
+		render: (toolPart: AnyToolPart) => <ExecutePythonToolCall toolPart={toolPart as never} />,
+		toolPart: partWithoutOutput('tool-execute_python', {}),
+	},
+];
+
+// These bodies live inside a collapsed `ToolCallWrapper`, and its Radix accordion does not mount
+// the content until it is open — the same reason the defect is only visible to a user who has
+// expanded the tool block. Open it first, then assert on what is inside.
+const renderExpanded = (node: React.ReactNode, toolPart: AnyToolPart, isSettled: boolean) => {
+	const view = renderIn(node, toolPart, isSettled);
+	const trigger = view.container.querySelector('button');
+	expect(trigger).not.toBeNull();
+	fireEvent.click(trigger as HTMLButtonElement);
+	return view;
+};
+
+describe.each(cases)('$name with no output', ({ render: renderComponent, toolPart, runningLabel }) => {
+	afterEach(cleanup);
+
+	it(`still shows "${runningLabel}" while unsettled`, () => {
+		renderExpanded(renderComponent(toolPart), toolPart, false);
+		expect(screen.getByText(runningLabel)).toBeDefined();
+	});
+
+	it('shows the missing-result state instead once settled', () => {
+		renderExpanded(renderComponent(toolPart), toolPart, true);
+
+		expect(screen.queryByText(runningLabel)).toBeNull();
+		expect(screen.getByText(MISSING_TEXT)).toBeDefined();
+	});
+});

--- a/apps/frontend/src/components/tool-calls/tool-output-fallback.tsx
+++ b/apps/frontend/src/components/tool-calls/tool-output-fallback.tsx
@@ -1,0 +1,51 @@
+import { RotateCw } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useToolCallContext } from '@/contexts/tool-call';
+
+interface Props {
+	/** What to show while the call is genuinely in flight, e.g. "Executing query...". */
+	runningLabel: string;
+}
+
+/**
+ * Body for a tool call that has no output to render.
+ *
+ * A tool part without output means one of two things, and they must not look alike: the call is
+ * still running, or the message stopped streaming and the output never arrived. The second
+ * happens when the stream to this tab drops mid-run; the server usually finished and persisted
+ * the result, so a reload shows it.
+ *
+ * Rendering the in-flight placeholder for both is what makes a dropped stream read as a hung
+ * page: the tab has already set `isRunning=false`, so nothing is going to update it.
+ *
+ * `read.tsx`, `grep.tsx` and `read-query-result.tsx` already gate their placeholder on
+ * `isSettled`; this centralizes the same rule for the tool bodies that did not.
+ */
+export const ToolOutputFallback = ({ runningLabel }: Props) => {
+	const { isSettled } = useToolCallContext();
+
+	if (!isSettled) {
+		return <div className='p-4 text-center text-foreground/50 text-sm'>{runningLabel}</div>;
+	}
+
+	return (
+		<div className='p-4 text-center'>
+			<p className='text-sm text-foreground/70'>No result reached this tab.</p>
+			<p className='mt-1 text-xs text-muted-foreground'>
+				The connection dropped before the result arrived. It may have completed on the server — reload to load
+				the stored result.
+			</p>
+			<Button
+				variant='outline'
+				size='sm'
+				className='mt-3 h-7 text-xs gap-1.5'
+				onClick={() => {
+					window.location.reload();
+				}}
+			>
+				<RotateCw className='size-3' />
+				Reload page
+			</Button>
+		</div>
+	);
+};


### PR DESCRIPTION
Fixes #1546.

The three tool bodies that rendered their in-flight placeholder whenever `output` was missing now use a shared `ToolOutputFallback`, which keeps the running label while the message is unsettled and otherwise says the result never reached this tab and offers a reload. `read.tsx` and `grep.tsx` already worked this way; this just gives the rest the same rule.

Verified with `npm run test -w @nao/frontend -- src/components/tool-calls/tool-output-fallback.test.tsx` (8 passed), and the new tests fail against the unpatched components. `tsc --noEmit`, eslint and prettier are clean on the touched files.

This PR was written using Claude Opus 5 (claude-opus-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

