### PR TITLE
feat(backend): make unauthenticated OAuth DCR configurable

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -222,7 +222,7 @@ async function createAuthInstance(baseURL: string) {
 				accessTokenExpiresIn: 86400,
 				refreshTokenExpiresIn: 604800,
 				allowDynamicClientRegistration: true,
-				allowUnauthenticatedClientRegistration: true,
+				allowUnauthenticatedClientRegistration: env.ALLOW_UNAUTHENTICATED_DCR,
 				validAudiences: MCP_VALID_AUDIENCES,
 			}),
 			...ssoPlugins,

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -190,6 +190,18 @@ const envSchema = z.object({
 		.transform((val) => val?.trim() || undefined)
 		.pipe(z.url({ message: 'MCP_PUBLIC_URL must be a valid URL' }).optional()),
 
+	/**
+	 * Whether unauthenticated OAuth dynamic client registration (POST /api/auth/oauth2/register) is
+	 * allowed. MCP clients that self-register (Claude, Cursor, …) rely on it, so it defaults to true.
+	 * Self-hosted deployments that connect only via manually-created confidential clients can set it
+	 * to "false" to shrink the attack surface.
+	 */
+	ALLOW_UNAUTHENTICATED_DCR: z
+		.enum(['true', 'false'])
+		.optional()
+		.default('true')
+		.transform((val) => val === 'true'),
+
 	POSTHOG_KEY: z.string().optional(),
 	POSTHOG_HOST: z.url({ message: 'POSTHOG_HOST must be a valid URL' }).optional(),
 	POSTHOG_DISABLED: z

--- a/apps/backend/tests/mcp-unauthenticated-dcr-env.test.ts
+++ b/apps/backend/tests/mcp-unauthenticated-dcr-env.test.ts
@@ -1,37 +1,36 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-// ALLOW_UNAUTHENTICATED_DCR is parsed from env at module load, so each case resets
-// the module registry and re-imports env against process.env.
+import { __reloadEnvForTesting, env } from '../src/env';
+
+// ALLOW_UNAUTHENTICATED_DCR is parsed from env at load; __reloadEnvForTesting re-parses
+// process.env in place (without re-running dotenv) so cases can mutate it between runs.
 describe('ALLOW_UNAUTHENTICATED_DCR env', () => {
 	let originalEnv: typeof process.env;
 
 	beforeEach(() => {
 		originalEnv = { ...process.env };
-		process.env.BETTER_AUTH_URL = 'https://nao.internal.example';
 		delete process.env.ALLOW_UNAUTHENTICATED_DCR;
-		vi.resetModules();
 	});
 
 	afterEach(() => {
 		process.env = originalEnv;
-		vi.resetModules();
-		vi.restoreAllMocks();
+		__reloadEnvForTesting();
 	});
 
-	it('defaults to true (preserves prior behavior)', async () => {
-		const { env } = await import('../src/env');
+	it('defaults to true (preserves prior behavior)', () => {
+		__reloadEnvForTesting();
 		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(true);
 	});
 
-	it('can be disabled with "false"', async () => {
+	it('can be disabled with "false"', () => {
 		process.env.ALLOW_UNAUTHENTICATED_DCR = 'false';
-		const { env } = await import('../src/env');
+		__reloadEnvForTesting();
 		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(false);
 	});
 
-	it('accepts "true"', async () => {
+	it('accepts "true"', () => {
 		process.env.ALLOW_UNAUTHENTICATED_DCR = 'true';
-		const { env } = await import('../src/env');
+		__reloadEnvForTesting();
 		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(true);
 	});
 });

--- a/apps/backend/tests/mcp-unauthenticated-dcr-env.test.ts
+++ b/apps/backend/tests/mcp-unauthenticated-dcr-env.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ALLOW_UNAUTHENTICATED_DCR is parsed from env at module load, so each case resets
+// the module registry and re-imports env against process.env.
+describe('ALLOW_UNAUTHENTICATED_DCR env', () => {
+	let originalEnv: typeof process.env;
+
+	beforeEach(() => {
+		originalEnv = { ...process.env };
+		process.env.BETTER_AUTH_URL = 'https://nao.internal.example';
+		delete process.env.ALLOW_UNAUTHENTICATED_DCR;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		vi.resetModules();
+		vi.restoreAllMocks();
+	});
+
+	it('defaults to true (preserves prior behavior)', async () => {
+		const { env } = await import('../src/env');
+		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(true);
+	});
+
+	it('can be disabled with "false"', async () => {
+		process.env.ALLOW_UNAUTHENTICATED_DCR = 'false';
+		const { env } = await import('../src/env');
+		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(false);
+	});
+
+	it('accepts "true"', async () => {
+		process.env.ALLOW_UNAUTHENTICATED_DCR = 'true';
+		const { env } = await import('../src/env');
+		expect(env.ALLOW_UNAUTHENTICATED_DCR).toBe(true);
+	});
+});


### PR DESCRIPTION
Fixes #1623.

### Problem
`allowUnauthenticatedClientRegistration: true` is hardcoded. Unauthenticated DCR (`POST /api/auth/oauth2/register`) lets anyone who can reach the auth host mint an OAuth client. MCP clients that self-register (Claude, Cursor, …) need it, so `true` is a sensible default — but self-hosters who connect only via manually-created confidential clients (e.g. dust.tt Static OAuth) can't turn it off to reduce attack surface.

### Change
Add `ALLOW_UNAUTHENTICATED_DCR` (default `true`, so behavior is unchanged) and wire it into `allowUnauthenticatedClientRegistration`. Registered clients still require PKCE + consent + exact redirect_uri, so this is defense-in-depth.

### Testing
- `tests/mcp-unauthenticated-dcr-env.test.ts`: default true, `"false"` disables, `"true"` enables. Passes.
- `tsc --noEmit`, eslint, prettier clean on changed files.

_Disclosure: implemented with Claude (Opus 4.8)._

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

