### PR TITLE
Fix/bitbucket ssh access bug 1571

### DIFF
--- a/apps/frontend/src/components/settings/context-git-panel.tsx
+++ b/apps/frontend/src/components/settings/context-git-panel.tsx
@@ -295,6 +295,11 @@ export function ContextGitPanel({
 	const discardDisabledReason = hasUnsavedFileChanges
 		? 'Save or discard the open file before discarding saved changes.'
 		: null;
+	const handleOpenReviewRequest = () => {
+		if (reviewRequestUrl) {
+			window.open(reviewRequestUrl, '_blank', 'noopener,noreferrer');
+		}
+	};
 
 	return (
 		<div className='max-h-[65%] shrink-0 overflow-auto border-t'>
@@ -452,21 +457,14 @@ export function ContextGitPanel({
 									<div className='flex shrink-0 items-center gap-1'>
 										{reviewRequestUrl && (
 											<Button
-												asChild
 												variant='ghost-muted'
 												size='sm'
 												className='h-6 gap-1 px-1.5 text-[11px]'
+												aria-label={reviewRequestTitle}
+												onClick={handleOpenReviewRequest}
 											>
-												<a
-													href={reviewRequestUrl}
-													target='_blank'
-													rel='noreferrer'
-													aria-label={reviewRequestTitle}
-													title={reviewRequestTitle}
-												>
-													<GitPullRequest className='size-3' />
-													{reviewRequestLabel}
-												</a>
+												<GitPullRequest className='size-3' />
+												{reviewRequestLabel}
 											</Button>
 										)}
 										<Button

--- a/apps/frontend/src/components/settings/context-git-panel.tsx
+++ b/apps/frontend/src/components/settings/context-git-panel.tsx
@@ -487,6 +487,12 @@ export function ContextGitPanel({
 										review.
 									</p>
 								)}
+								{reviewRequest?.kind === 'link' && reviewRequest.apiRefused && (
+									<p className='text-xs text-amber-700 dark:text-amber-400'>
+										Branch pushed. The git provider could not create the {reviewRequestName}{' '}
+										automatically — click Open {reviewRequestAbbreviation} to finish.
+									</p>
+								)}
 								{pushBranch.error && <ErrorMessage message={pushBranch.error.message} />}
 							</div>
 						</>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -40,9 +40,11 @@ if [ "$NAO_CONTEXT_SOURCE" = "git" ]; then
             
             SSH_DIR="/tmp/.nao-ssh"
             mkdir -p "$SSH_DIR"
+            chmod 700 "$SSH_DIR"
             
             SSH_KEY_FILE="$SSH_DIR/id_deploy"
             printf '%s\n' "$NAO_CONTEXT_GIT_SSH_KEY" > "$SSH_KEY_FILE"
+            chmod 600 "$SSH_KEY_FILE"
             
             # Pre-pin host keys for GitHub (https://api.github.com/meta) and Bitbucket (https://bitbucket.org/site/ssh)
             KNOWN_HOSTS_FILE="$SSH_DIR/known_hosts"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -40,11 +40,9 @@ if [ "$NAO_CONTEXT_SOURCE" = "git" ]; then
             
             SSH_DIR="/tmp/.nao-ssh"
             mkdir -p "$SSH_DIR"
-            chmod 700 "$SSH_DIR"
             
             SSH_KEY_FILE="$SSH_DIR/id_deploy"
             printf '%s\n' "$NAO_CONTEXT_GIT_SSH_KEY" > "$SSH_KEY_FILE"
-            chmod 600 "$SSH_KEY_FILE"
             
             # Pre-pin host keys for GitHub (https://api.github.com/meta) and Bitbucket (https://bitbucket.org/site/ssh)
             KNOWN_HOSTS_FILE="$SSH_DIR/known_hosts"
@@ -56,7 +54,12 @@ bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0Mu
 bitbucket.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPIQmuzMBuKdWeF4+a2sjSSpBK0iqitSQ+5BM9KhpexuGt20JpTVM7u5BDZngncgrqDMbWdxMWWOGtZ9UgbqgZE=
 bitbucket.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQeJzhupRu0u0cdegZIa8e86EG2qOCsIsD1Xw0xSeiPDlCr7kq97NLmMbpKTX6Esc30NuoqEEHCuc7yWtwp8dI76EEEB1VqY9QJq6vk+aySyboD5QF61I/1WeTwu+deCbgKMGbUijeXhtfbxSxm6JwGrXrhBdofTsbKRUsrN1WoNgUa8uqN1Vx6WAJw1JHPhglEGGHea6QICwJOAr/6mrui/oB7pkaWKHj3z7d1IC4KWLtY47elvjbaTlkN04Kc/5LFEirorGYVbt15kAUlqGM65pk6ZBxtaO3+30LVlORZkxOh+LKL/BvbZ/iRNhItLqNyieoQj/uh/7Iv4uyH/cV/0b4WDSd3DptigWq84lJubb9t/DnZlrJazxyDCulTmKdOR7vs9gMTo+uoIrPSb8ScTtvw65+odKAlBj59dhnVp9zd7QUojOpXlL62Aw56U4oO+FALuevvMjiWeavKhJqlR7i5n9srYcrNV7ttmDw7kf/97P5zauIhxcjX+xHv4M=
 EOF
-            chmod 644 "$KNOWN_HOSTS_FILE"
+            chown root:nao "$SSH_DIR"
+            chown nao:nao "$SSH_KEY_FILE"
+            chown root:nao "$KNOWN_HOSTS_FILE"
+            chmod 750 "$SSH_DIR"
+            chmod 600 "$SSH_KEY_FILE"
+            chmod 640 "$KNOWN_HOSTS_FILE"
             
             export GIT_SSH_COMMAND="ssh -i $SSH_KEY_FILE -o IdentitiesOnly=yes -o UserKnownHostsFile=$KNOWN_HOSTS_FILE -o StrictHostKeyChecking=yes"
             echo "Using SSH deploy key authentication"


### PR DESCRIPTION
## Summary
- Let nao securely access Docker SSH credentials, fixing File Explorer and recommendation PRs for SSH repositories.
- Keep host verification files managed by root.
- Remove the browser URL overlay from the Open PR button (*Because it was super ugly*)

Closes #1571

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

