### PR TITLE
Fix chart label overflow 1554

### DIFF
--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -1,4 +1,4 @@
-import { buildChart, bucketPieData, buildStoryChartBlock, labelize, resolveDataKey } from '@nao/shared';
+import { buildChart, bucketPieData, buildStoryChartBlock, DEFAULT_COLORS, labelize, resolveDataKey } from '@nao/shared';
 import { appendBlockToStoryCode } from '@nao/shared/story-tabs';
 import { displayChart } from '@nao/shared/tools';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -51,9 +51,8 @@ import { cn } from '@/lib/utils';
 import { ExportDataMenu } from '@/components/export-data-menu';
 import { useSourceQuery } from '@/hooks/use-source-query';
 
-const Colors = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)'];
+const Colors = DEFAULT_COLORS.map((_, index) => `var(--chart-${index + 1})`);
 const LEGEND_SCROLL_OFFSET = 120;
-const PIE_LEGEND_BREAKPOINT = 280;
 const HORIZONTAL_LABEL_GAP = 12;
 const DIAGONAL_LABEL_GAP = 8;
 const CHAR_WIDTH_RATIO = 0.6;
@@ -417,6 +416,7 @@ export const DisplayChartToolCall = ({ toolPart }: ToolCallComponentProps<'displ
 					showDataLabels={chartConfig.show_data_labels}
 					comparisonMode={'comparison_mode' in chartConfig ? chartConfig.comparison_mode : undefined}
 					hideTotal={chartConfig.hide_total}
+					className={displayChart.isPieChart(chartConfig.chart_type) ? 'flex-1 justify-center' : undefined}
 				/>
 			)}
 		</div>
