### PR TITLE
fix(security): resolve symlinks before accepting a tool path

### DIFF
--- a/apps/backend/src/utils/tools.ts
+++ b/apps/backend/src/utils/tools.ts
@@ -293,15 +293,35 @@ export const toRealPath = (virtualPath: string, projectFolder: string): string =
 	const relativePath = virtualPath.startsWith('/') ? virtualPath.slice(1) : virtualPath;
 
 	// Resolve and normalize (this handles .. and .)
-	const resolvedPath = path.resolve(normalizedFolder, relativePath);
+	const candidatePath = path.resolve(normalizedFolder, relativePath);
 
-	// Check if path is outside project folder
-	const withinFolder = resolvedPath === normalizedFolder || resolvedPath.startsWith(normalizedFolder + path.sep);
+	const lexicallyWithinFolder =
+		candidatePath === normalizedFolder || candidatePath.startsWith(normalizedFolder + path.sep);
+	if (!lexicallyWithinFolder) {
+		throw new Error(`Access denied: path '${virtualPath}' is outside the project folder`);
+	}
+
+	// The lexical check above is not enough on its own: a symlink inside the project folder can
+	// point anywhere, and fs follows it. Re-check containment against the symlink-resolved path
+	// (and, for a path that does not exist yet, against its resolved parent), so every guard
+	// below sees the file that will actually be opened.
+	let resolvedPath = candidatePath;
+	if (fs.existsSync(candidatePath)) {
+		resolvedPath = fs.realpathSync(candidatePath);
+	} else {
+		const parentPath = path.dirname(candidatePath);
+		if (fs.existsSync(parentPath)) {
+			resolvedPath = path.join(fs.realpathSync(parentPath), path.basename(candidatePath));
+		}
+	}
+
+	const realFolder = fs.existsSync(normalizedFolder) ? fs.realpathSync(normalizedFolder) : normalizedFolder;
+	const withinFolder = resolvedPath === realFolder || resolvedPath.startsWith(realFolder + path.sep);
 	if (!withinFolder) {
 		throw new Error(`Access denied: path '${virtualPath}' is outside the project folder`);
 	}
 
-	const normalizedRelativePath = path.relative(normalizedFolder, resolvedPath).replaceAll(path.sep, '/');
+	const normalizedRelativePath = path.relative(realFolder, resolvedPath).replaceAll(path.sep, '/');
 	if (isStoragePath(normalizedRelativePath)) {
 		throw new Error(`Path '${virtualPath}' is in permanent storage, not in the project folder`);
 	}
@@ -320,7 +340,7 @@ export const toRealPath = (virtualPath: string, projectFolder: string): string =
 	}
 
 	// Check if path is ignored by .naoignore
-	if (isIgnoredPath(resolvedPath, normalizedFolder)) {
+	if (isIgnoredPath(resolvedPath, realFolder)) {
 		throw new Error(`Access denied: path '${virtualPath}' is ignored by .naoignore`);
 	}
 

--- a/apps/backend/tests/tools-symlink-paths.test.ts
+++ b/apps/backend/tests/tools-symlink-paths.test.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { toRealPath } from '../src/utils/tools';
+
+/**
+ * `toRealPath` guards the agent's file tools. A lexical check alone lets a symlink inside the
+ * project folder point anywhere on the host, because fs follows the link when the file is read.
+ */
+describe('toRealPath with symlinks', () => {
+	let root: string;
+	let projectFolder: string;
+	let outside: string;
+
+	beforeEach(() => {
+		root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'nao-symlink-')));
+		projectFolder = path.join(root, 'project');
+		outside = path.join(root, 'outside');
+		fs.mkdirSync(projectFolder);
+		fs.mkdirSync(outside);
+		fs.writeFileSync(path.join(outside, 'secret.txt'), 'secret');
+		fs.writeFileSync(path.join(projectFolder, 'inside.txt'), 'inside');
+	});
+
+	afterEach(() => {
+		fs.rmSync(root, { recursive: true, force: true });
+	});
+
+	it('rejects a symlinked file that resolves outside the project folder', () => {
+		fs.symlinkSync(path.join(outside, 'secret.txt'), path.join(projectFolder, 'link.txt'));
+
+		expect(() => toRealPath('/link.txt', projectFolder)).toThrow(/outside the project folder/);
+	});
+
+	it('rejects a path reached through a symlinked directory', () => {
+		fs.symlinkSync(outside, path.join(projectFolder, 'linked-dir'));
+
+		expect(() => toRealPath('/linked-dir/secret.txt', projectFolder)).toThrow(/outside the project folder/);
+	});
+
+	it('still resolves a regular file inside the project folder', () => {
+		expect(toRealPath('/inside.txt', projectFolder)).toBe(path.join(projectFolder, 'inside.txt'));
+	});
+
+	it('still resolves a file that does not exist yet', () => {
+		expect(toRealPath('/new/file.txt', projectFolder)).toBe(path.join(projectFolder, 'new/file.txt'));
+	});
+
+	it('accepts a project folder that is itself reached through a symlink', () => {
+		const alias = path.join(root, 'project-alias');
+		fs.symlinkSync(projectFolder, alias);
+
+		expect(toRealPath('/inside.txt', alias)).toBe(path.join(projectFolder, 'inside.txt'));
+	});
+});


### PR DESCRIPTION
Fixes #1548.

`toRealPath` re-checks containment against the realpath of the candidate — or of its parent, for a file that does not exist yet — and against the realpath of the project folder, so the `.git`, env-file and `.naoignore` guards below it see the file that will actually be opened.

Verified with `npm run test -w @nao/backend -- tests/tools-symlink-paths.test.ts tests/tools-paths.test.ts` (70 passed) and `tests/sql-file-paths.test.ts` (16 passed). Three of the five new cases fail against the unpatched function. `tsc --noEmit`, eslint and prettier clean.

This PR was written using Claude Opus 5 (claude-opus-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

