### PR TITLE
fix(cli): escape schema and table names in metadata queries

### DIFF
--- a/cli/nao_core/config/databases/athena.py
+++ b/cli/nao_core/config/databases/athena.py
@@ -21,7 +21,8 @@ class AthenaDatabaseContext(DatabaseContext):
         return f"CAST({col_sql} AS VARCHAR)"
 
     def _quote(self, name: str) -> str:
-        return f'"{name}"'
+        escaped = name.replace('"', '""')
+        return f'"{escaped}"'
 
     def _cast_float(self, expr: str) -> str:
         return f"CAST({expr} AS DOUBLE)"

--- a/cli/nao_core/config/databases/bigquery.py
+++ b/cli/nao_core/config/databases/bigquery.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +170,7 @@ class BigQueryDatabaseContext(DatabaseContext):
             query = f"""
                 SELECT SUM(total_rows)
                 FROM `{self._project_id}.{self._schema}.INFORMATION_SCHEMA.PARTITIONS`
-                WHERE table_name = '{self._table_name}'
+                WHERE table_name = '{quote_sql_literal(self._table_name)}'
             """
             row = next(iter(self._conn.raw_sql(query)), None)  # type: ignore[union-attr]
             if row is not None and row[0] is not None:
@@ -249,7 +249,7 @@ class BigQueryDatabaseContext(DatabaseContext):
             part_query = f"""
                 SELECT ARRAY_AGG(partition_id ORDER BY partition_id DESC LIMIT 2)
                 FROM `{self._project_id}.{self._schema}.INFORMATION_SCHEMA.PARTITIONS`
-                WHERE table_name = '{self._table_name}' AND partition_id != '__NULL__'
+                WHERE table_name = '{quote_sql_literal(self._table_name)}' AND partition_id != '__NULL__'
             """
             first_row = next(iter(self._conn.raw_sql(part_query)), None)  # type: ignore[union-attr]
             partitions = first_row[0] if first_row and first_row[0] else []
@@ -258,7 +258,7 @@ class BigQueryDatabaseContext(DatabaseContext):
             col_query = f"""
                 SELECT column_name, data_type
                 FROM `{self._project_id}.{self._schema}.INFORMATION_SCHEMA.COLUMNS`
-                WHERE table_name = '{self._table_name}' AND is_partitioning_column = 'YES'
+                WHERE table_name = '{quote_sql_literal(self._table_name)}' AND is_partitioning_column = 'YES'
                 LIMIT 1
             """
             col_row = next(iter(self._conn.raw_sql(col_query)), None)  # type: ignore[union-attr]
@@ -304,6 +304,10 @@ class BigQueryDatabaseContext(DatabaseContext):
         return native_types, descriptions
 
     def _quote(self, name: str) -> str:
+        # BigQuery has no escape for a backtick inside a quoted identifier, and no BigQuery
+        # object name may contain one, so a name carrying it cannot be quoted safely.
+        if "`" in name:
+            raise ValueError(f"Invalid BigQuery identifier {name!r}: backticks are not allowed.")
         return f"`{name}`"
 
     def _cast_float(self, expr: str) -> str:

--- a/cli/nao_core/config/databases/clickhouse.py
+++ b/cli/nao_core/config/databases/clickhouse.py
@@ -730,7 +730,7 @@ class ClickHouseDatabaseContext(DatabaseContext):
 
         # AggregateFunction tables are skipped above; plain column selection is sufficient here.
         select_parts = [f"`{name}`" for name in schema]
