### PR TITLE
fix(frontend): prevent donut chart legend overflow

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -686,7 +686,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 							payload={legendPayload}
 							layout={isPie && !compactPieLegend ? 'vertical' : 'horizontal'}
 							align={isPie && !compactPieLegend ? 'right' : 'center'}
-							verticalAlign={isPie && !compactPieLegend ? 'middle' : 'bottom'}
+							verticalAlign={isPie && !compactPieLegend ? 'top' : 'bottom'}
 							content={
 								<ChartLegendContent
 									layout={isPie && !compactPieLegend ? 'vertical' : 'horizontal'}


### PR DESCRIPTION
Fixe #1554 

The Donut/Pie chart legend can move downward after switching between **chat tabs or between view data and view chart etc.** each time the chart becomes visible again, the legend may be positioned lower than before.

The issue was caused by Recharts recalculating the `verticalAlign="middle"` position while the chart was temporarily hidden and had no usable height. 

### Changes: 
Changed `verticalAlign` to `top` to avoid that calculation and keep the legend position stable.

### Before

https://github.com/user-attachments/assets/d7e96bb1-21a6-4867-9f73-ce3ba51d2b4c

### After (fixed)

https://github.com/user-attachments/assets/2faeb4f9-de1b-4dbf-812b-8b006b0f6351

Tested across different screen resolutions. no visual or layout issues.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

