### PR TITLE
fix(mcp): evict stuck ask_nao runs from in-memory registry

### DIFF
--- a/apps/backend/src/mcp/tools/ask-nao-runs.ts
+++ b/apps/backend/src/mcp/tools/ask-nao-runs.ts
@@ -26,7 +26,19 @@ export type AskNaoRunState =
 
 const runs = new Map<string, AskNaoRunState>();
 
-const FINISHED_RUN_TTL_MS = 30 * 60 * 1000;
+// Short: `get_nao_answer` only needs this while a client is actively polling right after
+// `ask_nao` returned `running`. Once a run is done, `resolveAnswerPayload` falls back to
+// `reconstructAnswerFromDb`, so we don't need to hold the full result in memory for long.
+const FINISHED_RUN_TTL_MS = 5 * 60 * 1000;
+
+// Backstop for runs that never leave the `running` state (e.g. a hung stream, or an
+// error thrown outside `runAskNaoInBackground`'s try/catch). Without this, such entries
+// are invisible to the sweep below (it only looks at `finishedAt`, which `running`
+// entries don't have) and accumulate for the lifetime of the process.
+const MAX_RUN_AGE_MS = 15 * 60 * 1000;
+
+// Hard cap so a future bug in the sweep/TTL logic can't reintroduce unbounded growth.
+const MAX_TRACKED_RUNS = 5_000;
 
 /**
  * Tracks `ask_nao` agent runs that outlive their originating MCP request.
@@ -37,6 +49,12 @@ const FINISHED_RUN_TTL_MS = 30 * 60 * 1000;
  */
 export const askNaoRuns = {
 	start(chatId: string): void {
+		if (runs.size >= MAX_TRACKED_RUNS) {
+			const oldestChatId = runs.keys().next().value;
+			if (oldestChatId !== undefined) {
+				runs.delete(oldestChatId);
+			}
+		}
 		runs.set(chatId, { status: 'running', startedAt: Date.now() });
 	},
 	complete(chatId: string, result: AskNaoResult): void {
@@ -54,7 +72,11 @@ setInterval(
 	() => {
 		const now = Date.now();
 		for (const [chatId, state] of runs) {
-			if (state.status !== 'running' && now - state.finishedAt > FINISHED_RUN_TTL_MS) {
+			const isStale =
+				state.status === 'running'
+					? now - state.startedAt > MAX_RUN_AGE_MS
+					: now - state.finishedAt > FINISHED_RUN_TTL_MS;
+			if (isStale) {
 				runs.delete(chatId);
 			}
 		}


### PR DESCRIPTION
## Summary

`askNaoRuns`'s cleanup sweep only expired runs already in `complete`/`error` state (it checks `finishedAt`, which only those states have). A run stuck in `running` forever — a hung `agent.stream()`, or an error thrown outside `runAskNaoInBackground`'s `try/catch` — was invisible to the sweep and stayed in the map for the life of the process.

We saw this in production: `container.memory.working_set` for the `nao` backend climbed for hours, then dropped sharply right when the pod got `OOMKilled` and restarted — repeating on both replicas. That's consistent with an in-memory map that only clears via process restart, not steady-state usage.

This PR:
- Expires `running` entries older than `MAX_RUN_AGE_MS` (15 min, well above the 45s sync budget), in addition to the existing finished-run TTL.
- Shortens the finished-run TTL from 30 to 5 minutes — safe because `resolveAnswerPayload` already falls back to `reconstructAnswerFromDb` when an entry is missing.
- Caps the map at `MAX_TRACKED_RUNS` (5,000) as a backstop against a future regression in the sweep.

Fixes #1575

This PR was written using Claude Sonnet 5 (claude-sonnet-5).

## Test plan
- `npm run lint:backend` (tsc + eslint) passes clean on this change.
- No test coverage existed for `ask-nao-runs.ts` before this change; didn't add any since I couldn't validate the surrounding agent/stream behavior against real services per the contributing guide — happy to add unit tests for the sweep logic itself if that's wanted.
- Manually traced the sweep against all three `AskNaoRunState` variants (`running`, `complete`, `error`) to confirm the new branch is correct.
- No behavior change for the happy path (run completes within the old/new TTL); only affects runs that were previously stuck forever or long-lived past 30 minutes.
