### PR TITLE
fix(backend): ignore helm release in version check

### DIFF
--- a/apps/backend/src/services/version-check.service.ts
+++ b/apps/backend/src/services/version-check.service.ts
@@ -1,7 +1,8 @@
 import { env } from '../env';
 
-const GITHUB_RELEASES_URL = 'https://api.github.com/repos/getnao/nao/releases/latest';
+const GITHUB_RELEASES_URL = 'https://api.github.com/repos/getnao/nao/releases';
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const APP_RELEASE_TAG_REGEX = /^v\d+\.\d+\.\d+$/;
 
 interface VersionCheckResult {
 	currentVersion: string;
@@ -36,8 +37,9 @@ async function fetchLatestVersion(): Promise<string | null> {
 		if (!response.ok) {
 			return null;
 		}
-		const data = (await response.json()) as { tag_name?: string };
-		return data.tag_name?.replace(/^v/, '') ?? null;
+		const releases = (await response.json()) as { tag_name?: string; prerelease?: boolean }[];
+		const appRelease = releases.find((r) => !r.prerelease && r.tag_name && APP_RELEASE_TAG_REGEX.test(r.tag_name));
+		return appRelease?.tag_name?.replace(/^v/, '') ?? null;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
Fixes #1601 

The update check can pick up a Helm release as the latest release, causing an incorrect update notification for the nao

the github `/releases/latest` endpoint returns the latest release for the repository, but nao also publishes helm releases in the same repository.

### Changes

- Switched from `/releases/latest` to `/releases`
- Select the latest stable nao app release only when it matches the vX.Y.Z format (use regex)
- Ignore **prereleases** and **helm releases**

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

