### PR TITLE
feat(cli): nao sync no longer fails on unresolved llm/slack secrets

### DIFF
--- a/cli/nao_core/commands/sync/__init__.py
+++ b/cli/nao_core/commands/sync/__init__.py
@@ -72,7 +72,11 @@ def sync(
     """
     console.print("\n[bold cyan]🔄 nao sync[/bold cyan]\n")
 
-    config = NaoConfig.try_load(resolve_project_path(), exit_on_error=True)
+    # Sync only reads the provider sections it runs (databases, repos, notion,
+    # confluence): an integration block that fails validation — typically an unset
+    # env('...') secret for llm or slack — is dropped with a warning instead of
+    # failing a run that never touches it.
+    config = NaoConfig.try_load(resolve_project_path(), exit_on_error=True, drop_invalid_optional_sections=True)
     assert config is not None  # Help type checker after exit_on_error=True
 
     project_path = Path.cwd()

--- a/cli/nao_core/config/base.py
+++ b/cli/nao_core/config/base.py
@@ -34,6 +34,13 @@ class NaoConfigError(Exception):
     pass
 
 
+# Integration blocks a command can run without. Commands that only read part of the
+# config (e.g. `nao sync` with the databases provider) can load with
+# drop_invalid_optional_sections=True so an unresolvable block here — typically an
+# unset env('...') secret — is ignored with a warning instead of failing the run.
+OPTIONAL_SECTIONS = ("llm", "slack", "notion", "confluence", "mcp", "skills", "test")
+
+
 class NaoConfig(BaseModel):
     """nao project configuration."""
 
@@ -190,15 +197,49 @@ class NaoConfig(BaseModel):
         cls,
         path: Path,
         extra_env: dict[str, str] | None = None,
+        drop_invalid_optional_sections: bool = False,
     ) -> "NaoConfig":
-        """Load the configuration from a YAML file."""
+        """Load the configuration from a YAML file.
+
+        With drop_invalid_optional_sections=True, a section from OPTIONAL_SECTIONS that
+        fails validation is replaced by None and reported as a warning, so commands that
+        do not use it can still run. Errors anywhere else fail the load as usual.
+        """
         config_file = path / "nao_config.yaml"
         content = config_file.read_text()
         processed_content, missing = process_secrets(content, extra_env=extra_env)
         cls._missing_secrets = {k: None for k, v in missing.items() if v is None}
         data = yaml.safe_load(processed_content)
         cls._warn_on_legacy_llm(data)
-        return cls.model_validate(data)
+        if not drop_invalid_optional_sections:
+            return cls.model_validate(data)
+        return cls._validate_dropping_optional_sections(data)
+
+    @classmethod
+    def _validate_dropping_optional_sections(cls, data: Any) -> "NaoConfig":
+        try:
+            return cls.model_validate(data)
+        except ValidationError as e:
+            if not isinstance(data, dict):
+                raise
+
+            dropped: dict[str, str] = {}
+            for error in e.errors():
+                section = error["loc"][0] if error["loc"] else None
+                if not isinstance(section, str) or section not in OPTIONAL_SECTIONS:
+                    raise
+                dropped.setdefault(section, str(error["msg"]))
+
+            config = cls.model_validate({**data, **{section: None for section in dropped}})
+            for section, reason in dropped.items():
+                hint = ""
+                if cls._missing_secrets:
+                    hint = f" (unset environment variables: {', '.join(cls._missing_secrets)})"
+                UI.warn(
+                    f"Ignoring invalid `{section}` config for this command: {reason}{hint}. "
+                    f"Commands that use `{section}` will keep failing until it validates."
+                )
+            return config
 
     @staticmethod
     def _warn_on_legacy_llm(data: Any) -> None:
@@ -231,6 +272,7 @@ class NaoConfig(BaseModel):
         exit_on_error: bool = False,
         raise_on_error: bool = False,
         extra_env: dict[str, str] | None = None,
+        drop_invalid_optional_sections: bool = False,
     ) -> "NaoConfig | None":
         """Try to load config from path.
 
@@ -239,6 +281,8 @@ class NaoConfig(BaseModel):
             exit_on_error: If True, prints error message and calls sys.exit(1) on failure.
             raise_on_error: If True, raises NaoConfigError on failure.
             extra_env: Optional env vars that take precedence over os.environ during template resolution.
+            drop_invalid_optional_sections: If True, an invalid OPTIONAL_SECTIONS block is
+                nulled with a warning instead of failing the load (see `load`).
         Returns:
             NaoConfig if loaded successfully, None if failed and both flags are False.
         """
@@ -259,7 +303,11 @@ class NaoConfig(BaseModel):
 
         try:
             os.chdir(path)
-            return cls.load(path, extra_env=extra_env)
+            return cls.load(
+                path,
+                extra_env=extra_env,
+                drop_invalid_optional_sections=drop_invalid_optional_sections,
+            )
         except yaml.YAMLError as e:
             handle_error(f"Failed to load nao_config.yaml: Invalid YAML syntax: {e}")
             return None

--- a/cli/tests/nao_core/config/test_optional_sections.py
+++ b/cli/tests/nao_core/config/test_optional_sections.py
@@ -1,0 +1,101 @@
+"""Loading with drop_invalid_optional_sections: integration blocks that fail
+validation (typically an unset env('...') secret) are nulled with a warning so
+commands that never read them, like `nao sync`, can still run."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from nao_core.config.base import NaoConfig
+
+VALID_CORE = """
+project_name: test-project
+databases:
+  - name: local
+    type: duckdb
+    path: ":memory:"
+"""
+
+LLM_WITH_ENV_KEY = """
+llm:
+  providers:
+    - provider: anthropic
+      api_key: "{{ env('TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY') }}"
+"""
+
+# Unquoted on purpose: with the env var unset the substitution leaves an empty
+# YAML value, which parses as null — the shape this feature exists for.
+SLACK_WITH_ENV_TOKENS = """
+slack:
+  bot_token: {{ env('TEST_OPTIONAL_SECTIONS_SLACK_BOT') }}
+  signing_secret: {{ env('TEST_OPTIONAL_SECTIONS_SLACK_SECRET') }}
+"""
+
+
+def write_config(path: Path, content: str) -> None:
+    (path / "nao_config.yaml").write_text(content)
+
+
+def test_strict_load_still_fails_on_unresolved_llm_secret(tmp_path):
+    write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY)
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
+        with pytest.raises(ValidationError):
+            NaoConfig.load(tmp_path)
+
+
+def test_invalid_llm_and_slack_are_dropped_with_flag(tmp_path):
+    write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY + SLACK_WITH_ENV_TOKENS)
+    for var in (
+        "TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY",
+        "TEST_OPTIONAL_SECTIONS_SLACK_BOT",
+        "TEST_OPTIONAL_SECTIONS_SLACK_SECRET",
+    ):
+        os.environ.pop(var, None)
+
+    config = NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
+
+    assert config.llm is None
+    assert config.slack is None
+    assert config.project_name == "test-project"
+    assert [db.name for db in config.databases] == ["local"]
+
+
+def test_valid_sections_are_kept_with_flag(tmp_path):
+    write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY)
+    with patch.dict(os.environ, {"TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY": "sk-test"}):
+        config = NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
+
+    assert config.llm is not None
+    assert config.llm.providers[0].api_key == "sk-test"
+
+
+def test_core_errors_still_fail_with_flag(tmp_path):
+    write_config(
+        tmp_path,
+        """
+project_name: test-project
+databases:
+  - name: broken
+    type: not-a-database
+"""
+        + LLM_WITH_ENV_KEY,
+    )
+    os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
+    with pytest.raises((ValidationError, ValueError)):
+        NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
+
+
+def test_try_load_passes_the_flag_through(tmp_path):
+    write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY)
+    os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
+
+    strict = NaoConfig.try_load(tmp_path)
+    assert strict is None
+
+    lenient = NaoConfig.try_load(tmp_path, drop_invalid_optional_sections=True)
+    assert lenient is not None
+    assert lenient.llm is None

