### PR TITLE
feat(backend): declarative Slack setup via SLACK_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,8 +133,9 @@ NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example
 
 # Slack integration — declarative alternative to the Settings > Slack form.
 # When SLACK_BOT_TOKEN is set, these seed the default project's Slack settings
-# on every boot (env wins for these fields; model selection, reply mode and
-# auto-created users stay UI-managed).
+# on boot. A config saved through the UI is never overwritten (delete it in
+# Settings > Slack to hand ownership to the environment); model selection,
+# reply mode and auto-created users stay UI-managed either way.
 # SLACK_BOT_TOKEN=xoxb-...
 # Socket Mode (recommended when nao is not reachable from the internet) — set
 # the app-level token; the transport defaults to socket when it is present.

--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,20 @@ NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example
 # NAO_LICENSE=/etc/nao/license.key
 # NAO_LICENSE=eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJnZXRuYW8iLC...
 
+# Slack integration — declarative alternative to the Settings > Slack form.
+# When SLACK_BOT_TOKEN is set, these seed the default project's Slack settings
+# on every boot (env wins for these fields; model selection, reply mode and
+# auto-created users stay UI-managed).
+# SLACK_BOT_TOKEN=xoxb-...
+# Socket Mode (recommended when nao is not reachable from the internet) — set
+# the app-level token; the transport defaults to socket when it is present.
+# SLACK_APP_TOKEN=xapp-...
+# Webhook mode instead: the signing secret is required and Slack must be able
+# to reach BETTER_AUTH_URL/api/webhooks/slack.
+# SLACK_SIGNING_SECRET=...
+# Optional explicit transport override: socket | webhook
+# SLACK_TRANSPORT_MODE=socket
+
 # SMTP server Configuration
 SMTP_HOST=              # smtp.yourservice.com
 SMTP_SSL=false

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -57,6 +57,7 @@ import { pingLicensesServer } from './services/ping';
 import { posthog, PostHogEvent } from './services/posthog';
 import { ensureRecurring, registerJob, startScheduler } from './services/scheduler.service';
 import { slackService } from './services/slack';
+import { seedSlackConfigFromEnv } from './services/slack-env-seed';
 import { TrpcRouter, trpcRouter } from './trpc/router';
 import { createContext } from './trpc/trpc';
 import { BudgetExceededError, HandlerError } from './utils/error';
