### PR TITLE
feat(budget): support budgets for OpenAI-compatible and other custom-priced providers

### DIFF
--- a/apps/backend/src/trpc/budget.routes.ts
+++ b/apps/backend/src/trpc/budget.routes.ts
@@ -1,23 +1,16 @@
-import { LlmProviderKind } from '@nao/shared/types';
 import { z } from 'zod/v4';
 
-import { PROVIDER_META } from '../agents/provider-meta';
 import * as budgetQueries from '../queries/budget.queries';
 import { hasFeature, LICENSE_FEATURES } from '../services/license.service';
 import { setBudgetsInputSchema } from '../types/budget';
 import { llmProviderSchema } from '../types/llm';
-import { checkBudgetStatus, getEffectiveProviderBudgets } from '../utils/budget';
+import { checkBudgetStatus, getEffectiveProviderBudgets, getProvidersCostSupport } from '../utils/budget';
 import { getProjectConfigLlm } from '../utils/llm';
 import { adminProtectedProcedure, projectProtectedProcedure } from './trpc';
 
 export const budgetRoutes = {
-	getProvidersCostSupport: projectProtectedProcedure.query(async () => {
-		return Object.fromEntries(
-			Object.entries(PROVIDER_META).map(([provider, meta]) => [
-				provider,
-				meta.models.some((m) => m.costPerM !== undefined),
-			]),
-		) as Record<LlmProviderKind, boolean>;
+	getProvidersCostSupport: projectProtectedProcedure.query(async ({ ctx }) => {
+		return getProvidersCostSupport(ctx.project.id);
 	}),
 
 	getBudgets: projectProtectedProcedure.query(async ({ ctx }) => {

--- a/apps/backend/src/utils/budget.ts
+++ b/apps/backend/src/utils/budget.ts
@@ -1,15 +1,23 @@
 import { getNextPeriodStart } from '@nao/shared/date';
-import { type LlmProvider, providerLabel, WARNING_BUDGET_THRESHOLD } from '@nao/shared/types';
+import {
+	type LlmProvider,
+	type LlmProviderKind,
+	providerKind,
+	providerLabel,
+	WARNING_BUDGET_THRESHOLD,
+} from '@nao/shared/types';
 
+import { PROVIDER_META } from '../agents/provider-meta';
 import type { DBProjectProviderBudget } from '../db/abstractSchema';
 import * as budgetQueries from '../queries/budget.queries';
 import * as projectQueries from '../queries/project.queries';
 import { emailService } from '../services/email';
 import { hasFeature, LICENSE_FEATURES } from '../services/license.service';
 import type { BudgetPeriod } from '../types/budget';
+import type { CustomModelMetadata } from '../types/llm';
 import { buildBudgetLimitReachedEmail } from './email-builders';
 import { BudgetExceededError } from './error';
-import { getProjectConfigLlm } from './llm';
+import { getProjectConfigLlm, getProjectDeclaredModels } from './llm';
 import { logger } from './logger';
 import type { ConfigProviderBudget } from './nao-config-llm';
 
@@ -51,6 +59,20 @@ export async function getEffectiveProviderBudgets(projectId: string): Promise<Ef
 	}
 
 	return [...byProvider.values()];
+}
+
+/**
+ * Whether spend can be computed for each provider of a project: either nao ships prices for the
+ * provider's models, or an admin declared token costs on at least one of its models.
+ */
+export async function getProvidersCostSupport(projectId: string): Promise<Record<LlmProvider, boolean>> {
+	const sources = await getProjectDeclaredModels(projectId);
+	return Object.fromEntries(
+		sources.map(({ provider, models }) => [
+			provider,
+			hasBuiltInCosts(providerKind(provider)) || models.some(hasDeclaredCosts),
+		]),
+	) as Record<LlmProvider, boolean>;
 }
 
 export async function checkBudgetStatus(
@@ -108,6 +130,14 @@ type BudgetUsage = {
 	scope: 'project' | 'user';
 	dbBudget: DBProjectProviderBudget | null;
 };
+
+function hasBuiltInCosts(kind: LlmProviderKind): boolean {
+	return PROVIDER_META[kind].models.some((model) => model.costPerM !== undefined);
+}
+
+function hasDeclaredCosts(model: CustomModelMetadata): boolean {
+	return Object.values(model.costPerM ?? {}).some((cost) => cost !== undefined);
+}
 
 function buildBudgetMessage(ratio: number, label: string, resetLabel: string, scope: 'project' | 'user'): string {
 	const percent = Math.min(Math.round(ratio * 100), 100);

--- a/apps/backend/tests/budget-cost-support.test.ts
+++ b/apps/backend/tests/budget-cost-support.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getProvidersCostSupport } from '../src/utils/budget';
+
+const mocks = vi.hoisted(() => ({
+	getProjectById: vi.fn(),
+	getProjectLlmConfigs: vi.fn(),
+}));
+
+vi.mock('../src/queries/project.queries', () => ({
+	getProjectById: mocks.getProjectById,
+	listProjectMembersWithRoles: vi.fn(),
+}));
+
+vi.mock('../src/queries/project-llm-config.queries', () => ({
+	getProjectLlmConfigs: mocks.getProjectLlmConfigs,
+	getProjectLlmConfigByProvider: vi.fn(),
+}));
+
+vi.mock('../src/queries/budget.queries', () => ({}));
+
+vi.mock('../src/services/email', () => ({
+	emailService: { isEnabled: () => false, sendEmail: vi.fn() },
+}));
+
+vi.mock('../src/services/license.service', () => ({
+	hasFeature: vi.fn(),
+	LICENSE_FEATURES: { userBudget: 'user-budget' },
+}));
+
+vi.mock('../src/utils/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const dirs: string[] = [];
+
+function writeConfig(lines: string[]): string {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nao-cost-support-'));
+	dirs.push(dir);
+	fs.writeFileSync(path.join(dir, 'nao_config.yaml'), lines.join('\n'));
+	return dir;
+}
+
+describe('getProvidersCostSupport', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.getProjectLlmConfigs.mockResolvedValue([]);
+		mocks.getProjectById.mockResolvedValue({ path: '/nonexistent', envVars: {} });
+	});
+
+	afterEach(() => {
+		while (dirs.length > 0) {
+			fs.rmSync(dirs.pop() as string, { force: true, recursive: true });
+		}
+	});
+
+	it('supports providers whose models nao already prices', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([
+			{ provider: 'anthropic', enabledModels: ['claude-sonnet-4-6'], customModels: [], baseUrl: null },
+		]);
+
+		const support = await getProvidersCostSupport('project-1');
+
+		expect(support.anthropic).toBe(true);
+	});
+
+	it('does not support an openai-compatible endpoint without declared costs', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([
+			{
+				provider: 'openaiCompatible/vllm',
+				enabledModels: ['llama-3'],
+				customModels: [{ id: 'llama-3', displayName: 'Llama 3' }],
+				baseUrl: 'http://vllm:8000/v1',
+			},
+		]);
+
+		const support = await getProvidersCostSupport('project-1');
+
+		expect(support['openaiCompatible/vllm']).toBe(false);
+	});
+
+	it('supports an openai-compatible endpoint once a model declares costs in the settings UI', async () => {
+		mocks.getProjectLlmConfigs.mockResolvedValue([
+			{
+				provider: 'openaiCompatible/vllm',
+				enabledModels: ['llama-3'],
+				customModels: [{ id: 'llama-3', costPerM: { inputNoCache: 0.5, output: 1.5 } }],
+				baseUrl: 'http://vllm:8000/v1',
+			},
+		]);
+
+		const support = await getProvidersCostSupport('project-1');
+
+		expect(support['openaiCompatible/vllm']).toBe(true);
+	});
+
+	it('supports an openai-compatible endpoint once a model declares costs in nao_config.yaml', async () => {
+		const dir = writeConfig([
+			'llm:',
+			'  providers:',
+			'  - provider: openai-compatible',
+			'    name: prod',
+			'    base_url: http://prod:8000/v1',
+			'    models:',
+			'    - id: llama-3',
+			'      costs:',
+			'        input_no_cache: 0.5',
+			'        output: 1.5',
+			'  - provider: openai-compatible',
+			'    name: staging',
+			'    base_url: http://staging:8000/v1',
+			'    models:',
+			'    - id: llama-3',
+		]);
+		mocks.getProjectById.mockResolvedValue({ path: dir, envVars: {} });
+
+		const support = await getProvidersCostSupport('project-1');
+
+		expect(support['openaiCompatible/prod']).toBe(true);
+		expect(support['openaiCompatible/staging']).toBe(false);
+	});
+});

