### PR TITLE
Fix cte excluded 1394

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/query_history.py
+++ b/cli/nao_core/commands/sync/providers/databases/query_history.py
@@ -40,6 +40,7 @@ def extract_table_references(sql: str, dialect: str | None = None) -> list[str]:
 
 
 def _statement_cte_names(statement: exp.Expr) -> set[str]:
+    """Return a set of CTE names (in lowercase) defined in the statement."""
     return {cte.alias_or_name.lower() for cte in statement.find_all(exp.CTE) if cte.alias_or_name}
 
 

--- a/cli/nao_core/commands/sync/providers/databases/query_history.py
+++ b/cli/nao_core/commands/sync/providers/databases/query_history.py
@@ -30,12 +30,17 @@ def extract_table_references(sql: str, dialect: str | None = None) -> list[str]:
     for statement in parsed:
         if statement is None:
             continue
+        cte_names = _statement_cte_names(statement)
         for table_node in statement.find_all(exp.Table):
             name = _table_node_to_name(table_node)
-            if name:
+            if name and name.lower() not in cte_names:
                 tables.add(name.lower())
 
     return sorted(tables) if tables else _extract_table_references_fallback(sql)
+
+
+def _statement_cte_names(statement: exp.Expr) -> set[str]:
+    return {cte.alias_or_name.lower() for cte in statement.find_all(exp.CTE) if cte.alias_or_name}
 
 
 def _table_node_to_name(table_node: exp.Table) -> str | None:
@@ -57,16 +62,26 @@ _TABLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_CTE_RE = re.compile(
+    r"""(?:\bWITH\b|,)\s*"""
+    r"""(?:RECURSIVE\s+)?"""
+    r"""`?(\w+)`?\s+AS\s*\(""",
+    re.IGNORECASE,
+)
+
 
 def _extract_table_references_fallback(sql: str) -> list[str]:
     """Regex fallback when sqlglot parsing yields nothing useful."""
     tables: set[str] = set()
+    cte_names = {match.group(1).lower() for match in _CTE_RE.finditer(sql)}
     for match in _TABLE_RE.finditer(sql):
         schema_part, table_part = match.group(1), match.group(2)
         if table_part.upper() in _SQL_KEYWORDS:
             continue
         name = f"{schema_part}.{table_part}" if schema_part else table_part
-        tables.add(name.lower())
+        normalized_name = name.lower()
+        if normalized_name not in cte_names:
+            tables.add(normalized_name)
     return sorted(tables)
 
 
