### PR TITLE
Match Slack users across equivalent email domains

### DIFF
--- a/apps/backend/src/queries/account.queries.ts
+++ b/apps/backend/src/queries/account.queries.ts
@@ -37,6 +37,33 @@ export const hasAccountForProvider = async (userId: string, providerId: string):
 	return !!account;
 };
 
+export const getUserIdByProviderAccount = async (providerId: string, accountId: string): Promise<string | null> => {
+	const [account] = await db
+		.select({ userId: s.account.userId })
+		.from(s.account)
+		.where(and(eq(s.account.providerId, providerId), eq(s.account.accountId, accountId)))
+		.limit(1)
+		.execute();
+
+	return account?.userId ?? null;
+};
+
+export const linkProviderAccount = async (data: {
+	providerId: string;
+	accountId: string;
+	userId: string;
+}): Promise<void> => {
+	const linkedUserId = await getUserIdByProviderAccount(data.providerId, data.accountId);
+	if (linkedUserId) {
+		return;
+	}
+
+	await db
+		.insert(s.account)
+		.values({ id: crypto.randomUUID(), ...data })
+		.execute();
+};
+
 export const updateAccountPassword = async (
 	accountId: string,
 	hashedPassword: string,

--- a/apps/backend/src/queries/project-slack-config.queries.ts
+++ b/apps/backend/src/queries/project-slack-config.queries.ts
@@ -44,6 +44,7 @@ export const getProjectSlackConfig = async (projectId: string): Promise<SlackCon
 		modelSelection: toLlmSelectedModel(settings.slackllmProvider, settings.slackllmModelId),
 		autoCreateUsersEnabled: settings.autoCreateUsersEnabled ?? false,
 		autoCreateUsersDomains: settings.autoCreateUsersDomains ?? [],
+		emailDomainAliases: settings.emailDomainAliases ?? [],
 		transportMode,
 		appToken: settings.slackAppToken ?? '',
 		replyMode: toSlackReplyMode(settings.slackReplyMode),
@@ -84,6 +85,7 @@ export const upsertProjectSlackConfig = async (data: {
 						slackllmModelId: data.modelId ?? '',
 						autoCreateUsersEnabled: existing?.autoCreateUsersEnabled ?? false,
 						autoCreateUsersDomains: existing?.autoCreateUsersDomains ?? [],
+						emailDomainAliases: existing?.emailDomainAliases ?? [],
 						slackTransportMode: data.transportMode,
 						slackAppToken: data.appToken ?? '',
 						slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
@@ -129,6 +131,7 @@ export const updateProjectSlackModel = async (
 					slackllmModelId: modelId ?? '',
 					autoCreateUsersEnabled: existing?.autoCreateUsersEnabled ?? false,
 					autoCreateUsersDomains: existing?.autoCreateUsersDomains ?? [],
+					emailDomainAliases: existing?.emailDomainAliases ?? [],
 					slackTransportMode: existing?.slackTransportMode ?? 'webhook',
 					slackAppToken: existing?.slackAppToken ?? '',
 					slackReplyMode: toSlackReplyMode(existing?.slackReplyMode),
@@ -192,6 +195,30 @@ export const updateProjectSlackAutoCreateUsers = async (
 	});
 };
 
+export const updateProjectSlackEmailDomainAliases = async (projectId: string, domains: string[]): Promise<void> => {
+	await db.transaction(async (tx) => {
+		const project = await takeFirstOrThrow(
+			tx.select().from(s.project).where(eq(s.project.id, projectId)).execute(),
+			`Project not found: ${projectId}`,
+		);
+		const existing = project.slackSettings;
+		if (!existing) {
+			throw new Error(`Slack is not configured for project ${projectId}`);
+		}
+
+		await tx
+			.update(s.project)
+			.set({
+				slackSettings: {
+					...existing,
+					emailDomainAliases: domains,
+				},
+			})
+			.where(eq(s.project.id, projectId))
+			.execute();
+	});
+};
+
 export const deleteProjectSlackConfig = async (projectId: string): Promise<void> => {
 	await db.update(s.project).set({ slackSettings: null }).where(eq(s.project.id, projectId)).execute();
 };
@@ -204,6 +231,7 @@ export interface SlackConfig {
 	modelSelection?: LlmSelectedModel;
 	autoCreateUsersEnabled: boolean;
 	autoCreateUsersDomains: string[];
+	emailDomainAliases: string[];
 	transportMode: SlackTransportMode;
 	appToken: string;
 	replyMode: SlackReplyMode;
@@ -225,6 +253,7 @@ export const listSocketModeSlackConfigs = async (): Promise<SlackConfig[]> => {
 			modelSelection: toLlmSelectedModel(settings.slackllmProvider, settings.slackllmModelId),
 			autoCreateUsersEnabled: settings.autoCreateUsersEnabled ?? false,
 			autoCreateUsersDomains: settings.autoCreateUsersDomains ?? [],
+			emailDomainAliases: settings.emailDomainAliases ?? [],
 			transportMode: 'socket',
 			appToken: settings.slackAppToken,
 			replyMode: toSlackReplyMode(settings.slackReplyMode),

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -16,6 +16,7 @@ import { Card, Chat, deriveChannelId, Message, parseMarkdown, SlashCommandEvent,
 
 import { generateChartImage } from '../components/generate-chart';
 import type { User } from '../db/abstractSchema';
+import * as accountQueries from '../queries/account.queries';
 import * as chartImageQueries from '../queries/chart-image';
 import * as chatQueries from '../queries/chat.queries';
 import * as feedbackQueries from '../queries/feedback.queries';
@@ -56,13 +57,14 @@ import {
 	type TruncationNotice,
 } from '../utils/messaging-provider';
 import { shouldReplyToSlackThreadMessage } from '../utils/slack-reply-policy';
-import { isEmailDomainAllowed } from '../utils/utils';
+import { buildEmailDomainAliases, isEmailDomainAllowed } from '../utils/utils';
 import { agentService } from './agent';
 import { posthog, PostHogEvent } from './posthog';
 import { SlackSocketBridge } from './slack-socket-bridge';
 import { ensureMessagingProviderUser } from './team-member';
 
 const UPDATE_INTERVAL_MS = 200;
+const SLACK_ACCOUNT_PROVIDER_ID = 'slack';
 
 const SLACK_MENTION_REGEX = /(?:<@|@)([A-Z0-9]+)(?:\|[^>]+)?>?\s*/g;
 const SLACK_USER_MENTION_REGEX = /(^|[^\w<])@([a-zA-Z0-9._-]+)/g;
@@ -71,6 +73,7 @@ const RESERVED_SLACK_MENTIONS = new Set(['channel', 'everyone', 'here']);
 
 type SlackReplyMessage = NonNullable<Awaited<ReturnType<WebClient['conversations']['replies']>>['messages']>[number];
 type SlackUser = NonNullable<Awaited<ReturnType<WebClient['users']['list']>>['members']>[number];
+type SlackUserInfo = NonNullable<Awaited<ReturnType<WebClient['users']['info']>>['user']>;
 
 type SlackBotWebhooks = NonNullable<Chat['webhooks']>;
 type SlackPostMessageOptions = {
@@ -132,6 +135,7 @@ class ProjectSlackBot {
 	private _adapterSigningSecret: string;
 	private _autoCreateUsersEnabled: boolean;
 	private _autoCreateUsersDomains: string[];
+	private _emailDomainAliases: string[];
 	private _lastCompletionCard = new Map<string, SlackCompletionCard>();
 	private _slackMentionByHandle: Map<string, string> = new Map();
 	private _channelMembershipAttempts: Set<string> = new Set();
@@ -143,6 +147,7 @@ class ProjectSlackBot {
 		this._config = config;
 		this._autoCreateUsersEnabled = config.autoCreateUsersEnabled;
 		this._autoCreateUsersDomains = config.autoCreateUsersDomains;
+		this._emailDomainAliases = config.emailDomainAliases;
 		this._redirectUrl = config.redirectUrl;
 		this._modelSelection = config.modelSelection;
 		this._slackClient = new WebClient(config.botToken);
@@ -485,7 +490,7 @@ class ProjectSlackBot {
 			const slackUserId = event.user?.userId;
 			const slackUser = slackUserId ? await this._getSlackUser(slackUserId) : null;
 			const email = slackUser?.profile?.email?.toLowerCase() || null;
-			const user = email ? await getUser({ email }) : null;
+			const user = slackUserId && email ? await this._findUser(slackUserId, email) : null;
 
 			if (ownerId !== user?.id) {
 				throw new Error(`You are not authorized to provide feedback on this message.`);
@@ -827,24 +832,14 @@ class ProjectSlackBot {
 
 		const timezone = slackUser?.tz || undefined;
 
-		if (this._canAutoProvision(email)) {
-			const project = await projectQueries.getProjectById(this.projectId);
-			const projectName = project?.name ?? 'nao';
-			const displayName = slackUser?.real_name || slackUser?.name || email.split('@')[0];
-			const user = await ensureMessagingProviderUser({
-				email,
-				name: displayName,
-				projectId: this.projectId,
-				buildEmail: (user, temporaryPassword) =>
-					buildUserAddedEmail(user, projectName, 'project', temporaryPassword),
-			});
-			return { status: 'authorized', user, timezone };
-		}
-
-		const user = await getUser({ email });
+		const user = await this._resolveUser(slackUserId, slackUser, email);
 		if (!user) {
 			return { status: 'user-not-found', email };
 		}
+		if (this._canAutoProvision(email)) {
+			return { status: 'authorized', user, timezone };
+		}
+
 		const role = await projectQueries.getUserRoleInProject(this.projectId, user.id);
 		if (role !== 'admin' && role !== 'user' && role !== 'context_admin') {
 			return { status: 'no-permission' };
@@ -921,26 +916,7 @@ class ProjectSlackBot {
 
 		ctx.timezone = slackUser?.tz || undefined;
 
-		if (this._canAutoProvision(email)) {
-			const project = await projectQueries.getProjectById(this.projectId);
-			const projectName = project?.name ?? 'nao';
-			const displayName = slackUser?.real_name || slackUser?.name || email.split('@')[0];
-			ctx.user = await ensureMessagingProviderUser({
-				email,
-				name: displayName,
-				projectId: this.projectId,
-				buildEmail: (user, temporaryPassword) =>
-					buildUserAddedEmail(user, projectName, 'project', temporaryPassword),
-			});
-			return;
-		}
-
-		await this._resolveExistingUser(ctx, email);
-		await this._checkUserBelongsToProject(ctx);
-	}
-
-	private async _resolveExistingUser(ctx: ConversationContext, email: string): Promise<void> {
-		const user = await getUser({ email });
+		const user = await this._resolveUser(slackUserId, slackUser, email);
 		if (!user) {
 			await ctx.thread.post(
 				`❌ No user found. Create an account with \`${email}\` on ${this._redirectUrl} to sign up.`,
@@ -948,6 +924,68 @@ class ProjectSlackBot {
 			throw new Error('User not found');
 		}
 		ctx.user = user;
+
+		if (!this._canAutoProvision(email)) {
+			await this._checkUserBelongsToProject(ctx);
+		}
+	}
+
+	/**
+	 * Resolves the nao user behind a Slack sender, auto-provisioning them when their domain allows it,
+	 * and records the Slack identity as a better-auth account so later lookups no longer depend on email.
+	 */
+	private async _resolveUser(
+		slackUserId: string,
+		slackUser: SlackUserInfo | null,
+		email: string,
+	): Promise<User | null> {
+		const user = this._canAutoProvision(email)
+			? await this._provisionUser(slackUserId, slackUser, email)
+			: await this._findUser(slackUserId, email);
+
+		if (user) {
+			await accountQueries.linkProviderAccount({
+				providerId: SLACK_ACCOUNT_PROVIDER_ID,
+				accountId: slackUserId,
+				userId: user.id,
+			});
+		}
+		return user;
+	}
+
+	private async _provisionUser(slackUserId: string, slackUser: SlackUserInfo | null, email: string): Promise<User> {
+		const project = await projectQueries.getProjectById(this.projectId);
+		const projectName = project?.name ?? 'nao';
+		const displayName = slackUser?.real_name || slackUser?.name || email.split('@')[0];
+		return ensureMessagingProviderUser({
+			email,
+			name: displayName,
+			projectId: this.projectId,
+			buildEmail: (user, temporaryPassword) =>
+				buildUserAddedEmail(user, projectName, 'project', temporaryPassword),
+			findExistingUser: () => this._findUser(slackUserId, email),
+		});
+	}
+
+	/** Linked Slack account first, then exact email, then the same local part under an aliased domain. */
+	private async _findUser(slackUserId: string, email: string): Promise<User | null> {
+		const linkedUserId = await accountQueries.getUserIdByProviderAccount(SLACK_ACCOUNT_PROVIDER_ID, slackUserId);
+		if (linkedUserId) {
+			return getUser({ id: linkedUserId });
+		}
+
+		const user = await getUser({ email });
+		return user ?? this._findUserByAliasEmail(email);
+	}
+
+	private async _findUserByAliasEmail(email: string): Promise<User | null> {
+		for (const aliasEmail of buildEmailDomainAliases(email, this._emailDomainAliases)) {
+			const user = await getUser({ email: aliasEmail });
+			if (user) {
+				return user;
+			}
+		}
+		return null;
 	}
 
 	private async _checkUserBelongsToProject(ctx: ConversationContext): Promise<void> {
@@ -1639,6 +1677,7 @@ class SlackService {
 			previous.replyMode !== next.replyMode ||
 			previous.autoCreateUsersEnabled !== next.autoCreateUsersEnabled ||
 			previous.autoCreateUsersDomains.join('\0') !== next.autoCreateUsersDomains.join('\0') ||
+			previous.emailDomainAliases.join('\0') !== next.emailDomainAliases.join('\0') ||
 			previous.modelSelection?.provider !== next.modelSelection?.provider ||
 			previous.modelSelection?.modelId !== next.modelSelection?.modelId
 		);

--- a/apps/backend/src/services/team-member.ts
+++ b/apps/backend/src/services/team-member.ts
@@ -73,11 +73,13 @@ interface EnsureMessagingProviderUserOptions {
 	name: string;
 	projectId: string;
 	buildEmail: (user: { name: string; email: string }, temporaryPassword?: string) => CreatedEmail;
+	findExistingUser?: (email: string) => Promise<User | null>;
 }
 
 /**
  * Ensure a user exists and has access to the project they are messaging from.
  * Used by messaging providers (Slack, Teams, etc.) to onboard senders on the fly.
+ * - Looks up the existing user by email, or with the provider-specific `findExistingUser` when given.
  * - Creates the user with a temporary password if missing.
  * - Adds the user to the project if not already a member (no org membership granted).
  * - Sends a welcome email (with credentials for brand-new users).
@@ -87,9 +89,12 @@ export async function ensureMessagingProviderUser({
 	name,
 	projectId,
 	buildEmail,
+	findExistingUser,
 }: EnsureMessagingProviderUserOptions): Promise<User> {
 	const normalizedEmail = email.toLowerCase();
-	const existingUser = await userQueries.getUser({ email: normalizedEmail });
+	const existingUser = findExistingUser
+		? await findExistingUser(normalizedEmail)
+		: await userQueries.getUser({ email: normalizedEmail });
 	const { user, temporaryPassword } = existingUser
 		? { user: existingUser, temporaryPassword: undefined }
 		: await createUserWithPassword(normalizedEmail, name);

--- a/apps/backend/src/trpc/project.routes.ts
+++ b/apps/backend/src/trpc/project.routes.ts
@@ -313,6 +313,7 @@ export const projectRoutes = {
 					modelSelection: config.modelSelection,
 					autoCreateUsersEnabled: config.autoCreateUsersEnabled,
 					autoCreateUsersDomains: config.autoCreateUsersDomains,
+					emailDomainAliases: config.emailDomainAliases,
 					replyMode: config.replyMode,
 				}
 			: null;
@@ -422,6 +423,22 @@ export const projectRoutes = {
 			const refreshedConfig = await slackConfigQueries.getProjectSlackConfig(ctx.project.id);
 			await slackService.syncProjectSocketMode(refreshedConfig, ctx.project.id);
 			return { enabled: input.enabled, domains: cleanedDomains };
+		}),
+
+	updateSlackEmailDomainAliases: adminProtectedProcedure
+		.input(z.object({ domains: z.array(z.string().trim().toLowerCase()).default([]) }))
+		.mutation(async ({ ctx, input }) => {
+			const cleanedDomains = [...new Set(input.domains.filter((domain) => domain.length > 0))];
+			if (cleanedDomains.length === 1) {
+				throw new TRPCError({
+					code: 'BAD_REQUEST',
+					message: 'Add at least two domains to treat them as aliases of each other.',
+				});
+			}
+			await slackConfigQueries.updateProjectSlackEmailDomainAliases(ctx.project.id, cleanedDomains);
+			const refreshedConfig = await slackConfigQueries.getProjectSlackConfig(ctx.project.id);
+			await slackService.syncProjectSocketMode(refreshedConfig, ctx.project.id);
+			return { domains: cleanedDomains };
 		}),
 
 	deleteSlackConfig: adminProtectedProcedure.mutation(async ({ ctx }) => {

--- a/apps/backend/src/types/messaging-provider.ts
+++ b/apps/backend/src/types/messaging-provider.ts
@@ -50,6 +50,7 @@ export type SlackSettings = {
 	slackllmModelId: string;
 	autoCreateUsersEnabled?: boolean;
 	autoCreateUsersDomains?: string[];
+	emailDomainAliases?: string[];
 	slackTransportMode?: SlackTransportMode;
 	slackAppToken?: string;
 	slackReplyMode?: SlackReplyMode;

--- a/apps/backend/src/utils/utils.ts
+++ b/apps/backend/src/utils/utils.ts
@@ -112,6 +112,26 @@ export const isEmailDomainAllowed = (userEmail: string, authDomains?: string) =>
 };
 
 /**
+ * Builds the emails equivalent to `email` under the given domain aliases: same local part, every other alias domain.
+ * Returns nothing when the email's domain is not itself one of the aliases.
+ */
+export const buildEmailDomainAliases = (email: string, aliasDomains: string[]): string[] => {
+	const [localPart, domain] = email.toLowerCase().split('@');
+	if (!localPart || !domain) {
+		return [];
+	}
+
+	const normalizedDomains = aliasDomains.map((aliasDomain) => aliasDomain.trim().toLowerCase());
+	if (!normalizedDomains.includes(domain)) {
+		return [];
+	}
+
+	return normalizedDomains
+		.filter((aliasDomain) => aliasDomain && aliasDomain !== domain)
+		.map((aliasDomain) => `${localPart}@${aliasDomain}`);
+};
+
+/**
  * Resolve the auth provider ID from the better-auth callback context.
  * Social providers use `params.id`, the genericOAuth plugin (OIDC) uses `params.providerId`.
  */

--- a/apps/frontend/src/components/settings-search-index.ts
+++ b/apps/frontend/src/components/settings-search-index.ts
@@ -662,6 +662,16 @@ export const settingsSearchIndex: SettingsSearchEntry[] = [
 		page: '/settings/project/integrations/slack',
 		pageLabel: 'Integrations & MCP',
 		section: 'Slack',
+		title: 'Email domain aliases',
+		description:
+			'Match Slack senders to existing nao users who share the same name under an equivalent email domain.',
+		keywords: ['alias', 'domain', 'duplicate users', 'merge users', 'email mismatch', 'same user'],
+		adminOnly: true,
+	},
+	{
+		page: '/settings/project/integrations/slack',
+		pageLabel: 'Integrations & MCP',
+		section: 'Slack',
 		title: 'Reply only when mentioned',
 		description:
 			'Control whether nao answers every message in active Slack threads or only messages that tag the bot.',

--- a/apps/frontend/src/components/settings/slack-config-section.tsx
+++ b/apps/frontend/src/components/settings/slack-config-section.tsx
@@ -301,8 +301,89 @@ export function SlackConfigSection({ isAdmin, onCancelSetup }: SlackConfigSectio
 				enabled={projectConfig.autoCreateUsersEnabled ?? false}
 				domains={projectConfig.autoCreateUsersDomains ?? []}
 			/>
+
+			<EmailDomainAliasesCard domains={projectConfig.emailDomainAliases ?? []} />
 		</div>
 	);
+}
+
+interface EmailDomainAliasesCardProps {
+	domains: string[];
+}
+
+function EmailDomainAliasesCard({ domains: initialDomains }: EmailDomainAliasesCardProps) {
+	const queryClient = useQueryClient();
+	const [domainsText, setDomainsText] = useState(initialDomains.join(', '));
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setDomainsText(initialDomains.join(', '));
+	}, [initialDomains]);
+
+	const parsedDomains = useMemo(() => parseDomains(domainsText), [domainsText]);
+	const hasChanges = useMemo(
+		() => !areDomainListsEqual(parsedDomains, initialDomains),
+		[parsedDomains, initialDomains],
+	);
+
+	const updateMutation = useMutation(
+		trpc.project.updateSlackEmailDomainAliases.mutationOptions({
+			onSuccess: () => {
+				setError(null);
+				queryClient.invalidateQueries(trpc.project.getSlackConfig.queryOptions());
+			},
+			onError: (err) => {
+				setError(err.message);
+			},
+		}),
+	);
+
+	const handleSave = () => {
+		if (parsedDomains.length === 1) {
+			setError('Add at least two domains to treat them as aliases of each other.');
+			return;
+		}
+		updateMutation.mutate({ domains: parsedDomains });
+	};
+
+	return (
+		<SettingsCard
+			title='Email domain aliases'
+			description='Treat these domains as the same company so a Slack sender matches the nao user with the same name under another domain.'
+		>
+			<div className='grid gap-2'>
+				<label htmlFor='slack-email-domain-aliases' className='text-sm font-medium text-foreground'>
+					Equivalent email domains
+				</label>
+				<p className='text-xs text-muted-foreground'>
+					Comma-separated list (e.g. <code>example.com, example.fr</code>). A Slack user{' '}
+					<code>jane@example.fr</code> is matched to the existing nao user <code>jane@example.com</code>{' '}
+					instead of creating a second account.
+				</p>
+				<Textarea
+					id='slack-email-domain-aliases'
+					value={domainsText}
+					onChange={(e) => {
+						setDomainsText(e.target.value);
+						setError(null);
+					}}
+					placeholder='example.com, example.fr'
+					rows={2}
+					disabled={updateMutation.isPending}
+				/>
+			</div>
+			<FormError error={error ?? undefined} />
+			<div className='flex justify-end'>
+				<Button size='sm' onClick={handleSave} disabled={!hasChanges || updateMutation.isPending}>
+					{updateMutation.isPending ? 'Saving…' : 'Save'}
+				</Button>
+			</div>
+		</SettingsCard>
+	);
+}
+
+function areDomainListsEqual(left: string[], right: string[]): boolean {
+	return left.length === right.length && left.every((domain, index) => domain === right[index]);
 }
 
 interface AutoCreateUsersCardProps {


### PR DESCRIPTION
## Summary
- Slack senders are now resolved in order: linked Slack account, exact email, then the same local part under an admin-configured alias domain (e.g. `jane@example.fr` → `jane@example.com`)
- A successful match is stored as a better-auth `account` row (`providerId=slack`), so later messages do not depend on email
- Admins can set equivalent domains in Slack settings; no user table migration

## Test plan
- [ ] Configure Slack, then set email domain aliases to `example.com, example.fr`
- [ ] Message from Slack as `jane@example.fr` when `jane@example.com` already exists — no second user is created, chats belong to the `.com` user
- [ ] Repeat a message from the same Slack user after changing their Slack email — still resolves via the linked Slack account
- [ ] Auto-create still provisions a new user when no exact or alias match exists and the domain is allowed
- [ ] Saving a single alias domain is rejected; two or more domains save and reload the Slack bot

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

