### PR TITLE
fix(cli): move pytest to dev deps and relax the posthog floor

### DIFF
--- a/cli/nao_core/tracking.py
+++ b/cli/nao_core/tracking.py
@@ -4,14 +4,24 @@ This module provides analytics tracking to help improve nao.
 Tracking is enabled when POSTHOG_DISABLED is not 'true' AND both POSTHOG_KEY and POSTHOG_HOST are configured.
 """
 
+from __future__ import annotations
+
 import atexit
 import os
 import uuid
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
-from posthog import Posthog
+if TYPE_CHECKING:
+    from posthog import Posthog
+else:
+    try:
+        from posthog import Posthog
+    except ImportError:
+        # posthog<3 has no Posthog client class (dbt toolchains commonly pin
+        # posthog<3, e.g. elementary-data). Tracking degrades to a no-op.
+        Posthog = None
 
 from nao_core import __version__
 from nao_core.mode import MODE
@@ -53,7 +63,7 @@ def get_or_create_posthog_client() -> Posthog | None:
     if _client is not None:
         return _client
 
-    if POSTHOG_DISABLED or not POSTHOG_KEY or not POSTHOG_HOST or MODE != "prod":
+    if Posthog is None or POSTHOG_DISABLED or not POSTHOG_KEY or not POSTHOG_HOST or MODE != "prod":
         return None
 
     try:

--- a/cli/nao_core/tracking.py
+++ b/cli/nao_core/tracking.py
@@ -19,8 +19,10 @@ else:
     try:
         from posthog import Posthog
     except ImportError:
-        # posthog<3 has no Posthog client class (dbt toolchains commonly pin
-        # posthog<3, e.g. elementary-data). Tracking degrades to a no-op.
+        # Some pinned posthog versions lack the Posthog client class (the
+        # relaxed floor exists because dbt toolchains commonly pin posthog<3,
+        # e.g. elementary-data — 2.5+ still works). Tracking degrades to a
+        # no-op when the class is unavailable.
         Posthog = None
 
 from nao_core import __version__

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -31,12 +31,14 @@ dependencies = [
     "uvicorn>=0.40.0",
     "cryptography>=46.0.3",
     "dotenv>=0.9.9",
-    "pytest>=9.0.2",
     "python-dotenv>=1.2.1",
     "jinja2>=3.1.0",
     "apscheduler>=3.10.0",
     "questionary>=2.1.0",
-    "posthog>=7.8.0",
+    # Loose floor on purpose: tracking.py degrades to no-op telemetry when the
+    # resolver lands on an old posthog (dbt toolchains commonly pin posthog<3,
+    # e.g. elementary-data), instead of making nao-core uninstallable there.
+    "posthog>=2.0.0",
     "pyngrok>=7.0.0",
     "python-dateutil>=2.8.0",
     "numpy>=1.26.0",
@@ -87,7 +89,7 @@ all-databases = [
 ]
 all-llms = ["nao-core[openai,anthropic,mistral,gemini,ollama]"]
 all = ["nao-core[all-databases,all-llms,notion,confluence,aws-secrets,k8s-secrets]"]
-dev = ["pytest-cov", "pytest-timeout>=2.3.0"]
+dev = ["pytest>=9.0.2", "pytest-cov", "pytest-timeout>=2.3.0"]
 
 [project.scripts]
 nao = "nao_core.main:main"
@@ -97,7 +99,7 @@ Homepage = "https://getnao.io"
 Repository = "https://github.com/naolabs/chat"
 
 [dependency-groups]
-dev = ["ruff>=0.8.0", "ty>=0.0.9", "nao-core[all]"]
+dev = ["pytest>=9.0.2", "ruff>=0.8.0", "ty>=0.0.9", "nao-core[all]"]
 
 [build-system]
 requires = ["hatchling"]

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -6,19 +6,19 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
 [options]
-exclude-newer = "2026-08-10T11:52:08.5784Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -1200,7 +1200,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2610,7 +2610,6 @@ dependencies = [
     { name = "posthog" },
     { name = "pydantic" },
     { name = "pyngrok" },
-    { name = "pytest" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2687,6 +2686,7 @@ databricks = [
     { name = "ibis-framework", extra = ["databricks"] },
 ]
 dev = [
+    { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
 ]
@@ -2744,6 +2744,7 @@ trino = [
 [package.dev-dependencies]
 dev = [
     { name = "nao-core", extra = ["all"] },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -2791,10 +2792,10 @@ requires-dist = [
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.1.0" },
-    { name = "posthog", specifier = ">=7.8.0" },
+    { name = "posthog", specifier = ">=2.0.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyngrok", specifier = ">=7.0.0" },
-    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
@@ -2813,6 +2814,7 @@ provides-extras = ["postgres", "bigquery", "snowflake", "duckdb", "clickhouse", 
 [package.metadata.requires-dev]
 dev = [
     { name = "nao-core", extras = ["all"] },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "ty", specifier = ">=0.0.9" },
 ]
@@ -2916,13 +2918,13 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
@@ -4378,8 +4380,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Closes #1555.

Makes nao-core installable next to a standard dbt toolchain:

- `pytest` moves from runtime dependencies to the dev extra and the dev dependency group (nothing in `nao_core/` imports it; CI installs via `uv sync --dev` so tests still get it).
- `posthog` floor relaxed to `>=2.0.0`, with the import in `tracking.py` guarded so telemetry becomes a no-op instead of an ImportError if an old posthog wins resolution (elementary-data pins `posthog<3` in every release, which previously made nao-core unresolvable next to it).
- `uv.lock` regenerated with `uv lock` (same `latest` uv the CI uses).

Tested:
- co-install proof: `uv pip install 'nao-core[snowflake]' elementary-data` now resolves (picks posthog 2.5.0); `nao_core.tracking` and `elementary` both import cleanly.
- the exact API `tracking.py` uses — `Posthog(key, host=, debug=)`, kwargs `.capture()`, `.shutdown()` — verified working on posthog 2.5.0 and 7.45.3, so telemetry keeps functioning on modern installs.
- unit suite (CI-equivalent, minus backends that need native libs on macOS): 1082 passed; `ruff` and `ty` clean on the touched file.

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