--- a/cli/tests/nao_core/config/test_optional_sections.py
+++ b/cli/tests/nao_core/config/test_optional_sections.py
@@ -49,14 +49,15 @@ def test_strict_load_still_fails_on_unresolved_llm_secret(tmp_path):
 
 def test_invalid_llm_and_slack_are_dropped_with_flag(tmp_path):
     write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY + SLACK_WITH_ENV_TOKENS)
-    for var in (
-        "TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY",
-        "TEST_OPTIONAL_SECTIONS_SLACK_BOT",
-        "TEST_OPTIONAL_SECTIONS_SLACK_SECRET",
-    ):
-        os.environ.pop(var, None)
+    with patch.dict(os.environ):
+        for var in (
+            "TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY",
+            "TEST_OPTIONAL_SECTIONS_SLACK_BOT",
+            "TEST_OPTIONAL_SECTIONS_SLACK_SECRET",
+        ):
+            os.environ.pop(var, None)
 
-    config = NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
+        config = NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
 
     assert config.llm is None
     assert config.slack is None
@@ -84,18 +85,20 @@ databases:
 """
         + LLM_WITH_ENV_KEY,
     )
-    os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
-    with pytest.raises((ValidationError, ValueError)):
-        NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
+    with patch.dict(os.environ):
+        os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
+        with pytest.raises((ValidationError, ValueError)):
+            NaoConfig.load(tmp_path, drop_invalid_optional_sections=True)
 
 
 def test_try_load_passes_the_flag_through(tmp_path):
     write_config(tmp_path, VALID_CORE + LLM_WITH_ENV_KEY)
-    os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
+    with patch.dict(os.environ):
+        os.environ.pop("TEST_OPTIONAL_SECTIONS_ANTHROPIC_KEY", None)
 
-    strict = NaoConfig.try_load(tmp_path)
-    assert strict is None
+        strict = NaoConfig.try_load(tmp_path)
+        assert strict is None
 
-    lenient = NaoConfig.try_load(tmp_path, drop_invalid_optional_sections=True)
-    assert lenient is not None
-    assert lenient.llm is None
+        lenient = NaoConfig.try_load(tmp_path, drop_invalid_optional_sections=True)
+        assert lenient is not None
+        assert lenient.llm is None


### PR DESCRIPTION
Closes #1569.

`NaoConfig.load`/`try_load` gain a `drop_invalid_optional_sections` flag: an integration block (`llm`, `slack`, `notion`, `confluence`, `mcp`, `skills`, `test`) that fails validation — typically an unset `env('...')` secret — is nulled with a warning naming the section, the pydantic reason and any unset env vars. Errors in core sections (`databases`, `project_name`, ...) still fail the load exactly as before.

Only `nao sync` opts in; every other command keeps strict upfront validation. Sync already copes with absent sections: providers skip themselves via `should_sync`, and the databases provider None-guards `config.llm`, so a dropped block just means "that provider doesn't run" — with the warning explaining why.

Tested:
- new `cli/tests/nao_core/config/test_optional_sections.py` (5 tests): strict load still fails, invalid llm+slack dropped with the flag, valid sections kept, core errors still fail with the flag, try_load pass-through
- end-to-end: a project with a duckdb database plus `llm`/`slack` blocks referencing unset env vars — `nao sync` previously exited 1 on validation; now it warns per section and syncs the database (exit 0). This is our production CI shape: our sync job currently exports `placeholder-sync-only` values for `ANTHROPIC_API_KEY`/`SLACK_*` to work around this, which this PR lets us delete.
- full cli unit suite (minus backends needing native libs on macOS): 1087 passed, failure set identical to main on this machine; `ruff check`, `ruff check --select I`, `ruff format --check` and `ty check` clean with the locked toolchain (ruff 0.15.7, ty 0.0.24)

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