-        quoted_table = f"`{self._schema}`.`{self._table_name}`"
+        quoted_table = f"{_quote_identifier(self._schema)}.{_quote_identifier(self._table_name)}"
         sql = f"SELECT {', '.join(select_parts)} FROM {quoted_table} LIMIT {limit}"
 
         try:

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -10,6 +10,15 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 
+def quote_sql_literal(value: str) -> str:
+    """Escape a value for use inside a single-quoted SQL literal.
+
+    `schema` and `table_name` come from nao_config.yaml and are interpolated into the metadata
+    queries the backends run during sync, so an unescaped quote in them changes those queries.
+    """
+    return value.replace("'", "''")
+
+
 class DatabaseContext:
     """Context object passed to Jinja2 templates during database sync.
 
@@ -309,7 +318,10 @@ class DatabaseContext:
     # ─── SQL primitives ───────────────────────────────────────────────────────
 
     def _quote(self, name: str) -> str:
-        return f'"{name}"'
+        # Doubling the quote is the SQL-standard escape; without it a name from nao_config.yaml
+        # can close the identifier and continue the statement.
+        escaped = name.replace('"', '""')
+        return f'"{escaped}"'
 
     def _cast_float(self, expr: str) -> str:
         return f"CAST({expr} AS DOUBLE)"

--- a/cli/nao_core/config/databases/databricks.py
+++ b/cli/nao_core/config/databases/databricks.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class DatabricksDatabaseContext(DatabaseContext):
         try:
             query = f"""
                 SELECT COMMENT FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+                WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -69,14 +69,14 @@ class DatabricksDatabaseContext(DatabaseContext):
     def _fetch_column_descriptions(self) -> dict[str, str]:
         query = f"""
             SELECT COLUMN_NAME, COMMENT FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+            WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
               AND COMMENT IS NOT NULL AND COMMENT != ''
         """
         rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
         return {row[0]: str(row[1]) for row in rows if row[1]}
 
     def _quote(self, name: str) -> str:
-        return f"`{name}`"
+        return _quote_ident(name)
 
     def _cast_float(self, expr: str) -> str:
         return f"CAST({expr} AS DOUBLE)"

--- a/cli/nao_core/config/databases/duckdb.py
+++ b/cli/nao_core/config/databases/duckdb.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 
 class DuckDBDatabaseContext(DatabaseContext):
@@ -21,7 +21,7 @@ class DuckDBDatabaseContext(DatabaseContext):
         try:
             query = (
                 "SELECT comment FROM duckdb_tables() "
-                f"WHERE schema_name = '{self._schema}' AND table_name = '{self._table_name}'"
+                f"WHERE schema_name = '{quote_sql_literal(self._schema)}' AND table_name = '{quote_sql_literal(self._table_name)}'"
             )
             row = self._fetchone(self._conn.raw_sql(query))  # type: ignore[union-attr]
             if row and row[0] is not None:
@@ -46,7 +46,7 @@ class DuckDBDatabaseContext(DatabaseContext):
     def _fetch_column_descriptions(self) -> dict[str, str]:
         query = (
             "SELECT column_name, comment FROM duckdb_columns() "
-            f"WHERE schema_name = '{self._schema}' AND table_name = '{self._table_name}'"
+            f"WHERE schema_name = '{quote_sql_literal(self._schema)}' AND table_name = '{quote_sql_literal(self._table_name)}'"
         )
         rows = self._fetchall(self._conn.raw_sql(query))  # type: ignore[union-attr]
         return {row[0]: str(row[1]) for row in rows if row[1] is not None}

--- a/cli/nao_core/config/databases/mysql.py
+++ b/cli/nao_core/config/databases/mysql.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 SYSTEM_SCHEMAS = ("information_schema", "mysql", "performance_schema", "sys")
 
@@ -20,14 +20,14 @@ class MysqlDatabaseContext(DatabaseContext):
     """MySQL context with information_schema description discovery."""
 
     def _quote(self, name: str) -> str:
-        return f"`{name}`"
+        return f"`{name.replace('`', '``')}`"
 
     def description(self) -> str | None:
         try:
             query = f"""
                 SELECT TABLE_COMMENT
                 FROM information_schema.TABLES
-                WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+                WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -51,7 +51,7 @@ class MysqlDatabaseContext(DatabaseContext):
         query = f"""
             SELECT COLUMN_NAME, COLUMN_COMMENT
             FROM information_schema.COLUMNS
-            WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+            WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
         """
         rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
         return {row[0]: str(row[1]) for row in rows if row[1]}

--- a/cli/nao_core/config/databases/postgres.py
+++ b/cli/nao_core/config/databases/postgres.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 
 class PostgresDatabaseContext(DatabaseContext):
@@ -24,7 +24,7 @@ class PostgresDatabaseContext(DatabaseContext):
                 FROM pg_catalog.pg_description d
                 JOIN pg_catalog.pg_class c ON c.oid = d.objoid
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid = 0
+                WHERE n.nspname = '{quote_sql_literal(self._schema)}' AND c.relname = '{quote_sql_literal(self._table_name)}' AND d.objsubid = 0
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -51,7 +51,7 @@ class PostgresDatabaseContext(DatabaseContext):
             JOIN pg_catalog.pg_class c ON c.oid = d.objoid
             JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.objsubid
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-            WHERE n.nspname = '{self._schema}' AND c.relname = '{self._table_name}' AND d.objsubid > 0
+            WHERE n.nspname = '{quote_sql_literal(self._schema)}' AND c.relname = '{quote_sql_literal(self._table_name)}' AND d.objsubid > 0
         """
         rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
         return {row[0]: str(row[1]) for row in rows if row[1]}

