### PR TITLE
Fix/slack split bug 1536

### DIFF
--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -1432,6 +1432,7 @@ class ProjectSlackBot {
 				blockIndex: run.blockIndex,
 				blockCount: run.blockCount,
 				blocks: createTextBlocks(streamState.latestSourceText.slice(run.sourceStart, run.sourceEnd), {
+					balanceIncompleteCodeFence: activeStream.stopRequested,
 					truncation: { kind: 'link', url: chatUrl },
 					tableState,
 				}),
@@ -1447,6 +1448,7 @@ class ProjectSlackBot {
 				blockIndex: ctx.textBlockIndex === -1 ? emptyRunBlockIndex : ctx.textBlockIndex,
 				blockCount: ctx.textBlockIndex === -1 ? 0 : ctx.textBlockCount,
 				blocks: createTextBlocks(openRunText, {
+					balanceIncompleteCodeFence: activeStream.stopRequested,
 					truncation: { kind: 'link', url: chatUrl },
 					tableState,
 				}),

--- a/apps/backend/src/services/slack.ts
+++ b/apps/backend/src/services/slack.ts
@@ -1479,7 +1479,11 @@ class ProjectSlackBot {
 		streamState.latestSourceText = stripAssistantTags(text);
 		const visibleText = streamState.latestSourceText.slice(streamState.textRunStart);
 		const tableState = { ...streamState.tableStateAtRunStart };
-		const blocks = createTextBlocks(visibleText, { ...options, tableState });
+		const blocks = createTextBlocks(visibleText, {
+			...options,
+			balanceIncompleteCodeFence: true,
+			tableState,
+		});
 		streamState.tableStateAtRunEnd = tableState;
 		if (blocks.length === 0) {
 			if (visibleText.trim() && streamState.emptyRunBlockIndex === -1) {

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -137,6 +137,8 @@ export const createTextBlock = (text: string): CardChild => {
 };
 
 export const SLACK_SECTION_TEXT_MAX_CHARS = 2900;
+const SLACK_CODE_FENCE_PREFIX = '```\n';
+const SLACK_CODE_FENCE_SUFFIX = '\n```';
 
 export type TruncationNotice = { kind: 'hidden' } | { kind: 'note' } | { kind: 'link'; url: string };
 
@@ -153,6 +155,7 @@ export const createSlackTableRenderState = (): SlackTableRenderState => ({
 });
 
 type CreateTextBlocksOptions = {
+	balanceIncompleteCodeFence?: boolean;
 	truncation?: TruncationNotice;
 	tableState?: SlackTableRenderState;
 };
@@ -161,7 +164,8 @@ export const createTextBlocks = (text: string, options: CreateTextBlocksOptions 
 	const blocks: CardChild[] = [];
 	const tableState = options.tableState ?? createSlackTableRenderState();
 	const truncation = options.truncation ?? { kind: 'note' };
-	for (const segment of splitMarkdownSegments(text)) {
+	const renderedText = options.balanceIncompleteCodeFence ? balanceSlackStreamingCodeFence(text) : text;
+	for (const segment of splitMarkdownSegments(renderedText)) {
 		if (segment.type === 'table') {
 			tableState.tableNumber++;
 			if (tableState.hasNativeTable) {
@@ -354,17 +358,40 @@ export function chunkSlackText(text: string, maxChars: number): string[] {
 	if (maxChars < 1) {
 		throw new Error('Slack text chunk size must be positive.');
 	}
-	const chunks: string[] = [];
-	let remaining = text.trim();
-	while (remaining.length > maxChars) {
-		const breakAt = findSlackChunkBreak(remaining, maxChars);
-		chunks.push(remaining.slice(0, breakAt).trimEnd());
-		remaining = remaining.slice(breakAt).trimStart();
+	const source = text.trim();
+	if (!source) {
+		return [];
 	}
-	if (remaining) {
-		chunks.push(remaining);
+
+	const chunks: string[] = [];
+	let sourceOffset = 0;
+	while (sourceOffset < source.length) {
+		const remaining = source.slice(sourceOffset);
+		const startsInsideFence = isTripleBacktickFenceOpen(source.slice(0, sourceOffset));
+		const prefix = startsInsideFence ? SLACK_CODE_FENCE_PREFIX : '';
+		if (prefix.length + remaining.length <= maxChars) {
+			chunks.push(prefix + remaining);
+			break;
+		}
+
+		const { breakAt, endsInsideFence } = findSlackFenceAwareBreak(source, sourceOffset, maxChars - prefix.length);
+		const sourceChunk = remaining.slice(0, breakAt);
+		const suffix = endsInsideFence ? SLACK_CODE_FENCE_SUFFIX : '';
+		chunks.push(prefix + (endsInsideFence ? sourceChunk : sourceChunk.trimEnd()) + suffix);
+
+		sourceOffset += breakAt;
+		if (!endsInsideFence) {
+			sourceOffset = skipLeadingWhitespace(source, sourceOffset);
+		}
 	}
 	return chunks;
+}
+
+export function balanceSlackStreamingCodeFence(text: string): string {
+	if (!isTripleBacktickFenceOpen(text)) {
+		return text;
+	}
+	return text.endsWith('\n') ? `${text}\`\`\`` : `${text}\n\`\`\``;
 }
 
 export function isRecoverableSlackPayloadError(error: unknown): boolean {
@@ -578,6 +605,45 @@ function cleanTableCell(cell: string): string {
 		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
 		.replace(/<br\s*\/?>/gi, ' ')
 		.trim();
+}
+
+function findSlackFenceAwareBreak(
+	source: string,
+	sourceOffset: number,
+	availableChars: number,
+): { breakAt: number; endsInsideFence: boolean } {
+	const remaining = source.slice(sourceOffset);
+	let breakAt = findSlackChunkBreak(remaining, availableChars);
+	let endsInsideFence = isTripleBacktickFenceOpen(source.slice(0, sourceOffset + breakAt));
+	if (endsInsideFence && breakAt + SLACK_CODE_FENCE_SUFFIX.length > availableChars) {
+		if (availableChars <= SLACK_CODE_FENCE_SUFFIX.length) {
+			throw new Error('Slack text chunk size is too small for fenced code.');
+		}
+		breakAt = findSlackChunkBreak(remaining, availableChars - SLACK_CODE_FENCE_SUFFIX.length);
+		endsInsideFence = isTripleBacktickFenceOpen(source.slice(0, sourceOffset + breakAt));
+	}
+	return { breakAt, endsInsideFence };
+}
+
+function isTripleBacktickFenceOpen(text: string): boolean {
+	let openFenceChar: string | null = null;
+	for (const line of text.split('\n')) {
+		const marker = fenceMarker(line);
+		if (!marker) {
+			continue;
+		}
+		if (openFenceChar === null) {
+			openFenceChar = marker;
+		} else if (marker === openFenceChar) {
+			openFenceChar = null;
+		}
+	}
+	return openFenceChar === '`';
+}
+
+function skipLeadingWhitespace(text: string, offset: number): number {
+	const remaining = text.slice(offset);
+	return offset + remaining.length - remaining.trimStart().length;
 }
 
 function findSlackChunkBreak(text: string, maxChars: number): number {

--- a/apps/backend/src/utils/messaging-provider.ts
+++ b/apps/backend/src/utils/messaging-provider.ts
@@ -374,13 +374,19 @@ export function chunkSlackText(text: string, maxChars: number): string[] {
 			break;
 		}
 
-		const { breakAt, endsInsideFence } = findSlackFenceAwareBreak(source, sourceOffset, maxChars - prefix.length);
+		const { breakAt, endsInsideFence, preserveBoundaryWhitespace } = findSlackFenceAwareBreak(
+			source,
+			sourceOffset,
+			maxChars - prefix.length,
+		);
 		const sourceChunk = remaining.slice(0, breakAt);
 		const suffix = endsInsideFence ? SLACK_CODE_FENCE_SUFFIX : '';
-		chunks.push(prefix + (endsInsideFence ? sourceChunk : sourceChunk.trimEnd()) + suffix);
+		chunks.push(
+			prefix + (endsInsideFence || preserveBoundaryWhitespace ? sourceChunk : sourceChunk.trimEnd()) + suffix,
+		);
 
 		sourceOffset += breakAt;
-		if (!endsInsideFence) {
+		if (!endsInsideFence && !preserveBoundaryWhitespace) {
 			sourceOffset = skipLeadingWhitespace(source, sourceOffset);
 		}
 	}
@@ -471,6 +477,7 @@ export const resolveMattermostCallbackBaseUrl = (callbackUrl: string | undefined
 type MarkdownSegment = { type: 'text'; text: string } | { type: 'table'; headers: string[]; rows: string[][] };
 
 const FENCE_REGEX = /^\s*(```|~~~)/;
+const TRIPLE_BACKTICK_FENCE_REGEX = /^\s*```/;
 const SEPARATOR_CELL_REGEX = /^:?-+:?$/;
 
 function splitMarkdownSegments(text: string): MarkdownSegment[] {
@@ -611,18 +618,60 @@ function findSlackFenceAwareBreak(
 	source: string,
 	sourceOffset: number,
 	availableChars: number,
-): { breakAt: number; endsInsideFence: boolean } {
+): { breakAt: number; endsInsideFence: boolean; preserveBoundaryWhitespace: boolean } {
+	if (availableChars < 1) {
+		throw new Error('Slack text chunk size is too small for fenced code.');
+	}
 	const remaining = source.slice(sourceOffset);
-	let breakAt = findSlackChunkBreak(remaining, availableChars);
+	let { breakAt, preserveBoundaryWhitespace } = findSlackFenceSafeChunkBreak(remaining, availableChars);
 	let endsInsideFence = isTripleBacktickFenceOpen(source.slice(0, sourceOffset + breakAt));
 	if (endsInsideFence && breakAt + SLACK_CODE_FENCE_SUFFIX.length > availableChars) {
 		if (availableChars <= SLACK_CODE_FENCE_SUFFIX.length) {
 			throw new Error('Slack text chunk size is too small for fenced code.');
 		}
-		breakAt = findSlackChunkBreak(remaining, availableChars - SLACK_CODE_FENCE_SUFFIX.length);
+		({ breakAt, preserveBoundaryWhitespace } = findSlackFenceSafeChunkBreak(
+			remaining,
+			availableChars - SLACK_CODE_FENCE_SUFFIX.length,
+		));
 		endsInsideFence = isTripleBacktickFenceOpen(source.slice(0, sourceOffset + breakAt));
 	}
-	return { breakAt, endsInsideFence };
+	return { breakAt, endsInsideFence, preserveBoundaryWhitespace };
+}
+
+function findSlackFenceSafeChunkBreak(
+	text: string,
+	maxChars: number,
+): { breakAt: number; preserveBoundaryWhitespace: boolean } {
+	const breakAt = findSlackChunkBreak(text, maxChars);
+	if (breakAt >= text.length) {
+		return { breakAt, preserveBoundaryWhitespace: false };
+	}
+	if (text[breakAt - 1] === '\n') {
+		const lineStart = text.lastIndexOf('\n', breakAt - 2) + 1;
+		const previousLine = text.slice(lineStart, breakAt - 1);
+		const nextNewlineAt = text.indexOf('\n', breakAt);
+		const nextLine = text.slice(breakAt, nextNewlineAt === -1 ? text.length : nextNewlineAt);
+		return {
+			breakAt,
+			preserveBoundaryWhitespace:
+				TRIPLE_BACKTICK_FENCE_REGEX.test(previousLine) || TRIPLE_BACKTICK_FENCE_REGEX.test(nextLine),
+		};
+	}
+
+	const lineStart = text.lastIndexOf('\n', breakAt - 1) + 1;
+	const newlineAt = text.indexOf('\n', breakAt);
+	const lineEnd = newlineAt === -1 ? text.length : newlineAt + 1;
+	const line = text.slice(lineStart, newlineAt === -1 ? text.length : newlineAt);
+	if (!TRIPLE_BACKTICK_FENCE_REGEX.test(line)) {
+		return { breakAt, preserveBoundaryWhitespace: false };
+	}
+	if (lineStart > 0) {
+		return { breakAt: lineStart, preserveBoundaryWhitespace: true };
+	}
+	if (lineEnd <= maxChars) {
+		return { breakAt: lineEnd, preserveBoundaryWhitespace: true };
+	}
+	throw new Error('Slack text chunk size is too small for a code fence marker line.');
 }
 
 function isTripleBacktickFenceOpen(text: string): boolean {

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+	balanceSlackStreamingCodeFence,
 	buildSlackCardNotificationText,
 	buildSlackTableBlocks,
 	chunkSlackText,
@@ -21,6 +22,31 @@ function tableChild(blocks: ReturnType<typeof createTextBlocks>) {
 		| undefined;
 }
 
+function textContents(blocks: ReturnType<typeof createTextBlocks>): string[] {
+	return blocks
+		.filter((block): block is Extract<(typeof blocks)[number], { type: 'text' }> => block.type === 'text')
+		.map((block) => block.content);
+}
+
+function reconstructChunkedText(chunks: string[]): string {
+	return chunks
+		.map((chunk, index) => {
+			let sourceChunk = chunk;
+			if (index > 0 && chunks[index - 1].endsWith('\n```') && sourceChunk.startsWith('```\n')) {
+				sourceChunk = sourceChunk.slice(4);
+			}
+			if (index < chunks.length - 1 && sourceChunk.endsWith('\n```') && chunks[index + 1].startsWith('```\n')) {
+				sourceChunk = sourceChunk.slice(0, -4);
+			}
+			return sourceChunk;
+		})
+		.join('');
+}
+
+function tripleBacktickCount(text: string): number {
+	return text.split('\n').filter((line) => line.trimStart().startsWith('```')).length;
+}
+
 describe('createTextBlocks', () => {
 	it('returns a single text block when there is no table', () => {
 		const blocks = createTextBlocks('Just a plain answer with **bold**.');
@@ -36,6 +62,80 @@ describe('createTextBlocks', () => {
 		expect(
 			blocks.every((block) => block.type !== 'text' || block.content.length <= SLACK_SECTION_TEXT_MAX_CHARS),
 		).toBe(true);
+	});
+
+	it('keeps a long fenced SQL block balanced across Slack sections', () => {
+		const sqlLines = Array.from(
+			{ length: 240 },
+			(_, index) => `    SELECT ${index} AS row_${index}, '${'value '.repeat(8)}' AS description;`,
+		);
+		const source = ['Before the query.', '', '```sql', ...sqlLines, '```', '', 'After the query.'].join('\n');
+		const chunks = textContents(createTextBlocks(source));
+		const codeChunks = chunks.filter((chunk) => chunk.includes('```'));
+
+		expect(chunks.length).toBeGreaterThanOrEqual(3);
+		expect(chunks.every((chunk) => chunk.length <= SLACK_SECTION_TEXT_MAX_CHARS)).toBe(true);
+		expect(codeChunks.every((chunk) => tripleBacktickCount(chunk) % 2 === 0)).toBe(true);
+		expect(codeChunks[0]).toContain('```sql');
+		expect(codeChunks.slice(1).every((chunk) => chunk.startsWith('```\n'))).toBe(true);
+		expect(codeChunks.slice(1).every((chunk) => !chunk.startsWith('```sql'))).toBe(true);
+		expect(codeChunks.slice(1, -1).every((chunk) => chunk.endsWith('\n```'))).toBe(true);
+		expect(codeChunks.at(-1)).toContain(`${sqlLines.at(-1)}\n\`\`\``);
+		expect(reconstructChunkedText(chunks)).toBe(source);
+	});
+
+	it('balances multiple fenced blocks without changing their content', () => {
+		const firstCode = Array.from({ length: 100 }, (_, index) => `    first_${index} = ${index}`).join('\n');
+		const secondCode = Array.from({ length: 100 }, (_, index) => `  second_${index} = ${index}`).join('\n');
+		const source = [
+			'First block:',
+			'```python',
+			firstCode,
+			'```',
+			'Between blocks.',
+			'```sql',
+			secondCode,
+			'```',
+			'Done.',
+		].join('\n');
+		const chunks = chunkSlackText(source, 500);
+
+		expect(chunks.every((chunk) => chunk.length <= 500)).toBe(true);
+		expect(
+			chunks.filter((chunk) => chunk.includes('```')).every((chunk) => tripleBacktickCount(chunk) % 2 === 0),
+		).toBe(true);
+		expect(reconstructChunkedText(chunks)).toBe(source);
+		expect(reconstructChunkedText(chunks)).toContain('Between blocks.');
+	});
+
+	it('temporarily closes an incomplete streaming fence without changing completed text', () => {
+		const incomplete = 'Before\n```sql\nSELECT **value**';
+		const updated = `${incomplete}\nFROM source`;
+		const completed = `${incomplete}\n\`\`\``;
+		const incompleteBlocks = textContents(createTextBlocks(incomplete, { balanceIncompleteCodeFence: true }));
+		const updatedBlocks = textContents(createTextBlocks(updated, { balanceIncompleteCodeFence: true }));
+		const completedBlocks = textContents(createTextBlocks(completed, { balanceIncompleteCodeFence: true }));
+
+		expect(incomplete).toBe('Before\n```sql\nSELECT **value**');
+		expect(incompleteBlocks).toEqual([`${incomplete}\n\`\`\``]);
+		expect(updatedBlocks).toEqual([`${updated}\n\`\`\``]);
+		expect(tripleBacktickCount(incompleteBlocks[0])).toBe(2);
+		expect(completedBlocks).toEqual([completed]);
+		expect(tripleBacktickCount(completedBlocks[0])).toBe(2);
+		expect(balanceSlackStreamingCodeFence(completed)).toBe(completed);
+	});
+
+	it('keeps long incomplete streaming code balanced within Slack limits', () => {
+		const incomplete = `\`\`\`sql\n${Array.from(
+			{ length: 200 },
+			(_, index) => `    SELECT ${index} AS value;`,
+		).join('\n')}`;
+		const chunks = textContents(createTextBlocks(incomplete, { balanceIncompleteCodeFence: true }));
+
+		expect(chunks.length).toBeGreaterThan(1);
+		expect(chunks.every((chunk) => chunk.length <= SLACK_SECTION_TEXT_MAX_CHARS)).toBe(true);
+		expect(chunks.every((chunk) => tripleBacktickCount(chunk) % 2 === 0)).toBe(true);
+		expect(chunks.at(-1)?.endsWith('\n```')).toBe(true);
 	});
 
 	it('splits a markdown table into a Table element with text around it', () => {
@@ -555,6 +655,31 @@ describe('Slack payload safety', () => {
 		expect(chunks.length).toBeGreaterThan(1);
 		expect(chunks.every((chunk) => chunk.length <= SLACK_SECTION_TEXT_MAX_CHARS)).toBe(true);
 		expect(chunks.every((chunk) => chunk.length > 0)).toBe(true);
+	});
+
+	it('keeps the established prose splitting behavior', () => {
+		expect(chunkSlackText('alpha beta gamma delta', 12)).toEqual(['alpha beta', 'gamma delta']);
+	});
+
+	it('reserves room for continuation fences near the chunk limit', () => {
+		const source = `\`\`\`sql\n${'x'.repeat(100)}\n\`\`\``;
+		const chunks = chunkSlackText(source, 30);
+
+		expect(chunks.length).toBeGreaterThanOrEqual(4);
+		expect(chunks.every((chunk) => chunk.length <= 30)).toBe(true);
+		expect(chunks.every((chunk) => tripleBacktickCount(chunk) % 2 === 0)).toBe(true);
+		expect(chunks.slice(1, -1).every((chunk) => chunk.startsWith('```\n') && chunk.endsWith('\n```'))).toBe(true);
+		expect(reconstructChunkedText(chunks)).toBe(source);
+	});
+
+	it('preserves indentation after fenced code splits', () => {
+		const codeLines = Array.from({ length: 30 }, (_, index) => `    indented_${index} = ${index}`);
+		const source = ['```python', ...codeLines, '```'].join('\n');
+		const chunks = chunkSlackText(source, 100);
+
+		expect(chunks.length).toBeGreaterThan(2);
+		expect(chunks.slice(1).some((chunk) => chunk.startsWith('```\n    indented_'))).toBe(true);
+		expect(reconstructChunkedText(chunks)).toBe(source);
 	});
 
 	it('keeps replies below the Slack message limit in one chunk', () => {

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -125,6 +125,16 @@ describe('createTextBlocks', () => {
 		expect(balanceSlackStreamingCodeFence(completed)).toBe(completed);
 	});
 
+	it('balances an incomplete final fence only for a stopped stream', () => {
+		const incomplete = 'Before\n```sql\nSELECT **value**';
+		const renderFinal = (stopRequested: boolean) =>
+			textContents(createTextBlocks(incomplete, { balanceIncompleteCodeFence: stopRequested }));
+
+		expect(renderFinal(false)).toEqual(['Before\n```sql\nSELECT *value*']);
+		expect(renderFinal(true)).toEqual([`${incomplete}\n\`\`\``]);
+		expect(incomplete).toBe('Before\n```sql\nSELECT **value**');
+	});
+
 	it('keeps long incomplete streaming code balanced within Slack limits', () => {
 		const incomplete = `\`\`\`sql\n${Array.from(
 			{ length: 200 },

--- a/apps/backend/tests/slack-message-blocks.test.ts
+++ b/apps/backend/tests/slack-message-blocks.test.ts
@@ -692,6 +692,41 @@ describe('Slack payload safety', () => {
 		expect(reconstructChunkedText(chunks)).toBe(source);
 	});
 
+	it.each([
+		{ maxChars: 40, prefixLength: 18, indentationLength: 20 },
+		{ maxChars: SLACK_SECTION_TEXT_MAX_CHARS, prefixLength: 1448, indentationLength: 1449 },
+	])('keeps an opening fence marker intact at a $maxChars-character boundary', (example) => {
+		const openingMarker = `${'\t'.repeat(example.indentationLength)}\`\`\`sql`;
+		const source = ['p'.repeat(example.prefixLength), openingMarker, 'SELECT 1;', '```', 'Done.'].join('\n');
+		const chunks = chunkSlackText(source, example.maxChars);
+
+		expect(chunks.every((chunk) => chunk.length <= example.maxChars)).toBe(true);
+		expect(chunks.some((chunk) => chunk.includes(openingMarker))).toBe(true);
+		expect(
+			chunks.filter((chunk) => chunk.includes('```')).every((chunk) => tripleBacktickCount(chunk) % 2 === 0),
+		).toBe(true);
+		expect(reconstructChunkedText(chunks)).toBe(source);
+	});
+
+	it('keeps an indented closing fence marker line intact when it fits the next chunk', () => {
+		const closingMarker = `${'\t'.repeat(19)}\`\`\``;
+		const source = ['```sql', 'x', closingMarker, 'Done.'].join('\n');
+		const chunks = chunkSlackText(source, 30);
+
+		expect(chunks.every((chunk) => chunk.length <= 30)).toBe(true);
+		expect(chunks.some((chunk) => chunk.includes(closingMarker))).toBe(true);
+		expect(
+			chunks.filter((chunk) => chunk.includes('```')).every((chunk) => tripleBacktickCount(chunk) % 2 === 0),
+		).toBe(true);
+		expect(reconstructChunkedText(chunks)).toBe(source);
+	});
+
+	it('rejects a chunk size too small for a complete fence marker line', () => {
+		expect(() => chunkSlackText('```sql\nx\n```', 6)).toThrow(
+			'Slack text chunk size is too small for a code fence marker line.',
+		);
+	});
+
 	it('keeps replies below the Slack message limit in one chunk', () => {
 		const text = 'x'.repeat(SLACK_SECTION_TEXT_MAX_CHARS - 1);
 		const chunks = chunkSlackText(text, SLACK_SECTION_TEXT_MAX_CHARS);


### PR DESCRIPTION
## Summary
- Keep long code blocks formatted when Slack splits an answer.
- Keep unfinished code formatted while generating and after stopping. (Add ``` at the end and add code before it so it streams formatted)
- Preserve indentation and surrounding text.
- Add a closing ``` if agent is stopped mid-streaming code

Closes #1536

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