@@ -405,7 +406,7 @@ export const startServer = async (opts: { port: number; host: string }) => {
 	app.log.info(`Server is running on ${address}`);
 
 	void pingLicensesServer();
-	void slackService.startSocketModeForAllProjects();
+	void seedSlackConfigFromEnv().then(() => slackService.startSocketModeForAllProjects());
 	void mattermostService.startForAllProjects();
 
 	posthog.capture(undefined, PostHogEvent.ServerStarted, { ...opts, address });

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -227,7 +227,7 @@ const baseEnvSchema = z.object({
 
 const envSchema = baseEnvSchema.superRefine((data, ctx) => {
 	if (!data.SLACK_BOT_TOKEN) {
-		if (data.SLACK_APP_TOKEN || data.SLACK_TRANSPORT_MODE) {
+		if (data.SLACK_SIGNING_SECRET || data.SLACK_APP_TOKEN || data.SLACK_TRANSPORT_MODE) {
 			ctx.addIssue({
 				code: 'custom',
 				path: ['SLACK_BOT_TOKEN'],

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -9,7 +9,7 @@ dotenv.config({
 	path: path.join(process.cwd(), '..', '..', '.env'),
 });
 
-const envSchema = z.object({
+const baseEnvSchema = z.object({
 	MODE: z.enum(['dev', 'prod', 'test']).default('dev'),
 
 	DB_URI: z.string().default('sqlite:./db.sqlite'),
@@ -97,6 +97,25 @@ const envSchema = z.object({
 	SMTP_USER: z.string().optional(),
 	SMTP_MAIL_FROM: z.string().optional(),
 	SMTP_SSL: z.enum(['true', 'false']).optional(),
+
+	/**
+	 * Declarative Slack setup: when SLACK_BOT_TOKEN is set, these seed the default project's Slack
+	 * settings on boot (see seedSlackConfigFromEnv), replacing the manual Settings > Slack form.
+	 * SLACK_TRANSPORT_MODE defaults to socket when SLACK_APP_TOKEN is present, webhook otherwise.
+	 */
+	SLACK_BOT_TOKEN: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined),
+	SLACK_SIGNING_SECRET: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined),
+	SLACK_APP_TOKEN: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined),
+	SLACK_TRANSPORT_MODE: z.enum(['webhook', 'socket']).optional(),
 
 	FASTAPI_PORT: z.coerce.number().default(8005),
 	APP_VERSION: z.string().default('dev'),
@@ -204,6 +223,34 @@ const envSchema = z.object({
 		.optional()
 		.default('false')
 		.transform((val) => val === 'true'),
+});
+
+const envSchema = baseEnvSchema.superRefine((data, ctx) => {
+	if (!data.SLACK_BOT_TOKEN) {
+		if (data.SLACK_APP_TOKEN || data.SLACK_TRANSPORT_MODE) {
+			ctx.addIssue({
+				code: 'custom',
+				path: ['SLACK_BOT_TOKEN'],
+				message: 'SLACK_BOT_TOKEN is required when other SLACK_* variables are set',
+			});
+		}
+		return;
+	}
+	const transport = data.SLACK_TRANSPORT_MODE ?? (data.SLACK_APP_TOKEN ? 'socket' : 'webhook');
+	if (transport === 'socket' && !data.SLACK_APP_TOKEN) {
+		ctx.addIssue({
+			code: 'custom',
+			path: ['SLACK_APP_TOKEN'],
+			message: 'SLACK_APP_TOKEN (xapp-...) is required when SLACK_TRANSPORT_MODE=socket',
+		});
+	}
+	if (transport === 'webhook' && !data.SLACK_SIGNING_SECRET) {
+		ctx.addIssue({
+			code: 'custom',
+			path: ['SLACK_SIGNING_SECRET'],
+			message: 'SLACK_SIGNING_SECRET is required when Slack runs in webhook mode',
+		});
+	}
 });
 
 const result = envSchema.safeParse(process.env);

--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -130,6 +130,7 @@ export const applySlackTransportSettings = async (data: {
 					slackSigningSecret: data.signingSecret,
 					slackTransportMode: data.transportMode,
 					slackAppToken: data.appToken,
+					slackSettingsSource: 'env',
 					slackllmProvider: existing?.slackllmProvider ?? '',
 					slackllmModelId: existing?.slackllmModelId ?? '',
 					autoCreateUsersEnabled: existing?.autoCreateUsersEnabled ?? false,

--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -168,6 +168,8 @@ export const updateProjectSlackModel = async (
 					slackTransportMode: existing?.slackTransportMode ?? 'webhook',
 					slackAppToken: existing?.slackAppToken ?? '',
 					slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
+					// A model change edits a UI-managed field; credential ownership is untouched.
+					slackSettingsSource: existing?.slackSettingsSource,
 				},
 			})
 			.where(eq(s.project.id, projectId))

--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -107,6 +107,41 @@ export const upsertProjectSlackConfig = async (data: {
 	};
 };
 
+/** Overwrite only the credential and transport fields, keeping the UI-managed ones. */
+export const applySlackTransportSettings = async (data: {
+	projectId: string;
+	botToken: string;
+	signingSecret: string;
+	transportMode: SlackTransportMode;
+	appToken: string;
+}): Promise<void> => {
+	await db.transaction(async (tx) => {
+		const project = await takeFirstOrThrow(
+			tx.select().from(s.project).where(eq(s.project.id, data.projectId)).execute(),
+			`Project not found: ${data.projectId}`,
+		);
+		const existing = project.slackSettings;
+
+		await tx
+			.update(s.project)
+			.set({
+				slackSettings: {
+					slackBotToken: data.botToken,
+					slackSigningSecret: data.signingSecret,
+					slackTransportMode: data.transportMode,
+					slackAppToken: data.appToken,
+					slackllmProvider: existing?.slackllmProvider ?? '',
+					slackllmModelId: existing?.slackllmModelId ?? '',
+					autoCreateUsersEnabled: existing?.autoCreateUsersEnabled ?? false,
+					autoCreateUsersDomains: existing?.autoCreateUsersDomains ?? [],
+					slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
+				},
+			})
+			.where(eq(s.project.id, data.projectId))
+			.execute();
+	});
+};
+
 export const updateProjectSlackModel = async (
 	projectId: string,
 	modelProvider: LlmProvider | null,

--- a/apps/backend/src/services/slack-env-seed.ts
+++ b/apps/backend/src/services/slack-env-seed.ts
@@ -1,0 +1,70 @@
+import { env } from '../env';
+import { getDefaultProject } from '../queries/project.queries';
+import { applySlackTransportSettings } from '../queries/project-slack-config.queries';
+import type { SlackTransportMode } from '../types/messaging-provider';
+import { logger } from '../utils/logger';
+
+/**
+ * Seed the default project's Slack settings from SLACK_* env vars on boot, so a deployment can
+ * declare its Slack integration instead of pasting tokens into Settings > Slack. The env owns the
+ * credential and transport fields while its variables are set; UI-managed fields (model selection,
+ * reply mode, auto-created users) are preserved. Never throws — Slack must not block startup.
+ */
+export async function seedSlackConfigFromEnv(): Promise<boolean> {
+	if (!env.SLACK_BOT_TOKEN) {
+		return false;
+	}
+
+	try {
+		const project = await getDefaultProject();
+		if (!project) {
+			logger.warn('SLACK_BOT_TOKEN is set but no project exists yet; Slack env seed skipped', {
+				source: 'system',
+			});
+			return false;
+		}
+
+		const transportMode = envSlackTransportMode();
+		if (matchesEnv(project.slackSettings, transportMode)) {
+			return false;
+		}
+
+		await applySlackTransportSettings({
+			projectId: project.id,
+			botToken: env.SLACK_BOT_TOKEN,
+			signingSecret: env.SLACK_SIGNING_SECRET ?? '',
+			transportMode,
+			appToken: env.SLACK_APP_TOKEN ?? '',
+		});
+		logger.info(`Slack settings seeded from environment for project ${project.id} (${transportMode} mode)`, {
+			source: 'system',
+			context: { projectId: project.id },
+		});
+		return true;
+	} catch (error) {
+		logger.error(`Failed to seed Slack settings from environment: ${String(error)}`, { source: 'system' });
+		return false;
+	}
+}
+
+/** Explicit override, else inferred from which secret is present: an app token means Socket Mode. */
+function envSlackTransportMode(): SlackTransportMode {
+	return env.SLACK_TRANSPORT_MODE ?? (env.SLACK_APP_TOKEN ? 'socket' : 'webhook');
+}
+
+type StoredSlackSettings = {
+	slackBotToken?: string;
+	slackSigningSecret?: string;
+	slackAppToken?: string;
+	slackTransportMode?: string;
+} | null;
+
+function matchesEnv(settings: StoredSlackSettings, transportMode: SlackTransportMode): boolean {
+	return (
+		!!settings &&
+		settings.slackBotToken === env.SLACK_BOT_TOKEN &&
+		(settings.slackSigningSecret ?? '') === (env.SLACK_SIGNING_SECRET ?? '') &&
+		(settings.slackAppToken ?? '') === (env.SLACK_APP_TOKEN ?? '') &&
+		settings.slackTransportMode === transportMode
+	);
+}

--- a/apps/backend/src/services/slack-env-seed.ts
+++ b/apps/backend/src/services/slack-env-seed.ts
@@ -6,9 +6,11 @@ import { logger } from '../utils/logger';
 
 /**
  * Seed the default project's Slack settings from SLACK_* env vars on boot, so a deployment can
- * declare its Slack integration instead of pasting tokens into Settings > Slack. The env owns the
- * credential and transport fields while its variables are set; UI-managed fields (model selection,
- * reply mode, auto-created users) are preserved. Never throws — Slack must not block startup.
+ * declare its Slack integration instead of pasting tokens into Settings > Slack. The seed only
+ * writes when the settings are absent or were written by a previous seed — a config saved through
+ * the UI is never overwritten, so deployments that already export SLACK_* for nao_config.yaml
+ * templating keep their existing setup on upgrade. UI-managed fields (model selection, reply mode,
+ * auto-created users) are preserved either way. Never throws — Slack must not block startup.
  */
 export async function seedSlackConfigFromEnv(): Promise<boolean> {
 	if (!env.SLACK_BOT_TOKEN) {
@@ -24,8 +26,17 @@ export async function seedSlackConfigFromEnv(): Promise<boolean> {
 			return false;
 		}
 
+		const settings = project.slackSettings;
+		if (settings && settings.slackSettingsSource !== 'env') {
+			logger.info(
+				'SLACK_* env vars are set but the Slack settings were saved through the UI; leaving them untouched (delete them in Settings > Slack to hand ownership to the environment)',
+				{ source: 'system', context: { projectId: project.id } },
+			);
+			return false;
+		}
+
 		const transportMode = envSlackTransportMode();
-		if (matchesEnv(project.slackSettings, transportMode)) {
+		if (matchesEnv(settings, transportMode)) {
 			return false;
 		}
 
@@ -57,6 +68,7 @@ type StoredSlackSettings = {
 	slackSigningSecret?: string;
 	slackAppToken?: string;
 	slackTransportMode?: string;
+	slackSettingsSource?: string;
 } | null;
 
 function matchesEnv(settings: StoredSlackSettings, transportMode: SlackTransportMode): boolean {

--- a/apps/backend/src/types/messaging-provider.ts
+++ b/apps/backend/src/types/messaging-provider.ts
@@ -53,6 +53,10 @@ export type SlackSettings = {
 	slackTransportMode?: SlackTransportMode;
 	slackAppToken?: string;
 	slackReplyMode?: SlackReplyMode;
+	// 'env' when the boot-time SLACK_* seed wrote the credentials; absent after a
+	// Settings > Slack save, which hands ownership back to the UI so the seed
+	// stops overwriting.
+	slackSettingsSource?: 'env';
 };
 
 export type TeamsSettings = {

--- a/apps/backend/src/types/messaging-provider.ts
+++ b/apps/backend/src/types/messaging-provider.ts
@@ -53,9 +53,10 @@ export type SlackSettings = {
 	slackTransportMode?: SlackTransportMode;
 	slackAppToken?: string;
 	slackReplyMode?: SlackReplyMode;
-	// 'env' when the boot-time SLACK_* seed wrote the credentials; absent after a
-	// Settings > Slack save, which hands ownership back to the UI so the seed
-	// stops overwriting.
+	// Who last wrote the credential/transport fields: 'env' after the boot-time
+	// SLACK_* seed, absent after a Settings > Slack credentials save (which hands
+	// ownership to the UI so the seed stops overwriting). Edits to UI-managed
+	// fields (model, reply mode, auto-create users) leave ownership untouched.
 	slackSettingsSource?: 'env';
 };
 

--- a/apps/backend/tests/slack-env-seed.test.ts
+++ b/apps/backend/tests/slack-env-seed.test.ts
@@ -65,6 +65,39 @@ describe('seedSlackConfigFromEnv', () => {
 		});
 	});
 
+	it('never overwrites settings that were saved through the UI', async () => {
+		testState.project = {
+			id: 'project-1',
+			slackSettings: {
+				slackBotToken: 'xoxb-ui',
+				slackSigningSecret: 'sig-ui',
+				slackAppToken: 'xapp-ui',
+				slackTransportMode: 'socket',
+			},
+		};
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_SIGNING_SECRET: 'sig-1' });
+		expect(await seedSlackConfigFromEnv()).toBe(false);
+		expect(testState.applySlackTransportSettings).not.toHaveBeenCalled();
+	});
+
+	it('updates settings that a previous seed wrote', async () => {
+		testState.project = {
+			id: 'project-1',
+			slackSettings: {
+				slackBotToken: 'xoxb-old',
+				slackSigningSecret: '',
+				slackAppToken: 'xapp-old',
+				slackTransportMode: 'socket',
+				slackSettingsSource: 'env',
+			},
+		};
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-new', SLACK_APP_TOKEN: 'xapp-new' });
+		expect(await seedSlackConfigFromEnv()).toBe(true);
+		expect(testState.applySlackTransportSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ botToken: 'xoxb-new', appToken: 'xapp-new' }),
+		);
+	});
+
 	it('seeds webhook mode when only a signing secret is present', async () => {
 		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_SIGNING_SECRET: 'sig-1' });
 		expect(await seedSlackConfigFromEnv()).toBe(true);
@@ -98,6 +131,7 @@ describe('seedSlackConfigFromEnv', () => {
 				slackSigningSecret: '',
 				slackAppToken: 'xapp-1',
 				slackTransportMode: 'socket',
+				slackSettingsSource: 'env',
 			},
 		};
 		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_APP_TOKEN: 'xapp-1' });
@@ -129,6 +163,9 @@ describe('seedSlackConfigFromEnv', () => {
 	it('rejects SLACK_* extras without the bot token at env parse time', () => {
 		delete process.env.SLACK_BOT_TOKEN;
 		process.env.SLACK_APP_TOKEN = 'xapp-1';
+		expect(() => __reloadEnvForTesting()).toThrow(/SLACK_BOT_TOKEN/);
+		delete process.env.SLACK_APP_TOKEN;
+		process.env.SLACK_SIGNING_SECRET = 'sig-1';
 		expect(() => __reloadEnvForTesting()).toThrow(/SLACK_BOT_TOKEN/);
 	});
 });

--- a/apps/backend/tests/slack-env-seed.test.ts
+++ b/apps/backend/tests/slack-env-seed.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+	project: null as Record<string, unknown> | null,
+	applySlackTransportSettings: vi.fn(),
+}));
+
+vi.mock('../src/db/db', () => ({ db: {} }));
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getDefaultProject: vi.fn(async () => testState.project),
+}));
+
+vi.mock('../src/queries/project-slack-config.queries', () => ({
+	applySlackTransportSettings: testState.applySlackTransportSettings,
+}));
+
+import { __reloadEnvForTesting } from '../src/env';
+import { seedSlackConfigFromEnv } from '../src/services/slack-env-seed';
+
+describe('seedSlackConfigFromEnv', () => {
+	let originalEnv: typeof process.env;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		testState.project = { id: 'project-1', slackSettings: null };
+		testState.applySlackTransportSettings.mockReset();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		__reloadEnvForTesting();
+	});
+
+	function setSlackEnv(vars: Record<string, string | undefined>) {
+		for (const key of ['SLACK_BOT_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_APP_TOKEN', 'SLACK_TRANSPORT_MODE']) {
+			delete process.env[key];
+		}
+		for (const [key, value] of Object.entries(vars)) {
+			if (value !== undefined) {
+				process.env[key] = value;
+			}
+		}
+		__reloadEnvForTesting();
+	}
+
+	it('does nothing when SLACK_BOT_TOKEN is unset', async () => {
+		setSlackEnv({});
+		expect(await seedSlackConfigFromEnv()).toBe(false);
+		expect(testState.applySlackTransportSettings).not.toHaveBeenCalled();
+	});
+
+	it('seeds socket mode when an app token is present', async () => {
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_APP_TOKEN: 'xapp-1' });
+		expect(await seedSlackConfigFromEnv()).toBe(true);
+		expect(testState.applySlackTransportSettings).toHaveBeenCalledWith({
+			projectId: 'project-1',
+			botToken: 'xoxb-1',
+			signingSecret: '',
+			transportMode: 'socket',
+			appToken: 'xapp-1',
+		});
+	});
+
+	it('seeds webhook mode when only a signing secret is present', async () => {
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_SIGNING_SECRET: 'sig-1' });
+		expect(await seedSlackConfigFromEnv()).toBe(true);
+		expect(testState.applySlackTransportSettings).toHaveBeenCalledWith({
+			projectId: 'project-1',
+			botToken: 'xoxb-1',
+			signingSecret: 'sig-1',
+			transportMode: 'webhook',
+			appToken: '',
+		});
+	});
+
+	it('honours an explicit transport override', async () => {
+		setSlackEnv({
+			SLACK_BOT_TOKEN: 'xoxb-1',
+			SLACK_SIGNING_SECRET: 'sig-1',
+			SLACK_APP_TOKEN: 'xapp-1',
+			SLACK_TRANSPORT_MODE: 'webhook',
+		});
+		expect(await seedSlackConfigFromEnv()).toBe(true);
+		expect(testState.applySlackTransportSettings).toHaveBeenCalledWith(
+			expect.objectContaining({ transportMode: 'webhook' }),
+		);
+	});
+
+	it('skips the write when the stored settings already match the environment', async () => {
+		testState.project = {
+			id: 'project-1',
+			slackSettings: {
+				slackBotToken: 'xoxb-1',
+				slackSigningSecret: '',
+				slackAppToken: 'xapp-1',
+				slackTransportMode: 'socket',
+			},
+		};
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_APP_TOKEN: 'xapp-1' });
+		expect(await seedSlackConfigFromEnv()).toBe(false);
+		expect(testState.applySlackTransportSettings).not.toHaveBeenCalled();
+	});
+
+	it('skips gracefully when no project exists yet', async () => {
+		testState.project = null;
+		setSlackEnv({ SLACK_BOT_TOKEN: 'xoxb-1', SLACK_APP_TOKEN: 'xapp-1' });
+		expect(await seedSlackConfigFromEnv()).toBe(false);
+		expect(testState.applySlackTransportSettings).not.toHaveBeenCalled();
+	});
+
+	it('rejects socket mode without an app token at env parse time', () => {
+		process.env.SLACK_BOT_TOKEN = 'xoxb-1';
+		process.env.SLACK_TRANSPORT_MODE = 'socket';
+		delete process.env.SLACK_APP_TOKEN;
+		expect(() => __reloadEnvForTesting()).toThrow(/SLACK_APP_TOKEN/);
+	});
+
+	it('rejects webhook mode without a signing secret at env parse time', () => {
+		process.env.SLACK_BOT_TOKEN = 'xoxb-1';
+		delete process.env.SLACK_SIGNING_SECRET;
+		delete process.env.SLACK_APP_TOKEN;
+		expect(() => __reloadEnvForTesting()).toThrow(/SLACK_SIGNING_SECRET/);
+	});
+
+	it('rejects SLACK_* extras without the bot token at env parse time', () => {
+		delete process.env.SLACK_BOT_TOKEN;
+		process.env.SLACK_APP_TOKEN = 'xapp-1';
+		expect(() => __reloadEnvForTesting()).toThrow(/SLACK_BOT_TOKEN/);
+	});
+});


