### PR TITLE
fix/nao sync fail now correctly throws error log #125

### DIFF
--- a/cli/nao_core/commands/sync/providers/confluence/provider.py
+++ b/cli/nao_core/commands/sync/providers/confluence/provider.py
@@ -362,12 +362,15 @@ class ConfluenceSyncProvider(SyncProvider):
             summary += f", {len(reused)} unchanged"
         if removed_count:
             summary += f", {removed_count} stale removed"
+        page_label = "page" if failed_pages == 1 else "pages"
+        error = f"Failed to sync {failed_pages} Confluence {page_label}" if failed_pages else None
 
         return SyncResult(
             provider_name=self.name,
             items_synced=pages_synced,
             details={"synced": len(written), "unchanged": len(reused), "removed": removed_count},
             summary=summary,
+            error=error,
         )
 
     @staticmethod

--- a/cli/nao_core/commands/sync/providers/confluence/provider.py
+++ b/cli/nao_core/commands/sync/providers/confluence/provider.py
@@ -11,6 +11,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 
 from nao_core.config.base import NaoConfig
 from nao_core.config.confluence import ConfluenceConfig
+from nao_core.ui import UI
 
 from ..base import SyncProvider, SyncResult
 from .client import ConfluenceClient, ConfluencePage, extract_page_id
@@ -223,7 +224,7 @@ def fetch_pages(client: ConfluenceClient, page_ids: list[str], threads: int) -> 
             except Exception as error:  # noqa: BLE001 - one unreadable page must not stop the rest
                 with lock:
                     failed += 1
-                console.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}")
+                UI.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_id)}: {escape(str(error))}")
                 progress.update(task, advance=1)
                 return
 