@@ -124,6 +139,7 @@ def extract_join_pairs(sql: str, dialect: str | None = None) -> list[tuple[str, 
     for statement in parsed:
         if statement is None:
             continue
+        cte_names = _statement_cte_names(statement)
         for join_node in statement.find_all(exp.Join):
             right_table = join_node.find(exp.Table)
             if right_table is None:
@@ -145,7 +161,12 @@ def extract_join_pairs(sql: str, dialect: str | None = None) -> list[tuple[str, 
             if not left_name:
                 continue
 
-            pairs.append((left_name.lower(), right_name.lower()))
+            normalized_left = left_name.lower()
+            normalized_right = right_name.lower()
+            if normalized_left in cte_names or normalized_right in cte_names:
+                continue
+
+            pairs.append((normalized_left, normalized_right))
 
     return pairs
 

--- a/cli/nao_core/commands/sync/providers/databases/query_history.py
+++ b/cli/nao_core/commands/sync/providers/databases/query_history.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 
 import sqlglot
 from sqlglot import exp
+from sqlglot.optimizer.scope import Scope, traverse_scope
 
 
 @dataclass
@@ -30,18 +31,22 @@ def extract_table_references(sql: str, dialect: str | None = None) -> list[str]:
     for statement in parsed:
         if statement is None:
             continue
-        cte_names = _statement_cte_names(statement)
+        cte_references = _cte_reference_ids(statement)
         for table_node in statement.find_all(exp.Table):
             name = _table_node_to_name(table_node)
-            if name and name.lower() not in cte_names:
+            if name and id(table_node) not in cte_references:
                 tables.add(name.lower())
 
     return sorted(tables) if tables else _extract_table_references_fallback(sql)
 
 
-def _statement_cte_names(statement: exp.Expr) -> set[str]:
-    """Return a set of CTE names (in lowercase) defined in the statement."""
-    return {cte.alias_or_name.lower() for cte in statement.find_all(exp.CTE) if cte.alias_or_name}
+def _cte_reference_ids(statement: exp.Expr) -> set[int]:
+    references: set[int] = set()
+    for scope in traverse_scope(statement):
+        for table_node in scope.tables:
+            if isinstance(scope.sources.get(table_node.alias_or_name), Scope):
+                references.add(id(table_node))
+    return references
 
 
 def _table_node_to_name(table_node: exp.Table) -> str | None:
@@ -66,7 +71,7 @@ _TABLE_RE = re.compile(
 _CTE_RE = re.compile(
     r"""(?:\bWITH\b|,)\s*"""
     r"""(?:RECURSIVE\s+)?"""
-    r"""`?(\w+)`?\s+AS\s*\(""",
+    r"""`?(\w+)`?(?:\s*\([^)]*\)\s*|\s+)AS\s*\(""",
     re.IGNORECASE,
 )
 
@@ -140,7 +145,7 @@ def extract_join_pairs(sql: str, dialect: str | None = None) -> list[tuple[str, 
     for statement in parsed:
         if statement is None:
             continue
-        cte_names = _statement_cte_names(statement)
+        cte_references = _cte_reference_ids(statement)
         for join_node in statement.find_all(exp.Join):
             right_table = join_node.find(exp.Table)
             if right_table is None:
@@ -164,7 +169,7 @@ def extract_join_pairs(sql: str, dialect: str | None = None) -> list[tuple[str, 
 
             normalized_left = left_name.lower()
             normalized_right = right_name.lower()
-            if normalized_left in cte_names or normalized_right in cte_names:
+            if id(left_table) in cte_references or id(right_table) in cte_references:
                 continue
 
             pairs.append((normalized_left, normalized_right))

--- a/cli/nao_core/commands/sync/providers/databases/query_history.py
+++ b/cli/nao_core/commands/sync/providers/databases/query_history.py
@@ -41,6 +41,7 @@ def extract_table_references(sql: str, dialect: str | None = None) -> list[str]:
 
 
 def _cte_reference_ids(statement: exp.Expr) -> set[int]:
+    """Return a set of ids for tables defined within a CTE (Common Table Expression) scope."""
     references: set[int] = set()
     for scope in traverse_scope(statement):
         for table_node in scope.tables:

--- a/cli/nao_core/commands/sync/providers/databases/query_history.py
+++ b/cli/nao_core/commands/sync/providers/databases/query_history.py
@@ -41,11 +41,11 @@ def extract_table_references(sql: str, dialect: str | None = None) -> list[str]:
 
 
 def _cte_reference_ids(statement: exp.Expr) -> set[int]:
-    """Return a set of ids for tables defined within a CTE (Common Table Expression) scope."""
+    """Return the ids of table nodes that reference CTEs."""
     references: set[int] = set()
     for scope in traverse_scope(statement):
-        for table_node in scope.tables:
-            if isinstance(scope.sources.get(table_node.alias_or_name), Scope):
+        for source_name, table_node in scope.references:
+            if isinstance(table_node, exp.Table) and isinstance(scope.sources.get(source_name), Scope):
                 references.add(id(table_node))
     return references
 

--- a/cli/tests/nao_core/commands/sync/test_query_history.py
+++ b/cli/tests/nao_core/commands/sync/test_query_history.py
@@ -1,5 +1,7 @@
 """Unit tests for query history extraction and analysis."""
 
+from unittest.mock import patch
+
 from nao_core.commands.sync.providers.databases.query_history import (
     TableUsageStats,
     compute_table_usage,
@@ -52,6 +54,38 @@ class TestExtractTableReferences:
         assert any("some_table" in r for r in refs)
         assert any("another_table" in r for r in refs)
 
+    def test_cte_names_are_excluded(self):
+        sql = """
+        WITH active_users AS (
+            SELECT * FROM analytics.users WHERE active = true
+        )
+        SELECT *
+        FROM active_users
+        JOIN analytics.orders ON active_users.id = orders.user_id
+        """
+        refs = extract_table_references(sql)
+
+        assert "active_users" not in refs
+        assert "analytics.users" in refs
+        assert "analytics.orders" in refs
+
+    def test_cte_names_are_excluded_by_regex_fallback(self):
+        sql = """
+        WITH active_users AS (
+            SELECT * FROM analytics.users
+        )
+        SELECT *
+        FROM active_users
+        JOIN analytics.orders ON active_users.id = orders.user_id
+        """
+        parse_path = "nao_core.commands.sync.providers.databases.query_history.sqlglot.parse"
+        with patch(parse_path, side_effect=ValueError):
+            refs = extract_table_references(sql)
+
+        assert "active_users" not in refs
+        assert "analytics.users" in refs
+        assert "analytics.orders" in refs
+
 
 class TestExtractJoinPairs:
     def test_simple_join(self):
@@ -75,6 +109,19 @@ class TestExtractJoinPairs:
 		"""
         pairs = extract_join_pairs(sql)
         assert len(pairs) >= 2
+
+    def test_cte_join_is_excluded(self):
+        sql = """
+        WITH active_users AS (
+            SELECT * FROM users WHERE active = true
+        )
+        SELECT *
+        FROM orders
+        JOIN active_users ON orders.user_id = active_users.id
+        """
+        pairs = extract_join_pairs(sql)
+
+        assert pairs == []
 
 
 class TestComputeTableUsage:

--- a/cli/tests/nao_core/commands/sync/test_query_history.py
+++ b/cli/tests/nao_core/commands/sync/test_query_history.py
@@ -69,6 +69,24 @@ class TestExtractTableReferences:
         assert "analytics.users" in refs
         assert "analytics.orders" in refs
 
+    def test_nested_cte_does_not_hide_outer_table_with_same_name(self):
+        sql = """
+        SELECT *
+        FROM users
+        JOIN orders ON users.id = orders.user_id
+        WHERE EXISTS (
+            WITH users AS (
+                SELECT * FROM staging.users
+            )
+            SELECT * FROM users
+        )
+        """
+        refs = extract_table_references(sql)
+
+        assert "users" in refs
+        assert "orders" in refs
+        assert "staging.users" in refs
+
     def test_cte_names_are_excluded_by_regex_fallback(self):
         sql = """
         WITH active_users AS (
@@ -85,6 +103,21 @@ class TestExtractTableReferences:
         assert "active_users" not in refs
         assert "analytics.users" in refs
         assert "analytics.orders" in refs
+
+    def test_cte_column_list_is_excluded_by_regex_fallback(self):
+        sql = """
+        WITH active_users (id, name) AS (
+            SELECT id, name FROM analytics.users
+        )
+        SELECT *
+        FROM active_users
+        """
+        parse_path = "nao_core.commands.sync.providers.databases.query_history.sqlglot.parse"
+        with patch(parse_path, side_effect=ValueError):
+            refs = extract_table_references(sql)
+
+        assert "active_users" not in refs
+        assert "analytics.users" in refs
 
 
 class TestExtractJoinPairs:
@@ -122,6 +155,22 @@ class TestExtractJoinPairs:
         pairs = extract_join_pairs(sql)
 
         assert pairs == []
+
+    def test_nested_cte_does_not_hide_outer_join_with_same_name(self):
+        sql = """
+        SELECT *
+        FROM users
+        JOIN orders ON users.id = orders.user_id
+        WHERE EXISTS (
+            WITH users AS (
+                SELECT * FROM staging.users
+            )
+            SELECT * FROM users
+        )
+        """
+        pairs = extract_join_pairs(sql)
+
+        assert ("users", "orders") in pairs
 
 
 class TestComputeTableUsage:


### PR DESCRIPTION
CTE names are now excluded from common joins. It will prevent the models from using invalid table names.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

