### PR TITLE
feat(backend): MCP_ENDPOINT_ENABLED env default for the MCP endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,12 @@ NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example
 # every backend; a bigger file is rejected before anything is stored.
 # NAO_STORAGE_MAX_FILE_SIZE_MB=10
 
+# Default for the MCP endpoint toggle (Settings > MCP Endpoint) while a project
+# has no stored settings — lets a fresh deployment come up with external MCP
+# clients already able to connect. Once an admin saves the settings in the UI,
+# the stored value wins and this is ignored.
+# MCP_ENDPOINT_ENABLED=true
+
 # Enterprise license — signed token issued by getnao.
 # Accepts either the raw token or a path to a file containing it.
 # When unset, the app runs in OSS mode and all EE features (SSO, …) stay off.

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -166,6 +166,16 @@ const envSchema = z.object({
 		.optional()
 		.transform((val) => val?.trim() || undefined),
 
+	/**
+	 * Default for the MCP endpoint toggle (Settings > MCP Endpoint) while a project has no stored
+	 * settings — lets a deployment come up with the endpoint already enabled. Once an admin saves
+	 * the settings, the stored value wins and this is ignored.
+	 */
+	MCP_ENDPOINT_ENABLED: z
+		.enum(['true', 'false'])
+		.optional()
+		.transform((val) => (val === undefined ? undefined : val === 'true')),
+
 	POSTHOG_KEY: z.string().optional(),
 	POSTHOG_HOST: z.url({ message: 'POSTHOG_HOST must be a valid URL' }).optional(),
 	POSTHOG_DISABLED: z

--- a/apps/backend/src/queries/mcp-endpoint.queries.ts
+++ b/apps/backend/src/queries/mcp-endpoint.queries.ts
@@ -3,6 +3,7 @@ import { desc, eq } from 'drizzle-orm';
 import type { NewMcpCallLog } from '../db/abstractSchema';
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
+import { env } from '../env';
 import { DEFAULT_MCP_ENDPOINT_SETTINGS, type McpEndpointSettings } from '../types/mcp-endpoint';
 
 export async function getMcpEndpointSettings(projectId: string): Promise<McpEndpointSettings> {
@@ -13,7 +14,15 @@ export async function getMcpEndpointSettings(projectId: string): Promise<McpEndp
 		.limit(1)
 		.execute();
 
-	return row?.mcpEndpointSettings ?? DEFAULT_MCP_ENDPOINT_SETTINGS;
+	return row?.mcpEndpointSettings ?? defaultMcpEndpointSettings();
+}
+
+/** Built-in defaults, with MCP_ENDPOINT_ENABLED as the deployment's opinion on the toggle. */
+function defaultMcpEndpointSettings(): McpEndpointSettings {
+	if (env.MCP_ENDPOINT_ENABLED === undefined) {
+		return DEFAULT_MCP_ENDPOINT_SETTINGS;
+	}
+	return { ...DEFAULT_MCP_ENDPOINT_SETTINGS, enabled: env.MCP_ENDPOINT_ENABLED };
 }
 
 export async function updateMcpEndpointSettings(

--- a/apps/backend/tests/mcp-endpoint-env.test.ts
+++ b/apps/backend/tests/mcp-endpoint-env.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+	storedSettings: null as Record<string, unknown> | null,
+}));
+
+vi.mock('../src/db/db', () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: () => ({
+						execute: async () => [{ mcpEndpointSettings: testState.storedSettings }],
+					}),
+				}),
+			}),
+		}),
+	},
+}));
+
+import { __reloadEnvForTesting } from '../src/env';
+import { getMcpEndpointSettings } from '../src/queries/mcp-endpoint.queries';
+
+describe('MCP_ENDPOINT_ENABLED default', () => {
+	let originalEnv: typeof process.env;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		testState.storedSettings = null;
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		__reloadEnvForTesting();
+	});
+
+	function setEnvToggle(value: string | undefined) {
+		if (value === undefined) {
+			delete process.env.MCP_ENDPOINT_ENABLED;
+		} else {
+			process.env.MCP_ENDPOINT_ENABLED = value;
+		}
+		__reloadEnvForTesting();
+	}
+
+	it('keeps the built-in default (disabled) when unset', async () => {
+		setEnvToggle(undefined);
+		const settings = await getMcpEndpointSettings('project-1');
+		expect(settings.enabled).toBe(false);
+		expect(settings.subAgentModeEnabled).toBe(true);
+		expect(settings.contextLayerModeEnabled).toBe(true);
+	});
+
+	it('enables the endpoint for projects with no stored settings', async () => {
+		setEnvToggle('true');
+		const settings = await getMcpEndpointSettings('project-1');
+		expect(settings.enabled).toBe(true);
+		expect(settings.subAgentModeEnabled).toBe(true);
+	});
+
+	it('can also pin the default to disabled explicitly', async () => {
+		setEnvToggle('false');
+		expect((await getMcpEndpointSettings('project-1')).enabled).toBe(false);
+	});
+
+	it('never overrides settings an admin saved', async () => {
+		testState.storedSettings = { enabled: false, subAgentModeEnabled: false, contextLayerModeEnabled: true };
+		setEnvToggle('true');
+		const settings = await getMcpEndpointSettings('project-1');
+		expect(settings.enabled).toBe(false);
+		expect(settings.subAgentModeEnabled).toBe(false);
+	});
+
+	it('rejects values other than true/false at env parse time', () => {
+		process.env.MCP_ENDPOINT_ENABLED = 'yes';
+		expect(() => __reloadEnvForTesting()).toThrow();
+	});
+});


### PR DESCRIPTION
Closes #1566.

Adds an `MCP_ENDPOINT_ENABLED` env var (`true`/`false`, validated) that acts as the deployment's default for the Settings > MCP Endpoint toggle:

- `getMcpEndpointSettings` falls back to the env-derived default only when the project has **no stored settings** — once an admin saves anything in the UI, the stored value wins and the env var is ignored. First-boot default, not an override.
- Applies everywhere the settings are read, including the `/mcp` route guard, so a fresh deployment comes up with external MCP clients able to connect.
- The mode toggles (sub-agent / context-layer) keep their built-in defaults (both on).
- Documented in `.env.example`.

Tested:
- new `tests/mcp-endpoint-env.test.ts` (5 tests): built-in default preserved when unset, enable/disable defaults for settings-less projects, admin-saved settings never overridden, invalid values rejected at parse time
- backend lint (`tsc --noEmit && eslint`) and prettier clean
- our production use case is exactly this: we connect dust.tt to nao's MCP endpoint on EKS, and today a reinstall breaks that integration until the toggle is clicked again

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