### PR DESCRIPTION
Closes #1564.

Adds `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `SLACK_APP_TOKEN` and `SLACK_TRANSPORT_MODE` env vars. When the bot token is set, `seedSlackConfigFromEnv()` runs on boot (chained before `startSocketModeForAllProjects()`, so the socket bridge comes up with the seeded settings) and writes the default project's Slack settings:

- transport defaults to `socket` when `SLACK_APP_TOKEN` is present, `webhook` otherwise; `SLACK_TRANSPORT_MODE` overrides
- invalid combinations (socket without app token, webhook without signing secret, SLACK_* extras without the bot token) fail env parsing with actionable messages
- env owns only the credential/transport fields — a new `applySlackTransportSettings` query merges them while preserving the UI-managed ones (model selection, reply mode, auto-created users)
- seed is idempotent (no write when the DB already matches) and never throws, so Slack can't block startup; skips with a warning when no project exists yet
- documented in `.env.example`

The Settings > Slack form keeps working unchanged; env values re-assert on the next boot while the vars are set, which is the declarative intent.

Tested:
- new `tests/slack-env-seed.test.ts` (9 tests): no-op without bot token, socket/webhook inference, explicit override, idempotence, missing-project skip, and the three env-validation rejections
- backend lint (`tsc --noEmit && eslint`) and prettier clean; full backend suite failure set identical to upstream/main baseline on this machine (24 pre-existing environment failures, nothing new)
- we run nao 0.3.10 in production on EKS with the Slack bot in Socket Mode — today the app token is pasted manually after every reinstall, which is exactly what this removes; we'll switch our deployment to these vars once released

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

