### PR TITLE
Fix autofill search bar bug in new settings page

### DIFF
--- a/apps/frontend/src/components/settings/env-vars-section.tsx
+++ b/apps/frontend/src/components/settings/env-vars-section.tsx
@@ -104,6 +104,7 @@ export function EnvVarsSection({ isAdmin }: { isAdmin: boolean }) {
 								<Input
 									id={inputId}
 									type='password'
+									autoComplete='new-password'
 									value={value}
 									onChange={(e) => handleChange(key, e.target.value)}
 									placeholder='Enter value...'

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -161,6 +161,7 @@ export function SidebarSettingsNav({
 	const navigate = useNavigate();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [query, setQuery] = useState('');
+	const [isSearchFocused, setIsSearchFocused] = useState(false);
 
 	const navContext = {
 		isAdmin,
@@ -214,8 +215,13 @@ export function SidebarSettingsNav({
 						<input
 							ref={inputRef}
 							type='text'
+							name='settings-search'
+							autoComplete='off'
 							placeholder='Search settings...'
 							value={query}
+							readOnly={!isSearchFocused}
+							onFocus={() => setIsSearchFocused(true)}
+							onBlur={() => setIsSearchFocused(false)}
 							onChange={(e) => setQuery(e.target.value)}
 							onKeyDown={handleKeyDown}
 							className={cn(

--- a/apps/frontend/src/components/sidebar-settings-nav.tsx
+++ b/apps/frontend/src/components/sidebar-settings-nav.tsx
@@ -206,6 +206,15 @@ export function SidebarSettingsNav({
 		}
 	};
 
+	const handlePointerDown = (e: React.PointerEvent<HTMLInputElement>) => {
+		if (!e.currentTarget.readOnly) {
+			return;
+		}
+		e.preventDefault();
+		e.currentTarget.readOnly = false;
+		e.currentTarget.focus();
+	};
+
 	return (
 		<div className={cn('flex flex-1 min-h-0 flex-col gap-1 overflow-y-auto', hideIf(isCollapsed))}>
 			{!isViewer && (
@@ -220,6 +229,7 @@ export function SidebarSettingsNav({
 							placeholder='Search settings...'
 							value={query}
 							readOnly={!isSearchFocused}
+							onPointerDown={handlePointerDown}
 							onFocus={() => setIsSearchFocused(true)}
 							onBlur={() => setIsSearchFocused(false)}
 							onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
Just making sure that the search bar cannot be autofilled by a password manager..
And avoiding the env fields from being autofilled, by suggesting they're keys, not passwords

**Note:** I found just setting `AutoComplete=off` wasn't enough, Password manager would still try to fill the search bar, so I made it so that the search bar field can be written to only when focused, i.e. when user is clicked on it, and is typing.

Closes  #1603

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

