### PR TITLE
feat: manage MCP OAuth clients from Settings > MCP Endpoint

### DIFF
--- a/apps/backend/src/trpc/mcp-oauth-clients.routes.ts
+++ b/apps/backend/src/trpc/mcp-oauth-clients.routes.ts
@@ -5,7 +5,24 @@ import { z } from 'zod/v4';
 import { getAuth } from '../auth';
 import s from '../db/abstractSchema';
 import { db } from '../db/db';
+import { isCloud } from '../env';
 import { adminProtectedProcedure, router } from './trpc';
+
+/**
+ * OAuth clients live in a single, deployment-wide table (better-auth has no per-workspace scoping),
+ * so managing them is restricted to self-hosted deployments — where "the deployment" is the
+ * workspace. In multi-tenant cloud a project admin must not enumerate or delete clients other
+ * projects rely on.
+ */
+const selfHostedAdminProcedure = adminProtectedProcedure.use(async ({ next }) => {
+	if (isCloud) {
+		throw new TRPCError({
+			code: 'FORBIDDEN',
+			message: 'MCP OAuth client management is only available on self-hosted deployments.',
+		});
+	}
+	return next();
+});
 
 /**
  * Admin management of the OAuth clients that external MCP consumers (Claude, Cursor, dust.tt, …)
@@ -14,7 +31,7 @@ import { adminProtectedProcedure, router } from './trpc';
  * returned once and never stored or listed afterwards.
  */
 export const mcpOAuthClientsRoutes = router({
-	list: adminProtectedProcedure.query(async () => {
+	list: selfHostedAdminProcedure.query(async () => {
 		const rows = await db
 			.select({
 				clientId: s.oauthClient.clientId,
@@ -37,7 +54,7 @@ export const mcpOAuthClientsRoutes = router({
 		}));
 	}),
 
-	create: adminProtectedProcedure
+	create: selfHostedAdminProcedure
 		.input(
 			z.object({
 				name: z.string().min(1).max(200),
@@ -77,7 +94,7 @@ export const mcpOAuthClientsRoutes = router({
 			return { clientId: created.client_id, clientSecret: created.client_secret ?? null };
 		}),
 
-	delete: adminProtectedProcedure.input(z.object({ clientId: z.string().min(1) })).mutation(async ({ input }) => {
+	delete: selfHostedAdminProcedure.input(z.object({ clientId: z.string().min(1) })).mutation(async ({ input }) => {
 		await db.delete(s.oauthClient).where(eq(s.oauthClient.clientId, input.clientId)).execute();
 		return { clientId: input.clientId };
 	}),

--- a/apps/backend/src/trpc/mcp-oauth-clients.routes.ts
+++ b/apps/backend/src/trpc/mcp-oauth-clients.routes.ts
@@ -1,0 +1,84 @@
+import { TRPCError } from '@trpc/server';
+import { desc, eq } from 'drizzle-orm';
+import { z } from 'zod/v4';
+
+import { getAuth } from '../auth';
+import s from '../db/abstractSchema';
+import { db } from '../db/db';
+import { adminProtectedProcedure, router } from './trpc';
+
+/**
+ * Admin management of the OAuth clients that external MCP consumers (Claude, Cursor, dust.tt, …)
+ * use to connect to this workspace's MCP endpoint. Creation goes through better-auth's own
+ * create-client endpoint so secret hashing/storage matches the token flow; the plaintext secret is
+ * returned once and never stored or listed afterwards.
+ */
+export const mcpOAuthClientsRoutes = router({
+	list: adminProtectedProcedure.query(async () => {
+		const rows = await db
+			.select({
+				clientId: s.oauthClient.clientId,
+				name: s.oauthClient.name,
+				redirectUris: s.oauthClient.redirectUris,
+				isPublic: s.oauthClient.public,
+				createdAt: s.oauthClient.createdAt,
+			})
+			.from(s.oauthClient)
+			.where(eq(s.oauthClient.disabled, false))
+			.orderBy(desc(s.oauthClient.createdAt))
+			.execute();
+
+		return rows.map((row) => ({
+			clientId: row.clientId,
+			name: row.name ?? null,
+			redirectUris: row.redirectUris ?? [],
+			isPublic: row.isPublic ?? false,
+			createdAt: row.createdAt,
+		}));
+	}),
+
+	create: adminProtectedProcedure
+		.input(
+			z.object({
+				name: z.string().min(1).max(200),
+				redirectUris: z.array(z.url()).min(1),
+				// Confidential clients get a secret (client_secret_basic) for server-to-server clients
+				// like dust.tt Static OAuth; public clients use PKCE only (no secret).
+				confidential: z.boolean().default(true),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const token = ctx.session?.session?.token;
+			if (!token) {
+				throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No active session.' });
+			}
+
+			const auth = await getAuth();
+			const created = (await auth.api.createOAuthClient({
+				body: {
+					client_name: input.name,
+					redirect_uris: input.redirectUris,
+					token_endpoint_auth_method: input.confidential ? 'client_secret_basic' : 'none',
+					grant_types: ['authorization_code', 'refresh_token'],
+					response_types: ['code'],
+				},
+				headers: new Headers({ authorization: `Bearer ${token}` }),
+			})) as { client_id?: string; client_secret?: string };
+
+			if (!created.client_id) {
+				throw new TRPCError({
+					code: 'INTERNAL_SERVER_ERROR',
+					message: 'Client creation returned no client id.',
+				});
+			}
+
+			// client_secret is present only for confidential clients, and only here — it is never
+			// retrievable again.
+			return { clientId: created.client_id, clientSecret: created.client_secret ?? null };
+		}),
+
+	delete: adminProtectedProcedure.input(z.object({ clientId: z.string().min(1) })).mutation(async ({ input }) => {
+		await db.delete(s.oauthClient).where(eq(s.oauthClient.clientId, input.clientId)).execute();
+		return { clientId: input.clientId };
+	}),
+});

--- a/apps/backend/src/trpc/router.ts
+++ b/apps/backend/src/trpc/router.ts
@@ -22,6 +22,7 @@ import { logRoutes } from './log.routes';
 import { mapRoutes } from './map.routes';
 import { mcpRoutes } from './mcp.routes';
 import { mcpEndpointRoutes } from './mcp-endpoint.routes';
+import { mcpOAuthClientsRoutes } from './mcp-oauth-clients.routes';
 import { memoryRoutes } from './memory.routes';
 import { organizationRoutes } from './organization.routes';
 import { posthogRoutes } from './posthog.routes';
@@ -76,6 +77,7 @@ export const trpcRouter = router({
 	apiKey: apiKeyRoutes,
 	mcp: mcpRoutes,
 	mcpEndpoint: mcpEndpointRoutes,
+	mcpOAuthClients: mcpOAuthClientsRoutes,
 	system: systemRoutes,
 	skill: skillRoutes,
 	transcribe: transcribeRoutes,

--- a/apps/backend/tests/mcp-oauth-clients.routes.test.ts
+++ b/apps/backend/tests/mcp-oauth-clients.routes.test.ts
@@ -101,9 +101,13 @@ describe('mcpOAuthClients router', () => {
 		);
 	});
 
-	it('deletes a client by id', async () => {
-		await caller().mcpOAuthClients.delete({ clientId: 'c1' });
+	it('deletes a client by id and returns it', async () => {
+		const result = await caller().mcpOAuthClients.delete({ clientId: 'c1' });
+		expect(result).toEqual({ clientId: 'c1' });
+		// Called once with a where condition (drizzle eq(), an opaque SQL object — the returned id
+		// mirrors the requested client, confirming the handler targets it).
 		expect(testState.deleteWhere).toHaveBeenCalledTimes(1);
+		expect(testState.deleteWhere.mock.calls[0][0]).toBeDefined();
 	});
 
 	it('rejects non-admins', async () => {

--- a/apps/backend/tests/mcp-oauth-clients.routes.test.ts
+++ b/apps/backend/tests/mcp-oauth-clients.routes.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+	rows: [] as Array<Record<string, unknown>>,
+	createOAuthClient: vi.fn(),
+	deleteWhere: vi.fn(),
+	role: 'admin' as string | null,
+}));
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../src/db/db', () => {
+	const selectChain = {
+		from: () => selectChain,
+		where: () => selectChain,
+		orderBy: () => selectChain,
+		execute: async () => testState.rows,
+	};
+	return {
+		db: {
+			select: () => selectChain,
+			delete: () => ({
+				where: (arg: unknown) => {
+					testState.deleteWhere(arg);
+					return { execute: async () => undefined };
+				},
+			}),
+		},
+	};
+});
+
+vi.mock('../src/queries/project.queries', () => ({
+	getProjectByUserId: vi.fn(async () => ({ id: 'project-id' })),
+	getUserRoleInProject: vi.fn(async () => testState.role),
+}));
+
+vi.mock('../src/auth', () => ({
+	getAuth: vi.fn(async () => ({ api: { createOAuthClient: testState.createOAuthClient } })),
+	getSession: vi.fn(async () => null),
+}));
+
+import { mcpOAuthClientsRoutes } from '../src/trpc/mcp-oauth-clients.routes';
+import { router } from '../src/trpc/trpc';
+
+const testRouter = router({ mcpOAuthClients: mcpOAuthClientsRoutes });
+
+function caller() {
+	return testRouter.createCaller({
+		session: { user: { id: 'user-id' }, session: { token: 'sess-tok' } },
+		selectedProjectId: 'project-id',
+	} as never);
+}
+
+describe('mcpOAuthClients router', () => {
+	beforeEach(() => {
+		testState.rows = [];
+		testState.role = 'admin';
+		testState.createOAuthClient.mockReset();
+		testState.deleteWhere.mockReset();
+	});
+
+	afterEach(() => vi.clearAllMocks());
+
+	it('lists clients without exposing secrets', async () => {
+		testState.rows = [
+			{ clientId: 'c1', name: 'dust', redirectUris: ['https://x/cb'], isPublic: false, createdAt: new Date() },
+		];
+		const result = await caller().mcpOAuthClients.list();
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({ clientId: 'c1', name: 'dust', isPublic: false });
+		expect(JSON.stringify(result)).not.toContain('secret');
+	});
+
+	it('creates a confidential client and returns the secret once', async () => {
+		testState.createOAuthClient.mockResolvedValue({ client_id: 'new-id', client_secret: 's3cr3t' });
+		const result = await caller().mcpOAuthClients.create({
+			name: 'dust.tt',
+			redirectUris: ['https://eu.dust.tt/oauth/mcp_static/finalize'],
+			confidential: true,
+		});
+		expect(result).toEqual({ clientId: 'new-id', clientSecret: 's3cr3t' });
+		expect(testState.createOAuthClient).toHaveBeenCalledWith(
+			expect.objectContaining({
+				body: expect.objectContaining({ token_endpoint_auth_method: 'client_secret_basic' }),
+			}),
+		);
+	});
+
+	it('creates a public client with no secret', async () => {
+		testState.createOAuthClient.mockResolvedValue({ client_id: 'pub-id' });
+		const result = await caller().mcpOAuthClients.create({
+			name: 'cli',
+			redirectUris: ['https://x/cb'],
+			confidential: false,
+		});
+		expect(result).toEqual({ clientId: 'pub-id', clientSecret: null });
+		expect(testState.createOAuthClient).toHaveBeenCalledWith(
+			expect.objectContaining({ body: expect.objectContaining({ token_endpoint_auth_method: 'none' }) }),
+		);
+	});
+
+	it('deletes a client by id', async () => {
+		await caller().mcpOAuthClients.delete({ clientId: 'c1' });
+		expect(testState.deleteWhere).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects non-admins', async () => {
+		testState.role = 'user';
+		await expect(caller().mcpOAuthClients.list()).rejects.toThrow(/admin/i);
+	});
+});

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -551,6 +551,9 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		title: 'Connected apps',
 		description: 'Create and manage the OAuth clients external MCP tools use to connect (client id + secret).',
 		keywords: ['oauth', 'client', 'client id', 'client secret', 'connected apps', 'dust', 'static oauth', 'mcp'],
+		// Admin-only card, self-hosted only (OAuth clients are deployment-wide).
+		adminOrContextAdmin: true,
+		cloudHidden: true,
 	},
 	{
 		page: '/settings/project/integrations',

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -548,6 +548,15 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		pageLabel: 'Integrations & MCP',
 		search: { tab: 'nao-mcp' },
 		section: 'nao MCP',
+		title: 'Connected apps',
+		description: 'Create and manage the OAuth clients external MCP tools use to connect (client id + secret).',
+		keywords: ['oauth', 'client', 'client id', 'client secret', 'connected apps', 'dust', 'static oauth', 'mcp'],
+	},
+	{
+		page: '/settings/project/integrations',
+		pageLabel: 'Integrations & MCP',
+		search: { tab: 'nao-mcp' },
+		section: 'nao MCP',
 		title: 'Sub-agent mode',
 		description:
 			"Exposes ask_nao and get_nao_answer — delegates the full analytics task to nao's agent. The reasoning trace is saved as a chat in the nao UI.",

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -545,6 +545,10 @@ function OAuthClientsCard() {
 			<AddClientDialog
 				open={addOpen}
 				onOpenChange={(open) => {
+					// Don't let a close race an in-flight create — the one-time secret would be lost.
+					if (!open && createMutation.isPending) {
+						return;
+					}
 					setAddOpen(open);
 					if (!open) {
 						createMutation.reset();
@@ -559,8 +563,10 @@ function OAuthClientsCard() {
 
 			<ConfirmationDialog
 				open={deleteClientId !== null}
+				preventCloseWhilePending
 				onOpenChange={(open) => {
-					if (!open) {
+					// preventCloseWhilePending blocks closing mid-delete; still guard the reset.
+					if (!open && !deleteMutation.isPending) {
 						setDeleteClientId(null);
 						deleteMutation.reset();
 					}

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -10,7 +10,6 @@ import { SettingsCard } from '@/components/ui/settings-card';
 import { SettingsToggleRow } from '@/components/ui/settings-toggle-row';
 import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { useIsCloud } from '@/hooks/use-nao-mode';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
 
@@ -445,11 +444,16 @@ function CopyButton({ text }: { text: string }) {
 type CreatedClient = { clientId: string; clientSecret: string | null };
 
 function OAuthClientsCard() {
-	const isCloud = useIsCloud();
 	const queryClient = useQueryClient();
 	// OAuth clients are deployment-wide (no per-workspace scoping), so this is self-hosted only —
-	// the backend enforces the same restriction.
-	const clientsQuery = useQuery({ ...trpc.mcpOAuthClients.list.queryOptions(), enabled: !isCloud });
+	// the backend enforces the same restriction. Wait for the config to resolve before deciding, so
+	// on cloud we neither fire the list request nor flash the card (naoMode is unknown until then).
+	const configQuery = useQuery(trpc.system.getPublicConfig.queryOptions());
+	const isCloud = configQuery.data?.naoMode === 'cloud';
+	const clientsQuery = useQuery({
+		...trpc.mcpOAuthClients.list.queryOptions(),
+		enabled: configQuery.isSuccess && !isCloud,
+	});
 	const listKey = trpc.mcpOAuthClients.list.queryOptions().queryKey;
 
 	const [addOpen, setAddOpen] = useState(false);
@@ -479,7 +483,8 @@ function OAuthClientsCard() {
 
 	const clients = clientsQuery.data ?? [];
 
-	if (isCloud) {
+	// Render nothing until the mode is known, and never on cloud.
+	if (!configQuery.isSuccess || isCloud) {
 		return null;
 	}
 
@@ -539,7 +544,12 @@ function OAuthClientsCard() {
 
 			<AddClientDialog
 				open={addOpen}
-				onOpenChange={setAddOpen}
+				onOpenChange={(open) => {
+					setAddOpen(open);
+					if (!open) {
+						createMutation.reset();
+					}
+				}}
 				onCreate={(input) => createMutation.mutate(input)}
 				pending={createMutation.isPending}
 				error={createMutation.error?.message ?? null}
@@ -549,7 +559,12 @@ function OAuthClientsCard() {
 
 			<ConfirmationDialog
 				open={deleteClientId !== null}
-				onOpenChange={(open) => !open && setDeleteClientId(null)}
+				onOpenChange={(open) => {
+					if (!open) {
+						setDeleteClientId(null);
+						deleteMutation.reset();
+					}
+				}}
 				title='Delete OAuth client?'
 				description='Apps using this client will immediately lose access to the MCP endpoint. This cannot be undone.'
 				confirmLabel='Delete'

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, ChevronLeft, ChevronRight, Copy, Plus, Trash2 } from 'lucide-react';
-import { Fragment, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
@@ -10,6 +10,7 @@ import { SettingsCard } from '@/components/ui/settings-card';
 import { SettingsToggleRow } from '@/components/ui/settings-toggle-row';
 import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useIsCloud } from '@/hooks/use-nao-mode';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
 
@@ -444,8 +445,11 @@ function CopyButton({ text }: { text: string }) {
 type CreatedClient = { clientId: string; clientSecret: string | null };
 
 function OAuthClientsCard() {
+	const isCloud = useIsCloud();
 	const queryClient = useQueryClient();
-	const clientsQuery = useQuery(trpc.mcpOAuthClients.list.queryOptions());
+	// OAuth clients are deployment-wide (no per-workspace scoping), so this is self-hosted only —
+	// the backend enforces the same restriction.
+	const clientsQuery = useQuery({ ...trpc.mcpOAuthClients.list.queryOptions(), enabled: !isCloud });
 	const listKey = trpc.mcpOAuthClients.list.queryOptions().queryKey;
 
 	const [addOpen, setAddOpen] = useState(false);
@@ -475,6 +479,10 @@ function OAuthClientsCard() {
 
 	const clients = clientsQuery.data ?? [];
 
+	if (isCloud) {
+		return null;
+	}
+
 	return (
 		<SettingsCard
 			title='Connected apps'
@@ -487,7 +495,11 @@ function OAuthClientsCard() {
 				</Button>
 			</div>
 
-			{clients.length === 0 ? (
+			{clientsQuery.isLoading ? (
+				<p className='text-sm text-muted-foreground text-center py-4'>Loading…</p>
+			) : clientsQuery.isError ? (
+				<p className='text-sm text-destructive text-center py-4'>Failed to load OAuth clients.</p>
+			) : clients.length === 0 ? (
 				<p className='text-sm text-muted-foreground text-center py-4'>No OAuth clients yet.</p>
 			) : (
 				<Table>
@@ -530,6 +542,7 @@ function OAuthClientsCard() {
 				onOpenChange={setAddOpen}
 				onCreate={(input) => createMutation.mutate(input)}
 				pending={createMutation.isPending}
+				error={createMutation.error?.message ?? null}
 			/>
 
 			<CreatedClientDialog created={created} onOpenChange={(open) => !open && setCreated(null)} />
@@ -541,6 +554,7 @@ function OAuthClientsCard() {
 				description='Apps using this client will immediately lose access to the MCP endpoint. This cannot be undone.'
 				confirmLabel='Delete'
 				isPending={deleteMutation.isPending}
+				error={deleteMutation.error?.message}
 				onConfirm={() => {
 					if (deleteClientId) {
 						deleteMutation.mutate({ clientId: deleteClientId });
@@ -556,15 +570,27 @@ function AddClientDialog({
 	onOpenChange,
 	onCreate,
 	pending,
+	error,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onCreate: (input: { name: string; redirectUris: string[]; confidential: boolean }) => void;
 	pending: boolean;
+	error: string | null;
 }) {
 	const [name, setName] = useState('');
 	const [redirectUri, setRedirectUri] = useState('');
 	const [confidential, setConfidential] = useState(true);
+
+	// Reset once the dialog is closed (the parent closes it only on success), so a fresh open never
+	// shows the previous client's values. Inputs are kept while it stays open — e.g. after an error.
+	useEffect(() => {
+		if (!open) {
+			setName('');
+			setRedirectUri('');
+			setConfidential(true);
+		}
+	}, [open]);
 
 	const canSubmit = name.trim().length > 0 && redirectUri.trim().length > 0 && !pending;
 
@@ -573,9 +599,6 @@ function AddClientDialog({
 			return;
 		}
 		onCreate({ name: name.trim(), redirectUris: [redirectUri.trim()], confidential });
-		setName('');
-		setRedirectUri('');
-		setConfidential(true);
 	};
 
 	return (
@@ -613,13 +636,21 @@ function AddClientDialog({
 					</div>
 					<div className='flex items-center justify-between'>
 						<div>
-							<p className='text-sm font-medium text-foreground'>Confidential client</p>
+							<label htmlFor='oauth-client-confidential' className='text-sm font-medium text-foreground'>
+								Confidential client
+							</label>
 							<p className='text-xs text-muted-foreground'>
 								Issues a client secret (server-to-server). Turn off for PKCE-only public clients.
 							</p>
 						</div>
-						<Switch checked={confidential} onCheckedChange={setConfidential} />
+						<Switch
+							id='oauth-client-confidential'
+							checked={confidential}
+							onCheckedChange={setConfidential}
+						/>
 					</div>
+
+					{error && <p className='text-sm text-destructive'>{error}</p>}
 				</div>
 
 				<div className='flex justify-end gap-2'>

--- a/apps/frontend/src/components/settings/mcp-endpoint.tsx
+++ b/apps/frontend/src/components/settings/mcp-endpoint.tsx
@@ -1,10 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronLeft, ChevronRight, Copy } from 'lucide-react';
+import { Check, ChevronLeft, ChevronRight, Copy, Plus, Trash2 } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { SettingsCard } from '@/components/ui/settings-card';
 import { SettingsToggleRow } from '@/components/ui/settings-toggle-row';
+import { Switch } from '@/components/ui/switch';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { trpc } from '@/main';
@@ -98,6 +102,8 @@ export function McpEndpointSettings({ isAdmin }: Props) {
 			</SettingsCard>
 
 			<ConnectionCard />
+
+			{isAdmin && <OAuthClientsCard />}
 
 			{isAdmin && (
 				<CallLogsCard
@@ -432,6 +438,252 @@ function CopyButton({ text }: { text: string }) {
 			{copied ? <Check className='size-3.5 mr-1.5' /> : <Copy className='size-3.5 mr-1.5' />}
 			{copied ? 'Copied' : 'Copy'}
 		</Button>
+	);
+}
+
+type CreatedClient = { clientId: string; clientSecret: string | null };
+
+function OAuthClientsCard() {
+	const queryClient = useQueryClient();
+	const clientsQuery = useQuery(trpc.mcpOAuthClients.list.queryOptions());
+	const listKey = trpc.mcpOAuthClients.list.queryOptions().queryKey;
+
+	const [addOpen, setAddOpen] = useState(false);
+	const [created, setCreated] = useState<CreatedClient | null>(null);
+	const [deleteClientId, setDeleteClientId] = useState<string | null>(null);
+
+	const invalidate = () => queryClient.invalidateQueries({ queryKey: listKey });
+
+	const createMutation = useMutation(
+		trpc.mcpOAuthClients.create.mutationOptions({
+			onSuccess: (result) => {
+				setAddOpen(false);
+				setCreated(result);
+				invalidate();
+			},
+		}),
+	);
+
+	const deleteMutation = useMutation(
+		trpc.mcpOAuthClients.delete.mutationOptions({
+			onSuccess: () => {
+				setDeleteClientId(null);
+				invalidate();
+			},
+		}),
+	);
+
+	const clients = clientsQuery.data ?? [];
+
+	return (
+		<SettingsCard
+			title='Connected apps'
+			description='OAuth clients external MCP tools use to connect to this workspace (Claude, Cursor, dust.tt, …).'
+		>
+			<div className='flex justify-end'>
+				<Button size='sm' variant='outline' onClick={() => setAddOpen(true)}>
+					<Plus className='size-3.5 mr-1.5' />
+					Add client
+				</Button>
+			</div>
+
+			{clients.length === 0 ? (
+				<p className='text-sm text-muted-foreground text-center py-4'>No OAuth clients yet.</p>
+			) : (
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>Name</TableHead>
+							<TableHead>Client ID</TableHead>
+							<TableHead>Type</TableHead>
+							<TableHead className='w-8' />
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{clients.map((client) => (
+							<TableRow key={client.clientId}>
+								<TableCell className='text-sm'>{client.name ?? '—'}</TableCell>
+								<TableCell>
+									<code className='text-xs'>{client.clientId}</code>
+								</TableCell>
+								<TableCell>
+									<Badge variant='outline'>{client.isPublic ? 'Public' : 'Confidential'}</Badge>
+								</TableCell>
+								<TableCell>
+									<Button
+										variant='ghost'
+										size='icon-sm'
+										aria-label='Delete client'
+										onClick={() => setDeleteClientId(client.clientId)}
+									>
+										<Trash2 className='size-3.5' />
+									</Button>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+
+			<AddClientDialog
+				open={addOpen}
+				onOpenChange={setAddOpen}
+				onCreate={(input) => createMutation.mutate(input)}
+				pending={createMutation.isPending}
+			/>
+
+			<CreatedClientDialog created={created} onOpenChange={(open) => !open && setCreated(null)} />
+
+			<ConfirmationDialog
+				open={deleteClientId !== null}
+				onOpenChange={(open) => !open && setDeleteClientId(null)}
+				title='Delete OAuth client?'
+				description='Apps using this client will immediately lose access to the MCP endpoint. This cannot be undone.'
+				confirmLabel='Delete'
+				isPending={deleteMutation.isPending}
+				onConfirm={() => {
+					if (deleteClientId) {
+						deleteMutation.mutate({ clientId: deleteClientId });
+					}
+				}}
+			/>
+		</SettingsCard>
+	);
+}
+
+function AddClientDialog({
+	open,
+	onOpenChange,
+	onCreate,
+	pending,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onCreate: (input: { name: string; redirectUris: string[]; confidential: boolean }) => void;
+	pending: boolean;
+}) {
+	const [name, setName] = useState('');
+	const [redirectUri, setRedirectUri] = useState('');
+	const [confidential, setConfidential] = useState(true);
+
+	const canSubmit = name.trim().length > 0 && redirectUri.trim().length > 0 && !pending;
+
+	const submit = () => {
+		if (!canSubmit) {
+			return;
+		}
+		onCreate({ name: name.trim(), redirectUris: [redirectUri.trim()], confidential });
+		setName('');
+		setRedirectUri('');
+		setConfidential(true);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className='sm:max-w-md'>
+				<DialogHeader>
+					<DialogTitle>Add OAuth client</DialogTitle>
+					<DialogDescription>
+						Register a client for an external MCP tool. The secret is shown once after creation.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className='grid gap-4'>
+					<div className='grid gap-2'>
+						<label htmlFor='oauth-client-name' className='text-sm font-medium text-foreground'>
+							Name
+						</label>
+						<Input
+							id='oauth-client-name'
+							placeholder='dust.tt'
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+						/>
+					</div>
+					<div className='grid gap-2'>
+						<label htmlFor='oauth-client-redirect' className='text-sm font-medium text-foreground'>
+							Redirect URI
+						</label>
+						<Input
+							id='oauth-client-redirect'
+							placeholder='https://eu.dust.tt/oauth/mcp_static/finalize'
+							value={redirectUri}
+							onChange={(e) => setRedirectUri(e.target.value)}
+						/>
+					</div>
+					<div className='flex items-center justify-between'>
+						<div>
+							<p className='text-sm font-medium text-foreground'>Confidential client</p>
+							<p className='text-xs text-muted-foreground'>
+								Issues a client secret (server-to-server). Turn off for PKCE-only public clients.
+							</p>
+						</div>
+						<Switch checked={confidential} onCheckedChange={setConfidential} />
+					</div>
+				</div>
+
+				<div className='flex justify-end gap-2'>
+					<Button variant='outline' onClick={() => onOpenChange(false)}>
+						Cancel
+					</Button>
+					<Button onClick={submit} disabled={!canSubmit}>
+						Create
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function CreatedClientDialog({
+	created,
+	onOpenChange,
+}: {
+	created: CreatedClient | null;
+	onOpenChange: (open: boolean) => void;
+}) {
+	return (
+		<Dialog open={created !== null} onOpenChange={onOpenChange}>
+			<DialogContent className='sm:max-w-md'>
+				<DialogHeader>
+					<DialogTitle>Client created</DialogTitle>
+					<DialogDescription>
+						{created?.clientSecret
+							? 'Copy the secret now — it is not shown again.'
+							: 'Public client — no secret is issued (PKCE only).'}
+					</DialogDescription>
+				</DialogHeader>
+
+				{created && (
+					<div className='grid gap-3'>
+						<div className='grid gap-1'>
+							<span className='text-xs font-medium text-muted-foreground'>Client ID</span>
+							<div className='flex items-center gap-2'>
+								<code className='text-xs bg-muted p-2 rounded flex-1 break-all'>
+									{created.clientId}
+								</code>
+								<CopyButton text={created.clientId} />
+							</div>
+						</div>
+						{created.clientSecret && (
+							<div className='grid gap-1'>
+								<span className='text-xs font-medium text-muted-foreground'>Client secret</span>
+								<div className='flex items-center gap-2'>
+									<code className='text-xs bg-muted p-2 rounded flex-1 break-all'>
+										{created.clientSecret}
+									</code>
+									<CopyButton text={created.clientSecret} />
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+
+				<div className='flex justify-end'>
+					<Button onClick={() => onOpenChange(false)}>Done</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
 	);
 }
 


### PR DESCRIPTION
Closes #1587.

Adds an admin "Connected apps" panel under Settings > MCP Endpoint to create and manage the OAuth clients external MCP tools use to connect. Previously a confidential client (client id + secret, needed for e.g. dust.tt Static OAuth) could only be produced by registering via DCR — which mints public clients when unauthenticated — and then editing the `oauth_client` row by hand.

- **Backend** `mcpOAuthClients` tRPC router (adminProtectedProcedure): `list` (safe fields only — never returns the secret), `create` (delegates to better-auth's `createOAuthClient` so secret hashing/storage matches the token flow; `confidential` → `client_secret_basic`, else PKCE-only public), `delete`.
- **Frontend** card in `mcp-endpoint.tsx` (admin only): clients table, "Add client" dialog (name, redirect URI, confidential toggle), one-time secret reveal dialog, delete with confirmation.
- Settings search index entry.

Design note: create runs as the requesting admin (Bearer session token → `auth.api.createOAuthClient`), so the client is owned by them and better-auth handles secret generation/hashing — no secret ever touches nao's own code or the list endpoint.

Tested:
- new `tests/mcp-oauth-clients.routes.test.ts` (5): list hides secrets, confidential create returns the secret and maps to `client_secret_basic`, public create returns null secret and maps to `none`, delete calls through, non-admins are rejected.
- `tsc --noEmit && eslint` clean across backend + frontend + shared; prettier clean; full backend suite shows no regressions vs `main`.
- Note on verification level: the backend router and the frontend card are typecheck/lint-verified and the router is unit-tested, but I could not run a live click-through of the UI in my environment — a maintainer sanity-check of the panel UX would be welcome. The create flow mirrors the exact confidential-client shape we've already validated end-to-end against a live nao (dust.tt connecting with client_secret_basic).

This PR was written using Claude Fable 5 (claude-fable-5).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

