### PR TITLE
fix: improve LLM provider error message

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -536,7 +536,7 @@ class AgentManager {
 					projectId: this.chat.projectId,
 					context: { chatId: this.chat.id, modelId: this._modelSelection.modelId },
 				});
-				return String(err);
+				return formatErrorMessageForUI(err);
 			},
 			onFinish: async (e) => {
 				try {

--- a/apps/backend/src/utils/utils.ts
+++ b/apps/backend/src/utils/utils.ts
@@ -1,5 +1,9 @@
 import { IncomingHttpHeaders } from 'node:http';
 
+import { APICallError, RetryError } from 'ai';
+
+import { logger } from './logger';
+
 /** Convert fastify headers to basic `Headers` for better-auth. */
 export const convertHeaders = (headers: IncomingHttpHeaders) => {
 	const convertedHeaders = new Headers();
@@ -26,7 +30,52 @@ export const getErrorMessage = (error: unknown): string | null => {
 };
 
 export const formatErrorMessageForUI = (error: unknown): string => {
-	const message = error instanceof Error ? getErrorMessage(error)?.trim() : null;
+	let unwrapped = error;
+	if (RetryError.isInstance(error)) {
+		unwrapped = error.lastError ?? error;
+	}
+
+	if (APICallError.isInstance(unwrapped)) {
+		let code = 'PROVIDER_ERROR';
+		let uiMessage = 'An error occurred with the AI provider. Please try again.';
+
+		if (unwrapped.statusCode === 429) {
+			code = 'RATE_LIMIT_EXCEEDED';
+			uiMessage = 'Rate limited by the provider. Please try again later.';
+		} else if (unwrapped.statusCode === 401 || unwrapped.statusCode === 403) {
+			code = 'PROVIDER_AUTH_ERROR';
+			uiMessage = 'The AI provider rejected the request due to authentication issues.';
+		} else if (unwrapped.statusCode === 408 || unwrapped.statusCode === 504) {
+			code = 'TIMEOUT';
+			uiMessage = 'The provider request timed out. Please try again.';
+		}
+
+		logger.error(`AI SDK APICallError: ${unwrapped.message}`, {
+			source: 'agent',
+			context: {
+				statusCode: unwrapped.statusCode,
+				url: unwrapped.url,
+				providerMessage: unwrapped.message,
+			},
+		});
+
+		return JSON.stringify({
+			error: { code, message: uiMessage },
+			message: uiMessage,
+		});
+	}
+
+	if (RetryError.isInstance(error)) {
+		return JSON.stringify({
+			error: {
+				code: 'PROVIDER_NETWORK_ERROR',
+				message: "Couldn't reach the LLM provider. Please try again.",
+			},
+			message: "Couldn't reach the LLM provider. Please try again.",
+		});
+	}
+
+	const message = unwrapped instanceof Error ? getErrorMessage(unwrapped)?.trim() : null;
 	return message || 'An error occurred.';
 };
 

--- a/apps/backend/tests/utils.test.ts
+++ b/apps/backend/tests/utils.test.ts
@@ -1,3 +1,4 @@
+import { APICallError, RetryError } from 'ai';
 import { describe, expect, it } from 'vitest';
 
 import type { UIMessage, UIMessagePart } from '../src/types/chat';
@@ -35,6 +36,89 @@ describe('formatErrorMessageForUI', () => {
 			expect(formatErrorMessageForUI(error)).toBe('An error occurred.');
 		},
 	);
+
+	it('formats APICallError with rate limit correctly', () => {
+		const apiError = new APICallError({
+			message: 'Rate limit exceeded',
+			url: 'https://api.example.com',
+			requestBodyValues: {},
+			statusCode: 429,
+		});
+
+		const result = formatErrorMessageForUI(apiError);
+		expect(JSON.parse(result)).toEqual({
+			error: {
+				code: 'RATE_LIMIT_EXCEEDED',
+				message: 'Rate limited by the provider. Please try again later.',
+			},
+			message: 'Rate limited by the provider. Please try again later.',
+		});
+	});
+
+	it('formats APICallError with timeout correctly', () => {
+		const apiError = new APICallError({
+			message: 'Timeout error',
+			url: 'https://api.example.com',
+			requestBodyValues: {},
+			statusCode: 504,
+		});
+
+		const result = formatErrorMessageForUI(apiError);
+		expect(JSON.parse(result)).toEqual({
+			error: {
+				code: 'TIMEOUT',
+				message: 'The provider request timed out. Please try again.',
+			},
+			message: 'The provider request timed out. Please try again.',
+		});
+	});
+
+	it('unwraps RetryError containing APICallError', () => {
+		const apiError = new APICallError({
+			message: 'Timeout error',
+			url: 'https://example.com',
+			requestBodyValues: {},
+			statusCode: 504,
+		});
+		const retryError = new RetryError({
+			message: 'Failed after 3 attempts.',
+			reason: 'maxRetriesExceeded',
+			errors: [apiError],
+		});
+
+		const result = formatErrorMessageForUI(retryError);
+		expect(JSON.parse(result)).toEqual({
+			error: {
+				code: 'TIMEOUT',
+				message: 'The provider request timed out. Please try again.',
+			},
+			message: 'The provider request timed out. Please try again.',
+		});
+	});
+
+	it('handles RetryError wrapping a generic error', () => {
+		const genericError = new Error('fetch failed');
+		const retryError = new RetryError({
+			message: 'Failed after 3 attempts.',
+			reason: 'maxRetriesExceeded',
+			errors: [genericError],
+		});
+
+		const result = formatErrorMessageForUI(retryError);
+		expect(JSON.parse(result)).toEqual({
+			error: {
+				code: 'PROVIDER_NETWORK_ERROR',
+				message: "Couldn't reach the LLM provider. Please try again.",
+			},
+			message: "Couldn't reach the LLM provider. Please try again.",
+		});
+	});
+
+	it('returns the message from an AbortError unchanged', () => {
+		const abortError = new Error('The operation was aborted');
+		abortError.name = 'AbortError';
+		expect(formatErrorMessageForUI(abortError)).toBe('The operation was aborted');
+	});
 });
 
 describe('truncateMiddle', () => {


### PR DESCRIPTION
Fixes #1006

LLM provider errors such as rate limits and timeouts were being surfaced as
raw/unhelpful messages in chat.

### Changes

- Format AI SDK `APICallError` and `RetryError` into structured UI errors.
- Unwrap `RetryError.lastError` to classify the underlying provider error.
- Map provider status codes to user-friendly error messages.
- Use the formatter for the outer stream error handler as well.
- Add unit tests for provider and retry-wrapped errors.

### Verification

- Backend tests pass.

---

#### I intentionally triggered a `RetryError` with a `429` `APICallError` to simulate a provider rate-limit error.
### Before
<img width="950" height="393" alt="Screenshot 2026-09-10 at 12 39 09 AM" src="https://github.com/user-attachments/assets/c655f4a6-5da5-4326-be7c-c8b4af0f0d1c" />


### After

<img width="950" height="393" alt="Screenshot 2026-09-10 at 12 33 04 AM" src="https://github.com/user-attachments/assets/7bd7c16a-2d34-4713-9deb-0c964aaf467d" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

