### PR TITLE
fix: personalize donut chart slice colors

### DIFF
--- a/apps/backend/src/components/generate-chart.tsx
+++ b/apps/backend/src/components/generate-chart.tsx
@@ -60,15 +60,22 @@ export function renderChartToSvg(input: RenderChartInput): string {
 	const xAxisKey = resolveDataKey(data, config.x_axis_key ?? undefined);
 	const series = config.series.map((s) => ({ ...s, data_key: resolveDataKey(data, s.data_key) }));
 
+	const isPie = chartType === 'pie' || chartType === 'donut';
+
 	const colorFor = (key: string, index: number) => {
+		if (isPie) {
+			return (
+				(Array.isArray(series[0]?.category_colors)
+					? series[0].category_colors.find((c) => c.category === key)?.color
+					: undefined) || defaultColorFor(key, index)
+			);
+		}
 		const matched = series.find((s) => s.data_key === key);
 		return matched?.color || defaultColorFor(key, index);
 	};
 
 	const labelFormatter = (value: string) => labelize(value, dateFormat);
 	const maxLabelWidth = estimateMaxLabelWidth(data, xAxisKey, dateFormat);
-
-	const isPie = chartType === 'pie' || chartType === 'donut';
 
 	const chartData = isPie ? bucketPieData(data, xAxisKey, series[0]?.data_key ?? '') : data;
 

--- a/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart-edit-dialog.tsx
@@ -1,4 +1,4 @@
-import { computeKpiComparison, DEFAULT_COLORS } from '@nao/shared';
+import { bucketPieData, computeKpiComparison, DEFAULT_COLORS } from '@nao/shared';
 import { displayChart } from '@nao/shared/tools';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChartArea, ChartBar, ChartColumn, ChartColumnIncreasing, ChartLine, Plus, Trash2, X } from 'lucide-react';
