### PR TITLE
feat(helm): existingSecret and extraEnv/extraEnvFrom support

### DIFF
--- a/helm/ARCHITECTURE.md
+++ b/helm/ARCHITECTURE.md
@@ -145,7 +145,7 @@ The chart creates the following resources. Resources marked *(conditional)* are 
 | `Deployment` | `<release>-nao` | Always |
 | `Service` | `<release>-nao` | Always |
 | `ConfigMap` | `<release>-nao` | Always |
-| `Secret` | `<release>-nao` | Always |
+| `Secret` | `<release>-nao` | `existingSecret` unset |
 | `ServiceAccount` | `<release>-nao` | `serviceAccount.create=true` |
 | `PersistentVolumeClaim` (context) | `<release>-nao-context` | `contextSource=local` + `persistence.enabled=true` + no `existingClaim` |
 | `PersistentVolumeClaim` (projects) | `<release>-nao-projects` | `contextSource=api` + `projectsPersistence.enabled=true` + no `existingClaim` |
@@ -228,7 +228,7 @@ Environment variables are split between a `ConfigMap` (non-sensitive) and a `Sec
 - SMTP credentials, OAuth client secrets (Google, GitHub)
 - `NOTION_API_KEY`
 
-> In production, manage Secret values with an external secret manager (External Secrets Operator, AWS Secrets Manager, Sealed Secrets) rather than hardcoding them in values files.
+> In production, manage Secret values with an external secret manager (External Secrets Operator, AWS Secrets Manager, Sealed Secrets) rather than hardcoding them in values files. Set `existingSecret` to point the deployment at such a pre-existing Secret — the chart then renders no Secret of its own and the `secrets.*` values are ignored. The pod-template checksum only tracks the chart-rendered Secret, so rotate-and-roll of an external Secret needs its own trigger (stakater/reloader, ESO templated annotations, or `kubectl rollout restart`). Env vars the chart has no key for can be injected with `extraEnv` / `extraEnvFrom`.
 
 ---
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nao
 description: Helm chart for nao — an open-source agent to do analytics on your data with AI.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: '0.3.5'
 icon: https://raw.githubusercontent.com/getnao/nao/main/apps/frontend/public/appicon.png
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -128,6 +128,9 @@ projectsPersistence:
 | `config.gitlabBaseUrl` | `""` | Self-hosted GitLab instance URL |
 | `config.betaAutomationsEnabled` | `true` | Recurring prompt automations |
 | `config.betaContextRecommendationsEnabled` | `false` | Context recommendations |
+| `existingSecret` | `""` | Load all secret env vars from a pre-existing Secret instead of rendering one (the `secrets.*` block is then ignored). Rotations of that Secret need an external rollout trigger |
+| `extraEnv` | `[]` | Extra env vars appended verbatim to the nao container |
+| `extraEnvFrom` | `[]` | Extra `envFrom` sources appended after the chart's ConfigMap/Secret |
 | `secrets.betterAuthSecret` | `""` | **Required.** Auth session secret |
 | `secrets.openaiApiKey` | `""` | OpenAI API key |
 | `secrets.anthropicApiKey` | `""` | Anthropic API key |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -107,3 +107,10 @@ set secrets.dbUri manually with the full connection string.
 {{- .Values.secrets.dbUri -}}
 {{- end -}}
 {{- end }}
+{{/*
+Name of the Secret the pod loads env vars from: the chart-rendered Secret,
+or a pre-existing one when existingSecret is set.
+*/}}
+{{- define "nao.secretName" -}}
+{{- default (include "nao.fullname" .) .Values.existingSecret -}}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -43,12 +43,16 @@ spec:
               value: {{ .Values.config.gitSync.branch | quote }}
             - name: GIT_URL
               value: {{ .Values.config.gitSync.url | quote }}
-            {{- if .Values.secrets.contextGitToken }}
+            {{- if or .Values.secrets.contextGitToken .Values.existingSecret }}
             - name: GIT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "nao.fullname" . }}
+                  name: {{ include "nao.secretName" . }}
                   key: NAO_CONTEXT_GIT_TOKEN
+                  {{- if .Values.existingSecret }}
+                  # The pre-existing secret may not carry a git token (e.g. public repo)
+                  optional: true
+                  {{- end }}
             - name: GIT_ASKPASS
               value: /bin/true
             - name: GIT_TERMINAL_PROMPT
@@ -82,11 +86,18 @@ spec:
             - name: http
               containerPort: {{ .Values.config.serverPort | int }}
               protocol: TCP
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "nao.fullname" . }}
             - secretRef:
-                name: {{ include "nao.fullname" . }}
+                name: {{ include "nao.secretName" . }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -123,3 +124,4 @@ stringData:
   {{- if .Values.secrets.notionApiKey }}
   NOTION_API_KEY: {{ .Values.secrets.notionApiKey | quote }}
   {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -175,6 +175,30 @@ config:
 # =============================================================================
 # Secrets
 # =============================================================================
+# -- Name of a pre-existing Secret to load env vars from INSTEAD of the
+#    chart-rendered one. When set, the chart renders no Secret at all and the
+#    whole `secrets:` block below is ignored — the referenced Secret must carry
+#    the same env var keys (BETTER_AUTH_SECRET, DB_URI, provider API keys, ...).
+#    Useful with GitOps (ArgoCD/Flux), where plaintext helm values would land in
+#    the rendered Application manifests, and with external secret operators.
+existingSecret: ""
+
+# -- Extra env vars appended verbatim to the nao container (list of
+#    corev1.EnvVar). Lets you inject deployment-specific configuration the
+#    chart has no first-class key for, e.g. NAO_STORAGE_* or SNOWFLAKE_*
+#    referenced from nao_config.yaml via {{ env('...') }}.
+extraEnv: []
+# extraEnv:
+#   - name: NAO_STORAGE_BACKEND
+#     value: s3
+
+# -- Extra envFrom sources (configMapRef/secretRef) appended after the
+#    chart's own ConfigMap and Secret.
+extraEnvFrom: []
+# extraEnvFrom:
+#   - secretRef:
+#       name: my-extra-secret
+
 secrets:
   # -- Required. Generate with: openssl rand -base64 32
   betterAuthSecret: ""

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -181,6 +181,10 @@ config:
 #    the same env var keys (BETTER_AUTH_SECRET, DB_URI, provider API keys, ...).
 #    Useful with GitOps (ArgoCD/Flux), where plaintext helm values would land in
 #    the rendered Application manifests, and with external secret operators.
+#    NOTE: the pod-template checksum only tracks the chart-rendered Secret, so
+#    rotating an external Secret does NOT restart pods — pair it with a rollout
+#    trigger (e.g. stakater/reloader, ESO's templated annotations) or run
+#    `kubectl rollout restart` after rotation.
 existingSecret: ""
 
 # -- Extra env vars appended verbatim to the nao container (list of


### PR DESCRIPTION
Closes #1556.

Makes the chart usable under GitOps controllers without a replacement chart:

- `existingSecret`: when set, the chart renders no Secret of its own; the container's `secretRef` and the git-sync initContainer's `NAO_CONTEXT_GIT_TOKEN` (now `optional: true` in that mode, for public context repos) point at the referenced Secret. Implemented via a `nao.secretName` helper.
- `extraEnv` / `extraEnvFrom`: appended verbatim after the chart's own ConfigMap/Secret sources — covers `NAO_STORAGE_*`, `SNOWFLAKE_*` for `env('...')` in nao_config.yaml, and anything else without growing the templates key by key.
- chart version 0.1.0 → 0.1.1.

Tested:
- `helm lint` clean; CI's `helm template` invocation renders fine.
- default-values rendering is **byte-identical** to the current chart (including the secret checksum annotation), so existing installs get no diff and no pod restart.
- rendered and verified both new paths (`existingSecret` + gitSync, `extraEnv`/`extraEnvFrom`); this is the exact wiring we run in production on EKS/ArgoCD today, currently via a replacement chart this PR would let us retire.

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