@@ -254,7 +255,7 @@ def write_documents(pages: list[ConfluencePage], output_path: Path) -> tuple[set
             target.write_text(render_document(page), encoding="utf-8")
         except (OSError, UnicodeError) as error:
             failed += 1
-            console.print(f"[bold red]✗[/bold red] Failed to write {escape(str(relative))}: {escape(str(error))}")
+            UI.print(f"[bold red]✗[/bold red] Failed to write {escape(str(relative))}: {escape(str(error))}")
             continue
         written.add(target.resolve())
 
@@ -272,7 +273,7 @@ def cleanup_stale_pages(kept: set[Path], output_path: Path, verbose: bool = Fals
             file_path.unlink()
             removed_count += 1
             if verbose:
-                console.print(f"  [dim red]removing stale page:[/dim red] {file_path.relative_to(output_path)}")
+                UI.print(f"  [dim red]removing stale page:[/dim red] {file_path.relative_to(output_path)}")
 
     prune_empty_dirs(output_path)
     return removed_count
@@ -292,7 +293,7 @@ def cleanup_if_fully_synced(failed_pages: int, kept: set[Path], output_path: Pat
     delete markdown that is still good, losing content to what is often a transient error.
     """
     if failed_pages:
-        console.print(
+        UI.print(
             f"[yellow]⚠[/yellow]  Keeping existing files: {failed_pages} page(s) failed, so stale ones were "
             "left in place and will remain until a run succeeds in full"
         )
@@ -340,8 +341,8 @@ class ConfluenceSyncProvider(SyncProvider):
         config = items[0]
         output_path.mkdir(parents=True, exist_ok=True)
 
-        console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
-        console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
+        UI.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
+        UI.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
 
         with ConfluenceClient(config) as client:
             refs = gather_page_refs(client, config)

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -499,6 +499,7 @@ class DatabaseSyncProvider(SyncProvider):
         total_tables = 0
         total_removed = 0
         sync_states: list[DatabaseSyncState] = []
+        failures: list[str] = []
 
         nao_ctx = create_nao_context(self._nao_config, project_path=project_path) if self._nao_config else None
         llm_config = self._nao_config.llm if self._nao_config else None
@@ -545,7 +546,9 @@ class DatabaseSyncProvider(SyncProvider):
                         total_datasets += state.schemas_synced
                         total_tables += state.tables_synced
                     except Exception as e:
-                        console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {_fmt_error(e)}")
+                        error = _fmt_error(e)
+                        failures.append(f"{db.name}: {error}")
+                        console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {error}")
             else:
                 with ThreadPoolExecutor(max_workers=min(threads, len(items))) as executor:
                     futures = {
@@ -570,7 +573,9 @@ class DatabaseSyncProvider(SyncProvider):
                             total_datasets += state.schemas_synced
                             total_tables += state.tables_synced
                         except Exception as e:
-                            console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {_fmt_error(e)}")
+                            error = _fmt_error(e)
+                            failures.append(f"{db.name}: {error}")
+                            console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {error}")
 
         if not select:
             for state in sync_states:
@@ -582,6 +587,11 @@ class DatabaseSyncProvider(SyncProvider):
         if total_removed > 0:
             summary += f", {total_removed} stale removed"
 
+        error = None
+        if failures:
+            database_label = "database" if len(failures) == 1 else "databases"
+            error = f"Failed to sync {len(failures)} {database_label}: {'; '.join(failures)}"
+
         return SyncResult(
             provider_name=self.name,
             items_synced=total_tables,
@@ -591,4 +601,5 @@ class DatabaseSyncProvider(SyncProvider):
                 "removed": total_removed,
             },
             summary=summary,
+            error=error,
         )

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -509,7 +509,7 @@ class DatabaseSyncProvider(SyncProvider):
 
         for db in items:
             template_names = [t.value for t in db.templates]
-            console.print(f"[dim]{db.name}:[/dim] {', '.join(template_names)}")
+            console.print(f"[dim]{escape(db.name)}:[/dim] {', '.join(template_names)}")
         if threads > 1 and len(items) > 1:
             console.print(f"[dim]Threads:[/dim] {threads}")
         if select:
@@ -547,8 +547,9 @@ class DatabaseSyncProvider(SyncProvider):
                         total_tables += state.tables_synced
                     except Exception as e:
                         error = _fmt_error(e)
-                        failures.append(f"{db.name}: {error}")
-                        console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {error}")
+                        database_name = escape(db.name)
+                        failures.append(f"{database_name}: {error}")
+                        console.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
             else:
                 with ThreadPoolExecutor(max_workers=min(threads, len(items))) as executor:
                     futures = {
@@ -574,8 +575,9 @@ class DatabaseSyncProvider(SyncProvider):
                             total_tables += state.tables_synced
                         except Exception as e:
                             error = _fmt_error(e)
-                            failures.append(f"{db.name}: {error}")
-                            console.print(f"[bold red]✗[/bold red] Failed to sync {db.name}: {error}")
+                            database_name = escape(db.name)
+                            failures.append(f"{database_name}: {error}")
+                            console.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
 
         if not select:
             for state in sync_states:

--- a/cli/nao_core/commands/sync/providers/databases/provider.py
+++ b/cli/nao_core/commands/sync/providers/databases/provider.py
@@ -47,6 +47,7 @@ from nao_core.config.databases.column_catalog import (
 from nao_core.config.llm import LLMConfig
 from nao_core.templates.context import NaoContext, create_nao_context
 from nao_core.templates.engine import get_template_engine
+from nao_core.ui import UI
 
 from ..base import SyncProvider, SyncResult
 
@@ -110,7 +111,7 @@ def _fetch_query_history(db_config: DatabaseConfig, conn: BaseBackend) -> list[s
     days = db_config.query_history_days or 30
     history_sql = db_config.get_query_history_sql(days)
     if not history_sql:
-        console.print("  [yellow]⚠[/yellow] [dim]Query history not supported for this database type[/dim]")
+        UI.print("  [yellow]⚠[/yellow] [dim]Query history not supported for this database type[/dim]")
         return []
 
     try:
@@ -120,10 +121,10 @@ def _fetch_query_history(db_config: DatabaseConfig, conn: BaseBackend) -> list[s
         queries = db_config.filter_query_history(queries)
         excluded = fetched - len(queries)
         suffix = f" [dim](excluded {excluded} via query_history_exclude_patterns)[/dim]" if excluded else ""
-        console.print(f"  [dim]Fetched[/dim] [bold]{fetched}[/bold] [dim]queries for history analysis[/dim]{suffix}")
+        UI.print(f"  [dim]Fetched[/dim] [bold]{fetched}[/bold] [dim]queries for history analysis[/dim]{suffix}")
         return queries
     except Exception as e:
-        console.print(f"  [yellow]⚠[/yellow] [dim]Failed to fetch query history:[/dim] {_fmt_error(e)}")
+        UI.print(f"  [yellow]⚠[/yellow] [dim]Failed to fetch query history:[/dim] {_fmt_error(e)}")
         return []
 
 
@@ -233,7 +234,7 @@ def sync_database(
     t_connect = time.monotonic()
     conn = db_config.connect()
     try:
-        console.print(
+        UI.print(
             f"  [dim]Connected to[/dim] [bold]{db_config.name}[/bold] "
             f"[dim]({_fmt_duration(time.monotonic() - t_connect)})[/dim]"
         )
@@ -249,7 +250,7 @@ def sync_database(
 
         t_schemas = time.monotonic()
         schemas = db_config.get_schemas(conn)
-        console.print(
+        UI.print(
             f"  [dim]Found[/dim] [bold]{len(schemas)}[/bold] "
             f"[dim]schemas ({_fmt_duration(time.monotonic() - t_schemas)})[/dim]"
         )
@@ -270,7 +271,7 @@ def sync_database(
                 t_list = time.monotonic()
                 all_tables = conn.list_tables(database=schema)
             except Exception as e:
-                console.print(f"  [yellow]⚠[/yellow] [dim]Skipping schema[/dim] {schema}: {_fmt_error(e)}")
+                UI.print(f"  [yellow]⚠[/yellow] [dim]Skipping schema[/dim] {schema}: {_fmt_error(e)}")
                 failed_schemas.add(schema)
                 progress.update(schema_task, advance=1)
                 continue
@@ -283,7 +284,7 @@ def sync_database(
 
             if tables:
                 list_dur = _fmt_duration(time.monotonic() - t_list)
-                console.print(
+                UI.print(
                     f"  [cyan]▸ {schema}[/cyan] [dim]— {len(tables)} tables "
                     f"(of {len(all_tables)} total, listed in {list_dur})[/dim]"
                 )
@@ -357,7 +358,7 @@ def sync_database(
 
                     if tpl_name == "profiling":
                         if not profiling_due:
-                            console.print(
+                            UI.print(
                                 f"    [dim]⏭ {schema}.{table} profiling skipped "
                                 f"(policy: {db_config.profiling.refresh_policy.value})[/dim]"
                             )
@@ -365,7 +366,7 @@ def sync_database(
                         extra_ctx["profiling"] = profiling_data
                     if tpl_name == "ai_summary":
                         if not summary_due:
-                            console.print(
+                            UI.print(
                                 f"    [dim]⏭ {schema}.{table} ai_summary skipped "
                                 f"(policy: {db_config.ai_summary.refresh_policy.value})[/dim]"
                             )
@@ -385,7 +386,7 @@ def sync_database(
                         )
                         render_dur = time.monotonic() - t_render
                         if render_dur > 5:
-                            console.print(
+                            UI.print(
                                 f"    [yellow]⏱[/yellow] [dim]{schema}.{table}[/dim] "
                                 f"[yellow]{tpl_name}[/yellow] [dim]took {_fmt_duration(render_dur)}[/dim]"
                             )
@@ -393,7 +394,7 @@ def sync_database(
                         render_dur = time.monotonic() - t_render
                         schema_errors += 1
                         total_errors += 1
-                        console.print(
+                        UI.print(
                             f"    [bold red]✗[/bold red] [dim]{schema}.{table}[/dim] "
                             f"[red]{tpl_name}[/red] [dim]failed after "
                             f"{_fmt_duration(render_dur)}:[/dim] {_fmt_error(e)}"
@@ -416,7 +417,7 @@ def sync_database(
             if tables:
                 schema_dur = _fmt_duration(time.monotonic() - schema_start)
                 error_suffix = f" [red]({schema_errors} errors)[/red]" if schema_errors else ""
-                console.print(
+                UI.print(
                     f"  [green]✓ {schema}[/green] [dim]— {len(tables)} tables synced in {schema_dur}{error_suffix}[/dim]"
                 )
 
@@ -435,12 +436,12 @@ def sync_database(
                         content_parts.append(f"```sql\n{sv['definition']}\n```\n")
                     (sv_path / "definition.md").write_text(with_generated_marker("\n".join(content_parts)))
                     state.add_table(schema, sv["name"])
-                console.print(f"  [green]✓ {schema}[/green] [dim]— {len(semantic_views)} semantic views synced[/dim]")
+                UI.print(f"  [green]✓ {schema}[/green] [dim]— {len(semantic_views)} semantic views synced[/dim]")
 
             progress.update(schema_task, advance=1)
 
         if total_errors:
-            console.print(f"  [yellow]⚠ {total_errors} total errors during sync[/yellow]")
+            UI.print(f"  [yellow]⚠ {total_errors} total errors during sync[/yellow]")
 
         catalog_project_path = project_path if project_path is not None else base_path.parent
         _save_column_catalog(
@@ -492,7 +493,7 @@ class DatabaseSyncProvider(SyncProvider):
         select: list[str] | None = None,
     ) -> SyncResult:
         if not items:
-            console.print("\n[dim]No databases configured[/dim]")
+            UI.print("\n[dim]No databases configured[/dim]")
             return SyncResult(provider_name=self.name, items_synced=0)
 
         total_datasets = 0
@@ -504,17 +505,17 @@ class DatabaseSyncProvider(SyncProvider):
         nao_ctx = create_nao_context(self._nao_config, project_path=project_path) if self._nao_config else None
         llm_config = self._nao_config.llm if self._nao_config else None
 
-        console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
-        console.print(f"[dim]Location:[/dim] {output_path.absolute()}")
+        UI.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
+        UI.print(f"[dim]Location:[/dim] {output_path.absolute()}")
 
         for db in items:
             template_names = [t.value for t in db.templates]
-            console.print(f"[dim]{escape(db.name)}:[/dim] {', '.join(template_names)}")
+            UI.print(f"[dim]{escape(db.name)}:[/dim] {', '.join(template_names)}")
         if threads > 1 and len(items) > 1:
-            console.print(f"[dim]Threads:[/dim] {threads}")
+            UI.print(f"[dim]Threads:[/dim] {threads}")
         if select:
-            console.print(f"[dim]Select:[/dim] {', '.join(select)} [dim](stale cleanup skipped)[/dim]")
-        console.print()
+            UI.print(f"[dim]Select:[/dim] {', '.join(select)} [dim](stale cleanup skipped)[/dim]")
+        UI.print()
 
         sync_start = time.monotonic()
 
@@ -549,7 +550,7 @@ class DatabaseSyncProvider(SyncProvider):
                         error = _fmt_error(e)
                         database_name = escape(db.name)
                         failures.append(f"{database_name}: {error}")
-                        console.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
+                        UI.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
             else:
                 with ThreadPoolExecutor(max_workers=min(threads, len(items))) as executor:
                     futures = {
@@ -577,7 +578,7 @@ class DatabaseSyncProvider(SyncProvider):
                             error = _fmt_error(e)
                             database_name = escape(db.name)
                             failures.append(f"{database_name}: {error}")
-                            console.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
+                            UI.print(f"[bold red]✗[/bold red] Failed to sync {database_name}: {error}")
 
         if not select:
             for state in sync_states:

--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -390,10 +390,13 @@ class NotionSyncProvider(SyncProvider):
         summary = f"{pages_synced} pages synced as markdown"
         if removed_count > 0:
             summary += f", {removed_count} stale removed"
+        page_label = "page" if failed_pages == 1 else "pages"
+        error = f"Failed to sync {failed_pages} Notion {page_label}" if failed_pages else None
 
         return SyncResult(
             provider_name=self.name,
             items_synced=pages_synced,
             details={"pages": synced_pages, "removed": removed_count},
             summary=summary,
+            error=error,
         )

--- a/cli/nao_core/commands/sync/providers/notion/provider.py
+++ b/cli/nao_core/commands/sync/providers/notion/provider.py
@@ -11,6 +11,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn
 
 from nao_core.config.base import NaoConfig
 from nao_core.config.notion import NotionConfig
+from nao_core.ui import UI
 
 from ..base import SyncProvider, SyncResult
 from .database import get_database_as_markdown, inject_child_databases
@@ -54,7 +55,7 @@ def cleanup_stale_pages(synced_files: set[str], output_path: Path, verbose: bool
                 file_path.unlink()
                 removed_count += 1
                 if verbose:
-                    console.print(f"  [dim red]removing stale page:[/dim red] {file_path.name}")
+                    UI.print(f"  [dim red]removing stale page:[/dim red] {file_path.name}")
 
     return removed_count
 
@@ -113,7 +114,7 @@ def cleanup_if_fully_synced(failed_pages: int, synced_files: set[str], output_pa
     Files no longer in Notion therefore survive until every page syncs again.
     """
     if failed_pages:
-        console.print(
+        UI.print(
             f"[yellow]⚠[/yellow]  Keeping existing files: {failed_pages} page(s) failed, so stale ones were "
             "left in place and will remain until a run succeeds in full"
         )
@@ -154,7 +155,7 @@ def fetch_documents(page_urls: list[str], api_key: str, threads: int) -> tuple[l
                 progress.update(task, advance=1, description=f"Synced: {escape(title)}")
             except Exception as error:  # noqa: BLE001 - one unreadable item must not stop the rest
                 failed += 1
-                console.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_url)}: {escape(str(error))}")
+                UI.print(f"[bold red]✗[/bold red] Failed to sync page {escape(page_url)}: {escape(str(error))}")
                 progress.update(task, advance=1)
 
         if threads <= 1 or len(page_urls) == 1:
@@ -186,7 +187,7 @@ def write_documents(documents: list[tuple[str, str, str]], output_path: Path) ->
             (output_path / filename).write_text(markdown, encoding="utf-8")
         except (OSError, UnicodeError) as error:
             failed += 1
-            console.print(f"[bold red]✗[/bold red] Failed to write {escape(filename)}: {escape(str(error))}")
+            UI.print(f"[bold red]✗[/bold red] Failed to write {escape(filename)}: {escape(str(error))}")
             continue
 
         written.add(filename)
@@ -367,16 +368,16 @@ class NotionSyncProvider(SyncProvider):
             SyncResult with statistics about what was synced.
         """
         if not items:
-            console.print("\n[dim]No Notion pages configured[/dim]")
+            UI.print("\n[dim]No Notion pages configured[/dim]")
             return SyncResult(provider_name=self.name, items_synced=0, summary="No Notion configurations configured")
 
         notion_config = items[0]
         output_path.mkdir(parents=True, exist_ok=True)
 
-        console.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
-        console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
+        UI.print(f"\n[bold cyan]{self.emoji}  Syncing {self.name}[/bold cyan]")
+        UI.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
         if threads > 1 and len(notion_config.pages) > 1:
-            console.print(f"[dim]Threads:[/dim] {threads}\n")
+            UI.print(f"[dim]Threads:[/dim] {threads}\n")
 
         api_key = notion_config.api_key
 

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -257,6 +257,7 @@ class RepositorySyncProvider(SyncProvider):
 
         output_path.mkdir(parents=True, exist_ok=True)
         success_count = 0
+        failed_repositories: list[str] = []
 
         console.print(f"\n[bold cyan]{self.emoji} Syncing {self.name}[/bold cyan]")
         console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
@@ -266,6 +267,8 @@ class RepositorySyncProvider(SyncProvider):
                 if sync_repo(repo, output_path):
                     success_count += 1
                     console.print(f"  [green]✓[/green] {repo.name}")
+                else:
+                    failed_repositories.append(repo.name)
         else:
             console.print(f"[dim]Threads:[/dim] {threads}\n")
             with ThreadPoolExecutor(max_workers=min(threads, len(items))) as executor:
@@ -276,7 +279,16 @@ class RepositorySyncProvider(SyncProvider):
                         if future.result():
                             success_count += 1
                             console.print(f"  [green]✓[/green] {repo.name}")
+                        else:
+                            failed_repositories.append(repo.name)
                     except Exception as e:
+                        failed_repositories.append(repo.name)
                         console.print(f"  [yellow]⚠[/yellow] Error syncing {repo.name}: {e}")
 
-        return SyncResult(provider_name=self.name, items_synced=success_count)
+        error = None
+        if failed_repositories:
+            failed_names = ", ".join(sorted(failed_repositories))
+            repository_label = "repository" if len(failed_repositories) == 1 else "repositories"
+            error = f"Failed to sync {len(failed_repositories)} {repository_label}: {failed_names}"
+
+        return SyncResult(provider_name=self.name, items_synced=success_count, error=error)

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -8,6 +8,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from rich.console import Console
+from rich.markup import escape
 
 from nao_core.commands.sync.cleanup import cleanup_stale_repos
 from nao_core.config import NaoConfig
@@ -26,11 +27,11 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     try:
         # Guard against path traversal via malicious repo.name (e.g. "../other")
         if not repo_path.resolve().is_relative_to(base_path.resolve()):
-            console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {repo.name}")
+            console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {escape(repo.name)}")
             return False
 
         action = "Re-cloning" if repo_path.exists() else "Cloning"
-        console.print(f"  [dim]{action}[/dim] {repo.name}")
+        console.print(f"  [dim]{action}[/dim] {escape(repo.name)}")
 
         if tmp_path.exists():
             shutil.rmtree(tmp_path)
@@ -49,7 +50,7 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
         )
 
         if result.returncode != 0:
-            console.print(f"  [yellow]⚠[/yellow] Failed to clone {repo.name}: {result.stderr.strip()}")
+            console.print(f"  [yellow]⚠[/yellow] Failed to clone {escape(repo.name)}: {result.stderr.strip()}")
             shutil.rmtree(tmp_path, ignore_errors=True)
             return False
 
@@ -68,7 +69,7 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
         return True
 
     except Exception as e:
-        console.print(f"  [yellow]⚠[/yellow] Error syncing {repo.name}: {e}")
+        console.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
         shutil.rmtree(tmp_path, ignore_errors=True)
         return False
 
@@ -177,7 +178,7 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
             console.print(f"  [yellow]⚠[/yellow] Local path is not a directory: {source_path}")
             return False
 
-        console.print(f"  [dim]Syncing local path[/dim] {repo.name} [dim]from[/dim] {source_path}")
+        console.print(f"  [dim]Syncing local path[/dim] {escape(repo.name)} [dim]from[/dim] {source_path}")
 
         if repo_path.exists():
             shutil.rmtree(repo_path)
@@ -212,7 +213,7 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
         return True
 
     except Exception as e:
-        console.print(f"  [yellow]⚠[/yellow] Error syncing local path {repo.name}: {e}")
+        console.print(f"  [yellow]⚠[/yellow] Error syncing local path {escape(repo.name)}: {e}")
         return False
 
 
@@ -266,7 +267,7 @@ class RepositorySyncProvider(SyncProvider):
             for repo in items:
                 if sync_repo(repo, output_path):
                     success_count += 1
-                    console.print(f"  [green]✓[/green] {repo.name}")
+                    console.print(f"  [green]✓[/green] {escape(repo.name)}")
                 else:
                     failed_repositories.append(repo.name)
         else:
@@ -278,16 +279,16 @@ class RepositorySyncProvider(SyncProvider):
                     try:
                         if future.result():
                             success_count += 1
-                            console.print(f"  [green]✓[/green] {repo.name}")
+                            console.print(f"  [green]✓[/green] {escape(repo.name)}")
                         else:
                             failed_repositories.append(repo.name)
                     except Exception as e:
                         failed_repositories.append(repo.name)
-                        console.print(f"  [yellow]⚠[/yellow] Error syncing {repo.name}: {e}")
+                        console.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
 
         error = None
         if failed_repositories:
-            failed_names = ", ".join(sorted(failed_repositories))
+            failed_names = ", ".join(escape(name) for name in sorted(failed_repositories))
             repository_label = "repository" if len(failed_repositories) == 1 else "repositories"
             error = f"Failed to sync {len(failed_repositories)} {repository_label}: {failed_names}"
 

--- a/cli/nao_core/commands/sync/providers/repositories/provider.py
+++ b/cli/nao_core/commands/sync/providers/repositories/provider.py
@@ -13,6 +13,7 @@ from rich.markup import escape
 from nao_core.commands.sync.cleanup import cleanup_stale_repos
 from nao_core.config import NaoConfig
 from nao_core.config.repos import RepoConfig
+from nao_core.ui import UI
 
 from ..base import SyncProvider, SyncResult
 
@@ -27,11 +28,11 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
     try:
         # Guard against path traversal via malicious repo.name (e.g. "../other")
         if not repo_path.resolve().is_relative_to(base_path.resolve()):
-            console.print(f"  [yellow]⚠[/yellow] Invalid repo path: {escape(repo.name)}")
+            UI.print(f"  [yellow]⚠[/yellow] Invalid repo path: {escape(repo.name)}")
             return False
 
         action = "Re-cloning" if repo_path.exists() else "Cloning"
-        console.print(f"  [dim]{action}[/dim] {escape(repo.name)}")
+        UI.print(f"  [dim]{action}[/dim] {escape(repo.name)}")
 
         if tmp_path.exists():
             shutil.rmtree(tmp_path)
@@ -50,7 +51,7 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
         )
 
         if result.returncode != 0:
-            console.print(f"  [yellow]⚠[/yellow] Failed to clone {escape(repo.name)}: {result.stderr.strip()}")
+            UI.print(f"  [yellow]⚠[/yellow] Failed to clone {escape(repo.name)}: {result.stderr.strip()}")
             shutil.rmtree(tmp_path, ignore_errors=True)
             return False
 
@@ -69,7 +70,7 @@ def clone_or_pull_repo(repo: RepoConfig, base_path: Path) -> bool:
         return True
 
     except Exception as e:
-        console.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
+        UI.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
         shutil.rmtree(tmp_path, ignore_errors=True)
         return False
 
@@ -171,14 +172,14 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
 
     try:
         if not source_path.exists():
-            console.print(f"  [yellow]⚠[/yellow] Local path does not exist: {source_path}")
+            UI.print(f"  [yellow]⚠[/yellow] Local path does not exist: {source_path}")
             return False
 
         if not source_path.is_dir():
-            console.print(f"  [yellow]⚠[/yellow] Local path is not a directory: {source_path}")
+            UI.print(f"  [yellow]⚠[/yellow] Local path is not a directory: {source_path}")
             return False
 
-        console.print(f"  [dim]Syncing local path[/dim] {escape(repo.name)} [dim]from[/dim] {source_path}")
+        UI.print(f"  [dim]Syncing local path[/dim] {escape(repo.name)} [dim]from[/dim] {source_path}")
 
         if repo_path.exists():
             shutil.rmtree(repo_path)
@@ -213,7 +214,7 @@ def sync_local_repo(repo: RepoConfig, base_path: Path) -> bool:
         return True
 
     except Exception as e:
-        console.print(f"  [yellow]⚠[/yellow] Error syncing local path {escape(repo.name)}: {e}")
+        UI.print(f"  [yellow]⚠[/yellow] Error syncing local path {escape(repo.name)}: {e}")
         return False
 
 
@@ -260,18 +261,18 @@ class RepositorySyncProvider(SyncProvider):
         success_count = 0
         failed_repositories: list[str] = []
 
-        console.print(f"\n[bold cyan]{self.emoji} Syncing {self.name}[/bold cyan]")
-        console.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
+        UI.print(f"\n[bold cyan]{self.emoji} Syncing {self.name}[/bold cyan]")
+        UI.print(f"[dim]Location:[/dim] {output_path.absolute()}\n")
 
         if threads <= 1 or len(items) == 1:
             for repo in items:
                 if sync_repo(repo, output_path):
                     success_count += 1
-                    console.print(f"  [green]✓[/green] {escape(repo.name)}")
+                    UI.print(f"  [green]✓[/green] {escape(repo.name)}")
                 else:
                     failed_repositories.append(repo.name)
         else:
-            console.print(f"[dim]Threads:[/dim] {threads}\n")
+            UI.print(f"[dim]Threads:[/dim] {threads}\n")
             with ThreadPoolExecutor(max_workers=min(threads, len(items))) as executor:
                 futures = {executor.submit(sync_repo, repo, output_path): repo for repo in items}
                 for future in as_completed(futures):
@@ -279,12 +280,12 @@ class RepositorySyncProvider(SyncProvider):
                     try:
                         if future.result():
                             success_count += 1
-                            console.print(f"  [green]✓[/green] {escape(repo.name)}")
+                            UI.print(f"  [green]✓[/green] {escape(repo.name)}")
                         else:
                             failed_repositories.append(repo.name)
                     except Exception as e:
                         failed_repositories.append(repo.name)
-                        console.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
+                        UI.print(f"  [yellow]⚠[/yellow] Error syncing {escape(repo.name)}: {e}")
 
         error = None
         if failed_repositories:

--- a/cli/tests/nao_core/commands/sync/test_column_catalog.py
+++ b/cli/tests/nao_core/commands/sync/test_column_catalog.py
@@ -236,7 +236,7 @@ def _sync(
             "nao_core.commands.sync.providers.databases.provider.get_template_engine",
             return_value=engine,
         ),
-        patch("nao_core.commands.sync.providers.databases.provider.console"),
+        patch("nao_core.commands.sync.providers.databases.provider.UI._console"),
     ):
         sync_database(
             config,

--- a/cli/tests/nao_core/commands/sync/test_confluence_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_confluence_provider.py
@@ -280,6 +280,7 @@ def test_sync_keeps_existing_files_when_a_page_failed(tmp_path: Path):
 
     assert (stale / "stale-999.md").read_text() == "outdated"
     assert result.details is not None and result.details["removed"] == 0
+    assert result.error == "Failed to sync 1 Confluence page"
 
 
 def test_sync_places_a_blogpost_under_blog(tmp_path: Path):

--- a/cli/tests/nao_core/commands/sync/test_database_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_database_provider.py
@@ -152,11 +152,13 @@ class TestDatabaseSyncProvider:
         )
 
         with patch("nao_core.commands.sync.providers.databases.provider.console", console):
-            provider.sync([db], tmp_path)
+            result = provider.sync([db], tmp_path)
 
         text = output.getvalue()
         assert "ibis-framework[postgres]" in text
         assert "nao-core[redshift]" in text
+        assert result.error is not None
+        assert result.error.startswith("Failed to sync 1 database: redshift:")
 
 
 class TestMatchesSelection:

--- a/cli/tests/nao_core/commands/sync/test_database_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_database_provider.py
@@ -160,6 +160,29 @@ class TestDatabaseSyncProvider:
         assert result.error is not None
         assert result.error.startswith("Failed to sync 1 database: redshift:")
 
+    @patch(
+        "nao_core.commands.sync.providers.databases.provider.get_database_folder_names",
+        return_value=["database=prod-red"],
+    )
+    @patch("nao_core.commands.sync.providers.databases.provider.sync_database")
+    def test_sync_escapes_database_name_markup(
+        self, mock_sync_database, _mock_get_database_folder_names, tmp_path: Path
+    ):
+        provider = DatabaseSyncProvider()
+        output = StringIO()
+        console = Console(file=output, force_terminal=False)
+
+        db = MagicMock()
+        db.name = "prod[red]"
+        db.templates = [MagicMock(value="columns")]
+        mock_sync_database.side_effect = RuntimeError("connection failed")
+
+        with patch("nao_core.commands.sync.providers.databases.provider.console", console):
+            result = provider.sync([db], tmp_path)
+            console.print(result.error)
+
+        assert "prod[red]" in output.getvalue()
+
 
 class TestMatchesSelection:
     def test_schema_only_pattern_selects_whole_schema(self):

--- a/cli/tests/nao_core/commands/sync/test_database_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_database_provider.py
@@ -15,6 +15,7 @@ from nao_core.commands.sync.providers.databases.provider import (
 from nao_core.config.base import NaoConfig
 from nao_core.config.databases.duckdb import DuckDBConfig
 from nao_core.deps import MissingDependencyError
+from nao_core.ui import UI
 
 
 class TestDatabaseSyncProvider:
@@ -46,7 +47,7 @@ class TestDatabaseSyncProvider:
 
         assert items == []
 
-    @patch("nao_core.commands.sync.providers.databases.provider.console")
+    @patch("nao_core.commands.sync.providers.databases.provider.UI._console")
     def test_sync_returns_zero_when_no_items(self, mock_console, tmp_path: Path):
         provider = DatabaseSyncProvider()
 
@@ -151,7 +152,10 @@ class TestDatabaseSyncProvider:
             "to connect to redshift databases",
         )
 
-        with patch("nao_core.commands.sync.providers.databases.provider.console", console):
+        with (
+            patch("nao_core.commands.sync.providers.databases.provider.console", console),
+            patch.object(UI, "_console", console),
+        ):
             result = provider.sync([db], tmp_path)
 
         text = output.getvalue()
@@ -177,7 +181,10 @@ class TestDatabaseSyncProvider:
         db.templates = [MagicMock(value="columns")]
         mock_sync_database.side_effect = RuntimeError("connection failed")
 
-        with patch("nao_core.commands.sync.providers.databases.provider.console", console):
+        with (
+            patch("nao_core.commands.sync.providers.databases.provider.console", console),
+            patch.object(UI, "_console", console),
+        ):
             result = provider.sync([db], tmp_path)
             console.print(result.error)
 

--- a/cli/tests/nao_core/commands/sync/test_notion_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_notion_provider.py
@@ -74,6 +74,7 @@ def test_sync_keeps_existing_pages_when_one_failed(mock_get_page, tmp_path: Path
     assert result.items_synced == 1
     assert result.details is not None
     assert result.details["removed"] == 0
+    assert result.error == "Failed to sync 1 Notion page"
 
 
 def api_error(code: APIErrorCode, status: int) -> APIResponseError:
@@ -197,6 +198,7 @@ def test_sync_survives_an_error_that_looks_like_console_markup(mock_get_page, tm
     result = provider.sync([NotionConfig(api_key="secret", pages=["page-a"])], tmp_path)
 
     assert result.items_synced == 0
+    assert result.error == "Failed to sync 1 Notion page"
 
 
 def test_extract_ids_accept_dashed_uuids():

--- a/cli/tests/nao_core/commands/sync/test_provider_error_logging.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_error_logging.py
@@ -51,7 +51,7 @@ def create_mock_engine(templates, render_behavior):
 
 def run_sync_with_mocks(db_config, engine, tmp_path, progress):
     """Run sync_database with patched console and engine, return state and console mock."""
-    with patch("nao_core.commands.sync.providers.databases.provider.console") as mock_console:
+    with patch("nao_core.commands.sync.providers.databases.provider.UI._console") as mock_console:
         with patch(
             "nao_core.commands.sync.providers.databases.provider.get_template_engine",
             return_value=engine,

--- a/cli/tests/nao_core/commands/sync/test_provider_refresh.py
+++ b/cli/tests/nao_core/commands/sync/test_provider_refresh.py
@@ -58,7 +58,7 @@ def run_sync(config, engine, tmp_path):
             "nao_core.commands.sync.providers.databases.provider.get_template_engine",
             return_value=engine,
         ),
-        patch("nao_core.commands.sync.providers.databases.provider.console"),
+        patch("nao_core.commands.sync.providers.databases.provider.UI._console"),
     ):
         sync_database(config, tmp_path, progress)
 

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -115,7 +115,7 @@ class TestRepositorySyncProvider:
 
     @patch("nao_core.commands.sync.providers.repositories.provider.sync_repo")
     @patch("nao_core.commands.sync.providers.repositories.provider.console")
-    def test_sync_counts_successful_repos(self, mock_console, mock_sync, tmp_path: Path):
+    def test_sync_counts_successful_repos_and_reports_failures(self, mock_console, mock_sync, tmp_path: Path):
         provider = RepositorySyncProvider()
         repos = [
             RepoConfig(name="repo1", url="https://github.com/test/repo1"),
@@ -127,6 +127,7 @@ class TestRepositorySyncProvider:
         result = provider.sync(repos, tmp_path)
 
         assert result.items_synced == 2
+        assert result.error == "Failed to sync 1 repository: repo2"
 
     @patch("nao_core.commands.sync.providers.repositories.provider.sync_repo", return_value=True)
     @patch("nao_core.commands.sync.providers.repositories.provider.console")

--- a/cli/tests/nao_core/commands/sync/test_repository_provider.py
+++ b/cli/tests/nao_core/commands/sync/test_repository_provider.py
@@ -1,9 +1,11 @@
 """Unit tests for the repository sync provider."""
 
+from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rich.console import Console
 
 from nao_core.commands.sync.providers.repositories.provider import (
     RepositorySyncProvider,
@@ -128,6 +130,20 @@ class TestRepositorySyncProvider:
 
         assert result.items_synced == 2
         assert result.error == "Failed to sync 1 repository: repo2"
+
+    @patch("nao_core.commands.sync.providers.repositories.provider.sync_repo", return_value=False)
+    def test_sync_escapes_repository_name_markup(self, mock_sync, tmp_path: Path):
+        provider = RepositorySyncProvider()
+        output = StringIO()
+        console = Console(file=output, force_terminal=False)
+        repo = RepoConfig(name="my[b]db", url="https://github.com/test/repo")
+
+        with patch("nao_core.commands.sync.providers.repositories.provider.console", console):
+            result = provider.sync([repo], tmp_path)
+            console.print(result.error)
+
+        assert "my[b]db" in output.getvalue()
+        mock_sync.assert_called_once()
 
     @patch("nao_core.commands.sync.providers.repositories.provider.sync_repo", return_value=True)
     @patch("nao_core.commands.sync.providers.repositories.provider.console")

--- a/cli/tests/nao_core/commands/sync/test_sync.py
+++ b/cli/tests/nao_core/commands/sync/test_sync.py
@@ -21,6 +21,7 @@ def _make_provider(
     items_synced=0,
     output_dir="test-output",
     sync_error=None,
+    result_error=None,
     emoji=None,
 ):
     provider = MagicMock(spec=SyncProvider)
@@ -36,6 +37,7 @@ def _make_provider(
         provider.sync.return_value = SyncResult(
             provider_name=name,
             items_synced=items_synced,
+            error=result_error,
         )
     return ProviderSelection(provider)
 
@@ -170,6 +172,16 @@ class TestSyncCommand:
         # Verify both providers were attempted
         failing.provider.sync.assert_called_once()
         working.provider.sync.assert_called_once()
+
+    def test_sync_exits_when_provider_returns_failed_result(self, create_config):
+        create_config()
+        failing = _make_provider(items=["item1"], result_error="Failed to sync 1 item")
+
+        with patch("nao_core.commands.sync.console"):
+            with pytest.raises(SystemExit) as exc_info:
+                sync(_providers=[failing], render_templates=False)
+
+        assert exc_info.value.code == 1
 
     def test_sync_shows_partial_success_when_some_providers_fail(self, create_config):
         """Test that sync shows partial success status when some providers fail."""

--- a/example/nao_config.yaml
+++ b/example/nao_config.yaml
@@ -1,5 +1,4 @@
 project_name: example
-sso: true
 databases:
 - name: duckdb-jaffle-shop
   templates:

--- a/example/nao_config.yaml
+++ b/example/nao_config.yaml
@@ -1,4 +1,5 @@
 project_name: example
+sso: true
 databases:
 - name: duckdb-jaffle-shop
   templates:


### PR DESCRIPTION
Added error in providers' SyncResult so that has_failures bool line 187 in sync code (cli/nao_core/commands/sync/__init__.py) returns the correct error code.
Opened pull request to test GitHub actions.

Fixes #125 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