--- a/apps/frontend/src/components/settings/budget-settings.tsx
+++ b/apps/frontend/src/components/settings/budget-settings.tsx
@@ -1,14 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
 import { ChevronDown, ChevronUp, TriangleAlert } from 'lucide-react';
 import { getNextPeriodStart } from '@nao/shared/date';
-import {
-	BUDGET_PERIODS,
-	MAX_BUDGET_LIMIT_USD,
-	providerKind,
-	providerLabel,
-	WARNING_BUDGET_THRESHOLD,
-} from '@nao/shared/types';
+import { BUDGET_PERIODS, MAX_BUDGET_LIMIT_USD, providerLabel, WARNING_BUDGET_THRESHOLD } from '@nao/shared/types';
 import type { BudgetPeriod } from '@nao/shared/types';
 
 import { UpgradeToEnterprise } from '@/components/settings/upgrade-to-enterprise';
@@ -159,7 +154,7 @@ export function BudgetSettings() {
 				if (configManagedProviders.has(provider)) {
 					return false;
 				}
-				const hasCost = costSupport.data?.[providerKind(provider)] ?? false;
+				const hasCost = costSupport.data?.[provider] ?? false;
 				const budget = budgets[provider] ?? 0;
 				const perUserBudget = perUserBudgets[provider] ?? 0;
 				const period = periods[provider] ?? 'none';
@@ -196,17 +191,27 @@ export function BudgetSettings() {
 					</TableHeader>
 					<TableBody>
 						{allConfiguredProviders.map((provider) => {
-							const hasCost = costSupport.data?.[providerKind(provider)] ?? false;
+							const hasCost = costSupport.data?.[provider] ?? false;
 
 							if (!hasCost) {
 								return (
-									<TableRow key={provider} className='h-12 opacity-50'>
-										<TableCell>{providerLabel(provider)}</TableCell>
+									<TableRow key={provider} className='h-12'>
+										<TableCell className='opacity-50'>{providerLabel(provider)}</TableCell>
 										<TableCell colSpan={5}>
 											<span className='flex items-center gap-1.5 text-muted-foreground text-sm'>
-												<TriangleAlert className='size-4' />
-												Cost data unavailable for this provider — budget tracking is not
-												supported.
+												<TriangleAlert className='size-4 shrink-0' />
+												<span>
+													No token prices known for this provider. Set the costs of its models
+													in{' '}
+													<Link
+														to='/settings/project/agent'
+														search={{ tab: 'models' }}
+														className='underline underline-offset-2 hover:text-foreground'
+													>
+														Models
+													</Link>{' '}
+													to enable budget tracking.
+												</span>
 											</span>
 										</TableCell>
 									</TableRow>


### PR DESCRIPTION
## Why

A user asked: *"the feature of user budget is not supported for OpenAiCompatible?"*

Cost support was resolved per provider **kind** from nao's built-in price table, so OpenAI-compatible endpoints (and Ollama, Azure deployments, custom model ids) were always flagged as unsupported on the Budgets page, even when an admin had already declared token costs through the custom model dialog or `nao_config.yaml`. The pricing lookup in `usage.queries.ts` was already merging those declared costs, so only the gate was wrong.

## What

- `getProvidersCostSupport` now resolves support per provider **instance** (e.g. `openaiCompatible/my-vllm`). A provider is priceable when either its kind ships prices or at least one of its declared models carries a `costPerM` value. Reads through `getProjectDeclaredModels`, so it covers the settings UI, `nao_config.yaml`, and env-configured providers.
- Budgets page keys on the provider instead of its kind. The unsupported row is now actionable: it explains that no prices are known and links to the Models tab where costs can be set.
- Tests for the helper: built-in provider, OpenAI-compatible with/without UI-declared costs, and two named endpoints in `nao_config.yaml` where only one declares prices.

Docs: https://github.com/getnao/nao-docs/pull/82

## Checks

- `npm run lint`, `npm run format:check`, backend vitest all pass (pre-commit hook ran the full suite including `cli:check`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->