--- a/cli/nao_core/config/databases/redshift.py
+++ b/cli/nao_core/config/databases/redshift.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 
 class RedshiftAuthMode(str, Enum):
@@ -33,8 +33,8 @@ class RedshiftDatabaseContext(DatabaseContext):
                     column_name, data_type, is_nullable,
                     character_maximum_length, numeric_precision, numeric_scale
                 FROM information_schema.columns
-                WHERE table_schema = '{self._schema}'
-                AND table_name = '{self._table_name}'
+                WHERE table_schema = '{quote_sql_literal(self._schema)}'
+                AND table_name = '{quote_sql_literal(self._table_name)}'
                 ORDER BY ordinal_position
             """
             result = self._fetchall(self._conn.raw_sql(query))  # type: ignore[union-attr]
@@ -133,7 +133,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                 JOIN pg_catalog.pg_class c ON c.oid = d.objoid
                 JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.objsubid
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '{_quote_literal(self._schema)}' AND c.relname = '{_quote_literal(self._table_name)}' AND d.objsubid > 0
+                WHERE n.nspname = '{quote_sql_literal(self._schema)}' AND c.relname = '{quote_sql_literal(self._table_name)}' AND d.objsubid > 0
             """
             rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]
             return {row[0]: str(row[1]) for row in rows if row[1]}
@@ -148,7 +148,7 @@ class RedshiftDatabaseContext(DatabaseContext):
                 FROM pg_catalog.pg_description d
                 JOIN pg_catalog.pg_class c ON c.oid = d.objoid
                 JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-                WHERE n.nspname = '{_quote_literal(self._schema)}' AND c.relname = '{_quote_literal(self._table_name)}' AND d.objsubid = 0
+                WHERE n.nspname = '{quote_sql_literal(self._schema)}' AND c.relname = '{quote_sql_literal(self._table_name)}' AND d.objsubid = 0
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -164,15 +164,10 @@ class RedshiftDatabaseContext(DatabaseContext):
         return f"JSON_SERIALIZE({col_sql})"
 
 
-def _quote_literal(value: str) -> str:
-    """Escape a value for safe use inside a SQL string literal."""
-    return value.replace("'", "''")
-
-
 def _get_redshift_sortkey_columns(conn: BaseBackend, schema: str, table: str) -> list[str]:
     """Return SORTKEY columns for a Redshift table, ordered by sort position."""
-    schema_literal = _quote_literal(schema)
-    table_literal = _quote_literal(table)
+    schema_literal = quote_sql_literal(schema)
+    table_literal = quote_sql_literal(table)
     query = f"""
         SELECT a.attname
         FROM pg_attribute a

--- a/cli/nao_core/config/databases/snowflake.py
+++ b/cli/nao_core/config/databases/snowflake.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class SnowflakeDatabaseContext(DatabaseContext):
         try:
             query = f"""
                 SELECT COMMENT FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+                WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
             """
             row = self._conn.raw_sql(query).fetchone()  # type: ignore[union-attr]
             if row and row[0]:
@@ -61,7 +61,7 @@ class SnowflakeDatabaseContext(DatabaseContext):
     def _fetch_column_descriptions(self) -> dict[str, str]:
         query = f"""
             SELECT COLUMN_NAME, COMMENT FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = '{self._schema}' AND TABLE_NAME = '{self._table_name}'
+            WHERE TABLE_SCHEMA = '{quote_sql_literal(self._schema)}' AND TABLE_NAME = '{quote_sql_literal(self._table_name)}'
               AND COMMENT IS NOT NULL AND COMMENT != ''
         """
         rows = self._conn.raw_sql(query).fetchall()  # type: ignore[union-attr]

--- a/cli/nao_core/config/databases/trino.py
+++ b/cli/nao_core/config/databases/trino.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ibis import BaseBackend
 
 from .base import DatabaseConfig
-from .context import DatabaseContext
+from .context import DatabaseContext, quote_sql_literal
 
 EXCLUDED_SCHEMAS = {"information_schema", "default", "sys", "pg_catalog", "test"}
 
@@ -52,8 +52,8 @@ class TrinoDatabaseContext(DatabaseContext):
             SELECT comment
             FROM system.metadata.table_comments
             WHERE catalog_name = '{catalog}'
-                AND schema_name = '{self._schema}'
-                AND table_name = '{self._table_name}'
+                AND schema_name = '{quote_sql_literal(self._schema)}'
+                AND table_name = '{quote_sql_literal(self._table_name)}'
         """.strip()
         try:
             row = cast(Any, self._conn).raw_sql(query).fetchone()

