### PR TITLE
fix - Chat cleanly displays provider 500 error #1633

### DIFF
--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -481,6 +481,15 @@ class AgentManager {
 	): ReadableStream<InferUIMessageChunk<UIMessage>> {
 		let error: unknown = undefined;
 		let result: StreamTextResult<AgentTools, never> | undefined;
+		const handleError = (err: unknown): string => {
+			error = err;
+			logger.error(`Agent stream error: ${String(err)}`, {
+				source: 'agent',
+				projectId: this.chat.projectId,
+				context: { chatId: this.chat.id, modelId: this._modelSelection.modelId },
+			});
+			return formatErrorMessageForUI(err);
+		};
 
 		return createUIMessageStream<UIMessage>({
 			generateId: () => crypto.randomUUID(),
@@ -525,19 +534,11 @@ class AgentManager {
 				writer.merge(
 					result.toUIMessageStream({
 						sendStart: false,
-						onError: formatErrorMessageForUI,
+						onError: handleError,
 					}),
 				);
 			},
-			onError: (err) => {
-				error = err;
-				logger.error(`Agent stream error: ${String(err)}`, {
-					source: 'agent',
-					projectId: this.chat.projectId,
-					context: { chatId: this.chat.id, modelId: this._modelSelection.modelId },
-				});
-				return String(err);
-			},
+			onError: handleError,
 			onFinish: async (e) => {
 				try {
 					const stopReason = e.isAborted ? 'interrupted' : e.finishReason;

--- a/apps/backend/src/utils/utils.ts
+++ b/apps/backend/src/utils/utils.ts
@@ -26,9 +26,64 @@ export const getErrorMessage = (error: unknown): string | null => {
 };
 
 export const formatErrorMessageForUI = (error: unknown): string => {
-	const message = error instanceof Error ? getErrorMessage(error)?.trim() : null;
+	if (isTypeValidationError(error)) {
+		const payload = error.value;
+		if (isProviderErrorPayload(payload)) {
+			const code = payload.error.code;
+			const requestId = getProviderRequestId(payload);
+			return JSON.stringify({
+				error: {
+					message: `The model provider returned an error${code ? ` (${code})` : ''}. Retry.`,
+					...(requestId && { requestId }),
+				},
+			});
+		}
+		return 'The model provider returned an error. Please retry.';
+	}
+	const message = error instanceof Error ? error.message.trim() : '';
 	return message || 'An error occurred.';
 };
+
+function isTypeValidationError(error: unknown): error is Error & { value: unknown } {
+	return error instanceof Error && error.name === 'AI_TypeValidationError' && 'value' in error;
+}
+
+function isProviderErrorPayload(
+	value: unknown,
+): value is { error: { message: string; code?: string | number | null } } {
+	if (!value || typeof value !== 'object' || !('error' in value)) {
+		return false;
+	}
+	const nestedError = value.error;
+	return (
+		!!nestedError &&
+		typeof nestedError === 'object' &&
+		'message' in nestedError &&
+		typeof nestedError.message === 'string'
+	);
+}
+
+function getProviderRequestId(payload: { error: { message: string } }): string | undefined {
+	const explicitRequestId =
+		readStringProperty(payload, 'request_id') ??
+		readStringProperty(payload, 'requestId') ??
+		readStringProperty(payload.error, 'request_id') ??
+		readStringProperty(payload.error, 'request ID') ??
+		readStringProperty(payload.error, 'requestId');
+	if (explicitRequestId) {
+		return explicitRequestId;
+	}
+
+	return payload.error.message.match(/\brequest\s+id\s+([a-z0-9][a-z0-9._:-]{5,127})\b/i)?.[1];
+}
+
+function readStringProperty(value: object, property: string): string | undefined {
+	if (!(property in value)) {
+		return undefined;
+	}
+	const result = (value as Record<string, unknown>)[property];
+	return typeof result === 'string' && result.trim() ? result.trim() : undefined;
+}
 
 /** GitHub and GitLab usernames are case-insensitive, so entries are normalized to lowercase. */
 export const buildUsernameAllowlist = (allowedUsers?: string): Set<string> => {

--- a/apps/backend/tests/utils.test.ts
+++ b/apps/backend/tests/utils.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import type { UIMessage, UIMessagePart } from '../src/types/chat';
@@ -27,6 +29,39 @@ describe('formatErrorMessageForUI', () => {
 	it('returns the message from a normal Error', () => {
 		const reason = 'Query blocked because main.customers.last_name is an excluded column.';
 		expect(formatErrorMessageForUI(new Error(reason))).toBe(reason);
+	});
+
+	it('replaces provider payload validation errors with a concise message', () => {
+		const requestId = randomUUID();
+		const error = Object.assign(new Error('Zod invalid_union details'), {
+			name: 'AI_TypeValidationError',
+			value: {
+				error: {
+					message: `Internal provider details. Please include the request ID ${requestId} in your email.`,
+					code: '500',
+				},
+			},
+		});
+
+		const message = formatErrorMessageForUI(error);
+
+		expect(JSON.parse(message)).toEqual({
+			error: {
+				message: 'The model provider returned an error (500). Retry.',
+				requestId,
+			},
+		});
+		expect(message).not.toContain('Internal provider details');
+		expect(message).not.toContain('invalid_union');
+	});
+
+	it('replaces other validation errors with a concise message', () => {
+		const error = Object.assign(new Error('Zod invalid_union details'), {
+			name: 'AI_TypeValidationError',
+			value: { unexpected: true },
+		});
+
+		expect(formatErrorMessageForUI(error)).toBe('The model provider returned an error. Please retry.');
 	});
 
 	it.each([undefined, null, '', 'raw error', {}, new Error(''), new Error('   ')])(

--- a/apps/frontend/src/components/chat-messages/assistant-message.tsx
+++ b/apps/frontend/src/components/chat-messages/assistant-message.tsx
@@ -21,6 +21,7 @@ import { useChatId } from '@/hooks/use-chat-id';
 import { useIsCancellingMessage } from '@/hooks/use-is-cancelling-message-store';
 import { useToolCallDensity } from '@/hooks/use-tool-call-density';
 import { AssistantMessageProvider, useAssistantMessage } from '@/contexts/assistant-message';
+import { useAgentContext } from '@/contexts/agent.provider';
 
 export const AssistantMessage = memo(
 	({
@@ -39,6 +40,7 @@ export const AssistantMessage = memo(
 		storyIntroMessageId: string | undefined;
 	}) => {
 		const chatId = useChatId();
+		const { error } = useAgentContext();
 		const [toolCallDensity] = useToolCallDensity();
 		const messageParts = useMemo(
 			() => groupToolCalls(message.parts, toolCallDensity),
@@ -63,7 +65,7 @@ export const AssistantMessage = memo(
 				<div className={cn('group px-3 flex flex-col gap-2 bg-transparent')}>
 					<MessageParts parts={messageParts} />
 
-					{isSettled && !hasContent && (
+					{isSettled && !hasContent && !(isLastMessage && error) && (
 						<div className='text-muted-foreground italic text-sm'>No response</div>
 					)}
 

--- a/apps/frontend/src/components/chat-messages/chat-error.tsx
+++ b/apps/frontend/src/components/chat-messages/chat-error.tsx
@@ -1,6 +1,7 @@
-import { AlertCircleIcon } from 'lucide-react';
-
-import { useAgentContext } from '@/contexts/agent.provider';
+import { AlertCircleIcon, CheckIcon, CopyIcon, RotateCcwIcon } from 'lucide-react';
+import { Button } from '../ui/button';
+import { useAgentContext, useAgentMessages } from '@/contexts/agent.provider';
+import { useCopyToClipboard } from '@/hooks/use-copy-to-clipboard';
 import { parseBudgetError } from '@/lib/ai';
 import { cn } from '@/lib/utils';
 
@@ -11,6 +12,7 @@ export interface Props {
 type ParsedError = {
 	error?: string;
 	message?: string;
+	requestId?: string;
 };
 
 function parseError(error: Error): ParsedError {
@@ -21,6 +23,7 @@ function parseError(error: Error): ParsedError {
 			return {
 				error: asString(nested.code) ?? asString(nested.type),
 				message: asString(nested.message) ?? asString(parsed.message) ?? error.message,
+				requestId: asString(nested.requestId),
 			};
 		}
 		return {
@@ -37,13 +40,25 @@ function asString(value: unknown): string | undefined {
 }
 
 export function ChatError({ className }: Props) {
-	const { error } = useAgentContext();
+	const { error, isRunning, resendMessage, clearError } = useAgentContext();
+	const messages = useAgentMessages();
+	const { isCopied, copy } = useCopyToClipboard();
 
 	if (!error || parseBudgetError(error)) {
 		return null;
 	}
 
 	const parsed = parseError(error);
+	const requestId = parsed.requestId;
+	const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+	const retry = async () => {
+		if (!lastUserMessage) {
+			return;
+		}
+
+		clearError();
+		await resendMessage({ messageId: lastUserMessage.id });
+	};
 
 	return (
 		<div className={cn('flex items-start gap-2.5 px-4 py-3 text-red-500', className)}>
@@ -52,6 +67,38 @@ export function ChatError({ className }: Props) {
 			<div className='flex-1 min-w-0 text-sm wrap-break-word'>
 				{parsed.error && <span className='font-medium'>{parsed.error}</span>}
 				{parsed.message && <p className='text-red-400 mt leading-relaxed'>{parsed.message}</p>}
+				{requestId && (
+					<div className='mt-2 flex items-center gap-1 text-xs text-muted-foreground'>
+						<span>Provider request ID:</span>
+						<code className='min-w-0 max-w-64 truncate' title={requestId}>
+							{requestId}
+						</code>
+						<Button
+							variant='ghost'
+							size='icon-sm'
+							aria-label='Copy provider request ID'
+							onClick={() => {
+								void copy(requestId);
+							}}
+						>
+							{isCopied ? <CheckIcon /> : <CopyIcon />}
+						</Button>
+					</div>
+				)}
+				{lastUserMessage && (
+					<Button
+						variant='outline'
+						size='sm'
+						className='mt-3'
+						disabled={isRunning}
+						onClick={() => {
+							void retry();
+						}}
+					>
+						<RotateCcwIcon />
+						Retry
+					</Button>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
When the LLM provider returns 500, the chat displays a clean error message followed by a copy-able request ID and a retry button.
Raw Zod dump is no longer displayed to the user.
<img width="899" height="346" alt="Capture d’écran 2026-09-14 à 15 09 56" src="https://github.com/user-attachments/assets/b911513e-dbf2-4971-812d-5d0f60807f2e" />

Fixes #1633 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/getnao/nao/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

