### PR TITLE
fix(sync): strip .git/ from local_path repos to fix gitlink bug

### DIFF
--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -151,7 +151,14 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
         has_filters = bool(repo.include or repo.exclude)
 
         if not has_filters:
-            shutil.copytree(source_path, repo_path, dirs_exist_ok=True)
+            # Skip .git/ so a source that happens to be a git checkout doesn't turn
+            # repo_path into a nested repo (which git records as a gitlink, not files).
+            shutil.copytree(
+                source_path,
+                repo_path,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns(".git"),
+            )
         else:
             repo_path.mkdir(parents=True, exist_ok=True)
             for file_path in source_path.rglob("*"):
@@ -159,6 +166,8 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
                     continue
 
                 relative = PurePosixPath(file_path.relative_to(source_path)).as_posix()
+                if relative == ".git" or relative.startswith(".git/"):
+                    continue
                 if not _matches_patterns(relative, repo.include, repo.exclude):
                     continue
 

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -385,6 +385,42 @@ class TestSyncLocalRepo:
         assert (output / "local-repo" / "new.txt").exists()
         assert not (output / "local-repo" / "old.txt").exists()
 
+    def test_strips_git_dir_without_filters(self, tmp_path: Path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "file1.txt").write_text("hello")
+        git_dir = source / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main")
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        repo = RepoConfig(name="local-repo", local_path=str(source))
+        result = sync_local_repo(repo, output)
+
+        assert result is True
+        assert (output / "local-repo" / "file1.txt").read_text() == "hello"
+        assert not (output / "local-repo" / ".git").exists()
+
+    def test_strips_git_dir_with_filters(self, tmp_path: Path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "model.sql").write_text("SELECT 1")
+        git_dir = source / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main")
+
+        output = tmp_path / "output"
+        output.mkdir()
+
+        repo = RepoConfig(name="filtered", local_path=str(source), exclude=["*.pyc"])
+        result = sync_local_repo(repo, output)
+
+        assert result is True
+        assert (output / "filtered" / "model.sql").exists()
+        assert not (output / "filtered" / ".git").exists()
+
     def test_returns_false_for_missing_path(self, tmp_path: Path):
         output = tmp_path / "output"
         output.mkdir()


### PR DESCRIPTION
Fixes #1595

## Problem

`sync_local_repo()` had the same gitlink bug #716 reported and #720 fixed — just in the `local_path` branch instead of the `url`/clone branch. It copied `source_path` with `shutil.copytree(..., dirs_exist_ok=True)` and no filtering, so a `.git/` folder in the source got copied straight into `repos/<name>/.git`. Git then treats `repos/<name>/` as a nested repo (gitlink, mode `160000`) instead of tracked files, and anyone who clones the parent repo afterward gets an empty folder.

## Fix

Same idea as #720, applied to the copy path instead of the clone path:

- Unfiltered copy: pass `ignore=shutil.ignore_patterns(".git")` to `shutil.copytree` so `.git/` is never copied in the first place.
- Filtered copy (the manual `rglob` loop): skip any path under `.git/` before the include/exclude check.

Added two tests mirroring the existing `TestSyncLocalRepo` cases — one for the unfiltered branch, one for the filtered branch — both asserting `.git/` doesn't exist in the synced output while regular files do.

`pytest tests/nao_core/commands/sync/test_repository_provider.py` — 48 passed. `ruff check` / `ruff format --check` on both changed files pass (no new warnings; the 5 pre-existing `BLE001`/`SIM102` hits are untouched code).

This PR was written using Claude Sonnet 5 (claude-sonnet-5).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