--- a/cli/tests/nao_core/config/test_metadata_query_quoting.py
+++ b/cli/tests/nao_core/config/test_metadata_query_quoting.py
@@ -1,0 +1,57 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from nao_core.config.databases.context import quote_sql_literal
+from nao_core.config.databases.databricks import DatabricksDatabaseContext
+from nao_core.config.databases.mysql import MysqlDatabaseContext
+from nao_core.config.databases.postgres import PostgresDatabaseContext
+from nao_core.config.databases.redshift import RedshiftDatabaseContext
+from nao_core.config.databases.snowflake import SnowflakeDatabaseContext
+from nao_core.config.databases.trino import TrinoDatabaseContext
+
+
+def test_quote_sql_literal_doubles_single_quotes():
+    assert quote_sql_literal("or'ders") == "or''ders"
+
+
+def test_quote_identifier_escapes_the_delimiter():
+    """Each dialect quotes identifiers with its own delimiter; none may be left unescaped."""
+    assert PostgresDatabaseContext(MagicMock(), "public", "orders")._quote('or"ders') == '"or""ders"'
+    assert MysqlDatabaseContext(MagicMock(), "public", "orders")._quote("or`ders") == "`or``ders`"
+
+
+CONTEXTS = [
+    MysqlDatabaseContext,
+    DatabricksDatabaseContext,
+    PostgresDatabaseContext,
+    RedshiftDatabaseContext,
+    SnowflakeDatabaseContext,
+    TrinoDatabaseContext,
+]
+
+
+@pytest.mark.parametrize("context_cls", CONTEXTS, ids=lambda cls: cls.__name__)
+def test_columns_escapes_quotes_in_identifiers(context_cls):
+    """schema/table_name come from nao_config.yaml and land inside SQL literals."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    cursor.description = []
+    conn.raw_sql.return_value = cursor
+    conn.sql.return_value.execute.return_value = MagicMock(empty=True)
+
+    context = context_cls(conn, "pub'lic", "or'ders")
+    try:
+        context.columns()
+    except Exception:
+        # Only the SQL text matters here; a mocked connection may fail afterwards.
+        pass
+
+    issued = " ".join(str(call[0][0]) for call in conn.raw_sql.call_args_list if call[0])
+    issued += " ".join(str(call[0][0]) for call in conn.sql.call_args_list if call[0])
+    assert issued, f"{context_cls.__name__} issued no metadata query"
+    # Either escape is acceptable: a doubled quote inside a literal, or a quoted identifier.
+    assert "pub''lic" in issued or '"pub\'lic"' in issued
+    assert "or''ders" in issued or '"or\'ders"' in issued
+    assert "'pub'lic'" not in issued


### PR DESCRIPTION
Fixes #1549.

`quote_sql_literal()` lands next to the base `DatabaseContext` and is applied at every site that pasted `schema`/`table_name` into a SQL literal (mysql, databricks, duckdb, postgres, trino, snowflake, bigquery, and redshift's information_schema query). Each dialect's `_quote()` now escapes its own delimiter, clickhouse reuses its `_quote_identifier`, and a backtick in a BigQuery identifier is rejected because BigQuery cannot escape one. Redshift's local `_quote_literal` duplicate is gone.

Verified with `uv run pytest` — 1143 passed, and the new `test_metadata_query_quoting.py` covers six backends plus both quoting helpers. Two pre-existing failures on this machine are unrelated and also fail on an unpatched checkout: `test_duckdb.py::test_preview_md_users`, and `test_mssql.py` cannot be collected without unixodbc. `ruff check` reports the same 371 findings as the unpatched tree and `ty check` one fewer (86 to 85), so the change adds none.

The Jinja sandbox part of the issue is deliberately not here; it needs four `test_engine.py` cases adapted first.

This PR was written using Claude Opus 5 (claude-opus-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

