### PR TITLE
fix(mcp): evict stuck ask_nao runs from in-memory registry

### DIFF
--- a/apps/backend/src/mcp/tools/ask-nao-runs.ts
+++ b/apps/backend/src/mcp/tools/ask-nao-runs.ts
@@ -26,7 +26,15 @@ export type AskNaoRunState =
 
 const runs = new Map<string, AskNaoRunState>();
 
-const FINISHED_RUN_TTL_MS = 30 * 60 * 1000;
+// `resolveAnswerPayload` falls back to `reconstructAnswerFromDb` on a miss, so finished
+// runs don't need to stay in memory long.
+const FINISHED_RUN_TTL_MS = 5 * 60 * 1000;
+
+// A run stuck in `running` (hung stream, error outside the try/catch) has no `finishedAt`,
+// so the sweep below would otherwise never evict it.
+const MAX_RUN_AGE_MS = 15 * 60 * 1000;
+
+const MAX_TRACKED_RUNS = 5_000;
 
 /**
  * Tracks `ask_nao` agent runs that outlive their originating MCP request.
@@ -37,6 +45,12 @@ const FINISHED_RUN_TTL_MS = 30 * 60 * 1000;
  */
 export const askNaoRuns = {
 	start(chatId: string): void {
+		if (runs.size >= MAX_TRACKED_RUNS) {
+			const oldestChatId = runs.keys().next().value;
+			if (oldestChatId !== undefined) {
+				runs.delete(oldestChatId);
+			}
+		}
 		runs.set(chatId, { status: 'running', startedAt: Date.now() });
 	},
 	complete(chatId: string, result: AskNaoResult): void {
@@ -54,7 +68,11 @@ setInterval(
 	() => {
 		const now = Date.now();
 		for (const [chatId, state] of runs) {
-			if (state.status !== 'running' && now - state.finishedAt > FINISHED_RUN_TTL_MS) {
+			const isStale =
+				state.status === 'running'
+					? now - state.startedAt > MAX_RUN_AGE_MS
+					: now - state.finishedAt > FINISHED_RUN_TTL_MS;
+			if (isStale) {
 				runs.delete(chatId);
 			}
 		}


### PR DESCRIPTION
## Summary

Replaces #1576, which I can no longer reopen after force-pushing over it (see maintainer comment there). Same fix, clean single commit off current `main`, no rebasing/amending planned on this branch going forward.

`askNaoRuns`'s cleanup sweep only expired runs already in `complete`/`error` state (it checks `finishedAt`, which only those states have). A run stuck in `running` forever — a hung `agent.stream()`, or an error thrown outside `runAskNaoInBackground`'s `try/catch` — was invisible to the sweep and stayed in the map for the life of the process.

We saw this in production (confirmed on #1576's thread): `container.memory.working_set` for the `nao` backend climbed for hours, then dropped sharply right when the pod got `OOMKilled` and restarted — repeating on both replicas. That's consistent with an in-memory map that only clears via process restart, not steady-state usage.

This PR:
- Expires `running` entries older than `MAX_RUN_AGE_MS` (15 min, well above the 45s sync budget), in addition to the existing finished-run TTL.
- Shortens the finished-run TTL from 30 to 5 minutes — safe because `resolveAnswerPayload` already falls back to `reconstructAnswerFromDb` when an entry is missing.
- Caps the map at `MAX_TRACKED_RUNS` (5,000) as a backstop against a future regression in the sweep.

Fixes #1575

This PR was written using Claude Sonnet 5 (claude-sonnet-5).

## Test plan
- `npm run lint:backend` (tsc + eslint) passes clean on this change.
- No test coverage existed for `ask-nao-runs.ts` before this change; happy to add unit tests for the sweep logic itself if wanted.
- Manually traced the sweep against all three `AskNaoRunState` variants (`running`, `complete`, `error`) to confirm the new branch is correct.
- No behavior change for the happy path; only affects runs that were previously stuck forever or long-lived past 30 minutes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