@@ -157,6 +157,16 @@ export function ChartConfigEditDialog({
 	const isCombo = displayChart.chartTypeSupportsComboSeries(draft.chart_type);
 	const hasRightAxis = isCombo && displayChart.hasRightAxisSeries(draft.series);
 	const hasLeftAxis = !isCombo || draft.series.some((s) => s.y_axis !== 'right');
+
+	const isPie = displayChart.isPieChart(draft.chart_type);
+	const pieCategories = useMemo(() => {
+		const xAxisKey = draft.x_axis_key;
+		if (!isPie || !data || data.length === 0 || !xAxisKey) {
+			return [];
+		}
+		const bucketed = bucketPieData(data, xAxisKey, draft.series[0]?.data_key || '');
+		return [...new Set(bucketed.map((row) => String(row[xAxisKey])))];
+	}, [isPie, data, draft.x_axis_key, draft.series]);
 
 	useEffect(() => {
 		if (open) {
@@ -483,16 +493,18 @@ export function ChartConfigEditDialog({
 											open={isOpen}
 											onClick={() => toggleValueFormat(index)}
 										/>
-										<input
-											type='color'
-											aria-label='Series color'
-											value={normalizeHexColor(
-												series.color,
-												paletteHexes[index % paletteHexes.length],
-											)}
-											onChange={(e) => updateSeriesAt(index, { color: e.target.value })}
-											className='h-8 w-8 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 [&::-moz-color-swatch]:rounded-lg [&::-moz-color-swatch]:border-none [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-lg [&::-webkit-color-swatch]:border-none'
-										/>
+										{!isPie && (
+											<input
+												type='color'
+												aria-label='Series color'
+												value={normalizeHexColor(
+													series.color,
+													paletteHexes[index % paletteHexes.length],
+												)}
+												onChange={(e) => updateSeriesAt(index, { color: e.target.value })}
+												className='h-8 w-8 shrink-0 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 [&::-moz-color-swatch]:rounded-lg [&::-moz-color-swatch]:border-none [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-lg [&::-webkit-color-swatch]:border-none'
+											/>
+										)}
 										<Button
 											type='button'
 											size='icon-sm'
@@ -526,6 +538,59 @@ export function ChartConfigEditDialog({
 														})
 													}
 												/>
+											)}
+											{isPie && pieCategories.length > 0 && (
+												<div className='mt-1 flex flex-col gap-2 rounded-md border border-border p-3'>
+													<div className='text-xs font-medium text-muted-foreground'>
+														Slice Colors
+													</div>
+													{pieCategories.map((category, catIndex) => (
+														<div
+															key={category}
+															className='flex items-center justify-between gap-2'
+														>
+															<span className='truncate text-sm'>{category}</span>
+															<input
+																type='color'
+																aria-label={`Color for ${category}`}
+																value={normalizeHexColor(
+																	Array.isArray(series.category_colors)
+																		? series.category_colors.find(
+																				(c) => c.category === category,
+																			)?.color
+																		: undefined,
+																	paletteHexes[catIndex % paletteHexes.length],
+																)}
+																onChange={(e) => {
+																	const current = Array.isArray(
+																		series.category_colors,
+																	)
+																		? series.category_colors
+																		: [];
+																	const existingIndex = current.findIndex(
+																		(c) => c.category === category,
+																	);
+																	const newColors = [...current];
+																	if (existingIndex >= 0) {
+																		newColors[existingIndex] = {
+																			category,
+																			color: e.target.value,
+																		};
+																	} else {
+																		newColors.push({
+																			category,
+																			color: e.target.value,
+																		});
+																	}
+																	updateSeriesAt(index, {
+																		category_colors: newColors,
+																	});
+																}}
+																className='h-8 w-8 shrink-0 cursor-pointer overflow-hidden rounded-lg border-none bg-transparent p-0 [&::-moz-color-swatch]:rounded-lg [&::-moz-color-swatch]:border-none [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-lg [&::-webkit-color-swatch]:border-none'
+															/>
+														</div>
+													))}
+												</div>
 											)}
 										</div>
 									);

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -526,7 +526,10 @@ export const ChartDisplay = memo(function ChartDisplay({
 					const category = String(item[xAxisKey]);
 					acc[toKey(category)] = {
 						label: labelize(category, dateFormat),
-						color: Colors[index % Colors.length],
+						color:
+							(Array.isArray(series[0]?.category_colors)
+								? series[0].category_colors.find((c) => c.category === category)?.color
+								: undefined) || Colors[index % Colors.length],
 					};
 					return acc;
 				},
@@ -567,7 +570,10 @@ export const ChartDisplay = memo(function ChartDisplay({
 				return {
 					value: category,
 					dataKey: toKey(category),
-					color: Colors[index % Colors.length],
+					color:
+						(Array.isArray(series[0]?.category_colors)
+							? series[0].category_colors.find((c) => c.category === category)?.color
+							: undefined) || Colors[index % Colors.length],
 					isHidden: false,
 				};
 			});

--- a/apps/shared/src/tools/display-chart.ts
+++ b/apps/shared/src/tools/display-chart.ts
@@ -85,6 +85,15 @@ export const SeriesConfigSchema = z.object({
 	y_axis: YAxisSideEnum.describe(
 		'Which Y-axis this series is plotted against ("left" or "right"). Only used when chart_type is "mixed"; defaults to "left". A right axis is drawn whenever any series uses "right" — use it to compare metrics with very different scales/units.',
 	).optional(),
+	category_colors: z
+		.array(
+			z.object({
+				category: z.string().describe('The value of the category (e.g., Apple).'),
+				color: z.string().describe('The CSS color for this category slice.'),
+			}),
+		)
+		.describe('Optional list of category values to CSS colors, used to personalize donut/pie chart slices.')
+		.optional(),
 });
 
 export const ColorScaleRuleSchema = z.object({


### PR DESCRIPTION
Fixes #1561 

Added the ability for users and the agents to personalize individual slice colors for Pie and Donut charts.

Changes:
- added a "slice colors" section to the chart edit dialog.
- updated the chart schema with `category_colors` so the agent can use it.

### Manually change

https://github.com/user-attachments/assets/af9ae017-d355-47dd-8cd9-d41b5c6811d8


### Using agent

https://github.com/user-attachments/assets/add2106b-e40b-4b76-8c9b-6d3874d03827



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

