### PR TITLE
fix: keep tooltip inside viewbox to prevent truncation

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -662,7 +662,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 						active={disableTooltip ? false : undefined}
 						animationDuration={150}
 						animationEasing='linear'
-						allowEscapeViewBox={{ y: true, x: false }}
+						allowEscapeViewBox={{ y: false, x: false }}
 						content={
 							<ChartTooltipContent
 								percent={isPercentStacked}


### PR DESCRIPTION
Fixe #1308 

Recharts tooltips get visually truncated off when hovering near the bottom edge of the chart.

## Changes: 
I changed `allowEscapeViewBox y: true` to `y: false` on the ChartTooltip Instead of trying to push the tooltip outside the view box, this forces Recharts to keep the tooltip inside the view box bounds and intelligently flip it upwards when near the bottom edge.

## Alternative Approache:
Removing **overflow-hidden**: This would let the tooltip bleed out, but it breaks the UI of other components in the wrapper (like SQL tables bleeding their square corners).


## Before

https://github.com/user-attachments/assets/7c09f141-90c7-4cca-8f04-ba2f95d8361e


## After (fixed)

https://github.com/user-attachments/assets/1619cd8c-86f1-424c-8335-e197acd51d56



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

