### PR TITLE
feat(backend): MCP_PUBLIC_URL for a public MCP host separate from the UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,14 @@ NAO_DEFAULT_PROJECT_PATH=/Users/blef/Work/naolabs/chat/example
 # the stored value wins and this is ignored.
 # MCP_ENDPOINT_ENABLED=true
 
+# Public base URL external MCP clients connect to, if it differs from
+# BETTER_AUTH_URL — e.g. the MCP endpoint is exposed on an internet-facing host
+# while the UI stays on a private/VPN-only host. Its /mcp URL is accepted as an
+# OAuth token audience, and the protected-resource metadata + WWW-Authenticate
+# header advertise whichever host the client used. Leave unset for single-host
+# deployments.
+# MCP_PUBLIC_URL=https://nao-mcp.example.com
+
 # Enterprise license — signed token issued by getnao.
 # Accepts either the raw token or a path to a file containing it.
 # When unset, the app runs in OSS mode and all EE features (SSO, …) stay off.

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -258,10 +258,12 @@ app.register(mcpServerRoutes, {
 	prefix: '/mcp',
 });
 
-app.get('/.well-known/oauth-protected-resource', async (_request, reply) => {
+app.get('/.well-known/oauth-protected-resource', async (request, reply) => {
 	const { buildProtectedResourceMetadata } = await import('./auth');
-	const { MCP_SERVER_URL } = await import('./env');
-	const metadata = await buildProtectedResourceMetadata({ resource: MCP_SERVER_URL });
+	const { resolveMcpFacingOrigin } = await import('./env');
+	const metadata = await buildProtectedResourceMetadata({
+		resource: `${resolveMcpFacingOrigin(request.host)}/mcp`,
+	});
 	reply
 		.status(200)
 		.header('Content-Type', 'application/json')

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -15,7 +15,7 @@ import type { JWTPayload } from 'jose';
 
 import { db } from './db/db';
 import dbConfig, { Dialect } from './db/dbConfig';
-import { env, isCloud, MCP_SERVER_URL } from './env';
+import { env, isCloud, MCP_VALID_AUDIENCES } from './env';
 import * as orgQueries from './queries/organization.queries';
 import * as projectQueries from './queries/project.queries';
 import * as userQueries from './queries/user.queries';
@@ -223,7 +223,7 @@ async function createAuthInstance(baseURL: string) {
 				refreshTokenExpiresIn: 604800,
 				allowDynamicClientRegistration: true,
 				allowUnauthenticatedClientRegistration: true,
-				validAudiences: [env.BETTER_AUTH_URL, MCP_SERVER_URL],
+				validAudiences: MCP_VALID_AUDIENCES,
 			}),
 			...ssoPlugins,
 		],

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -71,7 +71,7 @@ export function updateAuth() {
 	openIdConfigMetadataPromise = null;
 }
 
-export async function verifyOAuthAccessToken(token: string, audience: string | string[]): Promise<JWTPayload> {
+export async function verifyOAuthAccessToken(token: string, audience: string[]): Promise<JWTPayload> {
 	const { issuer, jwksUrl } = await getAuthServerEndpoints();
 	return verifyAccessToken(token, {
 		verifyOptions: { audience, issuer },

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -71,7 +71,7 @@ export function updateAuth() {
 	openIdConfigMetadataPromise = null;
 }
 
-export async function verifyOAuthAccessToken(token: string, audience: string): Promise<JWTPayload> {
+export async function verifyOAuthAccessToken(token: string, audience: string | string[]): Promise<JWTPayload> {
 	const { issuer, jwksUrl } = await getAuthServerEndpoints();
 	return verifyAccessToken(token, {
 		verifyOptions: { audience, issuer },

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -306,7 +306,10 @@ export const MCP_VALID_AUDIENCES = [
 	MCP_SERVER_URL,
 	...(MCP_PUBLIC_SERVER_URL ? [MCP_PUBLIC_SERVER_URL] : []),
 ];
+/** Audiences a bearer token may carry to call /mcp — the MCP resource URLs, on either host. */
+export const MCP_TOKEN_AUDIENCES = [MCP_SERVER_URL, ...(MCP_PUBLIC_SERVER_URL ? [MCP_PUBLIC_SERVER_URL] : [])];
 
+// URL normalizes host to lowercase; compare request hosts case-insensitively to match.
 const mcpPublicHost = normalizedMcpPublicUrl ? new URL(normalizedMcpPublicUrl).host : undefined;
 
 /**
@@ -315,7 +318,7 @@ const mcpPublicHost = normalizedMcpPublicUrl ? new URL(normalizedMcpPublicUrl).h
  * on it, else BETTER_AUTH_URL — never an arbitrary Host header, so only known origins are advertised.
  */
 export function resolveMcpFacingOrigin(requestHost: string | undefined): string {
-	if (normalizedMcpPublicUrl && requestHost && requestHost === mcpPublicHost) {
+	if (normalizedMcpPublicUrl && requestHost && requestHost.toLowerCase() === mcpPublicHost) {
 		return normalizedMcpPublicUrl;
 	}
 	return normalizedBaseUrl;

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -177,6 +177,19 @@ const envSchema = z.object({
 		.optional()
 		.transform((val) => (val === undefined ? undefined : val === 'true')),
 
+	/**
+	 * Public base URL external MCP clients connect to, when it differs from BETTER_AUTH_URL — e.g.
+	 * a deployment that serves the MCP endpoint on an internet-facing host while the UI stays on a
+	 * private/VPN-only host. Its `/mcp` URL is added to the OAuth token audiences, and the
+	 * protected-resource metadata + WWW-Authenticate header advertise whichever host the client
+	 * used. Leave unset for single-host deployments.
+	 */
+	MCP_PUBLIC_URL: z
+		.string()
+		.optional()
+		.transform((val) => val?.trim() || undefined)
+		.pipe(z.url({ message: 'MCP_PUBLIC_URL must be a valid URL' }).optional()),
+
 	POSTHOG_KEY: z.string().optional(),
 	POSTHOG_HOST: z.url({ message: 'POSTHOG_HOST must be a valid URL' }).optional(),
 	POSTHOG_DISABLED: z
@@ -283,6 +296,30 @@ export const isSelfHosted = env.NAO_MODE === 'self-hosted';
 
 const normalizedBaseUrl = env.BETTER_AUTH_URL.replace(/\/+$/, '');
 export const MCP_SERVER_URL = `${normalizedBaseUrl}/mcp`;
+
+const normalizedMcpPublicUrl = env.MCP_PUBLIC_URL?.replace(/\/+$/, '');
+/** The `/mcp` URL on the public host, when MCP_PUBLIC_URL is set. */
+export const MCP_PUBLIC_SERVER_URL = normalizedMcpPublicUrl ? `${normalizedMcpPublicUrl}/mcp` : undefined;
+/** OAuth resource identifiers the token endpoint accepts (RFC 8707 audiences). */
+export const MCP_VALID_AUDIENCES = [
+	env.BETTER_AUTH_URL,
+	MCP_SERVER_URL,
+	...(MCP_PUBLIC_SERVER_URL ? [MCP_PUBLIC_SERVER_URL] : []),
+];
+
+const mcpPublicHost = normalizedMcpPublicUrl ? new URL(normalizedMcpPublicUrl).host : undefined;
+
+/**
+ * The origin a client is talking to, so the protected-resource metadata and WWW-Authenticate
+ * header advertise the host actually in use. Returns the public MCP origin when the request came in
+ * on it, else BETTER_AUTH_URL — never an arbitrary Host header, so only known origins are advertised.
+ */
+export function resolveMcpFacingOrigin(requestHost: string | undefined): string {
+	if (normalizedMcpPublicUrl && requestHost && requestHost === mcpPublicHost) {
+		return normalizedMcpPublicUrl;
+	}
+	return normalizedBaseUrl;
+}
 
 export function noProjectMessage(): string {
 	return isCloud

--- a/apps/backend/src/mcp/auth.ts
+++ b/apps/backend/src/mcp/auth.ts
@@ -5,7 +5,7 @@ import { and, eq, gt } from 'drizzle-orm';
 import { getSession, verifyOAuthAccessToken } from '../auth';
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
-import { MCP_SERVER_URL } from '../env';
+import { MCP_TOKEN_AUDIENCES } from '../env';
 import { logger, serializeError } from '../utils/logger';
 import { convertHeaders } from '../utils/utils';
 
@@ -41,11 +41,11 @@ async function verifyBearerToken(authorization: string | null): Promise<string |
 
 async function verifyAsJwt(token: string): Promise<string | null> {
 	try {
-		const payload = await verifyOAuthAccessToken(token, MCP_SERVER_URL);
+		const payload = await verifyOAuthAccessToken(token, MCP_TOKEN_AUDIENCES);
 		return typeof payload.sub === 'string' ? payload.sub : null;
 	} catch (error) {
 		const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-		logger.warn(`MCP JWT verification failed (audience=${MCP_SERVER_URL}): ${message}`, {
+		logger.warn(`MCP JWT verification failed (audience=${MCP_TOKEN_AUDIENCES.join(',')}): ${message}`, {
 			source: 'http',
 			context: { error: serializeError(error) },
 		});

--- a/apps/backend/src/mcp/routes.ts
+++ b/apps/backend/src/mcp/routes.ts
@@ -3,7 +3,7 @@ import type { UserRole } from '@nao/shared/types';
 import type { FastifyReply, FastifyRequest } from 'fastify';
 
 import type { App } from '../app';
-import { env } from '../env';
+import { resolveMcpFacingOrigin } from '../env';
 import { getMcpEndpointSettings } from '../queries/mcp-endpoint.queries';
 import { getUserRoleInProject } from '../queries/project.queries';
 import { resolveUserId } from './auth';
@@ -39,7 +39,7 @@ export const mcpServerRoutes = async (app: App) => {
 async function requireAuthenticatedMcpUser(request: FastifyRequest, reply: FastifyReply): Promise<void> {
 	const userId = await resolveUserId(request);
 	if (!userId) {
-		replyUnauthorized(reply);
+		replyUnauthorized(request, reply);
 		return;
 	}
 	const projectId = await resolveProjectId(userId);
@@ -95,8 +95,8 @@ function replyMethodNotAllowed(reply: FastifyReply) {
 		});
 }
 
-function replyUnauthorized(reply: FastifyReply) {
-	const origin = env.BETTER_AUTH_URL.replace(/\/+$/, '');
+function replyUnauthorized(request: FastifyRequest, reply: FastifyReply) {
+	const origin = resolveMcpFacingOrigin(request.host);
 	const wwwAuth = `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`;
 	return reply
 		.status(401)

--- a/apps/backend/tests/mcp-public-url.test.ts
+++ b/apps/backend/tests/mcp-public-url.test.ts
@@ -23,21 +23,31 @@ describe('MCP_PUBLIC_URL', () => {
 		const env = await import('../src/env');
 		expect(env.MCP_PUBLIC_SERVER_URL).toBeUndefined();
 		expect(env.MCP_VALID_AUDIENCES).toEqual(['https://nao.internal.example', 'https://nao.internal.example/mcp']);
+		expect(env.MCP_TOKEN_AUDIENCES).toEqual(['https://nao.internal.example/mcp']);
 		expect(env.resolveMcpFacingOrigin('nao-mcp.public.example')).toBe('https://nao.internal.example');
 	});
 
-	it('adds the public /mcp URL to the audiences when set', async () => {
+	it('adds the public /mcp URL to the token and endpoint audiences when set', async () => {
 		process.env.MCP_PUBLIC_URL = 'https://nao-mcp.public.example';
 		const env = await import('../src/env');
 		expect(env.MCP_PUBLIC_SERVER_URL).toBe('https://nao-mcp.public.example/mcp');
 		expect(env.MCP_VALID_AUDIENCES).toContain('https://nao-mcp.public.example/mcp');
 		expect(env.MCP_VALID_AUDIENCES).toContain('https://nao.internal.example/mcp');
+		// Bearer verification must accept a token minted for either host's /mcp resource,
+		// but not the bare UI origin.
+		expect(env.MCP_TOKEN_AUDIENCES).toEqual([
+			'https://nao.internal.example/mcp',
+			'https://nao-mcp.public.example/mcp',
+		]);
+		expect(env.MCP_TOKEN_AUDIENCES).not.toContain('https://nao.internal.example');
 	});
 
 	it('advertises the public origin only for requests on the public host', async () => {
 		process.env.MCP_PUBLIC_URL = 'https://nao-mcp.public.example/';
 		const env = await import('../src/env');
 		expect(env.resolveMcpFacingOrigin('nao-mcp.public.example')).toBe('https://nao-mcp.public.example');
+		// Host is case-insensitive — an upper/mixed-case host still resolves to the public origin.
+		expect(env.resolveMcpFacingOrigin('NAO-MCP.Public.Example')).toBe('https://nao-mcp.public.example');
 		expect(env.resolveMcpFacingOrigin('nao.internal.example')).toBe('https://nao.internal.example');
 		expect(env.resolveMcpFacingOrigin(undefined)).toBe('https://nao.internal.example');
 		// An arbitrary Host header is never echoed back — only known origins are advertised.

--- a/apps/backend/tests/mcp-public-url.test.ts
+++ b/apps/backend/tests/mcp-public-url.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// MCP_VALID_AUDIENCES / MCP_PUBLIC_SERVER_URL / resolveMcpFacingOrigin are derived from env at
+// module load (like MCP_SERVER_URL), so each case resets the module registry and re-imports env
+// against the current process.env.
+describe('MCP_PUBLIC_URL', () => {
+	let originalEnv: typeof process.env;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		process.env.BETTER_AUTH_URL = 'https://nao.internal.example';
+		delete process.env.MCP_PUBLIC_URL;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it('leaves audiences and origin single-host when unset', async () => {
+		const env = await import('../src/env');
+		expect(env.MCP_PUBLIC_SERVER_URL).toBeUndefined();
+		expect(env.MCP_VALID_AUDIENCES).toEqual(['https://nao.internal.example', 'https://nao.internal.example/mcp']);
+		expect(env.resolveMcpFacingOrigin('nao-mcp.public.example')).toBe('https://nao.internal.example');
+	});
+
+	it('adds the public /mcp URL to the audiences when set', async () => {
+		process.env.MCP_PUBLIC_URL = 'https://nao-mcp.public.example';
+		const env = await import('../src/env');
+		expect(env.MCP_PUBLIC_SERVER_URL).toBe('https://nao-mcp.public.example/mcp');
+		expect(env.MCP_VALID_AUDIENCES).toContain('https://nao-mcp.public.example/mcp');
+		expect(env.MCP_VALID_AUDIENCES).toContain('https://nao.internal.example/mcp');
+	});
+
+	it('advertises the public origin only for requests on the public host', async () => {
+		process.env.MCP_PUBLIC_URL = 'https://nao-mcp.public.example/';
+		const env = await import('../src/env');
+		expect(env.resolveMcpFacingOrigin('nao-mcp.public.example')).toBe('https://nao-mcp.public.example');
+		expect(env.resolveMcpFacingOrigin('nao.internal.example')).toBe('https://nao.internal.example');
+		expect(env.resolveMcpFacingOrigin(undefined)).toBe('https://nao.internal.example');
+		// An arbitrary Host header is never echoed back — only known origins are advertised.
+		expect(env.resolveMcpFacingOrigin('evil.attacker.example')).toBe('https://nao.internal.example');
+	});
+
+	it('rejects a non-URL MCP_PUBLIC_URL at parse time', async () => {
+		process.env.MCP_PUBLIC_URL = 'not-a-url';
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+			throw new Error(`process.exit(${code})`);
+		}) as never);
+		await expect(import('../src/env')).rejects.toThrow(/process\.exit/);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+});


### PR DESCRIPTION
Closes #1583.

Adds an optional `MCP_PUBLIC_URL` env for deployments that serve the MCP endpoint on an internet-facing host while keeping the UI on a private/VPN-only host. Without it, an external client connecting to the public host sends that host as the RFC 8707 `resource`, which isn't in `validAudiences` (hardcoded from `BETTER_AUTH_URL`), and the token exchange 400s with `requested resource invalid`.

When `MCP_PUBLIC_URL` is set:
- its `/mcp` URL is appended to the token audiences (`MCP_VALID_AUDIENCES`), so a token request scoped to the public host is accepted;
- the protected-resource metadata `resource` and the `WWW-Authenticate` `resource_metadata` reflect whichever host the request came in on (`resolveMcpFacingOrigin`), so each host advertises itself. Only the known UI/public origins are ever advertised — an arbitrary `Host` header falls back to `BETTER_AUTH_URL`, so this can't be used to make nao advertise an attacker-chosen resource.

Unset (single-host deployments) is unchanged: audiences stay `[BETTER_AUTH_URL, BETTER_AUTH_URL/mcp]` and every host advertises the UI origin, exactly as before.

Tested:
- new `tests/mcp-public-url.test.ts` (4 tests): unset stays single-host; set adds the public `/mcp` audience; the advertised origin is public only for requests on the public host and falls back for the UI host, `undefined`, and an arbitrary/attacker Host; a non-URL value is rejected at parse time.
- backend `tsc --noEmit && eslint` and prettier clean; full backend suite failure set identical to `main` on this machine (pre-existing native-lib gaps only, nothing new).
- verified against our live deployment: an external client (dust.tt, from its real egress IP) completes the OAuth login and reaches the token endpoint; the only remaining error is exactly this `requested resource invalid`, which setting `MCP_PUBLIC_URL` to the public host resolves.

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

