### PR TITLE
fix(security): check ownership before serving images and chart downloads

### DIFF
--- a/apps/backend/src/queries/image.queries.ts
+++ b/apps/backend/src/queries/image.queries.ts
@@ -44,6 +44,20 @@ export const saveImages = async (
 		.execute();
 };
 
+/**
+ * Chats that reference `imageId`. An image row carries no owner column, so this join is the only
+ * path to one; a fork re-references the same row, hence the plural result.
+ */
+export const getChatIdsByImageId = async (imageId: string): Promise<string[]> => {
+	const rows = await db
+		.selectDistinct({ chatId: s.chatMessage.chatId })
+		.from(s.messagePart)
+		.innerJoin(s.chatMessage, eq(s.messagePart.messageId, s.chatMessage.id))
+		.where(eq(s.messagePart.imageId, imageId))
+		.execute();
+	return rows.map((row) => row.chatId);
+};
+
 export const getImageById = async (id: string): Promise<{ data: string; mediaType: string } | undefined> => {
 	const [row] = await db
 		.select({ data: s.messageImage.data, mediaType: s.messageImage.mediaType })

--- a/apps/backend/src/routes/image.ts
+++ b/apps/backend/src/routes/image.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod/v4';
 
 import type { App } from '../app';
-import { getImageById } from '../queries/image.queries';
+import { getAuth } from '../auth';
+import { canUserAccessChat } from '../queries/chat.queries';
+import { getChatIdsByImageId, getImageById } from '../queries/image.queries';
 import { HandlerError } from '../utils/error';
+import { convertHeaders } from '../utils/utils';
 
 const paramsSchema = z.object({
 	imageId: z.string().uuid(),
@@ -12,9 +15,28 @@ export const imageRoutes = async (app: App) => {
 	app.get('/:imageId', { schema: { params: paramsSchema } }, async (request, reply) => {
 		const { imageId } = request.params;
 
+		const auth = await getAuth();
+		const session = await auth.api.getSession({ headers: convertHeaders(request.headers) });
+		if (!session?.user) {
+			throw new HandlerError('UNAUTHORIZED', 'Unauthorized');
+		}
+
 		const image = await getImageById(imageId);
 		if (!image) {
 			throw new HandlerError('NOT_FOUND', 'Image not found');
+		}
+
+		// An image with no owning chat (never attached, or its message was removed) is reported as
+		// not found rather than served: there is no one to check access against.
+		const chatIds = await getChatIdsByImageId(imageId);
+		if (chatIds.length === 0) {
+			throw new HandlerError('NOT_FOUND', 'Image not found');
+		}
+
+		// A fork re-references the same image row, so access is granted through any owning chat.
+		const accessible = await Promise.all(chatIds.map((chatId) => canUserAccessChat(chatId, session.user.id)));
+		if (!accessible.some(Boolean)) {
+			throw new HandlerError('FORBIDDEN', 'Forbidden');
 		}
 
 		if (!image.mediaType.startsWith('image/')) {
@@ -24,7 +46,7 @@ export const imageRoutes = async (app: App) => {
 		const buffer = Buffer.from(image.data, 'base64');
 		return reply
 			.header('Content-Type', image.mediaType)
-			.header('Cache-Control', 'public, max-age=31536000, immutable')
+			.header('Cache-Control', 'private, max-age=31536000, immutable')
 			.send(buffer);
 	});
 };

--- a/apps/backend/src/trpc/chart.routes.ts
+++ b/apps/backend/src/trpc/chart.routes.ts
@@ -22,14 +22,21 @@ export const chartRoutes = {
 			}),
 		)
 		.query(async ({ input, ctx }) => {
+			const owner = await getChartOwnerInfo(input.toolCallId);
+			if (!owner) {
+				throw new TRPCError({ code: 'NOT_FOUND', message: 'Chart not found.' });
+			}
+			if (owner.projectId !== ctx.project.id) {
+				throw new TRPCError({ code: 'FORBIDDEN', message: 'You are not authorized to view this chart.' });
+			}
+
 			const config = await readDownloadableChartConfig(input.toolCallId);
 			const data = await getChartDataByQueryId(config.query_id);
 			const displaySettings = await getDisplaySettings(ctx.project.id);
 			const png = generateChartImage({ config, data, dateFormat: displaySettings.dateFormat });
 
 			try {
-				const owner = await getChartOwnerInfo(input.toolCallId);
-				if (owner?.chatId) {
+				if (owner.chatId) {
 					logAnalyticsEvent({
 						projectId: ctx.project.id,
 						type: 'download',

--- a/apps/backend/tests/image.routes.test.ts
+++ b/apps/backend/tests/image.routes.test.ts
@@ -1,0 +1,151 @@
+import '../src/env';
+
+import fastify from 'fastify';
+import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	getAuthMock: vi.fn(),
+	getImageByIdMock: vi.fn(),
+	getChatIdsByImageIdMock: vi.fn(),
+	canUserAccessChatMock: vi.fn(),
+}));
+
+vi.mock('../src/auth', () => ({
+	getAuth: mocks.getAuthMock,
+}));
+
+vi.mock('../src/queries/image.queries', () => ({
+	getImageById: mocks.getImageByIdMock,
+	getChatIdsByImageId: mocks.getChatIdsByImageIdMock,
+}));
+
+vi.mock('../src/queries/chat.queries', () => ({
+	canUserAccessChat: mocks.canUserAccessChatMock,
+}));
+
+import { imageRoutes } from '../src/routes/image';
+import { HandlerError } from '../src/utils/error';
+
+const IMAGE_ID = '4d182a5f-872e-42b8-a7ee-f6db1b5ef7fd';
+
+const buildApp = async () => {
+	const app = fastify({ logger: false }).withTypeProvider<ZodTypeProvider>();
+	app.setValidatorCompiler(validatorCompiler);
+	app.setSerializerCompiler(serializerCompiler);
+	// Mirrors the HandlerError -> HTTP status mapping registered in src/app.ts.
+	app.setErrorHandler((error, _request, reply) => {
+		if (error instanceof HandlerError) {
+			return reply.status(error.code).send({ error: error.message });
+		}
+		throw error;
+	});
+	await app.register(imageRoutes, { prefix: '/i' });
+	return app;
+};
+
+describe('image download route', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	beforeEach(() => {
+		mocks.getAuthMock.mockResolvedValue({
+			api: {
+				getSession: vi.fn().mockResolvedValue({ user: { id: 'user-1' } }),
+			},
+		});
+		mocks.getImageByIdMock.mockResolvedValue({
+			data: Buffer.from('png-bytes').toString('base64'),
+			mediaType: 'image/png',
+		});
+		mocks.getChatIdsByImageIdMock.mockResolvedValue(['chat-1']);
+		mocks.canUserAccessChatMock.mockResolvedValue(true);
+	});
+
+	it('rejects unauthenticated requests', async () => {
+		mocks.getAuthMock.mockResolvedValue({
+			api: {
+				getSession: vi.fn().mockResolvedValue(null),
+			},
+		});
+
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(401);
+		expect(response.json()).toEqual({ error: 'Unauthorized' });
+		expect(mocks.getImageByIdMock).not.toHaveBeenCalled();
+
+		await app.close();
+	});
+
+	it('rejects a caller without access to the owning chat', async () => {
+		mocks.canUserAccessChatMock.mockResolvedValue(false);
+
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(403);
+		expect(response.json()).toEqual({ error: 'Forbidden' });
+
+		await app.close();
+	});
+
+	it('serves the image for the chat owner', async () => {
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.headers['content-type']).toBe('image/png');
+		expect(response.headers['cache-control']).toBe('private, max-age=31536000, immutable');
+		expect(response.rawPayload.toString('base64')).toBe(Buffer.from('png-bytes').toString('base64'));
+
+		await app.close();
+	});
+
+	it('returns 404 when the image does not exist', async () => {
+		mocks.getImageByIdMock.mockResolvedValue(undefined);
+
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(404);
+		expect(response.json()).toEqual({ error: 'Image not found' });
+		expect(mocks.canUserAccessChatMock).not.toHaveBeenCalled();
+
+		await app.close();
+	});
+
+	it('returns 404 for an image with no owning chat instead of granting access', async () => {
+		mocks.getChatIdsByImageIdMock.mockResolvedValue([]);
+
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(404);
+		expect(response.json()).toEqual({ error: 'Image not found' });
+		expect(mocks.canUserAccessChatMock).not.toHaveBeenCalled();
+
+		await app.close();
+	});
+
+	// Forking a chat seeds new message_part rows that reference the same message_image row as
+	// the source chat, so one image is reachable through several unrelated chats. The route's
+	// job is to hand over EVERY owning chat; whether any of them grants access is decided (and
+	// tested against a real DB) in canUserAccessAnyChat -- see shared-chat-access.queries.test.ts.
+	// A route that narrowed the list to one id would deny a user who can reach the image only
+	// through their own fork, which is why this asserts the whole array.
+	it('passes every chat that references the image to the access check (fork case)', async () => {
+		mocks.getChatIdsByImageIdMock.mockResolvedValue(['chat-1', 'chat-2']);
+
+		const app = await buildApp();
+		const response = await app.inject({ method: 'GET', url: `/i/${IMAGE_ID}` });
+
+		expect(response.statusCode).toBe(200);
+		expect(mocks.canUserAccessChatMock).toHaveBeenCalledWith('chat-1', 'user-1');
+		expect(mocks.canUserAccessChatMock).toHaveBeenCalledWith('chat-2', 'user-1');
+
+		await app.close();
+	});
+});


### PR DESCRIPTION
Fixes #1547.

`GET /i/:imageId` now requires a session and grants access only through a chat that references the image (via a new `getChatIdsByImageId` query plus the existing `canUserAccessChat`); an image with no owning chat is a 404, and the response is `Cache-Control: private`. `chart.download` looks up the owner and compares the project before it fetches rows or renders the PNG, instead of after.

Verified with `npm run test -w @nao/backend -- tests/image.routes.test.ts` (6 passed; 5 of them fail against the unpatched route) and `tsc --noEmit`. The chart change has no test of its own — there is no harness for those tRPC procedures yet, so it rests on the typecheck and on reading the handler.

This PR was written using Claude Opus 5 (claude-opus-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