@@ -508,8 +508,7 @@ export const ChartDisplay = memo(function ChartDisplay({
 	const isPercentStacked = displayChart.isPercentStackedChartType(chartType);
 
 	const isPie = displayChart.isPieChart(chartType);
-	const compactPieLegend = isPie && width > 0 && width < PIE_LEGEND_BREAKPOINT;
-	const pieCenteringClass = isPie && !compactPieLegend ? 'mx-auto max-w-[480px]' : '';
+	const pieCenteringClass = isPie ? 'mx-auto max-w-[480px]' : '';
 	const pieValueKey = series[0]?.data_key ?? '';
 	const pieData = useMemo(
 		() => (isPie ? bucketPieData(data, xAxisKey, pieValueKey) : data),
@@ -684,13 +683,12 @@ export const ChartDisplay = memo(function ChartDisplay({
 						<ChartLegend
 							key='legend'
 							payload={legendPayload}
-							layout={isPie && !compactPieLegend ? 'vertical' : 'horizontal'}
-							align={isPie && !compactPieLegend ? 'right' : 'center'}
-							verticalAlign={isPie && !compactPieLegend ? 'middle' : 'bottom'}
+							layout='horizontal'
+							align='center'
+							verticalAlign='bottom'
 							content={
 								<ChartLegendContent
-									layout={isPie && !compactPieLegend ? 'vertical' : 'horizontal'}
-									className={compactPieLegend ? 'flex-wrap' : undefined}
+									className={isPie ? 'flex-wrap' : undefined}
 									onItemClick={isPie ? undefined : handleToggleSeriesVisibility}
 								/>
 							}
@@ -704,7 +702,6 @@ export const ChartDisplay = memo(function ChartDisplay({
 			pieData,
 			chartType,
 			isPie,
-			compactPieLegend,
 			compactXAxis,
 			compactXAxisInterval,
 			xAxisTickFontSize,

--- a/apps/frontend/src/components/tool-calls/display-chart.tsx
+++ b/apps/frontend/src/components/tool-calls/display-chart.tsx
@@ -251,6 +251,7 @@ export const DisplayChartToolCall = ({ toolPart }: ToolCallComponentProps<'displ
 	};
 
 	const isKpiChartView = viewMode === 'chart' && chartConfig.chart_type === 'kpi_card';
+	const isPieChartView = viewMode === 'chart' && displayChart.isPieChart(chartConfig.chart_type);
 
 	return (
 		<div
@@ -266,8 +267,14 @@ export const DisplayChartToolCall = ({ toolPart }: ToolCallComponentProps<'displ
 			<div
 				className={cn(
 					'flex items-center py-2',
-					isKpiChartView ? 'absolute top-0 right-0 z-10 gap-1 px-3' : 'w-full justify-between',
-					!isKpiChartView && (viewMode === 'chart' ? 'gap-2' : 'gap-0 px-3 border-b border-border'),
+					isKpiChartView
+						? 'absolute top-0 right-0 z-10 gap-1 px-3'
+						: isPieChartView
+							? 'absolute inset-x-0 top-0 z-10 w-full justify-between gap-2 px-3'
+							: 'w-full justify-between',
+					!isKpiChartView &&
+						!isPieChartView &&
+						(viewMode === 'chart' ? 'gap-2' : 'gap-0 px-3 border-b border-border'),
 				)}
 			>
 				{chartConfig.chart_type != 'kpi_card' ? (
@@ -417,6 +424,7 @@ export const DisplayChartToolCall = ({ toolPart }: ToolCallComponentProps<'displ
 					comparisonMode={'comparison_mode' in chartConfig ? chartConfig.comparison_mode : undefined}
 					hideTotal={chartConfig.hide_total}
 					className={displayChart.isPieChart(chartConfig.chart_type) ? 'flex-1 justify-center' : undefined}
+					chartContentClassName={displayChart.isPieChart(chartConfig.chart_type) ? 'aspect-4/3' : undefined}
 				/>
 			)}
 		</div>

--- a/apps/frontend/src/styles.css
+++ b/apps/frontend/src/styles.css
@@ -187,6 +187,9 @@ code.dollar:before {
 	--color-chart-6: var(--chart-6);
 	--color-chart-7: var(--chart-7);
 	--color-chart-8: var(--chart-8);
+	--color-chart-9: var(--chart-9);
+	--color-chart-10: var(--chart-10);
+	--color-chart-11: var(--chart-11);
 	--color-sidebar: var(--sidebar);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar-primary: var(--sidebar-primary);
@@ -242,6 +245,9 @@ code.dollar:before {
 	--chart-6: oklch(0.704 0.191 22.216);
 	--chart-7: oklch(0.58 0.22 295);
 	--chart-8: oklch(0.52 0.18 265);
+	--chart-9: oklch(0.62 0.18 145);
+	--chart-10: oklch(0.65 0.19 335);
+	--chart-11: oklch(0.68 0.15 210);
 
 	--sidebar: oklch(0.99 0 0);
 	--sidebar-foreground: oklch(0.129 0.042 264.695);
@@ -292,6 +298,9 @@ code.dollar:before {
 	--chart-6: oklch(0.76 0.19 22.216);
 	--chart-7: oklch(0.72 0.22 295);
 	--chart-8: oklch(0.68 0.18 265);
+	--chart-9: oklch(0.72 0.18 145);
+	--chart-10: oklch(0.74 0.18 335);
+	--chart-11: oklch(0.78 0.14 210);
 }
 
 @layer base {

--- a/apps/shared/src/chart-builder.tsx
+++ b/apps/shared/src/chart-builder.tsx
@@ -51,7 +51,19 @@ import {
 import { type DateFormatSettings, formatDateValue, isIsoDateLike } from './date';
 import * as displayChart from './tools/display-chart';
 
-export const DEFAULT_COLORS = ['#104e64', '#f54900', '#009689', '#ffb900', '#fe9a00'];
+export const DEFAULT_COLORS = [
+	'#104e64',
+	'#f54900',
+	'#009689',
+	'#ffb900',
+	'#fe9a00',
+	'#ff6467',
+	'#8851eb',
+	'#345fcf',
+	'#23a136',
+	'#d259bc',
+	'#00afcb',
+];
 
 const CHART_LABEL_FONT_SIZE = 12;
 const AXIS_TICK = { fontSize: CHART_LABEL_FONT_SIZE };
@@ -59,7 +71,7 @@ const CATEGORY_XAXIS_HEIGHT = 56;
 const X_AXIS_LABEL_HEIGHT = 22;
 
 /** Beyond this many slices, pie/donut charts bucket the smallest into a single "Other" slice. */
-const MAX_PIE_SLICES = 10;
+const MAX_PIE_SLICES = DEFAULT_COLORS.length - 1;
 
 const DONUT_INNER_RADIUS = '45%';
 

--- a/apps/shared/tests/bucket-pie-data.test.ts
+++ b/apps/shared/tests/bucket-pie-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { bucketPieData } from '../src/chart-builder';
+import { bucketPieData, DEFAULT_COLORS } from '../src/chart-builder';
 import { isPieChart } from '../src/tools/display-chart';
 
 const rowsOf = (values: number[]) => values.map((value, index) => ({ category: `cat-${index}`, total: value }));
@@ -24,6 +24,14 @@ describe('bucketPieData', () => {
 		const other = bucketed[bucketed.length - 1];
 		expect(other.category).toBe('Other');
 		expect(other.total).toBe(8);
+	});
+
+	it('limits default output to the available palette colors', () => {
+		const rows = rowsOf([120, 110, 100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
+		const bucketed = bucketPieData(rows, 'category', 'total');
+
+		expect(bucketed).toHaveLength(DEFAULT_COLORS.length);
+		expect(bucketed.at(-1)).toEqual({ category: 'Other', total: 30 });
 	});
 
 	it('keeps the largest slices regardless of input order', () => {


### PR DESCRIPTION
- Fix the layout issue of pie/donut chart after having switched tabs
- Legends are now below the chart. Looks better and match a user suggestion.
- Added more colors for pie charts following other colors of the repo.

Fixes #1554 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

