### PR TITLE
feat: implement per-table column_selection with include/exclude/glob …

### DIFF
--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -333,6 +333,8 @@ def sync_database(
 
                 ctx = db_config.create_context(conn, schema, table)
                 ctx.set_exclude_columns(db_config.exclude_columns)
+                include_patterns, exclude_patterns = db_config.column_selection_for(schema, table)
+                ctx.set_column_selection(include_patterns, exclude_patterns)
                 table_usage = usage_stats.get(f"{schema}.{table}", TableUsageStats())
                 has_profiling = DatabaseTemplate.PROFILING in db_config.templates
                 has_ai_summary = DatabaseTemplate.AI_SUMMARY in db_config.templates

--- a/cli/nao_core/config/databases/base.py
+++ b/cli/nao_core/config/databases/base.py
@@ -5,10 +5,10 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import questionary
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -89,6 +89,38 @@ class ProfilingConfig(RefreshConfig):
     """Configuration for profiling refresh policy."""
 
 
+class TableColumnSelection(BaseModel):
+    """Per-table column allow/deny rules used by ``column_selection``.
+
+    ``include`` keeps only matching columns (allowlist), ``exclude`` drops
+    matching columns (denylist). When both are set on the same table,
+    ``include`` is applied first and ``exclude`` then removes columns from
+    the survivors.
+    """
+
+    include: list[str] | None = Field(
+        default=None,
+        description=(
+            "Allowlist of column names or glob patterns (e.g., ['id', 'email', 'order_*']). "
+            "Only matching columns are kept. A single pattern string is also accepted."
+        ),
+    )
+    exclude: list[str] | None = Field(
+        default=None,
+        description=(
+            "Denylist of column names or glob patterns (e.g., ['ssn', '*_pii']). "
+            "Matching columns are dropped. A single pattern string is also accepted."
+        ),
+    )
+
+    @field_validator("include", "exclude", mode="before")
+    @classmethod
+    def _coerce_single_pattern(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return [value]
+        return value
+
+
 class DatabaseConfig(BaseModel, ABC):
     """Base configuration for all database backends."""
 
@@ -111,6 +143,18 @@ class DatabaseConfig(BaseModel, ABC):
             "Glob patterns for columns to exclude. Patterns are matched against the "
             "fully-qualified 'schema.table.column' name (e.g., '*.version', '*._peerdb_*', "
             "'analytics.events.*_id'). Empty means no columns are excluded."
+        ),
+    )
+    column_selection: dict[str, TableColumnSelection] = Field(
+        default_factory=dict,
+        description=(
+            "Per-table column selection rules, keyed by 'schema.table' or 'table' "
+            "(glob patterns are allowed, e.g., 'analytics.*'). Each entry accepts "
+            "'include' (allowlist) and/or 'exclude' (denylist) with column names or "
+            "glob patterns matched against the column name. When both are set on the "
+            "same table, 'include' is applied first, then 'exclude' removes columns "
+            "from the survivors. Global 'exclude_columns' still applies on top. "
+            "Example: {analytics.events: {exclude: ['*_pii']}, users: {include: ['id', 'email']}}."
         ),
     )
     templates: list[DatabaseTemplate] = Field(
@@ -260,13 +304,43 @@ class DatabaseConfig(BaseModel, ABC):
 
         return True
 
-    def column_matches_pattern(self, schema: str, table: str, column: str) -> bool:
-        """Check if a column should be included given the exclude_columns patterns.
+    def column_selection_for(self, schema: str, table: str) -> tuple[list[str], list[str]]:
+        """Resolve the (include, exclude) column patterns that apply to a table.
 
-        Patterns are matched against the fully-qualified ``schema.table.column``
-        name using shell-style globs (``fnmatch``). Returns ``True`` when the
-        column should be kept, ``False`` when it should be excluded.
+        Keys are looked up in tiers; only the first non-empty tier is used:
+        an exact ``schema.table`` key, then an exact ``table`` key, then every
+        key that glob-matches either name (their patterns are merged).
         """
+        if not self.column_selection:
+            return [], []
+
+        full_name = f"{schema}.{table}"
+        entry = self.column_selection.get(full_name) or self.column_selection.get(table)
+        if entry is not None:
+            return list(entry.include or []), list(entry.exclude or [])
+
+        include: list[str] = []
+        exclude: list[str] = []
+        for key, matched in self.column_selection.items():
+            if fnmatch.fnmatch(full_name, key) or fnmatch.fnmatch(table, key):
+                include.extend(matched.include or [])
+                exclude.extend(matched.exclude or [])
+        return include, exclude
+
+    def column_matches_pattern(self, schema: str, table: str, column: str) -> bool:
+        """Check if a column should be included given the configured column filters.
+
+        Per-table ``column_selection`` patterns are matched against the bare
+        column name; legacy ``exclude_columns`` patterns are matched against
+        the fully-qualified ``schema.table.column`` name using shell-style
+        globs (``fnmatch``). Returns ``True`` when the column should be kept,
+        ``False`` when it should be excluded.
+        """
+        include_patterns, exclude_patterns = self.column_selection_for(schema, table)
+        if include_patterns and not any(fnmatch.fnmatch(column, pattern) for pattern in include_patterns):
+            return False
+        if exclude_patterns and any(fnmatch.fnmatch(column, pattern) for pattern in exclude_patterns):
+            return False
         if not self.exclude_columns:
             return True
         full_name = f"{schema}.{table}.{column}"
@@ -301,7 +375,15 @@ class DatabaseConfig(BaseModel, ABC):
         """Create a DatabaseContext for this table. Override in subclasses for custom metadata."""
         from nao_core.config.databases.context import DatabaseContext
 
-        return DatabaseContext(conn, schema, table_name, exclude_columns=self.exclude_columns)
+        include_patterns, exclude_patterns = self.column_selection_for(schema, table_name)
+        return DatabaseContext(
+            conn,
+            schema,
+            table_name,
+            exclude_columns=self.exclude_columns,
+            include_patterns=include_patterns,
+            table_exclude_patterns=exclude_patterns,
+        )
 
     def get_semantic_views(self, conn: "BaseBackend", schema: str) -> list[dict[str, str]]:
         """Fetch semantic views for a schema. Override in subclasses that support semantic views."""

--- a/cli/nao_core/config/databases/column_access.py
+++ b/cli/nao_core/config/databases/column_access.py
@@ -24,6 +24,7 @@ from nao_core.config.databases.column_catalog import column_catalog_path, load_c
 class _DatabaseConfigLike(Protocol):
     type: str
     exclude_columns: list[str]
+    column_selection: dict[str, Any]
 
     def get_database_name(self) -> str: ...
 
@@ -62,7 +63,7 @@ def validate_column_access(
     db_config: _DatabaseConfigLike,
     project_path: Path,
 ) -> str:
-    if not db_config.exclude_columns:
+    if not db_config.exclude_columns and not db_config.column_selection:
         return sql
 
     dialect = _SQLGLOT_DIALECTS.get(db_config.type)

--- a/cli/nao_core/config/databases/column_access_analysis.py
+++ b/cli/nao_core/config/databases/column_access_analysis.py
@@ -266,4 +266,4 @@ def _star_excluded_names(star: exp.Star) -> set[str]:
 
 
 def _blocked(reason: str) -> ColumnAccessError:
-    return ColumnAccessError(f"Query blocked because exclude_columns could not safely validate it: {reason}")
+    return ColumnAccessError(f"Query blocked because the column filters could not safely validate it: {reason}")

--- a/cli/nao_core/config/databases/context.py
+++ b/cli/nao_core/config/databases/context.py
@@ -26,11 +26,15 @@ class DatabaseContext:
         schema: str,
         table_name: str,
         exclude_columns: list[str] | None = None,
+        include_patterns: list[str] | None = None,
+        table_exclude_patterns: list[str] | None = None,
     ):
         self._conn = conn
         self._schema = schema
         self._table_name = table_name
         self._exclude_columns = list(exclude_columns) if exclude_columns else []
+        self._include_patterns = list(include_patterns) if include_patterns else []
+        self._table_exclude_patterns = list(table_exclude_patterns) if table_exclude_patterns else []
         self._table_ref = None
         self._columns_cache: list[dict[str, Any]] | None = None
         self._columns_load_failed = False
@@ -46,28 +50,52 @@ class DatabaseContext:
         """
         self._exclude_columns = list(patterns) if patterns else []
 
-    def _is_column_excluded(self, column_name: str) -> bool:
-        """Return True when the column should be hidden based on ``exclude_columns``.
+    def set_column_selection(self, include_patterns: list[str] | None, exclude_patterns: list[str] | None) -> None:
+        """Set the per-table ``column_selection`` rules resolved for this table.
 
-        Patterns are matched against the fully-qualified ``schema.table.column``
-        name using shell-style globs.
+        Patterns are matched against the bare column name. ``include_patterns``
+        keep only matching columns; ``exclude_patterns`` drop matching columns.
+        Mirrors ``set_exclude_columns`` so the sync provider can thread
+        ``column_selection`` into any context implementation.
         """
+        self._include_patterns = list(include_patterns) if include_patterns else []
+        self._table_exclude_patterns = list(exclude_patterns) if exclude_patterns else []
+
+    def _is_column_excluded(self, column_name: str) -> bool:
+        """Return True when the column should be hidden from the agent.
+
+        Per-table ``column_selection`` patterns are matched against the bare
+        column name: the include allowlist is applied first, then the exclude
+        denylist. Global ``exclude_columns`` patterns are matched against the
+        fully-qualified ``schema.table.column`` name and always apply on top.
+        """
+        if self._include_patterns and not any(
+            fnmatch.fnmatch(column_name, pattern) for pattern in self._include_patterns
+        ):
+            return True
+        if self._table_exclude_patterns and any(
+            fnmatch.fnmatch(column_name, pattern) for pattern in self._table_exclude_patterns
+        ):
+            return True
         if not self._exclude_columns:
             return False
         full_name = f"{self._schema}.{self._table_name}.{column_name}"
         return any(fnmatch.fnmatch(full_name, pattern) for pattern in self._exclude_columns)
 
     def _filter_excluded_columns(self, cols: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Drop columns whose name matches an ``exclude_columns`` pattern."""
-        if not self._exclude_columns:
+        """Drop columns hidden by the configured column filters."""
+        if not self._has_column_filters():
             return cols
         return [col for col in cols if not self._is_column_excluded(str(col.get("name", "")))]
 
     def _filter_excluded_names(self, names: list[str]) -> list[str]:
-        """Drop column names that match an ``exclude_columns`` pattern."""
-        if not self._exclude_columns:
+        """Drop column names hidden by the configured column filters."""
+        if not self._has_column_filters():
             return names
         return [name for name in names if not self._is_column_excluded(name)]
+
+    def _has_column_filters(self) -> bool:
+        return bool(self._exclude_columns or self._include_patterns or self._table_exclude_patterns)
 
     @property
     def table(self):
@@ -122,8 +150,8 @@ class DatabaseContext:
         return rows
 
     def _filter_excluded_row(self, row: dict[str, Any]) -> dict[str, Any]:
-        """Drop keys from a preview row that match an ``exclude_columns`` pattern."""
-        if not self._exclude_columns:
+        """Drop keys from a preview row that are hidden by the configured column filters."""
+        if not self._has_column_filters():
             return row
         return {key: val for key, val in row.items() if not self._is_column_excluded(str(key))}
 

--- a/cli/tests/nao_core/commands/sync/integration/base.py
+++ b/cli/tests/nao_core/commands/sync/integration/base.py
@@ -14,6 +14,7 @@ import pytest
 from rich.progress import Progress
 
 from nao_core.commands.sync.providers.databases.provider import sync_database
+from nao_core.config.databases.base import TableColumnSelection
 
 
 @dataclass(frozen=True)
@@ -289,6 +290,33 @@ class BaseSyncIntegrationTests:
         config = db_config.model_copy(update={"exclude_columns": [f"*.*.{spec.excluded_column_name}"]})
 
         output = tmp_path_factory.mktemp(f"{spec.db_type}_exclude_columns")
+        with Progress(transient=True) as progress:
+            sync_database(config, output, progress)
+
+        users_columns = self._read_table_file(output, config, spec, spec.users_table, "columns.md")
+        assert f"- {spec.excluded_column_name} (" not in users_columns
+
+        preview_content = self._read_table_file(output, config, spec, spec.users_table, "preview.md")
+        for row in self._parse_preview_rows(preview_content):
+            assert spec.excluded_column_name not in row
+
+        profiling_content = self._read_table_file(output, config, spec, spec.users_table, "profiling.md")
+        for row in self._parse_preview_rows(profiling_content):
+            assert row.get("column") != spec.excluded_column_name
+
+    def test_column_selection_filter(self, tmp_path_factory, db_config, spec):
+        """Per-table column_selection rules should hide columns from output."""
+        if not spec.excluded_column_name:
+            pytest.skip("Provider spec does not declare a column to exclude")
+
+        table_key = f"{spec.effective_filter_schema}.{spec.users_table}"
+        config = db_config.model_copy(
+            update={
+                "column_selection": {table_key: TableColumnSelection(exclude=[spec.excluded_column_name])},
+            }
+        )
+
+        output = tmp_path_factory.mktemp(f"{spec.db_type}_column_selection")
         with Progress(transient=True) as progress:
             sync_database(config, output, progress)
 

--- a/cli/tests/nao_core/commands/sync/integration/test_duckdb.py
+++ b/cli/tests/nao_core/commands/sync/integration/test_duckdb.py
@@ -2,7 +2,10 @@
 
 import duckdb
 import pytest
+from rich.progress import Progress
 
+from nao_core.commands.sync.providers.databases.provider import sync_database
+from nao_core.config.databases.base import TableColumnSelection
 from nao_core.config.databases.duckdb import DuckDBConfig
 
 from .base import BaseSyncIntegrationTests, SyncTestSpec
@@ -171,3 +174,28 @@ def spec():
 
 class TestDuckDBSyncIntegration(BaseSyncIntegrationTests):
     """Verify the sync pipeline produces correct output against a local DuckDB database."""
+
+    def test_column_selection_include_allowlist(self, tmp_path_factory, db_config, spec):
+        """An include allowlist keeps only the listed columns in synced output."""
+        table_key = f"{spec.primary_schema}.{spec.users_table}"
+        config = db_config.model_copy(
+            update={
+                "column_selection": {table_key: TableColumnSelection(include=["id", "name", "active"])},
+            }
+        )
+
+        output = tmp_path_factory.mktemp("duckdb_column_selection_include")
+        with Progress(transient=True) as progress:
+            sync_database(config, output, progress)
+
+        users_columns = self._read_table_file(output, config, spec, spec.users_table, "columns.md")
+        assert "- email (" not in users_columns
+        assert "## Columns (3)" in users_columns
+
+        preview_content = self._read_table_file(output, config, spec, spec.users_table, "preview.md")
+        for row in self._parse_preview_rows(preview_content):
+            assert "email" not in row
+
+        profiling_content = self._read_table_file(output, config, spec, spec.users_table, "profiling.md")
+        for row in self._parse_preview_rows(profiling_content):
+            assert row.get("column") != "email"

--- a/cli/tests/nao_core/commands/sync/test_column_catalog.py
+++ b/cli/tests/nao_core/commands/sync/test_column_catalog.py
@@ -210,6 +210,7 @@ def _database_config() -> MagicMock:
     config.type = "duckdb"
     config.templates = []
     config.exclude_columns = ["*.email"]
+    config.column_selection_for.return_value = ([], [])
     config.get_database_name.return_value = "analytics"
     config.get_schemas.return_value = ["main"]
     config.matches_pattern.return_value = True

--- a/cli/tests/nao_core/commands/sync/test_context.py
+++ b/cli/tests/nao_core/commands/sync/test_context.py
@@ -13,7 +13,12 @@ from nao_core.config.databases.base import ProfilingConfig, ProfilingRefreshPoli
 
 
 class TestDatabaseContext:
-    def _make_context(self, exclude_columns: list[str] | None = None):
+    def _make_context(
+        self,
+        exclude_columns: list[str] | None = None,
+        include_patterns: list[str] | None = None,
+        table_exclude_patterns: list[str] | None = None,
+    ):
         mock_conn = MagicMock()
         mock_table = MagicMock()
         mock_schema = MagicMock()
@@ -25,7 +30,14 @@ class TestDatabaseContext:
         mock_schema.__len__ = lambda s: len(schema_items)
         mock_table.schema.return_value = mock_schema
         mock_conn.table.return_value = mock_table
-        ctx = DatabaseContext(mock_conn, "my_schema", "my_table", exclude_columns=exclude_columns)
+        ctx = DatabaseContext(
+            mock_conn,
+            "my_schema",
+            "my_table",
+            exclude_columns=exclude_columns,
+            include_patterns=include_patterns,
+            table_exclude_patterns=table_exclude_patterns,
+        )
         return ctx, mock_table
 
     def test_columns_returns_metadata(self):
@@ -206,6 +218,70 @@ class TestDatabaseContext:
     def test_column_count_uses_filtered_columns(self):
         ctx, _ = self._make_context(exclude_columns=["*.name"])
         assert ctx.column_count() == 1
+
+    def test_columns_filters_with_include_patterns(self):
+        ctx, _ = self._make_context(include_patterns=["id"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_columns_include_supports_glob_on_column_name(self):
+        ctx, _ = self._make_context(include_patterns=["i*"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_columns_filters_with_table_exclude_patterns(self):
+        ctx, _ = self._make_context(table_exclude_patterns=["name"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_include_patterns_applied_before_table_exclude_patterns(self):
+        ctx, _ = self._make_context(include_patterns=["id", "name"], table_exclude_patterns=["name"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_include_patterns_combine_with_exclude_columns(self):
+        ctx, _ = self._make_context(exclude_columns=["my_schema.my_table.name"], include_patterns=["id", "name"])
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_preview_filters_with_include_patterns(self):
+        ctx, mock_table = self._make_context(include_patterns=["id"])
+        df = pd.DataFrame({"id": [1, 2], "name": ["Alice", "Bob"]})
+        mock_table.limit.return_value.execute.return_value = df
+
+        rows = ctx.preview(limit=2)
+
+        assert rows[0] == {"id": 1}
+        assert rows[1] == {"id": 2}
+
+    def test_all_columns_ignores_include_patterns(self):
+        ctx, _ = self._make_context(include_patterns=["id"])
+
+        columns = ctx.all_columns()
+
+        assert columns is not None
+        assert [column["name"] for column in columns] == ["id", "name"]
+
+    def test_set_column_selection_overrides_constructor_value(self):
+        ctx, _ = self._make_context(include_patterns=["id"])
+        ctx.set_column_selection(None, ["name"])
+
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id"]
+
+    def test_set_column_selection_with_none_clears_filters(self):
+        ctx, _ = self._make_context(include_patterns=["id"], table_exclude_patterns=["name"])
+        ctx.set_column_selection(None, None)
+
+        columns = ctx.columns()
+
+        assert [c["name"] for c in columns] == ["id", "name"]
 
 
 class TestNormalizeType:

--- a/cli/tests/nao_core/commands/sync/test_provider_error_logging.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_error_logging.py
@@ -31,6 +31,7 @@ def create_mock_db_config(
     mock_config.name = name
     mock_config.type = db_type
     mock_config.templates = list(DatabaseTemplate)
+    mock_config.column_selection_for.return_value = ([], [])
     mock_conn = MagicMock()
     mock_config.connect.return_value = mock_conn
     mock_config.get_database_name.return_value = database_name

--- a/cli/tests/nao_core/commands/sync/test_provider_refresh.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_refresh.py
@@ -17,6 +17,7 @@ def create_sync_setup(profiling_policy, summary_policy):
     config.type = "duckdb"
     config.templates = [DatabaseTemplate.PROFILING, DatabaseTemplate.AI_SUMMARY]
     config.exclude_columns = []
+    config.column_selection_for.return_value = ([], [])
     config.query_history_days = None
     config.profiling = ProfilingConfig(refresh_policy=profiling_policy)
     config.ai_summary = RefreshConfig(refresh_policy=summary_policy)

--- a/cli/tests/nao_core/config/test_base.py
+++ b/cli/tests/nao_core/config/test_base.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from nao_core.config.base import LLM_OVERRIDE_NOTICE, NaoConfig, annotate_llm_override, annotate_optional_templates
-from nao_core.config.databases.base import DatabaseTemplate, ProfilingRefreshPolicy
+from nao_core.config.databases.base import DatabaseTemplate, ProfilingRefreshPolicy, TableColumnSelection
 from nao_core.config.databases.duckdb import DuckDBConfig
 from nao_core.config.llm import LLMConfig, LLMProvider, ProviderConfig
 from nao_core.config.secrets import process_secrets
@@ -481,3 +481,119 @@ def test_query_history_fields_loaded_from_yaml_dict():
     assert db.query_history_days == 7
     assert db.query_history_exclude_patterns == [r"SYSTEM\$", r"CURRENT_SESSION"]
     assert db.get_query_history_sql(7) == "SELECT q AS query_text FROM log WHERE ts > now() - interval '7 days'"
+
+
+def test_column_selection_default_is_empty():
+    db = DuckDBConfig(name="test-db", path=":memory:")
+    assert db.column_selection == {}
+    assert db.column_selection_for("analytics", "users") == ([], [])
+
+
+def test_column_selection_loaded_from_yaml_dict():
+    db = DuckDBConfig.model_validate(
+        {
+            "type": "duckdb",
+            "name": "test-db",
+            "path": ":memory:",
+            "column_selection": {
+                "analytics.events": {"exclude": ["*_pii", "secret"]},
+                "users": {"include": ["id", "email"]},
+            },
+        }
+    )
+    assert db.column_selection["analytics.events"].exclude == ["*_pii", "secret"]
+    assert db.column_selection["users"].include == ["id", "email"]
+
+
+def test_column_selection_accepts_single_pattern_string():
+    db = DuckDBConfig.model_validate(
+        {
+            "type": "duckdb",
+            "name": "test-db",
+            "path": ":memory:",
+            "column_selection": {"events": {"exclude": "prefix_*"}},
+        }
+    )
+    assert db.column_selection["events"].exclude == ["prefix_*"]
+
+
+def test_column_selection_exact_full_key_wins_over_glob():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={
+            "analytics.*": TableColumnSelection(exclude=["glob_col"]),
+            "analytics.users": TableColumnSelection(exclude=["exact_col"]),
+        },
+    )
+    assert db.column_selection_for("analytics", "users") == ([], ["exact_col"])
+
+
+def test_column_selection_exact_table_key_wins_over_glob():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={
+            "analytics.*": TableColumnSelection(exclude=["glob_col"]),
+            "users": TableColumnSelection(include=["id"]),
+        },
+    )
+    assert db.column_selection_for("analytics", "users") == (["id"], [])
+
+
+def test_column_selection_glob_keys_are_merged():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={
+            "analytics.*": TableColumnSelection(exclude=["a_*"]),
+            "*.users": TableColumnSelection(include=["id"]),
+        },
+    )
+    assert db.column_selection_for("analytics", "users") == (["id"], ["a_*"])
+    assert db.column_selection_for("analytics", "orders") == ([], ["a_*"])
+
+
+def test_column_selection_include_allowlists_columns():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={"users": TableColumnSelection(include=["id", "email"])},
+    )
+    assert db.column_matches_pattern("analytics", "users", "id") is True
+    assert db.column_matches_pattern("analytics", "users", "ssn") is False
+    assert db.column_matches_pattern("analytics", "orders", "ssn") is True
+
+
+def test_column_selection_exclude_supports_glob_on_column_name():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={"users": TableColumnSelection(exclude=["*_pii"])},
+    )
+    assert db.column_matches_pattern("analytics", "users", "email_pii") is False
+    assert db.column_matches_pattern("analytics", "users", "email") is True
+
+
+def test_column_selection_include_applied_before_exclude():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        column_selection={"users": TableColumnSelection(include=["id", "*_id"], exclude=["user_id"])},
+    )
+    assert db.column_matches_pattern("analytics", "users", "id") is True
+    assert db.column_matches_pattern("analytics", "users", "order_id") is True
+    assert db.column_matches_pattern("analytics", "users", "user_id") is False
+    assert db.column_matches_pattern("analytics", "users", "name") is False
+
+
+def test_column_selection_combines_with_legacy_exclude_columns():
+    db = DuckDBConfig(
+        name="test-db",
+        path=":memory:",
+        exclude_columns=["*.version"],
+        column_selection={"users": TableColumnSelection(include=["id", "version"])},
+    )
+    assert db.column_matches_pattern("analytics", "users", "id") is True
+    assert db.column_matches_pattern("analytics", "users", "version") is False
+    assert db.column_matches_pattern("analytics", "users", "name") is False

--- a/cli/tests/nao_core/config/test_column_access.py
+++ b/cli/tests/nao_core/config/test_column_access.py
@@ -16,10 +16,12 @@ class FakeDatabaseConfig:
         exclude_columns: list[str],
         database_name: str = "local",
         database_type: str = "duckdb",
+        column_selection: dict | None = None,
     ):
         self.exclude_columns = exclude_columns
         self.database_name = database_name
         self.type = database_type
+        self.column_selection = column_selection or {}
 
     def connect(self):
         raise AssertionError("column validation must not connect")
@@ -28,8 +30,28 @@ class FakeDatabaseConfig:
         return self.database_name
 
     def column_matches_pattern(self, schema: str, table: str, column: str) -> bool:
-        name = f"{schema}.{table}.{column}"
-        return not any(fnmatch.fnmatch(name, pattern) for pattern in self.exclude_columns)
+        full_name = f"{schema}.{table}.{column}"
+        if any(fnmatch.fnmatch(full_name, pattern) for pattern in self.exclude_columns):
+            return False
+        include_patterns, exclude_patterns = self._column_selection_for(schema, table)
+        if include_patterns and not any(fnmatch.fnmatch(column, pattern) for pattern in include_patterns):
+            return False
+        return not any(fnmatch.fnmatch(column, pattern) for pattern in exclude_patterns)
+
+    def _column_selection_for(self, schema: str, table: str) -> tuple[list[str], list[str]]:
+        if not self.column_selection:
+            return [], []
+        full_name = f"{schema}.{table}"
+        entry = self.column_selection.get(full_name) or self.column_selection.get(table)
+        if entry is not None:
+            return list(entry.get("include") or []), list(entry.get("exclude") or [])
+        include: list[str] = []
+        exclude: list[str] = []
+        for key, matched in self.column_selection.items():
+            if fnmatch.fnmatch(full_name, key) or fnmatch.fnmatch(table, key):
+                include.extend(matched.get("include") or [])
+                exclude.extend(matched.get("exclude") or [])
+        return include, exclude
 
 
 @pytest.fixture
@@ -442,3 +464,55 @@ def test_unqualified_join_column_checks_every_missing_catalog_table(tmp_path: Pa
             config,
             tmp_path,
         )
+
+
+def test_column_selection_include_blocks_explicit_reference(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"main.users": {"include": ["id", "name"]}})
+
+    with pytest.raises(ColumnAccessError, match=r"main\.users\.email"):
+        validate_column_access("SELECT email FROM users", config, project_path)
+
+
+def test_column_selection_include_allows_listed_columns(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"main.users": {"include": ["id", "name"]}})
+    sql = "SELECT id, name FROM users"
+
+    assert validate_column_access(sql, config, project_path) == sql
+
+
+def test_column_selection_include_blocks_select_star(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"main.users": {"include": ["id", "name"]}})
+
+    with pytest.raises(ColumnAccessError, match=r"SELECT \* would include excluded column\(s\)"):
+        validate_column_access("SELECT * FROM users", config, project_path)
+
+
+def test_column_selection_exclude_blocks_explicit_reference(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"users": {"exclude": ["ssn"]}})
+
+    with pytest.raises(ColumnAccessError, match=r"main\.users\.ssn"):
+        validate_column_access("SELECT ssn FROM users", config, project_path)
+
+
+def test_column_selection_exclude_glob_blocks_matching_columns(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"users": {"exclude": ["_*"]}})
+
+    with pytest.raises(ColumnAccessError, match=r"main\.users\._peerdb_version"):
+        validate_column_access("SELECT _peerdb_version FROM users", config, project_path)
+
+
+def test_column_selection_does_not_affect_other_tables(project_path: Path):
+    config = FakeDatabaseConfig([], column_selection={"users": {"include": ["id"]}})
+    sql = "SELECT user_id, total FROM orders"
+
+    assert validate_column_access(sql, config, project_path) == sql
+
+
+def test_column_selection_combines_with_exclude_columns(project_path: Path):
+    config = FakeDatabaseConfig(["*.email"], column_selection={"users": {"exclude": ["ssn"]}})
+
+    with pytest.raises(ColumnAccessError, match=r"main\.users\.email"):
+        validate_column_access("SELECT email FROM users", config, project_path)
+
+    with pytest.raises(ColumnAccessError, match=r"main\.users\.ssn"):
+        validate_column_access("SELECT ssn FROM users", config, project_path)


### PR DESCRIPTION
Closes #1486

## What I did

Added a per-table `column_selection` block to `nao_config.yaml`:

```yaml
column_selection:
  analytics.events:
    exclude: ['*_pii', secret]
  main.customers:
    include: [customer_id, first_name]
  users:
    exclude: prefix_*
```

* Per-table `include` and/or `exclude` patterns, including glob patterns and string shorthand.
* Precedence: `include` first, then `exclude`; global `exclude_columns` still applies.
* Key resolution: exact `schema.table` → exact `table` → merged glob matches.
* `exclude_columns` remains fully backward compatible.
* Applies to sync output and SQL column-access validation.
* Prevents hidden columns from being queried, including `SELECT *` on restricted tables.

## How I tested

* Added 31 unit/integration tests covering config parsing, precedence, context filtering, SQL validation, provider integration, and DuckDB end-to-end behavior.
* Tested `nao sync` against the bundled `jaffle_shop.duckdb` example.
* Ran Ruff checks and formatting checks.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

