### PR TITLE
Remove useless AI SDK logs and fix lags

### DIFF
--- a/apps/backend/src/agents/compaction/compaction-llm.ts
+++ b/apps/backend/src/agents/compaction/compaction-llm.ts
@@ -29,6 +29,7 @@ export class CompactionLLM implements ICompactionLLM {
 
 		const { text, usage } = await generateText({
 			...this._model,
+			system: COMPACTION_SYSTEM_PROMPT,
 			messages: modelMessages,
 			maxOutputTokens: MAX_OUTPUT_TOKENS,
 			experimental_telemetry: llmTelemetry('nao-compaction'),
@@ -63,10 +64,6 @@ export class CompactionLLM implements ICompactionLLM {
 	}
 
 	private _composeMessages(selectedMessages: ModelMessage[]): ModelMessage[] {
-		return [
-			{ role: 'system', content: COMPACTION_SYSTEM_PROMPT },
-			...selectedMessages,
-			{ role: 'user', content: COMPACTION_USER_PROMPT },
-		];
+		return [...selectedMessages, { role: 'user', content: COMPACTION_USER_PROMPT }];
 	}
 }

--- a/apps/backend/src/agents/memory/memory-extractor-llm.ts
+++ b/apps/backend/src/agents/memory/memory-extractor-llm.ts
@@ -42,6 +42,7 @@ export class MemoryExtractorLLM {
 		const { output, usage } = await generateText({
 			...this.model,
 			output: Output.object({ schema: ExtractorOutputSchema }),
+			system: MEMORY_EXTRACTION_SYSTEM_PROMPT,
 			messages: modelMessages,
 			maxOutputTokens: MAX_OUTPUT_TOKENS,
 			experimental_telemetry: llmTelemetry('nao-memory-extraction'),
@@ -53,11 +54,7 @@ export class MemoryExtractorLLM {
 	}
 
 	private _buildModelMessages(memories: DBMemory[], uiMessages: UIMessage[]): ModelMessage[] {
-		return [
-			{ role: 'system', content: MEMORY_EXTRACTION_SYSTEM_PROMPT },
-			...this._buildConversationMessages(uiMessages),
-			this._buildUserMemoryMessage(memories),
-		];
+		return [...this._buildConversationMessages(uiMessages), this._buildUserMemoryMessage(memories)];
 	}
 
 	private _buildConversationMessages(uiMessages: UIMessage[]): ModelMessage[] {

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -65,7 +65,7 @@ import {
 } from '../utils/llm';
 import { logger } from '../utils/logger';
 import { extractConfiguredDatabases } from '../utils/nao-config';
-import { addPromptCache } from '../utils/prompt-cache';
+import { addPromptCache, cachedSystemInstructions } from '../utils/prompt-cache';
 import { scheduleSaveLlmInferenceRecord } from '../utils/schedule-task';
 import { sanitizeTitle, TITLE_MAX_OUTPUT_TOKENS, titleFromPrompt, titleGenerationUserMessage } from '../utils/title';
 import { isStoragePath } from '../utils/tools';
@@ -365,6 +365,7 @@ class AgentManager {
 	private readonly _finished: Promise<void>;
 	private _resolveFinished: (() => void) | undefined;
 	private _streamWriter?: UIMessageStreamWriter<UIMessage>;
+	private _systemPrompt = '';
 
 	constructor(
 		readonly chat: AgentChat,
@@ -392,6 +393,10 @@ class AgentManager {
 			...(callSettings.temperature !== undefined && { temperature: callSettings.temperature }),
 			...(callSettings.topP !== undefined && { topP: callSettings.topP }),
 			...(callSettings.topK !== undefined && { topK: callSettings.topK }),
+			prepareCall: async (args) => ({
+				...args,
+				instructions: cachedSystemInstructions(this._systemPrompt, this._modelSelection),
+			}),
 			prepareStep: async ({ messages }) => this._prepareStep(messages),
 			stopWhen,
 			experimental_context: this._toolContext,
@@ -416,11 +421,15 @@ class AgentManager {
 	}
 
 	private async _prepareStep(messages: ModelMessage[]): Promise<{ messages: ModelMessage[] }> {
+		const workingMessages: ModelMessage[] =
+			this._systemPrompt && messages[0]?.role !== 'system'
+				? [{ role: 'system', content: this._systemPrompt }, ...messages]
+				: messages;
 		await compactionService.compactConversationIfNeeded({
 			chat: this.chat,
 			provider: this._modelSelection.provider,
 			modelId: this._modelSelection.modelId,
-			messages,
+			messages: workingMessages,
 			tools: this._agentTools,
 			maxOutputTokens: this._maxOutputTokens,
 			contextWindow: this._modelConfig.contextWindow,
@@ -438,7 +447,8 @@ class AgentManager {
 			},
 		});
 
-		return { messages: this._addCache(this._pruneMessages(messages)) };
+		const conversationMessages = workingMessages[0]?.role === 'system' ? workingMessages.slice(1) : workingMessages;
+		return { messages: this._addCache(this._pruneMessages(conversationMessages)) };
 	}
 
 	get generatedArtifacts(): ToolContext['generatedArtifacts'] {
@@ -571,18 +581,12 @@ class AgentManager {
 		const uiMessagesWithResolvedAttachments = await resolveAttachments(uiMessagesWithCompaction);
 
 		const systemPrompt = this._systemPromptOverride ?? (await this._buildSystemPrompt(provider, timezone, chatUrl));
+		this._systemPrompt = systemPrompt;
+		const conversationMessages = uiMessagesWithResolvedAttachments.filter((message) => message.role !== 'system');
 
-		const systemMessage: Omit<UIMessage, 'id'> = {
-			role: 'system',
-			parts: [{ type: 'text', text: systemPrompt }],
-		};
-
-		const modelMessages = await convertToModelMessages<UIMessage>(
-			[systemMessage, ...uiMessagesWithResolvedAttachments],
-			{
-				tools: this._agentTools,
-			},
-		);
+		const modelMessages = await convertToModelMessages<UIMessage>(conversationMessages, {
+			tools: this._agentTools,
+		});
 
 		return modelMessages;
 	}
@@ -980,10 +984,7 @@ class AgentManager {
 	/**
 	 * Add Anthropic cache breakpoints to messages.
 	 * Applies to direct Anthropic, Vertex Claude, and Bedrock Anthropic models.
-	 *
-	 * Cache strategy:
-	 * - System message: 1h TTL (instructions rarely change)
-	 * - Last message: 5m TTL (current step's leaf for agentic caching)
+	 * The one-hour system breakpoint is applied separately to instructions.
 	 */
 	private _addCache(messages: ModelMessage[]): ModelMessage[] {
 		return addPromptCache(messages, this._modelSelection);

--- a/apps/backend/src/services/mattermost-helpers.ts
+++ b/apps/backend/src/services/mattermost-helpers.ts
@@ -279,22 +279,56 @@ export async function patchMattermostAnswerPost(input: {
 	baseProps: Record<string, unknown>;
 	attachments: MattermostStopAttachment[];
 	fetchImpl?: typeof fetch;
+	sleep?: (ms: number) => Promise<void>;
 }): Promise<void> {
 	const fetchImpl = input.fetchImpl ?? fetch;
+	const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
 	const url = createMattermostPostPatchUrl(input.baseUrl, input.postId);
 	const headers = {
 		Accept: 'application/json',
 		Authorization: `Bearer ${input.botToken}`,
 		'Content-Type': 'application/json',
 	};
-	const response = await fetchImpl(url, {
-		method: 'PUT',
-		headers,
-		body: JSON.stringify(buildMattermostAnswerPatchBody(input.message, input.baseProps, input.attachments)),
-	});
-	if (!response.ok) {
-		throw new Error(`Mattermost post patch failed with status ${response.status}`);
+	const body = JSON.stringify(buildMattermostAnswerPatchBody(input.message, input.baseProps, input.attachments));
+
+	for (let retryCount = 0; ; retryCount += 1) {
+		const response = await fetchImpl(url, {
+			method: 'PUT',
+			headers,
+			body,
+		});
+		if (response.ok) {
+			return;
+		}
+		if (response.status !== 429 || retryCount === MATTERMOST_PATCH_MAX_RETRIES) {
+			throw new Error(`Mattermost post patch failed with status ${response.status}`);
+		}
+		await sleep(getMattermostPatchRetryDelayMs(response.headers));
 	}
+}
+
+function getMattermostPatchRetryDelayMs(headers: Headers): number {
+	const resetSeconds = parseNonNegativeNumber(headers.get('X-Ratelimit-Reset'));
+	if (resetSeconds !== null) {
+		return Math.min(resetSeconds * 1000, MATTERMOST_PATCH_MAX_RETRY_DELAY_MS);
+	}
+	const retryAfterSeconds = parseNonNegativeInteger(headers.get('Retry-After'));
+	if (retryAfterSeconds !== null) {
+		return Math.min(retryAfterSeconds * 1000, MATTERMOST_PATCH_MAX_RETRY_DELAY_MS);
+	}
+	return MATTERMOST_PATCH_DEFAULT_RETRY_DELAY_MS;
+}
+
+function parseNonNegativeNumber(value: string | null): number | null {
+	if (value === null || value.trim() === '') {
+		return null;
+	}
+	const number = Number(value);
+	return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function parseNonNegativeInteger(value: string | null): number | null {
+	return value !== null && /^\d+$/.test(value.trim()) ? Number(value) : null;
 }
 
 export async function validateMattermostConnection(input: {
@@ -500,6 +534,9 @@ const MATTERMOST_TABLE_COLUMN_LIMIT = 20;
 const MATTERMOST_TABLE_CELL_LIMIT = 160;
 const MATTERMOST_TABLE_MAX_LENGTH = 12_000;
 const MISSING_EMAIL_CACHE_TTL_MS = 5 * 60 * 1000;
+const MATTERMOST_PATCH_MAX_RETRIES = 3;
+const MATTERMOST_PATCH_MAX_RETRY_DELAY_MS = 2_000;
+const MATTERMOST_PATCH_DEFAULT_RETRY_DELAY_MS = 500;
 
 function extractMentionTokens(value: unknown): string[] {
 	if (Array.isArray(value)) {

--- a/apps/backend/src/services/mattermost.ts
+++ b/apps/backend/src/services/mattermost.ts
@@ -57,8 +57,8 @@ import {
 } from './mattermost-helpers';
 import { posthog, PostHogEvent } from './posthog';
 
-/** Mattermost throttles frequent post edits and the adapter has no rate-limit backoff. */
-const UPDATE_INTERVAL_MS = 1000;
+/** 5 patches/s. Mattermost rate limiting is off by default; when on, default is 10/s. */
+const UPDATE_INTERVAL_MS = 200;
 
 type MattermostConversationContext = Omit<ConversationContext, 'blocks' | 'textBlockIndex'> & {
 	answerTextPartIndex: number;

--- a/apps/backend/src/services/mattermost.ts
+++ b/apps/backend/src/services/mattermost.ts
@@ -57,7 +57,7 @@ import {
 } from './mattermost-helpers';
 import { posthog, PostHogEvent } from './posthog';
 
-/** 5 patches/s. Mattermost rate limiting is off by default; when on, default is 10/s. */
+/** Matches Slack's 200ms cadence; 429s are retried because Mattermost's server bucket is shared. */
 const UPDATE_INTERVAL_MS = 200;
 
 type MattermostConversationContext = Omit<ConversationContext, 'blocks' | 'textBlockIndex'> & {
@@ -432,7 +432,7 @@ class ProjectMattermostBot {
 			const { lastMessage } = await this._readStreamAndUpdateMessage(stream, ctx);
 
 			const chatUrl = new URL(ctx.chatId, this._config.redirectUrl).toString();
-			await this._editAnswerMessage(ctx, chatUrl);
+			await this._editAnswerMessageFailSoft(ctx, chatUrl);
 			if (answerPostId) {
 				await this._setStopAttachment(answerPostId, false);
 			}
@@ -532,6 +532,19 @@ class ProjectMattermostBot {
 		});
 	}
 
+	private async _editAnswerMessageFailSoft(ctx: MattermostConversationContext, chatUrl?: string): Promise<boolean> {
+		try {
+			await this._editAnswerMessage(ctx, chatUrl);
+			return true;
+		} catch (error) {
+			logger.warn(`Failed to update Mattermost answer post: ${String(error)}`, {
+				source: 'system',
+				projectId: this._config.projectId,
+			});
+			return false;
+		}
+	}
+
 	private _handleClarificationPart(
 		part: Extract<UIMessagePart, { type: 'tool-clarification' }>,
 		state: StreamState,
@@ -553,8 +566,9 @@ class ProjectMattermostBot {
 		if (Date.now() - state.lastUpdateAt < UPDATE_INTERVAL_MS || !part.text) {
 			return;
 		}
-		await this._editAnswerMessage(ctx);
-		state.lastUpdateAt = Date.now();
+		if (await this._editAnswerMessageFailSoft(ctx)) {
+			state.lastUpdateAt = Date.now();
+		}
 	}
 
 	private _handleSqlPart(part: Extract<UIMessagePart, { type: 'tool-execute_sql' }>, state: StreamState): void {
@@ -614,7 +628,7 @@ class ProjectMattermostBot {
 			state.renderedToolCallIds.add(part.toolCallId);
 			ctx.answerTextPartIndex = -1;
 			ctx.bodyParts.push(table);
-			await this._editAnswerMessage(ctx);
+			await this._editAnswerMessageFailSoft(ctx);
 			return;
 		}
 		try {
@@ -728,8 +742,9 @@ class ProjectMattermostBot {
 		}
 
 		if (Date.now() - state.lastUpdateAt >= UPDATE_INTERVAL_MS) {
-			await this._editAnswerMessage(ctx);
-			state.lastUpdateAt = Date.now();
+			if (await this._editAnswerMessageFailSoft(ctx)) {
+				state.lastUpdateAt = Date.now();
+			}
 		}
 	}
 
@@ -746,7 +761,7 @@ class ProjectMattermostBot {
 		if (ctx.answerTextPartIndex === -1 || !ctx.convMessage) {
 			return;
 		}
-		await this._editAnswerMessage(ctx);
+		await this._editAnswerMessageFailSoft(ctx);
 	}
 
 	private _updateTextBlock(text: string, ctx: MattermostConversationContext): void {

--- a/apps/backend/src/utils/prompt-cache.ts
+++ b/apps/backend/src/utils/prompt-cache.ts
@@ -1,5 +1,5 @@
 import type { LlmSelectedModel } from '@nao/shared/types';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage, SystemModelMessage } from 'ai';
 
 import { CACHE_1H, CACHE_5M } from '../agents/providers';
 
@@ -9,6 +9,15 @@ const BEDROCK_CACHE_5M = { type: 'default' } as const;
 type AnthropicCache = typeof CACHE_1H | typeof CACHE_5M;
 type BedrockCache = typeof BEDROCK_CACHE_1H | typeof BEDROCK_CACHE_5M;
 type PromptCacheProvider = 'anthropic' | 'bedrock';
+
+export function cachedSystemInstructions(text: string, modelSelection: LlmSelectedModel): string | SystemModelMessage {
+	const cacheProvider = getPromptCacheProvider(modelSelection);
+	if (!cacheProvider) {
+		return text;
+	}
+
+	return withPromptCache({ role: 'system', content: text }, cacheProvider, '1h') as SystemModelMessage;
+}
 
 export function addPromptCache(messages: ModelMessage[], modelSelection: LlmSelectedModel): ModelMessage[] {
 	const cacheProvider = getPromptCacheProvider(modelSelection);

--- a/apps/backend/tests/compaction-llm.test.ts
+++ b/apps/backend/tests/compaction-llm.test.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from 'ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CompactionLLM } from '../src/agents/compaction/compaction-llm';
+import { COMPACTION_SYSTEM_PROMPT } from '../src/components/ai/compaction-system-prompt';
 import type { ITokenCounter } from '../src/services/token-counter';
 import { selectMessagesInBudget } from '../src/utils/ai';
 
@@ -145,10 +146,11 @@ describe('CompactionLLM', () => {
 
 		await llm.compact(messages);
 
-		const { messages: sent } = mocks.generateText.mock.calls[0][0];
-		expect(sent[0].role).toBe('system');
+		const { messages: sent, system } = mocks.generateText.mock.calls[0][0];
+		expect(system).toBe(COMPACTION_SYSTEM_PROMPT);
+		expect(sent[0]).toEqual(messages[0]);
 		expect(sent[sent.length - 1].role).toBe('user');
-		expect(sent.slice(1, -1)).toEqual(messages);
+		expect(sent.slice(0, -1)).toEqual(messages);
 	});
 
 	it('returns summary text and usage from generateText', async () => {
@@ -177,7 +179,7 @@ describe('CompactionLLM', () => {
 		await llm.compact(messages);
 
 		const { messages: sent } = mocks.generateText.mock.calls[0][0];
-		const body = sent.slice(1, -1); // strip system + user prompts
+		const body = sent.slice(0, -1);
 		expect(body).toHaveLength(1);
 		expect(body[0]).toEqual(messages[2]);
 	});

--- a/apps/backend/tests/mattermost-messaging.test.ts
+++ b/apps/backend/tests/mattermost-messaging.test.ts
@@ -483,6 +483,89 @@ describe('Mattermost answer rendering', () => {
 		);
 	});
 
+	it('retries a rate-limited post patch', async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(new Response(null, { status: 429 }))
+			.mockResolvedValueOnce(new Response(null, { status: 200 }));
+		const sleep = vi.fn(async () => undefined);
+
+		await patchMattermostAnswerPost({
+			baseUrl: 'https://mattermost.example/base/',
+			botToken: 'token',
+			postId: 'post-1',
+			message: 'Streaming answer',
+			baseProps: {},
+			attachments: [],
+			fetchImpl,
+			sleep,
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		expect(sleep).toHaveBeenCalledOnce();
+	});
+
+	it('uses the Mattermost rate-limit reset delay', async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(new Response(null, { status: 429, headers: { 'X-Ratelimit-Reset': '1' } }))
+			.mockResolvedValueOnce(new Response(null, { status: 200 }));
+		const sleep = vi.fn(async () => undefined);
+
+		await patchMattermostAnswerPost({
+			baseUrl: 'https://mattermost.example/base/',
+			botToken: 'token',
+			postId: 'post-1',
+			message: 'Streaming answer',
+			baseProps: {},
+			attachments: [],
+			fetchImpl,
+			sleep,
+		});
+
+		expect(sleep).toHaveBeenCalledWith(1000);
+	});
+
+	it('throws after exhausting post patch rate-limit retries', async () => {
+		const fetchImpl = vi.fn(async () => new Response(null, { status: 429 }));
+		const sleep = vi.fn(async () => undefined);
+
+		await expect(
+			patchMattermostAnswerPost({
+				baseUrl: 'https://mattermost.example/base/',
+				botToken: 'token',
+				postId: 'post-1',
+				message: 'Streaming answer',
+				baseProps: {},
+				attachments: [],
+				fetchImpl,
+				sleep,
+			}),
+		).rejects.toThrow('Mattermost post patch failed with status 429');
+		expect(fetchImpl).toHaveBeenCalledTimes(4);
+		expect(sleep).toHaveBeenCalledTimes(3);
+	});
+
+	it('does not retry other post patch failures', async () => {
+		const fetchImpl = vi.fn(async () => new Response(null, { status: 500 }));
+		const sleep = vi.fn(async () => undefined);
+
+		await expect(
+			patchMattermostAnswerPost({
+				baseUrl: 'https://mattermost.example/base/',
+				botToken: 'token',
+				postId: 'post-1',
+				message: 'Streaming answer',
+				baseProps: {},
+				attachments: [],
+				fetchImpl,
+				sleep,
+			}),
+		).rejects.toThrow('Mattermost post patch failed with status 500');
+		expect(fetchImpl).toHaveBeenCalledOnce();
+		expect(sleep).not.toHaveBeenCalled();
+	});
+
 	it('keeps the answer and link in markdown without a card', () => {
 		const message = createMattermostAnswerMessage('Answer text', 'https://nao.example/chat-1');
 

--- a/apps/backend/tests/prompt-cache.test.ts
+++ b/apps/backend/tests/prompt-cache.test.ts
@@ -2,7 +2,23 @@ import type { LlmSelectedModel } from '@nao/shared/types';
 import type { ModelMessage } from 'ai';
 import { describe, expect, it } from 'vitest';
 
-import { addPromptCache, getPromptCacheProvider } from '../src/utils/prompt-cache';
+import { addPromptCache, cachedSystemInstructions, getPromptCacheProvider } from '../src/utils/prompt-cache';
+
+describe('cachedSystemInstructions', () => {
+	it('returns plain instructions for providers without prompt caching', () => {
+		expect(cachedSystemInstructions('System prompt', modelSelection('openai', 'gpt-5.2'))).toBe('System prompt');
+	});
+
+	it('adds a one-hour Anthropic cache breakpoint', () => {
+		expect(cachedSystemInstructions('System prompt', modelSelection('anthropic', 'claude-sonnet-4.5'))).toEqual({
+			role: 'system',
+			content: 'System prompt',
+			providerOptions: {
+				anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+			},
+		});
+	});
+});
 
 describe('addPromptCache', () => {
 	const messages: ModelMessage[] = [


### PR DESCRIPTION
## Summary

- Stopped a repeating AI SDK warning that filled the backend logs on every chat (web, Slack, Mattermost, etc.).
- Made the Mattermost bot update its message every 200ms, same as Slack, Teams, and Telegram, so streaming no longer feels a second behind.
- If Mattermost asks the bot to slow down, we wait and retry instead of replacing the answer with an error.

Closes #1627

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

