### PR TITLE
fix(backend): verify MCP access tokens against the local JWKS

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -8,7 +8,6 @@ import type { BetterAuthPlugin, Session } from 'better-auth';
 import { APIError, betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { createAuthMiddleware } from 'better-auth/api';
-import { verifyAccessToken } from 'better-auth/oauth2';
 import { jwt } from 'better-auth/plugins';
 import { bearer } from 'better-auth/plugins/bearer';
 import type { JWTPayload } from 'jose';
@@ -16,6 +15,7 @@ import type { JWTPayload } from 'jose';
 import { db } from './db/db';
 import dbConfig, { Dialect } from './db/dbConfig';
 import { env, isCloud, MCP_VALID_AUDIENCES } from './env';
+import { verifyJwtWithLocalJwks } from './mcp/verify-jwt';
 import * as orgQueries from './queries/organization.queries';
 import * as projectQueries from './queries/project.queries';
 import * as userQueries from './queries/user.queries';
@@ -72,11 +72,17 @@ export function updateAuth() {
 }
 
 export async function verifyOAuthAccessToken(token: string, audience: string[]): Promise<JWTPayload> {
-	const { issuer, jwksUrl } = await getAuthServerEndpoints();
-	return verifyAccessToken(token, {
-		verifyOptions: { audience, issuer },
-		jwksUrl,
-	});
+	const auth = await getAuth();
+	const { issuer } = await getAuthServerEndpoints();
+	// Verify against the LOCAL JWKS. nao is the token issuer, so it already holds
+	// its own signing keys. better-auth's verifyAccessToken instead fetches them
+	// over the external issuer URL (BETTER_AUTH_URL/jwks); in self-hosted
+	// split-horizon deployments that host is not resolvable from the server's own
+	// network, so the fetch throws, better-auth swallows it, and every MCP token
+	// is rejected with "no token payload". Using the in-process key set avoids the
+	// self-referential round-trip entirely.
+	const { keys } = await auth.api.getJwks();
+	return verifyJwtWithLocalJwks(token, { audience, issuer, keys });
 }
 
 export async function buildProtectedResourceMetadata(
@@ -389,9 +395,8 @@ async function refreshAuthAfterInitialSelfHostedSignup(): Promise<void> {
 	}
 }
 
-async function getAuthServerEndpoints(): Promise<{ issuer: string; jwksUrl: string }> {
+async function getAuthServerEndpoints(): Promise<{ issuer: string }> {
 	const auth = await getAuth();
 	const context = await auth.$context;
-	const issuer = context.baseURL;
-	return { issuer, jwksUrl: `${issuer}/jwks` };
+	return { issuer: context.baseURL };
 }

--- a/apps/backend/src/mcp/verify-jwt.ts
+++ b/apps/backend/src/mcp/verify-jwt.ts
@@ -1,0 +1,25 @@
+import { createLocalJWKSet, type JSONWebKeySet, type JWTPayload, jwtVerify } from 'jose';
+
+/**
+ * Verify an OAuth access token (JWT) against an in-process JWK set — no network
+ * round-trip.
+ *
+ * nao is the token issuer, so it already holds its own signing keys. Fetching
+ * them over the external issuer URL (BETTER_AUTH_URL/jwks), as better-auth's
+ * `verifyAccessToken` does, breaks self-hosted split-horizon deployments where
+ * that host is not resolvable from the server's own network: the fetch throws,
+ * better-auth swallows it, and every MCP token is rejected with "no token
+ * payload". Passing the local key set to jose avoids the self-referential fetch
+ * entirely.
+ *
+ * `keys` is the `keys` array returned by better-auth's `auth.api.getJwks()`
+ * (kept as `unknown` to avoid coupling to its exact JWK type).
+ */
+export async function verifyJwtWithLocalJwks(
+	token: string,
+	{ audience, issuer, keys }: { audience: string[]; issuer: string; keys: unknown },
+): Promise<JWTPayload> {
+	const keySet = createLocalJWKSet({ keys } as unknown as JSONWebKeySet);
+	const { payload } = await jwtVerify(token, keySet, { audience, issuer });
+	return payload;
+}

--- a/apps/backend/tests/mcp-local-jwks-verify.test.ts
+++ b/apps/backend/tests/mcp-local-jwks-verify.test.ts
@@ -1,0 +1,75 @@
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { describe, expect, it } from 'vitest';
+
+import { verifyJwtWithLocalJwks } from '../src/mcp/verify-jwt';
+
+// Regression test for the split-horizon breakage: nao must verify its own MCP
+// access tokens against the in-process JWK set, never by fetching the external
+// issuer URL (which is unreachable from the server's own network in a
+// VPN-only / private-DNS self-hosted deployment). These cases exercise the
+// local-verification helper with no network involved at all.
+
+const ISSUER = 'https://nao.internal.example/api/auth';
+const AUDIENCE = 'https://nao-mcp.public.example/mcp';
+const KID = 'test-kid';
+
+async function makeKeys() {
+	const { publicKey, privateKey } = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+	const publicJwk = await exportJWK(publicKey);
+	publicJwk.kid = KID;
+	publicJwk.alg = 'EdDSA';
+	return { privateKey, keys: [publicJwk] };
+}
+
+async function sign(privateKey: CryptoKey, claims: { aud: string | string[]; iss?: string }): Promise<string> {
+	return new SignJWT({})
+		.setProtectedHeader({ alg: 'EdDSA', kid: KID })
+		.setSubject('user-123')
+		.setIssuer(claims.iss ?? ISSUER)
+		.setAudience(claims.aud)
+		.setIssuedAt()
+		.setExpirationTime('5m')
+		.sign(privateKey);
+}
+
+describe('verifyJwtWithLocalJwks', () => {
+	it('verifies a token against the local JWK set (no network fetch)', async () => {
+		const { privateKey, keys } = await makeKeys();
+		const token = await sign(privateKey, { aud: AUDIENCE });
+		const payload = await verifyJwtWithLocalJwks(token, { audience: [AUDIENCE], issuer: ISSUER, keys });
+		expect(payload.sub).toBe('user-123');
+		expect(payload.aud).toContain(AUDIENCE);
+	});
+
+	it('accepts a token whose aud matches any of the allowed audiences', async () => {
+		const { privateKey, keys } = await makeKeys();
+		const token = await sign(privateKey, {
+			aud: [AUDIENCE, 'https://nao.internal.example/api/auth/oauth2/userinfo'],
+		});
+		const payload = await verifyJwtWithLocalJwks(token, {
+			audience: ['https://nao.internal.example/mcp', AUDIENCE],
+			issuer: ISSUER,
+			keys,
+		});
+		expect(payload.sub).toBe('user-123');
+	});
+
+	it('rejects a token minted for a different audience', async () => {
+		const { privateKey, keys } = await makeKeys();
+		const token = await sign(privateKey, { aud: 'https://someone-else.example/mcp' });
+		await expect(verifyJwtWithLocalJwks(token, { audience: [AUDIENCE], issuer: ISSUER, keys })).rejects.toThrow();
+	});
+
+	it('rejects a token from a different issuer', async () => {
+		const { privateKey, keys } = await makeKeys();
+		const token = await sign(privateKey, { aud: AUDIENCE, iss: 'https://evil.example/api/auth' });
+		await expect(verifyJwtWithLocalJwks(token, { audience: [AUDIENCE], issuer: ISSUER, keys })).rejects.toThrow();
+	});
+
+	it('rejects a token signed by a key outside the set', async () => {
+		const { keys } = await makeKeys();
+		const other = await generateKeyPair('EdDSA', { crv: 'Ed25519', extractable: true });
+		const token = await sign(other.privateKey, { aud: AUDIENCE });
+		await expect(verifyJwtWithLocalJwks(token, { audience: [AUDIENCE], issuer: ISSUER, keys })).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
Fixes #1620.

### Problem
`verifyOAuthAccessToken` verified MCP tokens via better-auth's `verifyAccessToken` with `jwksUrl = ${BETTER_AUTH_URL}/api/auth/jwks` — the server fetching its **own** JWKS over its **external** issuer URL. In self-hosted split-horizon deployments that host isn't resolvable from the server's own network, so the fetch throws, better-auth swallows it, and every MCP token is rejected with `no token payload` (even valid ones). Full repro in #1620.

### Fix
Verify against the in-process JWK set (`auth.api.getJwks()`) with `jose` (`createLocalJWKSet` + `jwtVerify`), keeping the same `audience`/`issuer` checks — no self-referential network fetch. Extracted the crypto path into `mcp/verify-jwt.ts` so it's unit-testable without a live auth instance.

### Testing
- New `tests/mcp-local-jwks-verify.test.ts` (5 cases): valid token, multi-audience match, wrong audience, wrong issuer, key-not-in-set. All pass.
- `tsc --noEmit`, eslint, prettier clean on the changed files.
- Verified against a live self-hosted deployment: after this change `/mcp` accepts the same token the external-fetch path was rejecting.

_Disclosure: implemented with Claude (Opus 4.8)._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

