### PR TITLE
feat(helm): ingress template

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nao
 description: Helm chart for nao — an open-source agent to do analytics on your data with AI.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: '0.3.5'
 icon: https://raw.githubusercontent.com/getnao/nao/main/apps/frontend/public/appicon.png
 

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.ingress.enabled -}}
+{{- if not .Values.ingress.hosts }}
+{{- fail "ingress.enabled=true requires at least one entry in ingress.hosts" }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,6 +32,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
+    {{- if not .paths }}
+    {{- fail (printf "ingress host %q needs at least one entry in paths" .host) }}
+    {{- end }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "nao.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nao.labels" . | nindent 4 }}
+  {{- $ann := dict }}
+  {{- with include "nao.annotations" . }}
+    {{- with . }}
+      {{- $ann = merge $ann (fromYaml .) }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.ingress.annotations }}
+    {{- $ann = merge . $ann }}
+  {{- end }}
+  {{- with $ann }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "nao.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -276,6 +276,32 @@ service:
   annotations: {}
 
 # =============================================================================
+# Ingress
+# =============================================================================
+
+# -- Expose nao through an Ingress controller. Remember to set
+#    config.betterAuthUrl (and the OAuth redirect URIs of your SSO provider)
+#    to the public URL served by the ingress.
+ingress:
+  enabled: false
+  # -- IngressClass name (e.g. nginx, traefik, alb)
+  className: ""
+  # -- Controller-specific annotations (cert-manager issuer, ALB scheme, ...),
+  #    merged on top of commonAnnotations
+  annotations: {}
+  hosts:
+    - host: nao.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- TLS configuration; reference a pre-existing certificate Secret or let
+  #    cert-manager populate it via annotations
+  tls: []
+  #  - secretName: nao-tls
+  #    hosts:
+  #      - nao.example.com
+
+# =============================================================================
 # Resources
 # =============================================================================
 resources:


### PR DESCRIPTION
Closes #1559.

Adds the standard Ingress scaffold to the chart, off by default:

- `ingress.enabled` / `className` / per-host `paths` / `tls` / `annotations`, with annotations merged on top of `commonAnnotations` using the same idiom as `service.yaml`.
- Backend points at the chart Service (`service.port`); the values comment reminds users to set `config.betterAuthUrl` (and their SSO redirect URIs) to the public URL.
- Chart version 0.1.0 → 0.1.1 — same bump as #1558, whichever merges second needs a trivial rebase; happy to do it.

Tested:
- `helm lint` clean; CI's `helm template` invocation renders fine.
- default-values rendering is byte-identical to the current chart (no Ingress rendered).
- enabled render verified with className, multi-annotation merge (cert-manager + commonAnnotations), and TLS — output attached to the issue if useful. We run an equivalent ingress in production on EKS (ALB) today via our replacement chart, which #1556/#1558 plus this would let us retire.

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

