### PR TITLE
fix/sql query display fixed 1530

### DIFF
--- a/apps/backend/migrations-postgres/meta/_journal.json
+++ b/apps/backend/migrations-postgres/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1787660347486,
       "tag": "0064_add_mattermost",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1788363370802,
+      "tag": "0065_add_user_email_domains",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/migrations-postgres/meta/_journal.json
+++ b/apps/backend/migrations-postgres/meta/_journal.json
@@ -456,13 +456,6 @@
       "when": 1787660347486,
       "tag": "0064_add_mattermost",
       "breakpoints": true
-    },
-    {
-      "idx": 65,
-      "version": "7",
-      "when": 1788363370802,
-      "tag": "0065_add_user_email_domains",
-      "breakpoints": true
     }
   ]
 }

--- a/apps/frontend/src/components/tool-calls/sql-query-display.tsx
+++ b/apps/frontend/src/components/tool-calls/sql-query-display.tsx
@@ -1,16 +1,52 @@
-import { Streamdown } from 'streamdown';
-import { code } from '@streamdown/code';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
+import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import type { CSSProperties } from 'react';
+import { useIsDarkMode } from '@/contexts/theme.provider';
 
 interface SqlQueryDisplayProps {
 	query: string;
 }
 
+SyntaxHighlighter.registerLanguage('sql', sql);
+
 export function SqlQueryDisplay({ query }: SqlQueryDisplayProps) {
+	const isDarkMode = useIsDarkMode();
+
 	return (
-		<div className='overflow-auto max-h-80 hide-code-header py-2'>
-			<Streamdown mode='static' controls={{ code: false }} plugins={{ code }}>
-				{`\`\`\`sql\n${query}\n\`\`\``}
-			</Streamdown>
+		<div className='max-h-80 overflow-auto py-2 hide-code-header'>
+			<SyntaxHighlighter
+				language='sql'
+				style={isDarkMode ? oneDark : oneLight}
+				customStyle={highlighterStyle}
+				codeTagProps={{ style: codeStyle }}
+				showLineNumbers
+				lineNumberStyle={lineNumberStyle}
+			>
+				{query.trim()}
+			</SyntaxHighlighter>
 		</div>
 	);
 }
+
+const highlighterStyle: CSSProperties = {
+	background: 'transparent',
+	borderRadius: 0,
+	fontSize: '0.8125rem',
+	lineHeight: '1.25rem',
+	margin: 0,
+	padding: '0.625rem 0',
+};
+
+const codeStyle: CSSProperties = {
+	background: 'transparent',
+	fontFamily: 'inherit',
+};
+
+const lineNumberStyle: CSSProperties = {
+	color: 'var(--muted-foreground)',
+	minWidth: '3rem',
+	opacity: 0.45,
+	paddingRight: '1rem',
+	userSelect: 'none',
+};

--- a/apps/frontend/src/components/tool-calls/sql-query-display.tsx
+++ b/apps/frontend/src/components/tool-calls/sql-query-display.tsx
@@ -1,52 +1,16 @@
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql';
-import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import type { CSSProperties } from 'react';
-import { useIsDarkMode } from '@/contexts/theme.provider';
+import { Streamdown } from 'streamdown';
+import { code } from '@streamdown/code';
 
 interface SqlQueryDisplayProps {
 	query: string;
 }
 
-SyntaxHighlighter.registerLanguage('sql', sql);
-
 export function SqlQueryDisplay({ query }: SqlQueryDisplayProps) {
-	const isDarkMode = useIsDarkMode();
-
 	return (
-		<div className='max-h-80 overflow-auto py-2 hide-code-header'>
-			<SyntaxHighlighter
-				language='sql'
-				style={isDarkMode ? oneDark : oneLight}
-				customStyle={highlighterStyle}
-				codeTagProps={{ style: codeStyle }}
-				showLineNumbers
-				lineNumberStyle={lineNumberStyle}
-			>
-				{query.trim()}
-			</SyntaxHighlighter>
+		<div className='overflow-auto max-h-80 hide-code-header py-2'>
+			<Streamdown className='sql-query-display' mode='static' controls={{ code: false }} plugins={{ code }}>
+				{`\`\`\`sql\n${query.trim()}\n\`\`\``}
+			</Streamdown>
 		</div>
 	);
 }
-
-const highlighterStyle: CSSProperties = {
-	background: 'transparent',
-	borderRadius: 0,
-	fontSize: '0.8125rem',
-	lineHeight: '1.25rem',
-	margin: 0,
-	padding: '0.625rem 0',
-};
-
-const codeStyle: CSSProperties = {
-	background: 'transparent',
-	fontFamily: 'inherit',
-};
-
-const lineNumberStyle: CSSProperties = {
-	color: 'var(--muted-foreground)',
-	minWidth: '3rem',
-	opacity: 0.45,
-	paddingRight: '1rem',
-	userSelect: 'none',
-};

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -902,3 +902,10 @@ code.dollar:before {
 		stroke-dashoffset: 0;
 	}
 }
+
+.sql-query-display code {
+	background: transparent;
+	border-radius: 0;
+	font-family: inherit;
+	padding: 0;
+}


### PR DESCRIPTION
- The grey squares on top and bottom of sql query displays in stories do not appear anymore
- Changed the Streamdown component that was used to display sql to PrismLight syntax highlighter
<img width="253" height="314" alt="Capture d’écran 2026-09-04 à 10 00 27" src="https://github.com/user-attachments/assets/12f4c51c-1c7d-4eec-affb-8c38a6167d75" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

