### PR TITLE
feat(backend): DISABLED_PROVIDERS env to opt providers out of a deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,12 @@ ANTHROPIC_API_KEY=sk-123456789
 #       leave no env footprint, so opt in explicitly:
 # AWS_USE_INSTANCE_CREDENTIALS=true
 
+# Providers to keep out of this deployment entirely (comma-separated kinds, or
+# openaiCompatible/<name> for a named instance). A disabled provider never
+# auto-registers from ambient credentials — e.g. IRSA on EKS surfaces Bedrock
+# on every pod — and is ignored even when configured in the UI or nao_config.yaml.
+# DISABLED_PROVIDERS=bedrock,vertex
+
 # App metadata (optional)
 APP_VERSION=dev
 APP_COMMIT=unknown

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
 
+import { LLM_PROVIDERS, NAMED_PROVIDER_KIND } from '@nao/shared/types';
 import dotenv from 'dotenv';
 import { z } from 'zod/v4';
 
@@ -172,6 +173,33 @@ const envSchema = z.object({
 		.enum(['true', 'false'])
 		.optional()
 		.transform((val) => val === 'true'),
+
+	/**
+	 * Comma-separated providers to keep out of the deployment entirely, regardless of where their
+	 * credentials come from. Ambient credentials otherwise auto-register providers — e.g. EKS IRSA
+	 * sets AWS_WEB_IDENTITY_TOKEN_FILE on every pod, which surfaces Bedrock even when the role has
+	 * no Bedrock permissions. Accepts provider kinds and named instances (openaiCompatible/name).
+	 */
+	DISABLED_PROVIDERS: z
+		.string()
+		.optional()
+		.transform((val) =>
+			(val ?? '')
+				.split(',')
+				.map((entry) => entry.trim())
+				.filter(Boolean),
+		)
+		.refine(
+			(providers) =>
+				providers.every(
+					(provider) =>
+						(LLM_PROVIDERS as readonly string[]).includes(provider) ||
+						provider.startsWith(`${NAMED_PROVIDER_KIND}/`),
+				),
+			{
+				message: `DISABLED_PROVIDERS must be a comma-separated list of provider kinds (${LLM_PROVIDERS.join(', ')}) or named instances (${NAMED_PROVIDER_KIND}/<name>)`,
+			},
+		),
 
 	LANGFUSE_PUBLIC_KEY: z
 		.string()

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
 
-import { LLM_PROVIDERS, NAMED_PROVIDER_KIND } from '@nao/shared/types';
+import { isLlmProvider, LLM_PROVIDERS, NAMED_PROVIDER_KIND } from '@nao/shared/types';
 import dotenv from 'dotenv';
 import { z } from 'zod/v4';
 
@@ -189,17 +189,9 @@ const envSchema = z.object({
 				.map((entry) => entry.trim())
 				.filter(Boolean),
 		)
-		.refine(
-			(providers) =>
-				providers.every(
-					(provider) =>
-						(LLM_PROVIDERS as readonly string[]).includes(provider) ||
-						provider.startsWith(`${NAMED_PROVIDER_KIND}/`),
-				),
-			{
-				message: `DISABLED_PROVIDERS must be a comma-separated list of provider kinds (${LLM_PROVIDERS.join(', ')}) or named instances (${NAMED_PROVIDER_KIND}/<name>)`,
-			},
-		),
+		.refine((providers) => providers.every(isLlmProvider), {
+			message: `DISABLED_PROVIDERS must be a comma-separated list of provider kinds (${LLM_PROVIDERS.join(', ')}) or named instances (${NAMED_PROVIDER_KIND}/<name>)`,
+		}),
 
 	LANGFUSE_PUBLIC_KEY: z
 		.string()

--- a/apps/backend/src/utils/llm.ts
+++ b/apps/backend/src/utils/llm.ts
@@ -1,5 +1,5 @@
 import { type BackgroundModelCategory, selectBackgroundModel } from '@nao/shared';
-import type { LlmProvider, LlmSelectedModel } from '@nao/shared/types';
+import { type LlmProvider, type LlmSelectedModel, providerKind } from '@nao/shared/types';
 
 import {
 	createProviderModel,
@@ -8,6 +8,7 @@ import {
 	LLM_PROVIDERS,
 	type ProviderModelResult,
 } from '../agents/providers';
+import { env } from '../env';
 import * as projectQueries from '../queries/project.queries';
 import * as projectLlmConfigQueries from '../queries/project-llm-config.queries';
 import type { CustomModelMetadata, ProviderSettings } from '../types/llm';
@@ -26,8 +27,16 @@ export function getEnvBaseUrl(provider: LlmProvider): string | undefined {
 	return baseUrlEnvVar ? process.env[baseUrlEnvVar] : undefined;
 }
 
+/** Whether DISABLED_PROVIDERS opts this provider out, by its own id or by its kind. */
+export function isProviderDisabled(provider: LlmProvider): boolean {
+	return env.DISABLED_PROVIDERS.includes(provider) || env.DISABLED_PROVIDERS.includes(providerKind(provider));
+}
+
 /** Check if a provider has authentication configured via environment */
 export function hasEnvApiKey(provider: LlmProvider): boolean {
+	if (isProviderDisabled(provider)) {
+		return false;
+	}
 	if (getEnvApiKey(provider)) {
 		return true;
 	}
@@ -90,6 +99,9 @@ export async function resolveProviderSettings(
 	projectId: string,
 	provider: LlmProvider,
 ): Promise<ProviderSettings | null> {
+	if (isProviderDisabled(provider)) {
+		return null;
+	}
 	const config = await projectLlmConfigQueries.getProjectLlmConfigByProvider(projectId, provider);
 	if (config) {
 		return {
@@ -128,6 +140,9 @@ export async function resolveProviderModel(
 	modelId: string,
 	applyUserSettings = true,
 ): Promise<ProviderModelResult | null> {
+	if (isProviderDisabled(provider)) {
+		return null;
+	}
 	const config = await projectLlmConfigQueries.getProjectLlmConfigByProvider(projectId, provider);
 	if (config) {
 		return createProviderModel(
@@ -346,7 +361,7 @@ async function getProjectModelSources(projectId: string): Promise<ProviderModelS
 		}
 	}
 
-	return sources;
+	return sources.filter((source) => !isProviderDisabled(source.provider));
 }
 
 const getModelName = (provider: LlmProvider, modelId: string): string =>

--- a/apps/backend/tests/disabled-providers.test.ts
+++ b/apps/backend/tests/disabled-providers.test.ts
@@ -64,6 +64,15 @@ describe('DISABLED_PROVIDERS', () => {
 		__reloadEnvForTesting();
 	});
 
+	it('rejects malformed named-instance ids', () => {
+		process.env.DISABLED_PROVIDERS = 'openaiCompatible/Bad_Name';
+		expect(() => __reloadEnvForTesting()).toThrow(/DISABLED_PROVIDERS/);
+		process.env.DISABLED_PROVIDERS = 'anthropic/some-name';
+		expect(() => __reloadEnvForTesting()).toThrow(/DISABLED_PROVIDERS/);
+		delete process.env.DISABLED_PROVIDERS;
+		__reloadEnvForTesting();
+	});
+
 	it('disabling a kind covers its named instances, and an instance can be disabled alone', () => {
 		setDisabledProviders('openaiCompatible');
 		expect(isProviderDisabled('openaiCompatible/my-vllm')).toBe(true);

--- a/apps/backend/tests/disabled-providers.test.ts
+++ b/apps/backend/tests/disabled-providers.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+	dbConfig: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../src/db/db', () => ({ db: {} }));
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getProjectById: vi.fn(async () => null),
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigByProvider: vi.fn(async () => testState.dbConfig),
+	getProjectLlmConfigs: vi.fn(async () => []),
+}));
+
+import { __reloadEnvForTesting, env } from '../src/env';
+import { getEnvProviders, hasEnvApiKey, isProviderDisabled, resolveProviderSettings } from '../src/utils/llm';
+
+describe('DISABLED_PROVIDERS', () => {
+	let originalEnv: typeof process.env;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		testState.dbConfig = null;
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		__reloadEnvForTesting();
+	});
+
+	function setDisabledProviders(value: string | undefined) {
+		if (value === undefined) {
+			delete process.env.DISABLED_PROVIDERS;
+		} else {
+			process.env.DISABLED_PROVIDERS = value;
+		}
+		__reloadEnvForTesting();
+	}
+
+	it('defaults to an empty list', () => {
+		setDisabledProviders(undefined);
+		expect(env.DISABLED_PROVIDERS).toEqual([]);
+		expect(isProviderDisabled('bedrock')).toBe(false);
+	});
+
+	it('parses a comma-separated list, ignoring whitespace and empty entries', () => {
+		setDisabledProviders(' bedrock , vertex ,');
+		expect(env.DISABLED_PROVIDERS).toEqual(['bedrock', 'vertex']);
+		expect(isProviderDisabled('bedrock')).toBe(true);
+		expect(isProviderDisabled('vertex')).toBe(true);
+		expect(isProviderDisabled('anthropic')).toBe(false);
+	});
+
+	it('rejects unknown provider ids', () => {
+		process.env.DISABLED_PROVIDERS = 'bedrock,not-a-provider';
+		expect(() => __reloadEnvForTesting()).toThrow(/DISABLED_PROVIDERS/);
+		delete process.env.DISABLED_PROVIDERS;
+		__reloadEnvForTesting();
+	});
+
+	it('disabling a kind covers its named instances, and an instance can be disabled alone', () => {
+		setDisabledProviders('openaiCompatible');
+		expect(isProviderDisabled('openaiCompatible/my-vllm')).toBe(true);
+
+		setDisabledProviders('openaiCompatible/my-vllm');
+		expect(isProviderDisabled('openaiCompatible/my-vllm')).toBe(true);
+		expect(isProviderDisabled('openaiCompatible/other')).toBe(false);
+		expect(isProviderDisabled('openaiCompatible')).toBe(false);
+	});
+
+	it('keeps a disabled provider from auto-registering off ambient credentials', () => {
+		process.env.AWS_WEB_IDENTITY_TOKEN_FILE = '/var/run/secrets/token';
+		setDisabledProviders(undefined);
+		expect(hasEnvApiKey('bedrock')).toBe(true);
+		expect(getEnvProviders()).toContain('bedrock');
+
+		setDisabledProviders('bedrock');
+		expect(hasEnvApiKey('bedrock')).toBe(false);
+		expect(getEnvProviders()).not.toContain('bedrock');
+	});
+
+	it('overrides credentials configured in the database', async () => {
+		testState.dbConfig = { apiKey: 'db-key', baseUrl: null, credentials: null, modelSettings: {} };
+		setDisabledProviders(undefined);
+		expect(await resolveProviderSettings('project-1', 'bedrock')).not.toBeNull();
+
+		setDisabledProviders('bedrock');
+		expect(await resolveProviderSettings('project-1', 'bedrock')).toBeNull();
+	});
+});


### PR DESCRIPTION
Closes #1562.

Adds a `DISABLED_PROVIDERS` env var (comma-separated provider kinds, or `openaiCompatible/<name>` for a named instance) that keeps a provider out of the deployment entirely:

- declared and validated in `env.ts` against the known kinds — a typo fails boot with a clear message instead of silently doing nothing
- `hasEnvApiKey` returns false for it, so it never auto-registers from ambient credentials (the motivating case: EKS IRSA sets `AWS_WEB_IDENTITY_TOKEN_FILE` on every pod, surfacing Bedrock without any Bedrock permissions)
- `resolveProviderSettings` / `resolveProviderModel` return null even when the provider is configured in the DB or nao_config.yaml — it's a kill switch, not just detection suppression
- filtered out of `getProjectModelSources`, so it disappears from model listings; disabling a kind covers its named instances
- documented in `.env.example` next to the Bedrock auth block

Scope note: the settings UI catalog still lists a disabled provider; configuring it there simply has no effect. Hiding it in the UI could be a follow-up.

Tested:
- new `tests/disabled-providers.test.ts` (6 tests): parsing/trimming, boot rejection of unknown ids, kind-vs-named-instance semantics, the IRSA case (`AWS_WEB_IDENTITY_TOKEN_FILE` set → bedrock gone from env providers), and DB-config override
- backend lint (`tsc --noEmit && eslint`) and prettier clean
- full backend suite run before/after the change on this machine: identical failure sets (24 pre-existing environment failures — no bun, macOS), nothing new
- we run nao on EKS in production where this exact Bedrock-via-IRSA behaviour is what we currently mask with an `llm.providers` allow-list

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

